### PR TITLE
fix: allow copying user messages in mobile chat

### DIFF
--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -46,7 +46,7 @@ class _UserMessageCard extends StatelessWidget {
             bottomRight: Radius.circular(4),
           ),
         ),
-        child: Text(
+        child: SelectableText(
           message.content ?? '',
           style: TextStyle(
             fontSize: 14,


### PR DESCRIPTION
## Summary
- User-sent messages in the mobile chat used a plain `Text` widget, making them non-selectable and non-copyable
- Changed `Text` → `SelectableText` in `_UserMessageCard` so users can long-press to select and copy their messages
- Consistent with assistant messages which already use `selectable: true` on `MarkdownBody`