### PR TITLE
fix: make slash commands sheet scrollable in mobile app

### DIFF
--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -385,16 +385,23 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
                   style: Theme.of(ctx).textTheme.titleSmall,
                 ),
               ),
-              ...commands.map((cmd) => ListTile(
-                leading: Icon(_iconForCommand(cmd.icon)),
-                title: Text(cmd.name, style: const TextStyle(fontFamily: 'monospace', fontWeight: FontWeight.w600)),
-                subtitle: Text(cmd.description, style: const TextStyle(fontSize: 12)),
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _sendCommand(cmd.name);
-                },
-              )),
-              const SizedBox(height: 8),
+              Flexible(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: [
+                    ...commands.map((cmd) => ListTile(
+                      leading: Icon(_iconForCommand(cmd.icon)),
+                      title: Text(cmd.name, style: const TextStyle(fontFamily: 'monospace', fontWeight: FontWeight.w600)),
+                      subtitle: Text(cmd.description, style: const TextStyle(fontSize: 12)),
+                      onTap: () {
+                        Navigator.pop(ctx);
+                        _sendCommand(cmd.name);
+                      },
+                    )),
+                    const SizedBox(height: 8),
+                  ],
+                ),
+              ),
             ],
           ),
         );


### PR DESCRIPTION
## Ticket

Closes #5

## Description

The `/` commands bottom sheet was not scrollable. Commands were spread directly into a `Column` with no scroll container, causing overflow when the list exceeded the visible area.

**Fix:** Wrapped the commands list in `Flexible` + `ListView` so it scrolls when items overflow the bottom sheet height.

## Type of change

- [x] Bug fix

## How Has This Been Tested

- Manually verified the bottom sheet scrolls when commands exceed the visible area
- Verified tapping a command still dismisses the sheet and executes the command
- Verified the sheet remains compact (shrinkWrap) when few commands are present

## Impacted Areas

- Mobile app: slash commands bottom sheet (`session_detail_screen.dart`)