### PR TITLE
fix: make links clickable in assistant messages

### DIFF
--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../models/message.dart';
 import '../services/voice_service.dart';
 import '../utils/markdown_stripper.dart';
@@ -139,6 +140,14 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
               MarkdownBody(
                 data: content,
                 selectable: true,
+                onTapLink: (text, href, title) async {
+                  if (href != null) {
+                    final uri = Uri.tryParse(href);
+                    if (uri != null) {
+                      await launchUrl(uri);
+                    }
+                  }
+                },
                 styleSheet: MarkdownStyleSheet(
                   p: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
                   code: TextStyle(


### PR DESCRIPTION
## Summary

- Add `onTapLink` handler to `MarkdownBody` widget in assistant message cards
- Links in assistant messages now open in external browser using the existing `url_launcher` package

## Changes

- Import `url_launcher` package in `message_card.dart`
- Add `onTapLink` callback that safely parses and launches URLs

## Testing

- ✅ `flutter analyze` passes with no issues
- Links are now tappable and open in external browser
- Invalid URLs are safely ignored via `Uri.tryParse()`

## Closes

Closes #9