### PR TITLE
fix: remove invalid -r flag from xattr command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 install: build
 	sudo cp helios /usr/local/bin/helios
 	sudo codesign -s - -f /usr/local/bin/helios
-	sudo xattr -dr com.apple.quarantine /usr/local/bin/helios
+	sudo xattr -d com.apple.quarantine /usr/local/bin/helios 2>/dev/null || true
 	@echo "helios installed to /usr/local/bin/helios"
 
 uninstall:


### PR DESCRIPTION
## Summary
- Removed invalid `-r` flag from `xattr` command in the `install` target
- Added error suppression (`|| true`) to handle cases where the quarantine attribute doesn't exist

## Problem
The `make install` command was failing with:
```
option -r not recognized
```

This occurred because macOS `xattr` does not support the `-r` (recursive) flag. Additionally, if the `com.apple.quarantine` attribute doesn't exist on the file, `xattr -d` exits with an error, causing the make target to fail.

## Solution
- Removed the `-r` flag since we're operating on a single file, not a directory
- Added `2>/dev/null || true` to suppress the error when the attribute doesn't exist

## Test plan
- [x] Run `make install` on macOS and verify it completes successfully
- [x] Verify the installed binary at `/usr/local/bin/helios` is properly signed and executable