### PR TITLE
ci: add apt/deb packaging and GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: .
+          destination: ./_site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -11,8 +14,33 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mobile-release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,4 +70,5 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEYSTORE_PATH: helios-release.jks
-        run: make release VERSION=${{ inputs.version }}
+          VERSION: ${{ inputs.version }}
+        run: make release VERSION="$VERSION"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,61 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - binary: helios
+    main: ./cmd/helios
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    tags:
+      - sqlite_math_functions
+
+archives:
+  - format: tar.gz
+    name_template: "helios_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+
+nfpms:
+  - package_name: helios
+    vendor: kamrul1157024
+    homepage: "https://github.com/kamrul1157024/helios"
+    description: "AI coding agent orchestrator via tmux - daemon, TUI, and mobile app"
+    license: "MIT"
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - tmux
+    bindir: /usr/local/bin
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: kamrul1157024
+    name: helios
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Each connection is fully independent — separate pairing, separate credentials,
 
 ### Prerequisites
 
+**macOS:**
 ```bash
-brew install go tmux                # Go (build helios), tmux (session management)
+brew install tmux                   # tmux (session management)
 
 # Pick ONE tunnel provider — exposes helios to your phone over the internet:
 brew install cloudflared            # Cloudflare Tunnel (recommended, free, no account needed)
@@ -90,7 +91,39 @@ brew install cloudflared            # Cloudflare Tunnel (recommended, free, no a
 brew install ngrok                  # ngrok (free tier, requires signup at ngrok.com)
 ```
 
+**Ubuntu/Debian:**
+```bash
+sudo apt-get update
+sudo apt-get install tmux           # tmux (session management)
+
+# Pick ONE tunnel provider:
+# Cloudflare Tunnel (recommended)
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb
+# or ngrok (requires signup at ngrok.com)
+curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+sudo apt-get update && sudo apt-get install ngrok
+```
+
 ### Step 1 — Install the binary
+
+#### Ubuntu/Debian
+
+Download and install the latest `.deb` package from the [releases page](https://github.com/kamrul1157024/helios/releases):
+
+```bash
+# Download the latest release (replace VERSION with actual version, e.g., 0.1.0)
+curl -LO https://github.com/kamrul1157024/helios/releases/download/vVERSION/helios_VERSION_linux_amd64.deb
+
+# Install
+sudo dpkg -i helios_VERSION_linux_amd64.deb
+
+# Install dependencies if needed
+sudo apt-get install -f
+```
+
+#### From source
 
 ```bash
 $ make install

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-midnight
+title: Helios
+description: AI coding agent orchestrator - daemon, TUI, and mobile app for managing Claude Code sessions via tmux


### PR DESCRIPTION
## Summary

Adds GoReleaser configuration and GitHub Actions workflows to enable:
- Automated `.deb` and `.rpm` package creation for Linux distributions
- GitHub Pages site with Jekyll (midnight theme) for project documentation
- Installation via `apt-get` on Ubuntu/Debian systems

## Changes

- **`.goreleaser.yml`**: GoReleaser configuration for multi-platform builds (Linux amd64/arm64, macOS) with deb/rpm package creation
- **`.github/workflows/release.yml`**: Updated to run GoReleaser on tag pushes (`v*`), while preserving existing manual mobile release workflow
- **`.github/workflows/pages.yml`**: New workflow to deploy Jekyll site to GitHub Pages on push to main
- **`_config.yml`**: Jekyll configuration with midnight theme
- **`README.md`**: Added Ubuntu/Debian installation instructions and prerequisites

## How to Test

1. **Enable GitHub Pages**: Go to repo Settings → Pages → Source: "GitHub Actions"
2. **Create a test release**: 
   ```bash
   git tag v0.1.0
   git push origin v0.1.0
   ```
3. **Verify**:
   - Check that GoReleaser creates `.deb` and `.rpm` packages in GitHub Releases
   - Confirm GitHub Pages site deploys to `https://kamrul1157024.github.io/helios/`
   - Test `.deb` installation on Ubuntu:
     ```bash
     curl -LO https://github.com/kamrul1157024/helios/releases/download/v0.1.0/helios_0.1.0_linux_amd64.deb
     sudo dpkg -i helios_0.1.0_linux_amd64.deb
     helios --version
     ```

## Implementation Notes

- GoReleaser handles cross-compilation for Linux arm64 using `gcc-aarch64-linux-gnu`
- Tmux is declared as a package dependency in `.goreleaser.yml`
- Release workflow now has two jobs: `goreleaser` (runs on tag push) and `mobile-release` (runs on manual workflow dispatch)
- Jekyll site uses midnight theme for a dev-tool aesthetic