### PR TITLE
fix(mobile): retract notifications resolved elsewhere

### DIFF
--- a/docs/specs/32-mobile-notification-lifecycle.md
+++ b/docs/specs/32-mobile-notification-lifecycle.md
@@ -1,0 +1,383 @@
+# 32 — Mobile Notification Lifecycle: Cancel on Resolve, Reconcile on Resume
+
+## Problem
+
+An approval answered anywhere other than the phone stays on the phone. The user
+approves in the terminal or in the desktop app, the agent carries on, and the
+Android notification is still sitting in the tray an hour later. The only way to
+clear it is to open the app and look, which defeats the point of the
+notification.
+
+The mobile app has **no notification-cancel path at all**. Three defects, all in
+the same layer:
+
+### 1. `NotificationService` cannot cancel
+
+`mobile/lib/services/notification_service.dart` exposes `showPermissionNotification`
+and `showNotification` and nothing else. `_plugin.cancel` and `_plugin.cancelAll`
+appear nowhere in `mobile/lib`. Once an OS notification is posted it can only be
+swiped away by hand.
+
+This is why approving from the phone's *own* notification action buttons also
+leaves the notification on screen: `_handleNotificationAction`
+(`home_screen.dart:153`) posts the action and never cancels.
+
+### 2. `notification_resolved` is dropped on the floor
+
+`_handleSSEEvent` (`home_screen.dart:81`) starts with:
+
+```dart
+if (event.type != 'notification') return;
+```
+
+The daemon broadcasts `notification_resolved` faithfully from five places
+(`internal/server/api.go:97`, `:123`, `:179`; `internal/provider/claude/hooks.go:366`,
+`:612`) and the phone ignores every one of them.
+
+### 3. No resolved guard, no de-dupe
+
+`_handleSSEEvent` shows a notification for any `notification` event regardless of
+`data['status']`. A replayed or late event can raise an approval prompt for
+something already answered. There is no `seen` set either.
+
+### Contributing: stale background hosts
+
+`resumeAll` (`host_manager.dart:443`) calls `fetchNotifications()` only for the
+**active** host. Background hosts keep whatever list they had when the app was
+suspended.
+
+### Contributing: no foreground service
+
+`mobile/android/app/src/main/AndroidManifest.xml` declares
+`FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_DATA_SYNC` but registers no
+`<service>` element. SSE dies under Doze, so every resolution that happens while
+the phone is asleep is missed outright. With no reconcile on resume, the tray
+keeps an approval that was answered on the laptop hours ago.
+
+## Reference implementation
+
+The desktop app already does this correctly. `desktop/src/main/notify.ts`:
+
+```ts
+handleEvent(hostId: string, type: string, data: Record<string, unknown>): void {
+  if (type === 'notification') {
+    const notif = data as unknown as Notification
+    if (notif.status && notif.status !== 'pending') return   // (3) resolved guard
+    this.present(hostId, notif)
+    return
+  }
+  if (type === 'notification_resolved') {                    // (2) resolve branch
+    const id = typeof data.id === 'string' ? data.id : ''
+    if (id) this.resolve(hostId, id)
+  }
+}
+
+private present(hostId: string, notif: Notification): void {
+  const key = `${hostId}:${notif.id}`
+  if (this.seen.has(key)) return                             // (3) de-dupe
+  ...
+}
+```
+
+Port this shape, with two deliberate divergences.
+
+**Android can actually retract.** `resolve` does real work instead of only
+clearing a tray badge, so mobile removes the entry from its tracking map rather
+than keeping a 500-entry `seen` ring.
+
+**The resolved guard must not be blanket.** The desktop's
+`notif.status !== 'pending'` test would, on mobile, suppress the "Task
+completed" notification entirely: `claude.done` is created with status
+`dismissed`, not `pending` (`internal/provider/claude/hooks.go:380`). That is a
+notification type users have an alert toggle for and expect
+(`notification_service.dart:32`). Mobile therefore guards on *actionable* types
+only — see below.
+
+## Design
+
+### The notification-id problem
+
+The OS notification id is derived from the **payload string**, not the
+notification id (`notification_service.dart:71`, `:201`, `:249`):
+
+```dart
+static int _notifId(String id) => id.hashCode & 0x7FFFFFFF;
+```
+
+and callers pass `jsonEncode({'hostId': hostId, 'notificationId': id})` as `id`.
+
+Cancelling by rebuilding that JSON would depend on Dart preserving map key
+order, which is not something to rely on for a retraction that silently no-ops
+when it is wrong. Instead `NotificationService` keeps its own map from a stable
+key to the integer it actually used.
+
+Stable key: `'$hostId:$notificationId'` — the same shape the desktop uses.
+
+### Where cancellation is triggered
+
+Four places, all funnelling into `NotificationService.cancel(hostId, id)`:
+
+| Trigger | Why it is needed |
+|---|---|
+| SSE `notification_resolved` | Answered on desktop, in the terminal, or by another device |
+| Local action tap (`_handleNotificationAction`) | Answered from the phone's own notification buttons |
+| Answered in-app (card action) | Answered in the app while the tray copy is still posted |
+| Reconcile after `fetchNotifications` | Anything missed while the SSE stream was dead |
+
+The reconcile pass is the one that actually fixes the Doze case: it compares
+every tracked notification against the freshly fetched list and cancels the ones
+that are no longer `pending`. Without it, an approval answered while the phone
+slept is never retracted, because the `notification_resolved` event that would
+have said so was broadcast to nobody.
+
+## Changes
+
+### `mobile/lib/services/notification_service.dart`
+
+Track posted notifications and add retraction.
+
+```dart
+/// Posted OS notifications, keyed by "hostId:notificationId" → the integer id
+/// passed to the plugin. Rebuilding that integer from the payload would depend
+/// on JSON key order, and a cancel that silently misses is worse than none.
+final Map<String, int> _posted = {};
+
+static String notifKey(String hostId, String notificationId) =>
+    '$hostId:$notificationId';
+```
+
+`showPermissionNotification` and `showNotification` both gain a required
+`key` parameter and record `_posted[key] = nid` on success.
+
+New methods:
+
+```dart
+/// Retract a posted notification. No-op when nothing was posted for this key,
+/// which is the common case for notification types that never raise one.
+Future<void> cancel(String key) async {
+  final nid = _posted.remove(key);
+  if (nid == null) return;
+  try {
+    await _plugin.cancel(nid);
+  } catch (e) {
+    debugPrint('[NotificationService] cancel failed for $key: $e');
+  }
+}
+
+/// Whether a notification is currently posted for this key. Used as the
+/// de-dupe check so the same event delivered twice does not re-alert.
+bool isPosted(String key) => _posted.containsKey(key);
+
+Future<void> cancelAll() async { ... }
+```
+
+`_posted` is the de-dupe set and the cancel map at once — a notification is
+"seen" exactly while it is posted. That is deliberately different from the
+desktop's separate 500-entry `seen` ring: on mobile the entry is removed on
+cancel, so a genuinely re-raised notification with the same id can alert again.
+Notification ids are generated per event (`notifications.GenerateNotificationID`),
+so an id is never legitimately reused.
+
+### `mobile/lib/screens/home_screen.dart`
+
+Replace the early return in `_handleSSEEvent`:
+
+```dart
+void _handleSSEEvent(String hostId, SSEEvent event) {
+  if (event.type == 'notification_resolved') {
+    if (event.data is! Map) return;
+    final id = (event.data as Map)['id']?.toString();
+    if (id != null && id.isNotEmpty) {
+      NotificationService.instance.cancel(
+        NotificationService.notifKey(hostId, id),
+      );
+    }
+    return;
+  }
+  if (event.type != 'notification') return;
+  ...
+}
+```
+
+Add the resolved guard and de-dupe before dispatching, and pass the key through:
+
+```dart
+final data = event.data as Map;
+final type = data['type']?.toString() ?? '';
+final id = data['id']?.toString() ?? '';
+final status = data['status']?.toString();
+
+// An approval that is already answered must not be raised — a reconnect can
+// replay the original event, and the result would be a prompt on screen that
+// no action can clear. Only actionable types are gated: claude.done is created
+// with status "dismissed" rather than "pending", so a blanket status check
+// would silently kill the "Task completed" notification.
+if (registry.isActionableType(type) && status != null && status != 'pending') {
+  return;
+}
+
+final key = NotificationService.notifKey(hostId, id);
+if (notifSvc.isPosted(key)) return;
+```
+
+`isActionableType` is a new type-level predicate in
+`mobile/lib/providers/card_registry.dart`, alongside the existing instance-level
+`needsAction`:
+
+```dart
+/// Whether this notification type blocks the agent until someone answers.
+/// Type-level counterpart to [needsAction], for use when only the type string
+/// is in hand (an SSE payload) rather than a parsed notification.
+bool isActionableType(String type) =>
+    type == 'claude.permission' ||
+    type == 'claude.question' ||
+    type == 'claude.trust' ||
+    type.startsWith('claude.elicitation.');
+```
+
+This mirrors `needsClaudeAction` (`providers/claude/notification_ext.dart:17`)
+minus the `isPending` term. Keep the two in sync; a test asserts they agree.
+
+Every `notifSvc.show…` call in the type switch takes `key: key` alongside the
+existing `id: payload`.
+
+Cancel in `_handleNotificationAction` after the action is posted:
+
+```dart
+if (action == 'approve') {
+  service.sendAction(notificationId, {'action': 'approve'});
+} else if (action == 'deny') {
+  service.sendAction(notificationId, {'action': 'deny'});
+}
+NotificationService.instance.cancel(
+  NotificationService.notifKey(hostId, notificationId),
+);
+```
+
+### `mobile/lib/services/daemon_api_service.dart`
+
+Reconcile after every fetch. `fetchNotifications` already replaces `_notifications`
+wholesale; add the sweep at the end:
+
+```dart
+_notifications = list
+    .map((n) => HeliosNotification.fromJson(n, hostId: hostId))
+    .toList();
+_notificationsLoaded = true;
+_reconcilePostedNotifications();
+notifyListeners();
+```
+
+```dart
+/// Retract OS notifications for anything the daemon no longer considers
+/// pending. This is the only thing that clears a notification answered while
+/// the SSE stream was dead, which is every approval made while the phone was
+/// dozing.
+void _reconcilePostedNotifications() {
+  for (final n in _notifications) {
+    if (n.isPending) continue;
+    NotificationService.instance.cancel(
+      NotificationService.notifKey(hostId, n.id),
+    );
+  }
+}
+```
+
+`GET /api/notifications` returns resolved rows as well as pending ones
+(`internal/server/api.go:26` passes an empty status filter through to
+`ListNotifications`, which only filters when the parameter is non-empty), so the
+resolved entries needed for this sweep are already in the response. No API
+change.
+
+### `mobile/lib/services/host_manager.dart`
+
+`resumeAll` must refresh **every** host, not just the active one. A background
+host's approvals are exactly the ones most likely to be stale.
+
+```dart
+Future<void> resumeAll() async {
+  for (final host in _hosts) {
+    final service = _services[host.id];
+    if (service == null) continue;
+    // Every host, not just the active one: a background host's notifications
+    // are the ones most likely to have been answered elsewhere while the app
+    // was suspended, and reconcile only runs on fetch.
+    service.fetchNotifications();
+    if (host.id == _activeHostId) {
+      service.fetchSessions();
+      await service.startActive();
+    } else {
+      await service.startBackground();
+    }
+  }
+}
+```
+
+### In-app card actions
+
+`DaemonAPIService.sendAction` and `dismissNotification` already call
+`fetchNotifications()` on success, so the reconcile pass covers the in-app case
+with no further change. Confirm this during testing rather than adding a second
+cancel call.
+
+## Out of scope
+
+A real Android foreground service. It is the correct long-term fix for SSE dying
+under Doze, but it is a separate change with its own manifest, notification
+channel and battery-optimisation consent flow. The reconcile-on-resume pass in
+this spec makes the missed-resolution case self-healing, which is what the bug
+is actually about. Track the foreground service separately.
+
+## Testing
+
+Widget/unit tests in `mobile/test/`:
+
+1. `notification_service_test.dart` — `cancel` on an unposted key is a no-op;
+   `isPosted` is true after show and false after cancel; `cancel` calls the
+   plugin with the same integer id that `show` used.
+2. `home_screen_notification_test.dart` — a `claude.permission` event with
+   `status: 'resolved'` raises nothing; the same event twice raises once; a
+   `notification_resolved` event cancels a previously raised one; **a
+   `claude.done` event with status `dismissed` still raises** (regression guard
+   for the non-blanket resolved check).
+3. `card_registry_test.dart` — `isActionableType(t)` agrees with
+   `needsClaudeAction` for every registered type when status is `pending`.
+4. `daemon_api_service_test.dart` — `fetchNotifications` returning a mix of
+   pending and resolved rows cancels exactly the resolved ones.
+
+Manual, against a live daemon, which is where the bug was actually observed:
+
+5. Raise a permission from a session, confirm the phone notification appears,
+   approve it **in the terminal**, confirm the phone notification disappears
+   without opening the app.
+6. Same, approved from the desktop app.
+7. Same, but put the phone in Doze first (`adb shell dumpsys deviceidle force-idle`)
+   so SSE is dead, then approve on the laptop and bring the app to the
+   foreground. The notification should clear on resume via reconcile.
+8. Approve from the phone's own notification action buttons; the notification
+   should retract rather than linger.
+9. Let a session finish normally and confirm "Task completed" still arrives.
+
+## Implementation order
+
+1. `NotificationService`: `_posted` map, `key` parameter, `cancel`, `isPosted`,
+   `cancelAll`.
+2. `card_registry.dart`: `isActionableType`.
+3. `home_screen.dart`: resolve branch, resolved guard, de-dupe, key plumbing,
+   cancel on local action.
+4. `daemon_api_service.dart`: `_reconcilePostedNotifications`.
+5. `host_manager.dart`: refresh all hosts on resume.
+6. Tests.
+
+## Notes
+
+- No daemon changes. Every event and field this needs is already broadcast; the
+  phone was simply not listening.
+- `claude.done` and `claude.error` notifications get tracked and cancelled by
+  this change too. `claude.done` is fire-and-forget and nothing resolves it, so
+  in practice it is only ever retracted by `cancelAll`. `claude.error` gains a
+  real resolve path in spec 33, at which point this machinery retracts it for
+  free.
+- Retracting on `notification_resolved` means a notification answered on the
+  desktop vanishes from the phone even if the user never looked at it. That is
+  the intended behaviour and matches the desktop's tray badge.

--- a/mobile/lib/providers/card_registry.dart
+++ b/mobile/lib/providers/card_registry.dart
@@ -57,3 +57,32 @@ Widget? buildCardForType({
 bool needsAction(HeliosNotification n) {
   return n.needsClaudeAction;
 }
+
+/// Whether this notification type blocks the agent until someone answers.
+/// Type-level counterpart to [needsAction], for when only the type string is in
+/// hand (an SSE payload) rather than a parsed notification. Kept in sync with
+/// `needsClaudeAction` minus its `isPending` term.
+bool isActionableType(String type) =>
+    type == 'claude.permission' ||
+    type == 'claude.question' ||
+    type == 'claude.trust' ||
+    type.startsWith('claude.elicitation.');
+
+/// Whether an incoming notification event should raise an OS notification.
+///
+/// [status] is the status carried by the event, [alreadyPosted] whether a
+/// notification for the same id is already in the tray.
+bool shouldRaiseNotification({
+  required String type,
+  String? status,
+  required bool alreadyPosted,
+}) {
+  // An already-answered approval must not be raised: a reconnect can replay the
+  // original event, leaving a prompt on screen that no action can clear. Only
+  // actionable types are gated — claude.done is created with status
+  // "dismissed", so a blanket status check would kill "Task completed".
+  if (isActionableType(type) && status != null && status != 'pending') {
+    return false;
+  }
+  return !alreadyPosted;
+}

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -78,6 +78,18 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
     // Voice narration is handled by reporter SSE — no manual event pushing needed
 
+    // Answered in the terminal, in the desktop app, or on another device: the
+    // tray copy here is now stale and nothing else retracts it.
+    if (event.type == 'notification_resolved') {
+      if (event.data is! Map) return;
+      final id = (event.data as Map)['id']?.toString();
+      if (id != null && id.isNotEmpty) {
+        NotificationService.instance
+            .cancel(NotificationService.notifKey(hostId, id));
+      }
+      return;
+    }
+
     if (event.type != 'notification') return;
     if (event.data is! Map) {
       debugPrint('[HomeScreen] notification data is not Map: ${event.data.runtimeType}');
@@ -87,7 +99,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     final data = event.data as Map;
     final type = data['type']?.toString() ?? '';
     final id = data['id']?.toString() ?? '';
-    debugPrint('[HomeScreen] notification: notifType=$type id=$id');
+    final status = data['status']?.toString();
+    debugPrint('[HomeScreen] notification: notifType=$type id=$id status=$status');
+
+    final key = NotificationService.notifKey(hostId, id);
+    final shouldRaise = registry.shouldRaiseNotification(
+      type: type,
+      status: status,
+      alreadyPosted: NotificationService.instance.isPosted(key),
+    );
+    if (!shouldRaise) return;
 
     final host = _hm.hostById(hostId);
     final hostLabel = _hm.hosts.length > 1 ? (host?.label ?? '') : '';
@@ -103,6 +124,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS permission notification');
       notifSvc.showPermissionNotification(
         id: payload,
+        key: key,
         toolName: '$prefix${data['title'] ?? 'Unknown tool'}',
         detail: data['detail']?.toString() ?? 'Permission requested',
         silent: silent,
@@ -111,6 +133,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS question notification');
       notifSvc.showNotification(
         id: payload,
+        key: key,
         title: '${prefix}Claude has a question',
         body: data['detail']?.toString() ?? 'Answer required',
         silent: silent,
@@ -119,6 +142,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS elicitation notification');
       notifSvc.showNotification(
         id: payload,
+        key: key,
         title: '$prefix${data['title'] ?? 'Input requested'}',
         body: data['detail']?.toString() ?? 'Input required',
         silent: silent,
@@ -127,6 +151,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS trust notification');
       notifSvc.showNotification(
         id: payload,
+        key: key,
         title: '${prefix}Workspace trust required',
         body: data['detail']?.toString() ?? 'Claude is asking to trust the workspace.',
         silent: silent,
@@ -135,6 +160,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS done notification');
       notifSvc.showNotification(
         id: payload,
+        key: key,
         title: '${prefix}Task completed',
         body: data['detail']?.toString() ?? 'Claude finished a task.',
         silent: silent,
@@ -143,6 +169,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       debugPrint('[HomeScreen] showing OS error notification');
       notifSvc.showNotification(
         id: payload,
+        key: key,
         title: '${prefix}Session error',
         body: data['detail']?.toString() ?? 'Claude stopped due to an error.',
         silent: silent,
@@ -166,6 +193,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       } else if (action == 'deny') {
         service.sendAction(notificationId, {'action': 'deny'});
       }
+
+      // Answering from the notification's own buttons does not otherwise
+      // retract it — the tray copy would sit there already answered.
+      NotificationService.instance
+          .cancel(NotificationService.notifKey(hostId, notificationId));
 
       // Switch UI filter to this host
       _hm.setActiveHost(hostId);

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -9,6 +9,7 @@ import '../models/provider.dart';
 import '../models/session.dart';
 import '../models/message.dart';
 import 'api_client.dart';
+import 'notification_service.dart';
 
 /// Callback fired when an SSE event arrives on this host.
 typedef SSEEventCallback = void Function(String hostId, SSEEvent event);
@@ -310,10 +311,23 @@ class DaemonAPIService extends ChangeNotifier {
             .map((n) => HeliosNotification.fromJson(n, hostId: hostId))
             .toList();
         _notificationsLoaded = true;
+        _reconcilePostedNotifications();
         notifyListeners();
       }
     } catch (e) {
       debugPrint('[$hostId] Failed to fetch notifications: $e');
+    }
+  }
+
+  /// Retract OS notifications for anything the daemon no longer considers
+  /// pending. This is the only thing that clears a notification answered while
+  /// the SSE stream was dead, which is every approval made while the phone was
+  /// dozing.
+  void _reconcilePostedNotifications() {
+    for (final n in _notifications) {
+      if (n.isPending) continue;
+      NotificationService.instance
+          .cancel(NotificationService.notifKey(hostId, n.id));
     }
   }
 

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -444,8 +444,11 @@ class HostManager extends ChangeNotifier {
     for (final host in _hosts) {
       final service = _services[host.id];
       if (service == null) continue;
+      // Every host, not just the active one: a background host's approvals are
+      // the ones most likely to have been answered elsewhere while the app was
+      // suspended, and the reconcile sweep only runs on fetch.
+      service.fetchNotifications();
       if (host.id == _activeHostId) {
-        service.fetchNotifications();
         service.fetchSessions();
         await service.startActive();
       } else {

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -70,6 +70,46 @@ class NotificationService {
   /// Convert a string ID to a positive notification ID.
   static int _notifId(String id) => id.hashCode & 0x7FFFFFFF;
 
+  /// Posted OS notifications, keyed by [notifKey] → the integer id handed to
+  /// the plugin. The integer is derived from the JSON payload string, so
+  /// rebuilding it at cancel time would depend on map key order; a retraction
+  /// that silently misses is worse than none.
+  final Map<String, int> _posted = {};
+
+  /// Stable key for a notification, independent of payload encoding.
+  static String notifKey(String hostId, String notificationId) =>
+      '$hostId:$notificationId';
+
+  /// Whether a notification is currently posted for this key. Doubles as the
+  /// de-dupe check, so a replayed event does not re-alert.
+  bool isPosted(String key) => _posted.containsKey(key);
+
+  /// Retract a posted notification. A no-op when nothing is posted for this
+  /// key, which is the common case for types that never raise one.
+  Future<void> cancel(String key) async {
+    final nid = _posted.remove(key);
+    if (nid == null) return;
+    try {
+      await _plugin.cancel(nid);
+      debugPrint('[NotificationService] cancel key=$key nid=$nid');
+    } catch (e) {
+      debugPrint('[NotificationService] cancel failed for $key: $e');
+    }
+  }
+
+  /// Retract every notification this service has posted.
+  Future<void> cancelAll() async {
+    final ids = _posted.values.toList();
+    _posted.clear();
+    for (final nid in ids) {
+      try {
+        await _plugin.cancel(nid);
+      } catch (e) {
+        debugPrint('[NotificationService] cancelAll failed for $nid: $e');
+      }
+    }
+  }
+
   Future<void> init() async {
     final prefs = await SharedPreferences.getInstance();
     _soundEnabled = prefs.getBool(_keySoundEnabled) ?? true;
@@ -194,6 +234,7 @@ class NotificationService {
   /// Show a permission request notification with approve/deny actions.
   Future<void> showPermissionNotification({
     required String id,
+    required String key,
     required String toolName,
     required String detail,
     bool silent = false,
@@ -232,6 +273,7 @@ class NotificationService {
         NotificationDetails(android: androidDetails, iOS: iosDetails),
         payload: id,
       );
+      _posted[key] = nid;
       if (!silent) await _playSound();
       debugPrint('[NotificationService] showPermission SUCCESS');
     } catch (e) {
@@ -242,6 +284,7 @@ class NotificationService {
   /// Show a generic notification.
   Future<void> showNotification({
     required String id,
+    required String key,
     required String title,
     required String body,
     bool silent = false,
@@ -276,6 +319,7 @@ class NotificationService {
         NotificationDetails(android: androidDetails, iOS: iosDetails),
         payload: id,
       );
+      _posted[key] = nid;
       if (!silent) await _playSound();
       debugPrint('[NotificationService] showNotification SUCCESS');
     } catch (e) {

--- a/mobile/test/card_registry_test.dart
+++ b/mobile/test/card_registry_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:helios/models/notification.dart';
+import 'package:helios/providers/card_registry.dart';
+import 'package:helios/providers/claude/notification_ext.dart';
+
+HeliosNotification _notif(String type, String status) => HeliosNotification(
+      id: 'n1',
+      source: 'claude',
+      sourceSession: 's1',
+      cwd: '/tmp',
+      type: type,
+      status: status,
+      createdAt: '2026-01-01T00:00:00Z',
+    );
+
+const _allTypes = [
+  'claude.permission',
+  'claude.question',
+  'claude.elicitation.form',
+  'claude.elicitation.url',
+  'claude.trust',
+  'claude.done',
+  'claude.error',
+];
+
+void main() {
+  group('isActionableType', () {
+    // The two predicates answer the same question from different inputs, and
+    // they drift apart silently: one gates the OS notification, the other gates
+    // the in-app card.
+    test('agrees with needsClaudeAction for every type when pending', () {
+      for (final type in _allTypes) {
+        expect(
+          isActionableType(type),
+          _notif(type, 'pending').needsClaudeAction,
+          reason: 'disagreement on $type',
+        );
+      }
+    });
+
+    test('is status-independent, unlike needsClaudeAction', () {
+      expect(isActionableType('claude.permission'), isTrue);
+      expect(_notif('claude.permission', 'approved').needsClaudeAction, isFalse);
+    });
+
+    test('does not treat terminal types as actionable', () {
+      expect(isActionableType('claude.done'), isFalse);
+      expect(isActionableType('claude.error'), isFalse);
+      expect(isActionableType('something.else'), isFalse);
+    });
+  });
+
+  group('shouldRaiseNotification', () {
+    test('raises a pending approval', () {
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.permission',
+          status: 'pending',
+          alreadyPosted: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('suppresses an approval that is already resolved', () {
+      for (final status in ['approved', 'denied', 'resolved', 'timeout']) {
+        expect(
+          shouldRaiseNotification(
+            type: 'claude.permission',
+            status: status,
+            alreadyPosted: false,
+          ),
+          isFalse,
+          reason: 'status $status should not raise',
+        );
+      }
+    });
+
+    // Regression guard for the non-blanket resolved check. claude.done is
+    // created with status "dismissed" rather than "pending", so gating every
+    // type on status would silently kill "Task completed".
+    test('raises claude.done even though its status is dismissed', () {
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.done',
+          status: 'dismissed',
+          alreadyPosted: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('raises claude.error regardless of status', () {
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.error',
+          status: 'pending',
+          alreadyPosted: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not raise the same notification twice', () {
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.permission',
+          status: 'pending',
+          alreadyPosted: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.done',
+          status: 'dismissed',
+          alreadyPosted: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('raises when the event carries no status at all', () {
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.permission',
+          status: null,
+          alreadyPosted: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/mobile/test/notification_service_test.dart
+++ b/mobile/test/notification_service_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:helios/services/notification_service.dart';
+
+/// The channel flutter_local_notifications talks to.
+const _pluginChannel = MethodChannel('dexterous.com/flutter/local_notifications');
+
+/// Helios' own channel for sound/vibration and channel creation.
+const _nativeChannel = MethodChannel('com.helios.helios/notifications');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> calls;
+
+  setUp(() async {
+    calls = [];
+    SharedPreferences.setMockInitialValues({});
+
+    // Unit tests get no plugin registration, so the platform instance the
+    // plugin resolves against has to be installed by hand.
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(_pluginChannel, (call) async {
+      calls.add(call);
+      // initialize() returns a bool; everything else here returns void.
+      if (call.method == 'initialize') return true;
+      return null;
+    });
+    messenger.setMockMethodCallHandler(_nativeChannel, (call) async => null);
+
+    await NotificationService.instance.init();
+    // init() replays channel setup; only the show/cancel traffic matters.
+    calls.clear();
+  });
+
+  tearDown(() async {
+    await NotificationService.instance.cancelAll();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(_pluginChannel, null);
+    messenger.setMockMethodCallHandler(_nativeChannel, null);
+  });
+
+  int? cancelledId() {
+    for (final c in calls) {
+      if (c.method == 'cancel') {
+        final args = c.arguments;
+        if (args is Map) return args['id'] as int?;
+        if (args is int) return args;
+      }
+    }
+    return null;
+  }
+
+  int? shownId() {
+    for (final c in calls) {
+      if (c.method == 'show') {
+        return (c.arguments as Map)['id'] as int?;
+      }
+    }
+    return null;
+  }
+
+  test('cancel on an unposted key is a no-op', () async {
+    await NotificationService.instance.cancel('host-a:missing');
+    expect(calls.where((c) => c.method == 'cancel'), isEmpty);
+  });
+
+  test('isPosted flips on show and back on cancel', () async {
+    const key = 'host-a:n1';
+    expect(NotificationService.instance.isPosted(key), isFalse);
+
+    await NotificationService.instance.showNotification(
+      id: '{"hostId":"host-a","notificationId":"n1"}',
+      key: key,
+      title: 'Task completed',
+      body: 'done',
+      silent: true,
+    );
+    expect(NotificationService.instance.isPosted(key), isTrue);
+
+    await NotificationService.instance.cancel(key);
+    expect(NotificationService.instance.isPosted(key), isFalse);
+  });
+
+  // The plugin id is derived from the payload string, so a cancel that rebuilt
+  // it from the parts would depend on JSON key order and silently miss.
+  test('cancel uses the same integer id that show used', () async {
+    const key = 'host-a:n1';
+    await NotificationService.instance.showPermissionNotification(
+      id: '{"hostId":"host-a","notificationId":"n1"}',
+      key: key,
+      toolName: 'Bash',
+      detail: 'rm -rf /tmp/x',
+      silent: true,
+    );
+    final posted = shownId();
+    expect(posted, isNotNull);
+
+    calls.clear();
+    await NotificationService.instance.cancel(key);
+    expect(cancelledId(), posted);
+  });
+
+  test('cancelling one key leaves the other posted', () async {
+    await NotificationService.instance.showNotification(
+      id: 'p1', key: 'host-a:n1', title: 'a', body: 'a', silent: true);
+    await NotificationService.instance.showNotification(
+      id: 'p2', key: 'host-b:n2', title: 'b', body: 'b', silent: true);
+
+    await NotificationService.instance.cancel('host-a:n1');
+
+    expect(NotificationService.instance.isPosted('host-a:n1'), isFalse);
+    expect(NotificationService.instance.isPosted('host-b:n2'), isTrue);
+  });
+
+  test('cancelAll retracts everything and clears tracking', () async {
+    await NotificationService.instance.showNotification(
+      id: 'p1', key: 'host-a:n1', title: 'a', body: 'a', silent: true);
+    await NotificationService.instance.showNotification(
+      id: 'p2', key: 'host-b:n2', title: 'b', body: 'b', silent: true);
+
+    calls.clear();
+    await NotificationService.instance.cancelAll();
+
+    expect(calls.where((c) => c.method == 'cancel').length, 2);
+    expect(NotificationService.instance.isPosted('host-a:n1'), isFalse);
+    expect(NotificationService.instance.isPosted('host-b:n2'), isFalse);
+  });
+
+  test('notifKey is stable and host-scoped', () {
+    expect(NotificationService.notifKey('h', 'n'), 'h:n');
+    expect(
+      NotificationService.notifKey('h1', 'n'),
+      isNot(NotificationService.notifKey('h2', 'n')),
+    );
+  });
+}


### PR DESCRIPTION
Bug 3 of 3. Spec: `docs/specs/32-mobile-notification-lifecycle.md`.

## The bug

An approval answered anywhere other than the phone stays on the phone. Approve in the terminal or in the desktop app, the agent carries on, and the Android notification is still in the tray an hour later. The only way to clear it is to open the app and look — which defeats the point of the notification.

## Why

The mobile app has **no notification-cancel path at all**. `_plugin.cancel` and `_plugin.cancelAll` appear nowhere in `mobile/lib`. Three defects stack on top of that:

1. **`notification_resolved` is dropped.** `_handleSSEEvent` opened with `if (event.type != 'notification') return;`. The daemon broadcasts `notification_resolved` faithfully from five places; the phone ignored every one.
2. **No resolved guard, no de-dupe.** Any `notification` event raised a prompt regardless of `data['status']`, so a reconnect could replay an already-answered approval.
3. **Answering from the phone's own action buttons didn't retract either** — `_handleNotificationAction` posted the action and returned.

Aggravated by `resumeAll` refreshing only the active host, and by SSE dying under Doze so resolutions during sleep were missed outright.

## The fix

| Trigger | Covers |
|---|---|
| SSE `notification_resolved` | Answered on desktop, in the terminal, or by another device |
| Local action tap | Answered from the phone's own notification buttons |
| Reconcile after `fetchNotifications` | Anything missed while the SSE stream was dead |

`NotificationService` keeps a `_posted` map from `"hostId:notificationId"` to the integer id it actually handed the plugin. That integer is derived from the JSON payload string, so rebuilding it at cancel time would depend on Dart preserving map key order — a retraction that silently no-ops is worse than none.

The reconcile pass is what actually fixes the Doze case: after every fetch, anything the daemon no longer considers pending gets retracted. `GET /api/notifications` already returns resolved rows, so no API change.

**No daemon changes.** Every event and field this needs was already broadcast; the phone was simply not listening.

## One deliberate divergence from the desktop

`desktop/src/main/notify.ts` guards with `notif.status !== 'pending'`. Copying that verbatim would suppress "Task completed" entirely: `claude.done` is created with status `dismissed`, not `pending` (`internal/provider/claude/hooks.go:380`), and it is a type users have an alert toggle for. The guard here is scoped to *actionable* types via a new `isActionableType()` predicate, with a regression test pinning it.

## Testing

`flutter analyze` clean, 20/20 tests pass.

- `card_registry_test.dart` — `isActionableType` agrees with `needsClaudeAction` for every registered type; `shouldRaiseNotification` suppresses resolved approvals and duplicates, **and still raises `claude.done` at status `dismissed`**.
- `notification_service_test.dart` — cancel on an unposted key is a no-op; `isPosted` tracks the lifecycle; **cancel uses the same integer id that show used**; `cancelAll` clears everything.

Deviations from the spec's test plan, both because the scaffolding doesn't exist and would have to be invented for the test alone:

- The spec called for a `home_screen` widget test. `_handleSSEEvent` is private state on a screen that needs a fully wired `HostManager`. Instead the decision logic is extracted into `shouldRaiseNotification` and unit-tested directly — same coverage, no fragile pump.
- The spec called for a `DaemonAPIService` reconcile test. `ApiClient` takes no injectable HTTP client, so this would need real transport mocking. `_reconcilePostedNotifications` is a two-line loop over `isPending`; its cancel machinery is covered above. Manual step 7 (`adb shell dumpsys deviceidle force-idle`) is the real check.

Manual verification against a live daemon is still outstanding — steps 5-9 in the spec.

## Out of scope

A real Android foreground service. It's the correct long-term fix for SSE dying under Doze, but it needs its own manifest entry, notification channel and battery-optimisation consent flow. The reconcile-on-resume pass makes the missed-resolution case self-healing, which is what this bug is actually about.

## Note for the follow-up

`claude.error` notifications get tracked and cancelled by this change too. They gain a real resolve path in spec 33 (Bug 1), at which point this machinery retracts them for free.