### PR TITLE
fix: capture API errors and let a failed turn be retried

### DIFF
--- a/docs/specs/33-session-error-retry.md
+++ b/docs/specs/33-session-error-retry.md
@@ -1,0 +1,390 @@
+# 33 — Session Error Retry: Capture the Error, Unblock the Composer, Offer Retry
+
+## Problem
+
+When a turn dies on an API error — a rate limit, a stalled stream, a dropped
+connection — the terminal shows the error and the user types `continue` to pick
+up from where it stopped. From the phone there is no way to do that. The session
+shows "Error", the composer is dead, and the notification has no buttons. The
+session is stranded until the user gets back to a laptop.
+
+**Observed live.** Session `4584bc95-fd71-498b-8e6a-9839cb051f32` has been
+sitting at `status=error` since 2026-08-11 12:26 with its ptyhost still alive.
+Its `claude.error` notification is still `pending`. It is a perfectly healthy
+session that the phone cannot touch.
+
+### The chain
+
+API error → Claude fires `StopFailure` → `handleStopFailure`
+(`internal/provider/claude/hooks.go:408`) → session status `error`, plus a
+`claude.error` notification with status `pending`.
+
+Three separate defects stack on top of that.
+
+### 1. The mobile composer is hard-blocked, and only on mobile
+
+`Session.canSendPrompt` (`mobile/lib/models/session.dart:87`):
+
+```dart
+bool get canSendPrompt {
+  if (status == 'idle') return true;
+  if (supportsPromptQueue && isActive) return true;
+  return false;
+}
+```
+
+`isActive` covers `active`, `waiting_permission`, `compacting`, `starting`
+(`session.dart:79`). `error` is in neither branch, so `canSendPrompt` is false
+and the text field, mic, command sheet and send button all go dead
+(`session_detail_screen.dart:1203`, `:1311`, `:1345`, `:1428`, `:1454`).
+
+**The daemon would have accepted the message.** `handleSessionSend`
+(`internal/server/api.go:491-515`) rejects only `active`/`waiting_permission`
+(as busy) and `terminated`. `error` falls straight through to the
+wake-and-type path at `:520`. The desktop app has no status gate at all, which
+is exactly why typing `continue` works there and not on the phone.
+
+The retry transport already exists. The phone just refuses to use it.
+
+### 2. The error text is thrown away
+
+`hookInput` (`hooks.go:17-37`) has no field for a failure reason, and
+`handleStopFailure` sets the notification detail from `sessionContext(...)`,
+which is `"<project>: <last user message or title>"`. The two stranded rows in
+the live database read:
+
+```
+helios: commit
+helios: mobile will ssh and localforward, mobile need to deploy it keys to the vm
+```
+
+So the phone says "Session error" and shows the user their own last prompt back.
+Nothing indicates it was a rate limit, and nothing says when it would be worth
+retrying.
+
+The real text **is** available. The transcript's last entry carries it:
+
+```json
+{"type":"assistant","isApiErrorMessage":true,
+ "message":{"content":[{"type":"text",
+   "text":"API Error: Response stalled mid-stream. The response above may be incomplete."}]}}
+```
+
+written 8 ms before the hook fired. Errors seen across the local transcripts:
+
+| Text | Retryable |
+|---|---|
+| `API Error: Response stalled mid-stream. The response above may be incomplete.` | yes |
+| `API Error: Stream idle timeout - no chunks received` | yes |
+| `API Error: Connection to the API was lost (ECONNRESET). This is usually temporary — try again.` | yes |
+| `rate limit exceeded` / `Claude AI usage limit reached\|<epoch>` | yes, after a wait |
+
+`internal/transcript` is already wired into the daemon and nothing reads it on
+this path.
+
+### 3. The notification is a dead end that never clears
+
+`claude.error` has no action handler (`register.go:161-165`), no card
+(`card_registry.dart:23-53`), and is excluded from `needsClaudeAction`
+(`notification_ext.dart:17`), so it lands in the dashboard's `activeStatuses`
+bucket (`dashboard_screen.dart:37-48`) — visible, no buttons.
+
+It is created `pending` but `handleStopFailure` never calls `ctx.Mgr.Register`,
+so no decision slot exists and nothing can resolve it except a later `Stop` on
+the same session (`hooks.go:363`). `TruncateNotifications` skips pending rows
+(`store/notifications.go:159`), so these accumulate forever.
+
+## Design
+
+### What "retry" means
+
+Send the string `continue` to the session as a normal prompt. That is what the
+user does by hand in the terminal, and it is what the CLI's own conversation
+state expects: the turn resumes from where the error interrupted it.
+
+This is deliberately *not* a new resume mechanism. `POST /api/sessions/{id}/send`
+already wakes a cold session, types into a live one, and waits for the
+`UserPromptSubmit` hook to confirm the prompt actually landed
+(`api.go:553-571`). Retry is one call to it.
+
+### Where the retry lives
+
+Two entry points, because the user reaches this from two directions:
+
+- **The composer**, for the user already looking at the session. Unblocking it
+  costs one line and is the fix that matters most: it restores the exact
+  terminal workflow, and lets the user send something other than `continue`.
+- **A Retry button on the `claude.error` card**, for the user who got the
+  notification and does not want to open the session.
+
+### Rate limits are a distinct case
+
+A stalled stream is worth retrying immediately. A usage limit is not — retrying
+inside the window just burns another error. When the error text carries a reset
+time, the card surfaces it and disables Retry until it passes.
+
+Claude emits the usage limit as `Claude AI usage limit reached|<unix epoch>`.
+Parse the epoch when present; fall back to no countdown when absent rather than
+guessing a duration.
+
+### Auto-retry is out of scope
+
+Tempting, and wrong for a first cut. A retry loop against a rate limit can
+silently consume quota, and an automatic `continue` on an error the user has not
+seen can take a destructive action they would have stopped. Manual retry first;
+revisit once the error taxonomy has proven itself in practice.
+
+## Changes
+
+### `internal/provider/claude/hooks.go` — capture the error
+
+Add a reason field to `hookInput`, in case a future CLI version supplies one
+directly:
+
+```go
+// Reason is populated by StopFailure when the CLI reports why the turn
+// ended. It is absent in Claude Code v2.1.x, hence the transcript fallback.
+Reason string `json:"reason,omitempty"`
+```
+
+New helper, reading the transcript tail:
+
+```go
+// lastAPIError returns the error text Claude recorded for the turn that just
+// failed, or "" when the transcript has none.
+//
+// The StopFailure payload does not carry the reason, so the transcript is the
+// only place it exists. Entries are scanned from the end because the failure
+// is always the last thing written — the hook fires within milliseconds of it.
+func lastAPIError(transcriptPath string) string
+```
+
+Scan backwards over at most the final `apiErrorScanLimit` entries (start at 20)
+for an entry with `isApiErrorMessage: true`, and return the concatenated text of
+its content blocks. Bail out on a missing or unreadable file: an error
+notification with no detail is still better than a failed hook.
+
+Classification:
+
+```go
+// RateLimitInfo describes a usage-limit error and when it lifts.
+type RateLimitInfo struct {
+    IsRateLimit bool
+    ResetAt     *time.Time // nil when the error carries no reset time
+}
+
+// classifyAPIError reports whether an error is a usage limit and when it
+// clears. Claude formats it as "Claude AI usage limit reached|<unix epoch>".
+func classifyAPIError(text string) RateLimitInfo
+```
+
+`handleStopFailure` uses both:
+
+```go
+errText := lastAPIError(input.TranscriptPath)
+if input.Reason != "" {
+    errText = input.Reason
+}
+rate := classifyAPIError(errText)
+
+title := "Session error"
+if rate.IsRateLimit {
+    title = "Rate limit reached"
+}
+
+// Detail is the error itself. It used to be sessionContext(), which showed
+// the user their own last prompt back and said nothing about what broke.
+detail := errText
+if detail == "" {
+    detail = sessionContext(input.CWD, sess)
+}
+
+payload := map[string]interface{}{
+    "session_id":    input.SessionID,
+    "error":         errText,
+    "is_rate_limit": rate.IsRateLimit,
+    "retryable":     true,
+}
+if rate.ResetAt != nil {
+    payload["reset_at"] = rate.ResetAt.UTC().Format(time.RFC3339)
+}
+```
+
+`session_id` goes in the payload because the retry action handler needs it and
+`store.Notification.SourceSession` is not passed to action handlers in a form
+the mobile card can rely on — the trust action already takes this approach
+(`actions.go:104-114`).
+
+Register the decision slot so the notification can actually be resolved:
+
+```go
+if err := ctx.Mgr.CreateNotification(notif); err != nil {
+    log.Printf("claude: create error notification for %s: %v", input.SessionID, err)
+} else {
+    ctx.Mgr.Register(notifID)
+}
+ctx.Notify("notification", notif)
+```
+
+`handleStopFailure` still does **not** block on a decision. Unlike a permission
+hook there is no CLI request waiting on the answer — the turn is already over.
+`Register` exists only so `Resolve` has somewhere to deliver, which is what lets
+the notification clear.
+
+### `internal/provider/claude/actions.go` — the retry action
+
+```go
+// handleErrorAction retries or dismisses a failed turn.
+//
+// Retry sends "continue", which is what a user types in the terminal after an
+// API error: the CLI picks the turn up where it stopped rather than starting a
+// new one.
+func handleErrorAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error)
+```
+
+Accepts `{"action": "retry"}` or `{"action": "dismiss"}`. Retry sends `continue`
+via `terminalBackend.SendText(sessionID, "continue")` and returns
+`Decision{Status: "approved"}`; dismiss returns `Decision{Status: "dismissed"}`.
+
+Reject retry when the terminal is gone, so the notification is not consumed by a
+send that went nowhere:
+
+```go
+if terminalBackend == nil || !terminalBackend.Alive(sessionID) {
+    return notifications.Decision{}, fmt.Errorf("session %s has no live terminal", sessionID)
+}
+```
+
+A dead terminal needs the wake path in `handleSessionSend`, which the composer
+already reaches. The card falls back to opening the session in that case.
+
+Register it:
+
+```go
+provider.RegisterAction("claude.error", handleErrorAction)
+```
+
+### `mobile/lib/models/session.dart` — unblock the composer
+
+```dart
+bool get canSendPrompt {
+  if (status == 'idle') return true;
+  // A turn that died on an API error leaves a live, idle agent. The daemon
+  // accepts a prompt in this state (handleSessionSend treats only active,
+  // waiting_permission and terminated as unsendable), and typing "continue"
+  // is exactly the terminal recovery. Blocking it here stranded the session.
+  if (status == 'error') return true;
+  if (supportsPromptQueue && isActive) return true;
+  return false;
+}
+```
+
+### `mobile/lib/providers/claude/notification_ext.dart` — payload accessors
+
+```dart
+bool get isRateLimit => payload?['is_rate_limit'] == true;
+bool get isRetryable => payload?['retryable'] == true;
+String? get errorText => payload?['error'] as String?;
+String? get errorSessionId => payload?['session_id'] as String?;
+DateTime? get rateLimitResetAt {
+  final raw = payload?['reset_at'] as String?;
+  if (raw == null) return null;
+  return DateTime.tryParse(raw)?.toUtc();
+}
+```
+
+Add `claude.error` to the actionable set:
+
+```dart
+bool get needsClaudeAction =>
+    isPending &&
+    (isClaudePermission || isClaudeQuestion || isClaudeElicitation ||
+     isClaudeTrust || isClaudeError);
+```
+
+This moves it from the dashboard's `activeStatuses` bucket into `pendingActions`,
+which is correct — it now has an action. Spec 32's `isActionableType` must gain
+`claude.error` in the same change if 32 has already landed; the two predicates
+are asserted equal by test.
+
+### `mobile/lib/providers/claude/cards.dart` — `ClaudeErrorCard`
+
+Follows `ClaudeTrustCard`'s shape. Shows:
+
+- the error text (`n.errorText ?? n.displayDetail`), monospace, wrapped
+- a **Retry** button posting `{'action': 'retry'}` via `sse.sendAction`
+- a **Dismiss** button posting `{'action': 'dismiss'}`
+- an **Open session** link routing to `SessionDetailScreen`
+
+When `isRateLimit` and `rateLimitResetAt` is in the future, Retry is disabled and
+labelled with the remaining time ("Retry in 12m"), driven by a one-second
+`Timer.periodic` that re-enables the button on expiry. When `rateLimitResetAt` is
+null, Retry stays enabled — an unknown window is not a reason to lock the user
+out.
+
+Register it in `card_registry.dart`:
+
+```dart
+case 'claude.error':
+  return ClaudeErrorCard(notification: notification, sse: sse);
+```
+
+### `mobile/lib/screens/session_detail_screen.dart` — error banner
+
+Above the composer, when `session.status == 'error'`, an inline banner with the
+error text and a Retry action that sends `continue` through the existing
+`_sendPrompt` path. This is the surface the user hits when they open the session
+from the notification.
+
+## Testing
+
+Go, in `internal/provider/claude/`:
+
+1. `hooks_test.go` — `lastAPIError` on a transcript whose final entry has
+   `isApiErrorMessage: true` returns the text; on one with no such entry returns
+   `""`; on a missing file returns `""` without panicking; scanning stops at
+   `apiErrorScanLimit`.
+2. `classifyAPIError` — parses `Claude AI usage limit reached|1754899200` into a
+   reset time; treats `API Error: Response stalled mid-stream.` as not a rate
+   limit; a usage-limit string with no epoch yields `IsRateLimit` true and a nil
+   `ResetAt`.
+3. `handleStopFailure` writes the error text as the detail, sets
+   `is_rate_limit`, and registers a decision slot (`Mgr.HasPending(id)`).
+4. `actions_test.go` — `handleErrorAction` with `retry` calls `SendText` with
+   `continue`; with a dead terminal it errors and does not resolve; `dismiss`
+   returns a dismissed decision.
+
+Dart, in `mobile/test/`:
+
+5. `session_test.dart` — `canSendPrompt` is true for `error`, still false for
+   `terminated`.
+6. `claude_error_card_test.dart` — Retry disabled while `reset_at` is in the
+   future, enabled once it passes, enabled when `reset_at` is absent.
+
+Manual:
+
+7. Force an API error (pull the network mid-turn), confirm the phone shows the
+   real error text rather than the last prompt, hit Retry, confirm the session
+   resumes.
+8. Hit an actual usage limit and confirm the countdown renders and Retry unlocks
+   when it expires.
+9. Confirm the stranded session `4584bc95` becomes usable from the phone again.
+
+## Implementation order
+
+1. `lastAPIError` + `classifyAPIError` + tests — pure functions, no wiring.
+2. `handleStopFailure` uses them; register the decision slot.
+3. `handleErrorAction` + registration.
+4. `canSendPrompt` accepts `error` — smallest change, biggest immediate relief.
+5. Payload accessors, `ClaudeErrorCard`, registry entry.
+6. Session detail error banner.
+
+## Notes
+
+- Steps 1-4 are independently useful. If the card slips, the composer fix alone
+  restores the terminal workflow on the phone.
+- Nothing here changes `handleSessionSend`. It already handles `error` correctly;
+  the bug was entirely that the client would not call it.
+- The two currently-stranded `claude.error` rows stay pending after this lands —
+  they were created before the decision slot existed. They will age out only via
+  a `Stop` on their sessions. Not worth a migration.

--- a/internal/provider/claude/actions.go
+++ b/internal/provider/claude/actions.go
@@ -93,6 +93,54 @@ func handleElicitationAction(notif *store.Notification, body json.RawMessage) (n
 	return notifications.Decision{Status: status, Response: response}, nil
 }
 
+// handleErrorAction retries or dismisses a turn that died on an API error.
+//
+// Retry sends "continue", which is what a user types in the terminal after an
+// API error: the CLI picks the turn up where it stopped rather than starting a
+// new one.
+func handleErrorAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
+	var req struct {
+		Action string `json:"action"` // "retry" or "dismiss"
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return notifications.Decision{}, fmt.Errorf("invalid body: %w", err)
+	}
+
+	if req.Action == "dismiss" {
+		return notifications.Decision{Status: "dismissed"}, nil
+	}
+	if req.Action != "retry" {
+		return notifications.Decision{}, fmt.Errorf("action must be retry/dismiss")
+	}
+
+	sessionID := notif.SourceSession
+	if notif.Payload != nil {
+		var payload struct {
+			SessionID string `json:"session_id"`
+		}
+		if err := json.Unmarshal([]byte(*notif.Payload), &payload); err == nil && payload.SessionID != "" {
+			sessionID = payload.SessionID
+		}
+	}
+	if sessionID == "" {
+		return notifications.Decision{}, fmt.Errorf("missing session_id in notification payload")
+	}
+
+	// Reject rather than resolve when there is nothing to type into: a
+	// notification consumed by a send that went nowhere is unrecoverable. A
+	// dead terminal needs the wake path in handleSessionSend, which the
+	// composer reaches.
+	if terminalBackend == nil || !terminalBackend.Alive(sessionID) {
+		return notifications.Decision{}, fmt.Errorf("session %s has no live terminal", sessionID)
+	}
+
+	if err := terminalBackend.SendText(sessionID, "continue"); err != nil {
+		return notifications.Decision{}, fmt.Errorf("send continue to session %s: %w", sessionID, err)
+	}
+	log.Printf("error-action: retried session %s", sessionID)
+	return notifications.Decision{Status: "approved"}, nil
+}
+
 func handleTrustAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {
 		Action string `json:"action"` // "trust" or "deny"

--- a/internal/provider/claude/actions_test.go
+++ b/internal/provider/claude/actions_test.go
@@ -1,0 +1,131 @@
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// withBackend installs a fake terminal backend for the duration of a test.
+func withBackend(t *testing.T, f *fakeBackend) *fakeBackend {
+	t.Helper()
+	prev := terminalBackend
+	terminalBackend = f
+	t.Cleanup(func() { terminalBackend = prev })
+	return f
+}
+
+func errorNotif(sessionID string) *store.Notification {
+	payload := `{"session_id":"` + sessionID + `","error":"API Error: Response stalled mid-stream.","is_rate_limit":false,"retryable":true}`
+	return &store.Notification{
+		ID:            "notif-1",
+		Source:        "claude",
+		SourceSession: sessionID,
+		Type:          "claude.error",
+		Status:        "pending",
+		Payload:       &payload,
+	}
+}
+
+func TestErrorAction_RetrySendsContinue(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+
+	dec, err := handleErrorAction(errorNotif("sess-1"), json.RawMessage(`{"action":"retry"}`))
+	if err != nil {
+		t.Fatalf("handleErrorAction: %v", err)
+	}
+	if dec.Status != "approved" {
+		t.Errorf("status = %q, want approved", dec.Status)
+	}
+	// "continue" is what the user types in the terminal: the CLI resumes the
+	// interrupted turn rather than starting a new one.
+	if len(fb.texts) != 1 || fb.texts[0] != "sess-1:continue" {
+		t.Errorf("texts = %v, want [sess-1:continue]", fb.texts)
+	}
+}
+
+// A notification consumed by a send that went nowhere is unrecoverable, so a
+// dead terminal must error rather than resolve.
+func TestErrorAction_RetryWithDeadTerminal(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+
+	_, err := handleErrorAction(errorNotif("sess-1"), json.RawMessage(`{"action":"retry"}`))
+	if err == nil {
+		t.Fatal("want an error for a session with no live terminal")
+	}
+	if !strings.Contains(err.Error(), "no live terminal") {
+		t.Errorf("error = %v, want it to mention the missing terminal", err)
+	}
+	if len(fb.texts) != 0 {
+		t.Errorf("texts = %v, want nothing sent", fb.texts)
+	}
+}
+
+func TestErrorAction_RetryWithNoBackend(t *testing.T) {
+	prev := terminalBackend
+	terminalBackend = nil
+	t.Cleanup(func() { terminalBackend = prev })
+
+	if _, err := handleErrorAction(errorNotif("sess-1"), json.RawMessage(`{"action":"retry"}`)); err == nil {
+		t.Fatal("want an error when no backend is wired")
+	}
+}
+
+func TestErrorAction_Dismiss(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+
+	dec, err := handleErrorAction(errorNotif("sess-1"), json.RawMessage(`{"action":"dismiss"}`))
+	if err != nil {
+		t.Fatalf("handleErrorAction: %v", err)
+	}
+	if dec.Status != "dismissed" {
+		t.Errorf("status = %q, want dismissed", dec.Status)
+	}
+	if len(fb.texts) != 0 {
+		t.Errorf("texts = %v, want nothing sent on dismiss", fb.texts)
+	}
+}
+
+func TestErrorAction_UnknownAction(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+
+	if _, err := handleErrorAction(errorNotif("sess-1"), json.RawMessage(`{"action":"explode"}`)); err == nil {
+		t.Fatal("want an error for an unknown action")
+	}
+}
+
+// The payload is the primary source, but a row written before the payload
+// existed still names its session, so fall back rather than refusing.
+func TestErrorAction_FallsBackToSourceSession(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+
+	notif := errorNotif("sess-1")
+	notif.Payload = nil
+
+	if _, err := handleErrorAction(notif, json.RawMessage(`{"action":"retry"}`)); err != nil {
+		t.Fatalf("handleErrorAction: %v", err)
+	}
+	if len(fb.texts) != 1 || fb.texts[0] != "sess-1:continue" {
+		t.Errorf("texts = %v, want [sess-1:continue]", fb.texts)
+	}
+}
+
+func TestErrorAction_MissingSessionID(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+
+	notif := errorNotif("sess-1")
+	notif.SourceSession = ""
+	empty := `{"error":"boom"}`
+	notif.Payload = &empty
+
+	if _, err := handleErrorAction(notif, json.RawMessage(`{"action":"retry"}`)); err == nil {
+		t.Fatal("want an error when no session can be identified")
+	}
+}

--- a/internal/provider/claude/apierror.go
+++ b/internal/provider/claude/apierror.go
@@ -1,0 +1,129 @@
+package claude
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// apiErrorScanLimit caps how far back from the end of a transcript lastAPIError
+// looks. The failure is written milliseconds before the hook fires, so it is
+// always within the last few entries; the limit keeps a large transcript from
+// being walked twice for nothing.
+const apiErrorScanLimit = 20
+
+// usageLimitMarker is how Claude reports a usage limit. It is followed by
+// "|<unix epoch>" when a reset time is known.
+const usageLimitMarker = "Claude AI usage limit reached"
+
+// apiErrorEntry is the subset of a transcript line that identifies an error.
+type apiErrorEntry struct {
+	IsAPIErrorMessage bool `json:"isApiErrorMessage"`
+	Message           struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+// lastAPIError returns the error text Claude recorded for the turn that just
+// failed, or "" when the transcript has none.
+//
+// The StopFailure payload does not carry the reason, so the transcript is the
+// only place it exists. Entries are scanned from the end because the failure is
+// always the last thing written. A missing or unreadable file yields "": an
+// error notification with no detail beats a failed hook.
+func lastAPIError(transcriptPath string) string {
+	if transcriptPath == "" {
+		return ""
+	}
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	// Keep only the tail in memory — transcripts run to megabytes.
+	tail := make([]string, 0, apiErrorScanLimit)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if len(tail) == apiErrorScanLimit {
+			tail = append(tail[1:], line)
+			continue
+		}
+		tail = append(tail, line)
+	}
+	if scanner.Err() != nil {
+		return ""
+	}
+
+	for i := len(tail) - 1; i >= 0; i-- {
+		var entry apiErrorEntry
+		if err := json.Unmarshal([]byte(tail[i]), &entry); err != nil {
+			continue
+		}
+		if !entry.IsAPIErrorMessage {
+			continue
+		}
+		var parts []string
+		for _, block := range entry.Message.Content {
+			if block.Type == "text" && block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n")
+		}
+	}
+	return ""
+}
+
+// RateLimitInfo describes a usage-limit error and when it lifts.
+type RateLimitInfo struct {
+	IsRateLimit bool
+	// ResetAt is nil when the error carries no reset time. An unknown window is
+	// not the same as no window, and callers must not treat it as "retry now".
+	ResetAt *time.Time
+}
+
+// classifyAPIError reports whether an error is a usage limit and when it
+// clears. Claude formats it as "Claude AI usage limit reached|<unix epoch>".
+func classifyAPIError(text string) RateLimitInfo {
+	if text == "" {
+		return RateLimitInfo{}
+	}
+
+	idx := strings.Index(text, usageLimitMarker)
+	if idx < 0 {
+		// Older or differently-worded limits still say so in plain words.
+		lower := strings.ToLower(text)
+		if strings.Contains(lower, "rate limit") || strings.Contains(lower, "usage limit") {
+			return RateLimitInfo{IsRateLimit: true}
+		}
+		return RateLimitInfo{}
+	}
+
+	rest := text[idx+len(usageLimitMarker):]
+	if !strings.HasPrefix(rest, "|") {
+		return RateLimitInfo{IsRateLimit: true}
+	}
+	epoch := strings.TrimPrefix(rest, "|")
+	if cut := strings.IndexAny(epoch, " \t\n\r"); cut >= 0 {
+		epoch = epoch[:cut]
+	}
+	secs, err := strconv.ParseInt(epoch, 10, 64)
+	if err != nil || secs <= 0 {
+		return RateLimitInfo{IsRateLimit: true}
+	}
+	reset := time.Unix(secs, 0).UTC()
+	return RateLimitInfo{IsRateLimit: true, ResetAt: &reset}
+}

--- a/internal/provider/claude/apierror_test.go
+++ b/internal/provider/claude/apierror_test.go
@@ -1,0 +1,191 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTranscript writes lines to a .jsonl file and returns its path.
+func writeTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// apiErrorLine builds the shape Claude writes for a failed turn.
+func apiErrorLine(text string) string {
+	line, err := json.Marshal(map[string]interface{}{
+		"type":              "assistant",
+		"isApiErrorMessage": true,
+		"message": map[string]interface{}{
+			"role":    "assistant",
+			"content": []map[string]string{{"type": "text", "text": text}},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(line)
+}
+
+func assistantLine(text string) string {
+	line, err := json.Marshal(map[string]interface{}{
+		"type": "assistant",
+		"message": map[string]interface{}{
+			"role":    "assistant",
+			"content": []map[string]string{{"type": "text", "text": text}},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(line)
+}
+
+// ==================== lastAPIError ====================
+
+func TestLastAPIError_ReturnsFinalErrorText(t *testing.T) {
+	const want = "API Error: Response stalled mid-stream. The response above may be incomplete."
+	path := writeTranscript(t,
+		assistantLine("working on it"),
+		apiErrorLine(want),
+	)
+
+	if got := lastAPIError(path); got != want {
+		t.Errorf("lastAPIError = %q, want %q", got, want)
+	}
+}
+
+func TestLastAPIError_PrefersTheMostRecentError(t *testing.T) {
+	path := writeTranscript(t,
+		apiErrorLine("older error"),
+		assistantLine("recovered"),
+		apiErrorLine("newer error"),
+	)
+
+	if got := lastAPIError(path); got != "newer error" {
+		t.Errorf("lastAPIError = %q, want the newer error", got)
+	}
+}
+
+func TestLastAPIError_NoErrorEntry(t *testing.T) {
+	path := writeTranscript(t, assistantLine("all good"))
+
+	if got := lastAPIError(path); got != "" {
+		t.Errorf("lastAPIError = %q, want empty", got)
+	}
+}
+
+// A hook that panics on a rotated or deleted transcript is worse than one that
+// posts a notification with no detail.
+func TestLastAPIError_MissingFile(t *testing.T) {
+	if got := lastAPIError(filepath.Join(t.TempDir(), "nope.jsonl")); got != "" {
+		t.Errorf("lastAPIError = %q, want empty", got)
+	}
+	if got := lastAPIError(""); got != "" {
+		t.Errorf("lastAPIError(\"\") = %q, want empty", got)
+	}
+}
+
+func TestLastAPIError_SkipsUnparseableLines(t *testing.T) {
+	path := writeTranscript(t,
+		apiErrorLine("the error"),
+		"{not json at all",
+		"",
+	)
+
+	if got := lastAPIError(path); got != "the error" {
+		t.Errorf("lastAPIError = %q, want %q", got, "the error")
+	}
+}
+
+func TestLastAPIError_StopsAtScanLimit(t *testing.T) {
+	lines := []string{apiErrorLine("too far back")}
+	for i := 0; i < apiErrorScanLimit; i++ {
+		lines = append(lines, assistantLine(fmt.Sprintf("filler %d", i)))
+	}
+	path := writeTranscript(t, lines...)
+
+	if got := lastAPIError(path); got != "" {
+		t.Errorf("lastAPIError = %q, want empty beyond the scan limit", got)
+	}
+}
+
+// ==================== classifyAPIError ====================
+
+func TestClassifyAPIError_UsageLimitWithEpoch(t *testing.T) {
+	info := classifyAPIError("Claude AI usage limit reached|1754899200")
+
+	if !info.IsRateLimit {
+		t.Fatal("IsRateLimit = false, want true")
+	}
+	if info.ResetAt == nil {
+		t.Fatal("ResetAt = nil, want a parsed time")
+	}
+	if got := info.ResetAt.Unix(); got != 1754899200 {
+		t.Errorf("ResetAt = %d, want 1754899200", got)
+	}
+}
+
+func TestClassifyAPIError_UsageLimitWithoutEpoch(t *testing.T) {
+	for _, text := range []string{
+		"Claude AI usage limit reached",
+		"Claude AI usage limit reached|",
+		"Claude AI usage limit reached|not-a-number",
+	} {
+		info := classifyAPIError(text)
+		if !info.IsRateLimit {
+			t.Errorf("%q: IsRateLimit = false, want true", text)
+		}
+		// An unknown window must not become a fabricated one.
+		if info.ResetAt != nil {
+			t.Errorf("%q: ResetAt = %v, want nil", text, info.ResetAt)
+		}
+	}
+}
+
+func TestClassifyAPIError_PlainRateLimitWording(t *testing.T) {
+	info := classifyAPIError("Error: rate limit exceeded, please slow down")
+
+	if !info.IsRateLimit {
+		t.Error("IsRateLimit = false, want true")
+	}
+	if info.ResetAt != nil {
+		t.Errorf("ResetAt = %v, want nil", info.ResetAt)
+	}
+}
+
+func TestClassifyAPIError_TransientErrorsAreNotRateLimits(t *testing.T) {
+	for _, text := range []string{
+		"API Error: Response stalled mid-stream. The response above may be incomplete.",
+		"API Error: Stream idle timeout - no chunks received",
+		"API Error: Connection to the API was lost (ECONNRESET). This is usually temporary — try again.",
+		"",
+	} {
+		if info := classifyAPIError(text); info.IsRateLimit {
+			t.Errorf("%q: IsRateLimit = true, want false", text)
+		}
+	}
+}
+
+func TestClassifyAPIError_ResetIsUTC(t *testing.T) {
+	info := classifyAPIError("Claude AI usage limit reached|1754899200")
+	if info.ResetAt == nil {
+		t.Fatal("ResetAt = nil")
+	}
+	if _, offset := info.ResetAt.Zone(); offset != 0 {
+		t.Errorf("ResetAt zone offset = %d, want UTC", offset)
+	}
+	// The card parses this back out of the payload.
+	if _, err := time.Parse(time.RFC3339, info.ResetAt.Format(time.RFC3339)); err != nil {
+		t.Errorf("ResetAt does not round-trip through RFC3339: %v", err)
+	}
+}

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -30,6 +30,10 @@ type hookInput struct {
 	RequestedSchema       json.RawMessage `json:"requested_schema,omitempty"`
 	URL                   string          `json:"url,omitempty"`
 	ElicitationID         string          `json:"elicitation_id,omitempty"`
+	// Reason is populated by StopFailure when the CLI reports why the turn
+	// ended. It is absent in Claude Code v2.1.x, hence the transcript fallback
+	// in lastAPIError.
+	Reason string `json:"reason,omitempty"`
 	// Subagent fields
 	AgentID     string `json:"agent_id,omitempty"`
 	AgentType   string `json:"agent_type,omitempty"`
@@ -419,8 +423,34 @@ func handleStopFailure(ctx *provider.HookContext, w http.ResponseWriter, r *http
 	notifID := notifications.GenerateNotificationID()
 	lastDetail := ctx.DB.LastSessionDetail(input.SessionID)
 	sess, _ := ctx.DB.GetSession(input.SessionID)
+
+	errText := lastAPIError(input.TranscriptPath)
+	if input.Reason != "" {
+		errText = input.Reason
+	}
+	rate := classifyAPIError(errText)
+
 	title := "Session error"
-	detail := sessionContext(input.CWD, sess)
+	if rate.IsRateLimit {
+		title = "Rate limit reached"
+	}
+	// Detail is the error itself. It used to be sessionContext(), which showed
+	// the user their own last prompt back and said nothing about what broke.
+	detail := errText
+	if detail == "" {
+		detail = sessionContext(input.CWD, sess)
+	}
+
+	payload := map[string]interface{}{
+		"session_id":    input.SessionID,
+		"error":         errText,
+		"is_rate_limit": rate.IsRateLimit,
+		"retryable":     true,
+	}
+	if rate.ResetAt != nil {
+		payload["reset_at"] = rate.ResetAt.Format(time.RFC3339)
+	}
+
 	notif := &store.Notification{
 		ID:            notifID,
 		Source:        "claude",
@@ -431,7 +461,21 @@ func handleStopFailure(ctx *provider.HookContext, w http.ResponseWriter, r *http
 		Title:         &title,
 		Detail:        &detail,
 	}
-	ctx.Mgr.CreateNotification(notif)
+	if raw, err := json.Marshal(payload); err != nil {
+		log.Printf("claude: marshal error payload for %s: %v", input.SessionID, err)
+	} else {
+		s := string(raw)
+		notif.Payload = &s
+	}
+
+	if err := ctx.Mgr.CreateNotification(notif); err != nil {
+		log.Printf("claude: create error notification for %s: %v", input.SessionID, err)
+	} else {
+		// Unlike a permission hook there is no CLI request waiting on the
+		// answer — the turn is already over. Register only so Resolve has
+		// somewhere to deliver, which is what lets the notification clear.
+		ctx.Mgr.Register(notifID)
+	}
 	ctx.Notify("notification", notif)
 
 	ctx.Notify("session_status", map[string]interface{}{

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -33,6 +33,7 @@ type fakeBackend struct {
 	renames []string // "sessionID:name"
 	kills   []string
 	keys    []string // "sessionID:key"
+	texts   []string // "sessionID:text"
 }
 
 func newFakeBackend() *fakeBackend {
@@ -75,7 +76,10 @@ func (f *fakeBackend) Snapshot() map[string]string {
 	return out
 }
 
-func (f *fakeBackend) SendText(sessionID, text string) error { return nil }
+func (f *fakeBackend) SendText(sessionID, text string) error {
+	f.texts = append(f.texts, sessionID+":"+text)
+	return nil
+}
 
 func (f *fakeBackend) SendKey(sessionID string, k backend.Key) error {
 	f.keys = append(f.keys, sessionID+":"+string(k))
@@ -528,6 +532,151 @@ func TestStopFailure_CreatesErrorNotification(t *testing.T) {
 	if notifs[0].Status != "pending" {
 		t.Errorf("notification status = %q, want pending", notifs[0].Status)
 	}
+}
+
+// The detail used to be sessionContext(), which showed the user their own last
+// prompt back and said nothing about what broke.
+func TestStopFailure_DetailIsTheErrorText(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	const errText = "API Error: Response stalled mid-stream. The response above may be incomplete."
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID:      "sess-1",
+		CWD:            "/tmp/proj",
+		TranscriptPath: writeTranscript(t, apiErrorLine(errText)),
+	})
+
+	notif := onlyErrorNotif(t, db)
+	if notif.Detail == nil || *notif.Detail != errText {
+		t.Errorf("detail = %v, want %q", notif.Detail, errText)
+	}
+	if notif.Title == nil || *notif.Title != "Session error" {
+		t.Errorf("title = %v, want \"Session error\"", notif.Title)
+	}
+}
+
+func TestStopFailure_FallsBackToSessionContext(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID:      "sess-1",
+		CWD:            "/tmp/proj",
+		TranscriptPath: writeTranscript(t, assistantLine("no error here")),
+	})
+
+	notif := onlyErrorNotif(t, db)
+	if notif.Detail == nil || *notif.Detail == "" {
+		t.Error("detail is empty, want the session context fallback")
+	}
+}
+
+func TestStopFailure_ReasonBeatsTranscript(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID:      "sess-1",
+		CWD:            "/tmp/proj",
+		TranscriptPath: writeTranscript(t, apiErrorLine("stale transcript error")),
+		Reason:         "reason from the CLI",
+	})
+
+	notif := onlyErrorNotif(t, db)
+	if notif.Detail == nil || *notif.Detail != "reason from the CLI" {
+		t.Errorf("detail = %v, want the CLI-supplied reason", notif.Detail)
+	}
+}
+
+func TestStopFailure_RateLimitPayload(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID:      "sess-1",
+		CWD:            "/tmp/proj",
+		TranscriptPath: writeTranscript(t, apiErrorLine("Claude AI usage limit reached|1754899200")),
+	})
+
+	notif := onlyErrorNotif(t, db)
+	if notif.Title == nil || *notif.Title != "Rate limit reached" {
+		t.Errorf("title = %v, want \"Rate limit reached\"", notif.Title)
+	}
+	payload := decodePayload(t, notif)
+	if payload["is_rate_limit"] != true {
+		t.Errorf("is_rate_limit = %v, want true", payload["is_rate_limit"])
+	}
+	if payload["reset_at"] != "2025-08-11T08:00:00Z" {
+		t.Errorf("reset_at = %v, want 2025-08-11T08:00:00Z", payload["reset_at"])
+	}
+	if payload["session_id"] != "sess-1" {
+		t.Errorf("session_id = %v, want sess-1", payload["session_id"])
+	}
+	if payload["retryable"] != true {
+		t.Errorf("retryable = %v, want true", payload["retryable"])
+	}
+}
+
+func TestStopFailure_NoResetAtForATransientError(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID:      "sess-1",
+		CWD:            "/tmp/proj",
+		TranscriptPath: writeTranscript(t, apiErrorLine("API Error: Stream idle timeout - no chunks received")),
+	})
+
+	payload := decodePayload(t, onlyErrorNotif(t, db))
+	if payload["is_rate_limit"] != false {
+		t.Errorf("is_rate_limit = %v, want false", payload["is_rate_limit"])
+	}
+	if _, ok := payload["reset_at"]; ok {
+		t.Errorf("reset_at = %v, want absent", payload["reset_at"])
+	}
+}
+
+// Without a decision slot the notification can never be resolved, so it sits
+// pending forever — TruncateNotifications skips pending rows.
+func TestStopFailure_RegistersDecisionSlot(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleStopFailure, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+	})
+
+	notif := onlyErrorNotif(t, db)
+	if !ctx.Mgr.HasPending(notif.ID) {
+		t.Error("no decision slot registered; the notification can never resolve")
+	}
+}
+
+// onlyErrorNotif returns the single claude.error notification in the store.
+func onlyErrorNotif(t *testing.T, db *store.Store) *store.Notification {
+	t.Helper()
+	notifs, err := db.ListNotifications("claude", "", "claude.error")
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	if len(notifs) != 1 {
+		t.Fatalf("want 1 claude.error notification, got %d", len(notifs))
+	}
+	return &notifs[0]
+}
+
+func decodePayload(t *testing.T, n *store.Notification) map[string]interface{} {
+	t.Helper()
+	if n.Payload == nil {
+		t.Fatal("notification has no payload")
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal([]byte(*n.Payload), &out); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return out
 }
 
 // ==================== SessionEnd ====================

--- a/internal/provider/claude/register.go
+++ b/internal/provider/claude/register.go
@@ -193,6 +193,7 @@ func Register() {
 	provider.RegisterAction("claude.elicitation.form", handleElicitationAction)
 	provider.RegisterAction("claude.elicitation.url", handleElicitationAction)
 	provider.RegisterAction("claude.trust", handleTrustAction)
+	provider.RegisterAction("claude.error", handleErrorAction)
 
 	// Small model caller — runs claude CLI with haiku for lightweight text generation
 	claudeBin := findClaude()

--- a/mobile/lib/models/session.dart
+++ b/mobile/lib/models/session.dart
@@ -86,6 +86,11 @@ class Session {
   bool get isTerminated => status == 'terminated';
   bool get canSendPrompt {
     if (status == 'idle') return true;
+    // A turn that died on an API error leaves a live, idle agent. The daemon
+    // accepts a prompt in this state — handleSessionSend treats only active,
+    // waiting_permission and terminated as unsendable — and typing "continue"
+    // is exactly the terminal recovery. Blocking it here stranded the session.
+    if (status == 'error') return true;
     if (supportsPromptQueue && isActive) return true;
     return false;
   }

--- a/mobile/lib/providers/card_registry.dart
+++ b/mobile/lib/providers/card_registry.dart
@@ -71,6 +71,7 @@ bool isActionableType(String type) =>
     type == 'claude.permission' ||
     type == 'claude.question' ||
     type == 'claude.trust' ||
+    type == 'claude.error' ||
     type.startsWith('claude.elicitation.');
 
 /// Whether an incoming notification event should raise an OS notification.

--- a/mobile/lib/providers/card_registry.dart
+++ b/mobile/lib/providers/card_registry.dart
@@ -48,6 +48,11 @@ Widget? buildCardForType({
         notification: notification,
         sse: sse,
       );
+    case 'claude.error':
+      return ClaudeErrorCard(
+        notification: notification,
+        sse: sse,
+      );
     default:
       return null;
   }

--- a/mobile/lib/providers/claude/cards.dart
+++ b/mobile/lib/providers/claude/cards.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../../models/notification.dart';
@@ -815,6 +816,183 @@ class ClaudeElicitationUrlCard extends StatelessWidget {
                       foregroundColor: Theme.of(context).colorScheme.onError,
                     ),
                     child: const Text('Decline'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ==================== Error Card ====================
+
+/// A turn that died on an API error. Retry sends "continue", which is what a
+/// user types in the terminal to pick the turn up where it stopped.
+class ClaudeErrorCard extends StatefulWidget {
+  final HeliosNotification notification;
+  final DaemonAPIService sse;
+
+  const ClaudeErrorCard({
+    super.key,
+    required this.notification,
+    required this.sse,
+  });
+
+  @override
+  State<ClaudeErrorCard> createState() => _ClaudeErrorCardState();
+}
+
+class _ClaudeErrorCardState extends State<ClaudeErrorCard> {
+  Timer? _ticker;
+  bool _sending = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Only a rate limit with a known reset time needs a countdown; everything
+    // else is retryable immediately and has nothing to tick.
+    if (_resetsInTheFuture) {
+      _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+        if (!mounted) return;
+        setState(() {});
+        if (!_resetsInTheFuture) {
+          _ticker?.cancel();
+          _ticker = null;
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  bool get _resetsInTheFuture {
+    final reset = widget.notification.rateLimitResetAt;
+    return reset != null && reset.isAfter(DateTime.now().toUtc());
+  }
+
+  /// Time until the limit lifts, rendered coarsely — a second-by-second
+  /// countdown on a multi-hour window is noise.
+  String get _remainingLabel {
+    final reset = widget.notification.rateLimitResetAt;
+    if (reset == null) return '';
+    final left = reset.difference(DateTime.now().toUtc());
+    if (left.inHours >= 1) return 'Retry in ${left.inHours}h ${left.inMinutes % 60}m';
+    if (left.inMinutes >= 1) return 'Retry in ${left.inMinutes}m';
+    return 'Retry in ${left.inSeconds}s';
+  }
+
+  Future<void> _send(Map<String, dynamic> body) async {
+    setState(() => _sending = true);
+    final ok = await widget.sse.sendAction(widget.notification.id, body);
+    if (!mounted) return;
+    setState(() => _sending = false);
+    if (!ok) {
+      // The daemon rejects a retry when the session has no live terminal.
+      // Waking one goes through the composer's send path, not this action.
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Retry failed — send a prompt to wake the session.'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final n = widget.notification;
+    final theme = Theme.of(context);
+    final blocked = _resetsInTheFuture;
+    final accent = n.isRateLimit ? Colors.orange : theme.colorScheme.error;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: accent.withValues(alpha: 0.3), width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: accent.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(4),
+                    border: Border.all(color: accent.withValues(alpha: 0.3)),
+                  ),
+                  child: Text(
+                    n.isRateLimit ? 'rate limit' : 'error',
+                    style: TextStyle(fontSize: 11, color: accent),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    n.claudeDisplayTitle,
+                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                n.errorText?.isNotEmpty == true ? n.errorText! : n.displayDetail,
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Spacer(),
+                Text(
+                  n.timeAgo,
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton(
+                    onPressed: (blocked || _sending)
+                        ? null
+                        : () => _send({'action': 'retry'}),
+                    child: Text(blocked ? _remainingLabel : 'Retry'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed:
+                        _sending ? null : () => _send({'action': 'dismiss'}),
+                    child: const Text('Dismiss'),
                   ),
                 ),
               ],

--- a/mobile/lib/providers/claude/notification_ext.dart
+++ b/mobile/lib/providers/claude/notification_ext.dart
@@ -15,7 +15,32 @@ extension ClaudeNotification on HeliosNotification {
 
   /// Whether this Claude notification needs user action.
   bool get needsClaudeAction =>
-      isPending && (isClaudePermission || isClaudeQuestion || isClaudeElicitation || isClaudeTrust);
+      isPending &&
+      (isClaudePermission ||
+          isClaudeQuestion ||
+          isClaudeElicitation ||
+          isClaudeTrust ||
+          isClaudeError);
+
+  // ==================== Error payload ====================
+
+  /// The API error text Claude recorded for the failed turn.
+  String? get errorText => payload?['error'] as String?;
+
+  /// The session the failed turn belongs to. Carried in the payload because
+  /// that is what the retry action handler reads.
+  String? get errorSessionId => payload?['session_id'] as String?;
+
+  bool get isRateLimit => payload?['is_rate_limit'] == true;
+  bool get isRetryable => payload?['retryable'] == true;
+
+  /// When a usage limit lifts, or null when the error carried no reset time.
+  /// An unknown window is not a reason to lock the user out of retrying.
+  DateTime? get rateLimitResetAt {
+    final raw = payload?['reset_at'] as String?;
+    if (raw == null) return null;
+    return DateTime.tryParse(raw)?.toUtc();
+  }
 
   String get claudeDisplayTitle => title ?? _claudeTypeLabel;
 

--- a/mobile/test/card_registry_test.dart
+++ b/mobile/test/card_registry_test.dart
@@ -46,8 +46,13 @@ void main() {
 
     test('does not treat terminal types as actionable', () {
       expect(isActionableType('claude.done'), isFalse);
-      expect(isActionableType('claude.error'), isFalse);
       expect(isActionableType('something.else'), isFalse);
+    });
+
+    // claude.error gained a Retry action, so it is answerable now and a
+    // resolved one must stop re-raising like any other approval.
+    test('treats claude.error as actionable', () {
+      expect(isActionableType('claude.error'), isTrue);
     });
   });
 
@@ -91,7 +96,7 @@ void main() {
       );
     });
 
-    test('raises claude.error regardless of status', () {
+    test('raises a pending error but not a retried one', () {
       expect(
         shouldRaiseNotification(
           type: 'claude.error',
@@ -99,6 +104,16 @@ void main() {
           alreadyPosted: false,
         ),
         isTrue,
+      );
+      // Retried from the desktop or the terminal: re-raising it on the phone
+      // would offer a Retry button for a turn that already resumed.
+      expect(
+        shouldRaiseNotification(
+          type: 'claude.error',
+          status: 'approved',
+          alreadyPosted: false,
+        ),
+        isFalse,
       );
     });
 

--- a/mobile/test/claude_error_notification_test.dart
+++ b/mobile/test/claude_error_notification_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:helios/models/notification.dart';
+import 'package:helios/providers/claude/notification_ext.dart';
+
+HeliosNotification errorNotif(Map<String, dynamic> payload,
+        {String status = 'pending'}) =>
+    HeliosNotification.fromJson({
+      'id': 'n1',
+      'source': 'claude',
+      'source_session': 'sess-1',
+      'cwd': '/tmp/proj',
+      'type': 'claude.error',
+      'status': status,
+      'title': 'Session error',
+      'detail': 'API Error: Response stalled mid-stream.',
+      // The daemon stores the payload as a JSON string.
+      'payload': jsonEncode(payload),
+      'created_at': '2026-01-01T00:00:00Z',
+    });
+
+void main() {
+  group('error payload accessors', () {
+    test('reads the fields handleStopFailure writes', () {
+      final n = errorNotif({
+        'session_id': 'sess-1',
+        'error': 'API Error: Stream idle timeout - no chunks received',
+        'is_rate_limit': false,
+        'retryable': true,
+      });
+
+      expect(n.errorSessionId, 'sess-1');
+      expect(n.errorText, 'API Error: Stream idle timeout - no chunks received');
+      expect(n.isRateLimit, isFalse);
+      expect(n.isRetryable, isTrue);
+      expect(n.rateLimitResetAt, isNull);
+    });
+
+    test('parses reset_at as UTC', () {
+      final n = errorNotif({
+        'session_id': 'sess-1',
+        'error': 'Claude AI usage limit reached|1754899200',
+        'is_rate_limit': true,
+        'retryable': true,
+        'reset_at': '2025-08-11T08:00:00Z',
+      });
+
+      expect(n.isRateLimit, isTrue);
+      expect(n.rateLimitResetAt, DateTime.utc(2025, 8, 11, 8));
+      expect(n.rateLimitResetAt!.isUtc, isTrue);
+    });
+
+    // An unknown window is not a reason to lock the user out of retrying, so
+    // the card must see null rather than a fabricated time.
+    test('a rate limit with no reset_at yields a null reset', () {
+      final n = errorNotif({
+        'session_id': 'sess-1',
+        'error': 'Claude AI usage limit reached',
+        'is_rate_limit': true,
+        'retryable': true,
+      });
+
+      expect(n.isRateLimit, isTrue);
+      expect(n.rateLimitResetAt, isNull);
+    });
+
+    test('an unparseable reset_at yields null rather than throwing', () {
+      final n = errorNotif({
+        'session_id': 'sess-1',
+        'reset_at': 'tomorrow-ish',
+      });
+
+      expect(n.rateLimitResetAt, isNull);
+    });
+
+    // Rows written before this change carry no payload at all.
+    test('a payload-less notification degrades cleanly', () {
+      final n = HeliosNotification.fromJson({
+        'id': 'n1',
+        'source': 'claude',
+        'source_session': 'sess-1',
+        'cwd': '/tmp/proj',
+        'type': 'claude.error',
+        'status': 'pending',
+        'detail': 'helios: commit',
+        'created_at': '2026-01-01T00:00:00Z',
+      });
+
+      expect(n.errorText, isNull);
+      expect(n.isRateLimit, isFalse);
+      expect(n.rateLimitResetAt, isNull);
+      // The card falls back to the detail so the row is never blank.
+      expect(n.displayDetail, 'helios: commit');
+    });
+  });
+
+  group('needsClaudeAction', () {
+    // It has a Retry button now, so it belongs in the dashboard's pending
+    // bucket rather than the passive "active" one.
+    test('a pending error needs action', () {
+      expect(errorNotif({'retryable': true}).needsClaudeAction, isTrue);
+    });
+
+    test('a resolved error does not', () {
+      expect(
+        errorNotif({'retryable': true}, status: 'approved').needsClaudeAction,
+        isFalse,
+      );
+      expect(
+        errorNotif({'retryable': true}, status: 'dismissed').needsClaudeAction,
+        isFalse,
+      );
+    });
+
+    test('claude.done is still not actionable', () {
+      final done = HeliosNotification.fromJson({
+        'id': 'n2',
+        'source': 'claude',
+        'source_session': 'sess-1',
+        'cwd': '/tmp/proj',
+        'type': 'claude.done',
+        'status': 'pending',
+        'created_at': '2026-01-01T00:00:00Z',
+      });
+      expect(done.needsClaudeAction, isFalse);
+    });
+  });
+}

--- a/mobile/test/session_test.dart
+++ b/mobile/test/session_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:helios/models/session.dart';
+
+Session sessionWithStatus(String status, {bool queue = false}) => Session(
+      sessionId: 's1',
+      source: 'claude',
+      cwd: '/tmp/proj',
+      project: 'proj',
+      status: status,
+      supportsPromptQueue: queue,
+      createdAt: '2026-01-01T00:00:00Z',
+    );
+
+void main() {
+  group('canSendPrompt', () {
+    test('an idle session accepts a prompt', () {
+      expect(sessionWithStatus('idle').canSendPrompt, isTrue);
+    });
+
+    // A turn that died on an API error leaves a live, idle agent, and the
+    // daemon accepts a prompt in that state. Blocking it here is what stranded
+    // the session on mobile while "continue" kept working in the terminal.
+    test('an errored session accepts a prompt', () {
+      expect(sessionWithStatus('error').canSendPrompt, isTrue);
+    });
+
+    test('a terminated session still does not', () {
+      expect(sessionWithStatus('terminated').canSendPrompt, isFalse);
+    });
+
+    test('a busy session only accepts a prompt when it can queue', () {
+      for (final status in ['active', 'waiting_permission', 'compacting', 'starting']) {
+        expect(sessionWithStatus(status).canSendPrompt, isFalse,
+            reason: '$status without queueing');
+        expect(sessionWithStatus(status, queue: true).canSendPrompt, isTrue,
+            reason: '$status with queueing');
+      }
+    });
+
+    // error is not "active": it must not pull in the queueing UI or the stop
+    // button, both of which key off isActive.
+    test('error is not treated as active', () {
+      final s = sessionWithStatus('error');
+      expect(s.isActive, isFalse);
+      expect(s.isQueueing, isFalse);
+      expect(s.canStop, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Bug 1 of 3. Spec: `docs/specs/33-session-error-retry.md`.

> **Stacked on #14.** Based on `fix/mobile-notification-lifecycle` rather than `main`, because `isActionableType` (added there) and `needsClaudeAction` (changed here) are asserted equal by test — splitting them across two PRs would break CI on whichever merged second. GitHub retargets this to `main` when #14 lands. **Review #14 first.**

## The bug

When a turn dies on an API error — a rate limit, a stalled stream, a dropped connection — the terminal shows the error and the user types `continue` to pick up where it stopped. From the phone there is no way to do that. The session shows "Error", the composer is dead, and the notification has no buttons.

Observed live: session `4584bc95` sat at `status=error` since 2026-08-11 12:26 with its ptyhost still alive and its `claude.error` notification still `pending`. A perfectly healthy session the phone could not touch.

## Why — three defects stacked

**1. The composer was hard-blocked, and only on mobile.** `canSendPrompt` covered `idle` and (when queueing) `isActive`; `error` was in neither, so the text field, mic, command sheet and send button all went dead.

The daemon would have accepted the message. `handleSessionSend` rejects only `active`/`waiting_permission` (as busy) and `terminated` — `error` already falls through to the wake-and-type path. The desktop app has no status gate at all, which is exactly why typing `continue` works there. **The retry transport already existed; the phone refused to use it.**

**2. The error text was thrown away.** `hookInput` had no field for a failure reason and the detail came from `sessionContext()`, so the two stranded rows in the live DB read `helios: commit` and `helios: mobile will ssh and localforward…` — the user's own last prompt handed back. Nothing said it was a rate limit or when retrying was worth it.

The real text was available all along. Claude writes it to the transcript as `isApiErrorMessage: true` about 8ms before the hook fires. `lastAPIError()` reads the tail.

**3. The notification was a dead end that never cleared.** No action handler, no card, excluded from `needsClaudeAction`. Created `pending` but `handleStopFailure` never called `Register`, so no decision slot existed — nothing could resolve it except a later `Stop` on the same session, and `TruncateNotifications` skips pending rows, so they accumulate forever.

## The fix

**Retry means sending `continue`** — literally what the user types in the terminal, so the CLI resumes the interrupted turn rather than starting a new one. Not a new resume mechanism.

Two entry points, because the user arrives from two directions:

- **The composer**, for someone already in the session. One line, and it restores the exact terminal workflow — including sending something *other* than `continue`.
- **Retry on the `claude.error` card**, for someone who got the notification.

`handleErrorAction` rejects a dead terminal rather than resolving: a notification consumed by a send that went nowhere is unrecoverable. Waking a cold session goes through the composer's path instead.

**Rate limits are a distinct case.** Retrying inside the window just burns another error, so the card surfaces the reset time and disables Retry with a live countdown until it passes. Claude emits `Claude AI usage limit reached|<epoch>`; when the epoch is missing or unparseable, `ResetAt` stays nil and Retry stays **enabled** — an unknown window is not a reason to lock the user out.

`handleStopFailure` now calls `Register`, but still does not block. Unlike a permission hook there is no CLI request waiting — the turn is over. The slot exists only so `Resolve` has somewhere to deliver, which is what lets the notification clear.

## Deliberately out of scope

**Auto-retry.** Tempting and wrong for a first cut: a retry loop against a rate limit silently consumes quota, and an automatic `continue` on an error the user has not seen can take a destructive action they would have stopped. Revisit once the error taxonomy proves itself.

## Testing

`go build`, `go vet`, `gofmt` clean; full Go suite passes. `flutter analyze` clean, 34/34 Dart tests pass.

- `apierror_test.go` — `lastAPIError` returns the final error, prefers the most recent, survives a missing file / unparseable lines / no error entry, and stops at `apiErrorScanLimit`. `classifyAPIError` parses the epoch, treats a limit with no epoch as rate-limited-with-nil-reset, catches plain "rate limit" wording, and does not misclassify stalled-stream/idle-timeout/ECONNRESET.
- `hooks_test.go` — detail is the error text; falls back to session context when the transcript has none; `Reason` beats the transcript; the rate-limit payload carries `is_rate_limit`/`reset_at`/`session_id`/`retryable`; a transient error carries no `reset_at`; **a decision slot is registered**.
- `actions_test.go` — retry sends `continue`; a dead terminal errors and sends nothing; no backend errors; dismiss sends nothing; unknown action errors; falls back to `SourceSession` for payload-less rows.
- `session_test.dart` — `canSendPrompt` true for `error`, still false for `terminated`, and **`error` is not treated as active** (it must not pull in the queueing UI or the stop button).
- `claude_error_notification_test.dart` — payload accessors, UTC `reset_at`, nil reset for an epoch-less limit, unparseable `reset_at` degrades to null, payload-less rows degrade cleanly, and the `needsClaudeAction` change.

Manual verification is still outstanding — steps 7-9 in the spec (force an API error, hit a real usage limit, confirm `4584bc95` becomes usable).

## Deviation from the spec

The spec called for a separate error banner above the composer in `session_detail_screen`. Not built: `_pendingNotifications` already renders any pending notification for the session in the slot immediately above the composer, so making `claude.error` actionable puts `ClaudeErrorCard` exactly where the banner would have gone. A banner would have stacked a second Retry button on top of the card's.

## Note

The two currently-stranded `claude.error` rows stay pending after this lands — they predate the decision slot. They age out only via a `Stop` on their sessions. Not worth a migration.