### PR TITLE
feat(desktop): commit history, worktrees, and a unified git panel

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -5,7 +5,9 @@ import type {
   FileContent,
   FileEntry,
   FileSearchResult,
+  GitChanges,
   GitDiff,
+  GitLog,
   GitStatus,
   GrepResult,
   ModelInfo,
@@ -221,8 +223,43 @@ export class ApiClient {
     return this.request('GET', `/api/git/status${queryString({ path })}`)
   }
 
-  gitDiff(path: string, file: string): Promise<GitDiff> {
-    return this.request('GET', `/api/git/diff${queryString({ path, file })}`)
+  /**
+   * The working-tree diff for a file, or its diff at a revision: `to` alone is
+   * that commit against its parent, `from` and `to` together are a range.
+   */
+  gitDiff(
+    path: string,
+    file: string,
+    at: { from?: string; to?: string; staged?: boolean; untracked?: boolean } = {},
+  ): Promise<GitDiff> {
+    return this.request(
+      'GET',
+      `/api/git/diff${queryString({
+        path,
+        file,
+        from: at.from,
+        to: at.to,
+        staged: at.staged ? 'true' : undefined,
+        untracked: at.untracked ? 'true' : undefined,
+      })}`,
+    )
+  }
+
+  gitLog(path: string, opts: { base?: string; all?: boolean; limit?: number; skip?: number } = {}): Promise<GitLog> {
+    return this.request(
+      'GET',
+      `/api/git/log${queryString({
+        path,
+        base: opts.base,
+        all: opts.all ? 'true' : undefined,
+        limit: opts.limit,
+        skip: opts.skip,
+      })}`,
+    )
+  }
+
+  gitChanges(path: string, to: string, from?: string): Promise<GitChanges> {
+    return this.request('GET', `/api/git/changes${queryString({ path, to, from })}`)
   }
 
   async gitWorktrees(path: string): Promise<Worktree[]> {
@@ -315,10 +352,10 @@ export class ApiClient {
   }
 }
 
-function queryString(params: Record<string, string | undefined>): string {
+function queryString(params: Record<string, string | number | undefined>): string {
   const pairs = Object.entries(params).filter(([, v]) => v !== undefined && v !== '')
   if (pairs.length === 0) return ''
-  return `?${pairs.map(([k, v]) => `${k}=${encodeURIComponent(v as string)}`).join('&')}`
+  return `?${pairs.map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&')}`
 }
 
 function safeParse(text: string): unknown {

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -32,6 +32,8 @@ const API_METHODS = new Set<keyof ApiClient>([
   'dismissNotification',
   'gitStatus',
   'gitDiff',
+  'gitLog',
+  'gitChanges',
   'gitWorktrees',
   'listFiles',
   'readFile',

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -4,7 +4,9 @@ import type {
   FileContent,
   FileEntry,
   FileSearchResult,
+  GitChanges,
   GitDiff,
+  GitLog,
   GitStatus,
   GrepResult,
   HostRecord,
@@ -162,8 +164,18 @@ export class HostApi {
   gitStatus(path: string): Promise<GitStatus> {
     return this.call('gitStatus', path)
   }
-  gitDiff(path: string, file: string): Promise<GitDiff> {
-    return this.call('gitDiff', path, file)
+  gitDiff(
+    path: string,
+    file: string,
+    at?: { from?: string; to?: string; staged?: boolean; untracked?: boolean },
+  ): Promise<GitDiff> {
+    return this.call('gitDiff', path, file, at)
+  }
+  gitLog(path: string, opts?: { base?: string; all?: boolean; limit?: number; skip?: number }): Promise<GitLog> {
+    return this.call('gitLog', path, opts)
+  }
+  gitChanges(path: string, to: string, from?: string): Promise<GitChanges> {
+    return this.call('gitChanges', path, to, from)
   }
   gitWorktrees(path: string): Promise<Worktree[]> {
     return this.call('gitWorktrees', path)

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -1,33 +1,152 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { DiffView } from './diff-view.tsx'
 import { PathLabel } from './path-label.tsx'
-import { timeAgo, type Commit, type GitChanges, type GitDiff, type GitLog } from '../../shared/models.ts'
+import { timeAgo, type Commit, type GitChanges, type GitDiff, type GitLog, type GitStatus } from '../../shared/models.ts'
 
 const PAGE = 50
 
-interface Selection {
-  /** The newer end of the comparison — a lone commit when `from` is null. */
+/** A lone commit when `from` is null, otherwise everything from `from` to `to`. */
+export interface CommitScope {
+  kind: 'commit'
   to: string
   from: string | null
-  /** How many commits the range spans, for the header. */
+  /** How many commits the range spans, for the label. */
   span: number
+  /** What the picker button shows — resolved when picked, so the log need not be loaded to render it. */
+  label: string
 }
 
+/** What the git panel is looking at: the working tree, or some history. */
+export type Scope = { kind: 'working' } | CommitScope
+
 /**
- * The commit history of the current branch, and what each commit changed.
+ * The control that chooses what the panel shows. Closed it is a one-line
+ * summary; open it is the commit log, with the working tree pinned at the top
+ * as just another thing to look at.
  *
- * Clicking a commit shows that commit; ⌘- or shift-clicking a second one shows
- * everything between them, which is the "what did this branch do" view.
+ * The log is fetched on first open rather than on mount: most visits to the
+ * panel are to read uncommitted changes and never touch history.
  */
-export function CommitsView({ hostId, root }: { hostId: string; root: string }): JSX.Element {
+export function ScopePicker({
+  hostId,
+  root,
+  scope,
+  status,
+  onPick,
+}: {
+  hostId: string
+  root: string
+  scope: Scope
+  status: GitStatus | null
+  onPick: (scope: Scope) => void
+}): JSX.Element {
+  const [at, setAt] = useState<Anchor | null>(null)
+  const button = useRef<HTMLButtonElement | null>(null)
+
+  // A different repository is a different history; the menu must not reopen
+  // onto the last one's commits.
+  useEffect(() => {
+    setAt(null)
+  }, [hostId, root])
+
+  // The menu is positioned from a rect taken when it opened, so anything that
+  // moves the button underneath it has to dismiss it.
+  useEffect(() => {
+    if (!at) return
+    const close = (): void => setAt(null)
+    window.addEventListener('resize', close)
+    return () => window.removeEventListener('resize', close)
+  }, [at])
+
+  return (
+    <div className="scope">
+      <button
+        ref={button}
+        className={at ? 'scope-button on' : 'scope-button'}
+        aria-expanded={at !== null}
+        onClick={() => setAt(at ? null : anchorFor(button.current))}
+      >
+        <span className="scope-label">{scope.kind === 'working' ? 'Uncommitted changes' : scope.label}</span>
+        {scope.kind === 'working' && dirtyCount(status) > 0 && (
+          <span className="pill">{dirtyCount(status)}</span>
+        )}
+        <span className="scope-caret">▾</span>
+      </button>
+
+      {at && (
+        <ScopeMenu
+          hostId={hostId}
+          root={root}
+          scope={scope}
+          status={status}
+          at={at}
+          onPick={(next, close) => {
+            onPick(next)
+            if (close) setAt(null)
+          }}
+          onClose={() => setAt(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+/** Where the open menu sits, in viewport coordinates. */
+interface Anchor {
+  left: number
+  top: number
+  width: number
+  maxHeight: number
+}
+
+const MENU_WIDTH = 440
+const MARGIN = 12
+
+/**
+ * The menu is `position: fixed` rather than absolute because `.panel-body`
+ * clips its overflow, and the git panel is often shorter than the menu — an
+ * absolutely positioned popover loses its bottom half whenever the terminal is
+ * open below it.
+ */
+function anchorFor(button: HTMLButtonElement | null): Anchor | null {
+  if (!button) return null
+  const rect = button.getBoundingClientRect()
+  const width = Math.min(MENU_WIDTH, window.innerWidth - MARGIN * 2)
+  const top = rect.bottom + 6
+  return {
+    left: Math.max(MARGIN, Math.min(rect.left, window.innerWidth - width - MARGIN)),
+    top,
+    width,
+    maxHeight: Math.max(220, window.innerHeight - top - MARGIN),
+  }
+}
+
+/** The open popover: working tree, then the log, with range selection. */
+function ScopeMenu({
+  hostId,
+  root,
+  scope,
+  status,
+  at,
+  onPick,
+  onClose,
+}: {
+  hostId: string
+  root: string
+  scope: Scope
+  status: GitStatus | null
+  at: Anchor
+  /** `close` is false for a range extension, which takes a second click. */
+  onPick: (scope: Scope, close: boolean) => void
+  onClose: () => void
+}): JSX.Element {
   const [log, setLog] = useState<GitLog | null>(null)
   const [commits, setCommits] = useState<Commit[]>([])
   const [all, setAll] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [selection, setSelection] = useState<Selection | null>(null)
   const commitsRef = useRef<Commit[]>(commits)
   commitsRef.current = commits
 
@@ -35,15 +154,12 @@ export function CommitsView({ hostId, root }: { hostId: string; root: string }):
     let cancelled = false
     setLoading(true)
     setError(null)
-    setSelection(null)
     api(hostId)
       .gitLog(root, { all: all || undefined, limit: PAGE })
       .then((result) => {
         if (cancelled) return
         setLog(result)
         setCommits(result.commits)
-        // The newest commit is what you came to look at.
-        if (result.commits[0]) setSelection({ to: result.commits[0].sha, from: null, span: 1 })
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err))
@@ -55,6 +171,14 @@ export function CommitsView({ hostId, root }: { hostId: string; root: string }):
       cancelled = true
     }
   }, [hostId, root, all])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
 
   const loadMore = async (): Promise<void> => {
     if (!log) return
@@ -70,88 +194,117 @@ export function CommitsView({ hostId, root }: { hostId: string; root: string }):
     }
   }
 
-  const pick = useCallback((sha: string, extend: boolean): void => {
-    setSelection((current) => {
-      if (!extend || !current) return { to: sha, from: null, span: 1 }
-      const list = commitsRef.current
-      const anchor = list.findIndex((commit) => commit.sha === current.to)
-      const picked = list.findIndex((commit) => commit.sha === sha)
-      if (anchor < 0 || picked < 0 || anchor === picked) return { to: sha, from: null, span: 1 }
-      // Lower in the list is older, and the older end is what we diff from.
-      const newer = Math.min(anchor, picked)
-      const older = Math.max(anchor, picked)
-      const to = list[newer]?.sha
-      const from = list[older]?.sha
-      if (!to || !from) return { to: sha, from: null, span: 1 }
-      return { to, from, span: older - newer + 1 }
-    })
-  }, [])
-
-  if (error) return <p className="empty-note">{error}</p>
+  /**
+   * Plain click picks one commit and closes. Shift or ⌘ extends from whatever
+   * is already picked, and keeps the menu open so the range can be adjusted.
+   */
+  const pick = (commit: Commit, extend: boolean): void => {
+    const single = (): void => {
+      onPick({ kind: 'commit', to: commit.sha, from: null, span: 1, label: commit.subject }, true)
+    }
+    if (!extend || scope.kind !== 'commit') {
+      single()
+      return
+    }
+    const list = commitsRef.current
+    const anchor = list.findIndex((entry) => entry.sha === scope.to)
+    const picked = list.findIndex((entry) => entry.sha === commit.sha)
+    if (anchor < 0 || picked < 0 || anchor === picked) {
+      single()
+      return
+    }
+    // Lower in the list is older, and the older end is what we diff from.
+    const newer = Math.min(anchor, picked)
+    const older = Math.max(anchor, picked)
+    const to = list[newer]
+    const from = list[older]
+    if (!to || !from) {
+      single()
+      return
+    }
+    const span = older - newer + 1
+    onPick({ kind: 'commit', to: to.sha, from: from.sha, span, label: `${span} commits` }, false)
+  }
 
   return (
-    <div className="git-body">
-      <div className="commit-list">
-        {log && (
-          <div className="commit-scope">
-            <button className={all ? 'ws-view' : 'ws-view on'} onClick={() => setAll(false)}>
-              Branch
-            </button>
-            <button className={all ? 'ws-view on' : 'ws-view'} onClick={() => setAll(true)}>
-              All
-            </button>
-            <span className="muted" title={`Compared against ${log.base || 'nothing'}`}>
-              {log.scope === 'branch' && log.base ? `vs ${log.base}` : 'full history'}
+    <>
+      <div className="scope-backdrop" onMouseDown={onClose} />
+      <div
+        className="scope-menu"
+        style={{ left: at.left, top: at.top, width: at.width, maxHeight: at.maxHeight }}
+      >
+        <button
+          className={`scope-row ${scope.kind === 'working' ? 'selected' : ''}`}
+          onClick={() => onPick({ kind: 'working' }, true)}
+        >
+          <span>Uncommitted changes</span>
+          {status && (
+            <span className="scope-row-meta">
+              {status.dirty ? `${dirtyCount(status)} files` : 'clean'}
             </span>
-          </div>
-        )}
+          )}
+        </button>
 
-        {commits.map((commit) => (
-          <button
-            key={commit.sha}
-            className={`commit-row ${rowClass(commit.sha, selection)}`}
-            onClick={(event) => pick(commit.sha, event.metaKey || event.ctrlKey || event.shiftKey)}
-          >
-            <span className="commit-subject">{commit.subject}</span>
-            <span className="commit-meta">
-              <span className="commit-sha">{commit.short}</span>
-              <span>{commit.author}</span>
-              <span>{timeAgo(commit.date)}</span>
-              {commit.insertions > 0 && <span className="d-add">+{commit.insertions}</span>}
-              {commit.deletions > 0 && <span className="d-del">−{commit.deletions}</span>}
-            </span>
+        <div className="scope-sep" />
+
+        <div className="commit-scope">
+          <button className={all ? 'ws-view' : 'ws-view on'} onClick={() => setAll(false)}>
+            Branch
           </button>
-        ))}
-
-        {loading && <p className="empty-note">Loading…</p>}
-        {!loading && commits.length === 0 && <p className="empty-note">No commits.</p>}
-        {log?.has_more && !loading && (
-          <button className="commit-more" onClick={() => void loadMore()}>
-            Load more
+          <button className={all ? 'ws-view on' : 'ws-view'} onClick={() => setAll(true)}>
+            All
           </button>
-        )}
-      </div>
-
-      {selection ? (
-        <CommitDetail hostId={hostId} root={root} selection={selection} />
-      ) : (
-        <div className="git-diff">
-          <p className="empty-note">Pick a commit.</p>
+          <span className="muted" title={`Compared against ${log?.base || 'nothing'}`}>
+            {log?.scope === 'branch' && log.base ? `vs ${log.base}` : 'full history'}
+          </span>
         </div>
-      )}
-    </div>
+
+        <div className="scope-list">
+          {error && <p className="empty-note">{error}</p>}
+          {commits.map((commit, index) => (
+            <button
+              key={commit.sha}
+              className={`commit-row ${rowClass(commit.sha, index, commits, scope)}`}
+              onClick={(event) => pick(commit, event.metaKey || event.ctrlKey || event.shiftKey)}
+            >
+              <span className="commit-subject">{commit.subject}</span>
+              <span className="commit-meta">
+                <span className="commit-sha">{commit.short}</span>
+                <span>{commit.author}</span>
+                <span>{timeAgo(commit.date)}</span>
+                {commit.insertions > 0 && <span className="d-add">+{commit.insertions}</span>}
+                {commit.deletions > 0 && <span className="d-del">−{commit.deletions}</span>}
+              </span>
+            </button>
+          ))}
+
+          {loading && <p className="empty-note">Loading…</p>}
+          {!loading && !error && commits.length === 0 && <p className="empty-note">No commits.</p>}
+          {log?.has_more && !loading && (
+            <button className="commit-more" onClick={() => void loadMore()}>
+              Load more
+            </button>
+          )}
+        </div>
+
+        {commits.length > 1 && <p className="scope-hint">⇧-click a second commit to compare a range.</p>}
+      </div>
+    </>
   )
 }
 
-/** The files a commit or a range touched, and the patch for whichever is open. */
-function CommitDetail({
+/**
+ * The files a commit or a range touched, and the patch for whichever is open —
+ * in the same files-left, diff-right shape the working tree uses.
+ */
+export function CommitChanges({
   hostId,
   root,
-  selection,
+  scope,
 }: {
   hostId: string
   root: string
-  selection: Selection
+  scope: CommitScope
 }): JSX.Element {
   const [changes, setChanges] = useState<GitChanges | null>(null)
   const [file, setFile] = useState<string | null>(null)
@@ -164,7 +317,7 @@ function CommitDetail({
     setDiff(null)
     setError(null)
     api(hostId)
-      .gitChanges(root, selection.to, selection.from ?? undefined)
+      .gitChanges(root, scope.to, scope.from ?? undefined)
       .then((result) => {
         if (cancelled) return
         setChanges(result)
@@ -176,7 +329,7 @@ function CommitDetail({
     return () => {
       cancelled = true
     }
-  }, [hostId, root, selection.to, selection.from])
+  }, [hostId, root, scope.to, scope.from])
 
   useEffect(() => {
     if (!file) {
@@ -185,7 +338,7 @@ function CommitDetail({
     }
     let cancelled = false
     api(hostId)
-      .gitDiff(root, file, { from: selection.from ?? undefined, to: selection.to })
+      .gitDiff(root, file, { from: scope.from ?? undefined, to: scope.to })
       .then((result) => {
         if (!cancelled) setDiff(result)
       })
@@ -195,36 +348,35 @@ function CommitDetail({
     return () => {
       cancelled = true
     }
-  }, [hostId, root, file, selection.to, selection.from])
+  }, [hostId, root, file, scope.to, scope.from])
 
   if (error) return <p className="empty-note">{error}</p>
   if (!changes) return <p className="empty-note">Loading…</p>
 
   return (
-    <div className="commit-detail">
-      <header className="commit-head">
-        <span className="commit-title">{changes.single ? changes.subject : `${selection.span} commits`}</span>
-        <span className="commit-meta">
-          {changes.single ? (
-            <>
-              <span className="commit-sha">{short(changes.to)}</span>
-              {changes.author && <span>{changes.author}</span>}
-              {changes.date && <span>{timeAgo(changes.date)}</span>}
-            </>
-          ) : (
-            <span className="commit-sha">
-              {short(changes.from)}…{short(changes.to)}
-            </span>
-          )}
+    <>
+      <div className="git-substatus">
+        {changes.single ? (
+          <>
+            <span className="commit-sha">{short(changes.to)}</span>
+            {changes.author && <span className="muted">{changes.author}</span>}
+            {changes.date && <span className="muted">{timeAgo(changes.date)}</span>}
+          </>
+        ) : (
+          <span className="commit-sha">
+            {short(changes.from)}…{short(changes.to)}
+          </span>
+        )}
+        <span className="commit-counts">
           <span className="d-add">+{changes.insertions}</span>
           <span className="d-del">−{changes.deletions}</span>
         </span>
-      </header>
+      </div>
 
       {changes.body && <pre className="commit-body">{changes.body}</pre>}
 
-      <div className="commit-split">
-        <div className="commit-files">
+      <div className="git-body">
+        <div className="git-files">
           {changes.files.map((entry) => (
             <button
               key={entry.path}
@@ -245,17 +397,37 @@ function CommitDetail({
         </div>
 
         <div className="git-diff">
-          {diff ? <DiffView diff={diff.diff} empty="No textual changes — binary, or a mode change." /> : null}
+          {diff ? (
+            <>
+              <header>
+                <span>{diff.file}</span>
+                <span className="muted">{diff.stat}</span>
+              </header>
+              <DiffView diff={diff.diff} empty="No textual changes — binary, or a mode change." />
+            </>
+          ) : (
+            <p className="empty-note">Pick a file.</p>
+          )}
         </div>
       </div>
-    </div>
+    </>
   )
 }
 
-function rowClass(sha: string, selection: Selection | null): string {
-  if (!selection) return ''
-  if (sha === selection.to || sha === selection.from) return 'selected'
-  return ''
+/** Endpoints of a range are selected; what lies between them is merely in it. */
+function rowClass(sha: string, index: number, commits: Commit[], scope: Scope): string {
+  if (scope.kind !== 'commit') return ''
+  if (sha === scope.to || sha === scope.from) return 'selected'
+  if (!scope.from) return ''
+  const newer = commits.findIndex((entry) => entry.sha === scope.to)
+  const older = commits.findIndex((entry) => entry.sha === scope.from)
+  if (newer < 0 || older < 0) return ''
+  return index > newer && index < older ? 'in-range' : ''
+}
+
+function dirtyCount(status: GitStatus | null): number {
+  if (!status) return 0
+  return (status.staged?.length ?? 0) + (status.unstaged?.length ?? 0) + (status.untracked?.length ?? 0)
 }
 
 function short(sha: string): string {

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { api } from '../bridge.ts'
+import { DiffView } from './diff-view.tsx'
+import { PathLabel } from './path-label.tsx'
+import { timeAgo, type Commit, type GitChanges, type GitDiff, type GitLog } from '../../shared/models.ts'
+
+const PAGE = 50
+
+interface Selection {
+  /** The newer end of the comparison — a lone commit when `from` is null. */
+  to: string
+  from: string | null
+  /** How many commits the range spans, for the header. */
+  span: number
+}
+
+/**
+ * The commit history of the current branch, and what each commit changed.
+ *
+ * Clicking a commit shows that commit; ⌘- or shift-clicking a second one shows
+ * everything between them, which is the "what did this branch do" view.
+ */
+export function CommitsView({ hostId, root }: { hostId: string; root: string }): JSX.Element {
+  const [log, setLog] = useState<GitLog | null>(null)
+  const [commits, setCommits] = useState<Commit[]>([])
+  const [all, setAll] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selection, setSelection] = useState<Selection | null>(null)
+  const commitsRef = useRef<Commit[]>(commits)
+  commitsRef.current = commits
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    setSelection(null)
+    api(hostId)
+      .gitLog(root, { all: all || undefined, limit: PAGE })
+      .then((result) => {
+        if (cancelled) return
+        setLog(result)
+        setCommits(result.commits)
+        // The newest commit is what you came to look at.
+        if (result.commits[0]) setSelection({ to: result.commits[0].sha, from: null, span: 1 })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, root, all])
+
+  const loadMore = async (): Promise<void> => {
+    if (!log) return
+    setLoading(true)
+    try {
+      const next = await api(hostId).gitLog(root, { all: all || undefined, limit: PAGE, skip: commits.length })
+      setCommits((current) => [...current, ...next.commits])
+      setLog(next)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const pick = useCallback((sha: string, extend: boolean): void => {
+    setSelection((current) => {
+      if (!extend || !current) return { to: sha, from: null, span: 1 }
+      const list = commitsRef.current
+      const anchor = list.findIndex((commit) => commit.sha === current.to)
+      const picked = list.findIndex((commit) => commit.sha === sha)
+      if (anchor < 0 || picked < 0 || anchor === picked) return { to: sha, from: null, span: 1 }
+      // Lower in the list is older, and the older end is what we diff from.
+      const newer = Math.min(anchor, picked)
+      const older = Math.max(anchor, picked)
+      const to = list[newer]?.sha
+      const from = list[older]?.sha
+      if (!to || !from) return { to: sha, from: null, span: 1 }
+      return { to, from, span: older - newer + 1 }
+    })
+  }, [])
+
+  if (error) return <p className="empty-note">{error}</p>
+
+  return (
+    <div className="git-body">
+      <div className="commit-list">
+        {log && (
+          <div className="commit-scope">
+            <button className={all ? 'ws-view' : 'ws-view on'} onClick={() => setAll(false)}>
+              Branch
+            </button>
+            <button className={all ? 'ws-view on' : 'ws-view'} onClick={() => setAll(true)}>
+              All
+            </button>
+            <span className="muted" title={`Compared against ${log.base || 'nothing'}`}>
+              {log.scope === 'branch' && log.base ? `vs ${log.base}` : 'full history'}
+            </span>
+          </div>
+        )}
+
+        {commits.map((commit) => (
+          <button
+            key={commit.sha}
+            className={`commit-row ${rowClass(commit.sha, selection)}`}
+            onClick={(event) => pick(commit.sha, event.metaKey || event.ctrlKey || event.shiftKey)}
+          >
+            <span className="commit-subject">{commit.subject}</span>
+            <span className="commit-meta">
+              <span className="commit-sha">{commit.short}</span>
+              <span>{commit.author}</span>
+              <span>{timeAgo(commit.date)}</span>
+              {commit.insertions > 0 && <span className="d-add">+{commit.insertions}</span>}
+              {commit.deletions > 0 && <span className="d-del">−{commit.deletions}</span>}
+            </span>
+          </button>
+        ))}
+
+        {loading && <p className="empty-note">Loading…</p>}
+        {!loading && commits.length === 0 && <p className="empty-note">No commits.</p>}
+        {log?.has_more && !loading && (
+          <button className="commit-more" onClick={() => void loadMore()}>
+            Load more
+          </button>
+        )}
+      </div>
+
+      {selection ? (
+        <CommitDetail hostId={hostId} root={root} selection={selection} />
+      ) : (
+        <div className="git-diff">
+          <p className="empty-note">Pick a commit.</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** The files a commit or a range touched, and the patch for whichever is open. */
+function CommitDetail({
+  hostId,
+  root,
+  selection,
+}: {
+  hostId: string
+  root: string
+  selection: Selection
+}): JSX.Element {
+  const [changes, setChanges] = useState<GitChanges | null>(null)
+  const [file, setFile] = useState<string | null>(null)
+  const [diff, setDiff] = useState<GitDiff | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setChanges(null)
+    setDiff(null)
+    setError(null)
+    api(hostId)
+      .gitChanges(root, selection.to, selection.from ?? undefined)
+      .then((result) => {
+        if (cancelled) return
+        setChanges(result)
+        setFile(result.files[0]?.path ?? null)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, root, selection.to, selection.from])
+
+  useEffect(() => {
+    if (!file) {
+      setDiff(null)
+      return
+    }
+    let cancelled = false
+    api(hostId)
+      .gitDiff(root, file, { from: selection.from ?? undefined, to: selection.to })
+      .then((result) => {
+        if (!cancelled) setDiff(result)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, root, file, selection.to, selection.from])
+
+  if (error) return <p className="empty-note">{error}</p>
+  if (!changes) return <p className="empty-note">Loading…</p>
+
+  return (
+    <div className="commit-detail">
+      <header className="commit-head">
+        <span className="commit-title">{changes.single ? changes.subject : `${selection.span} commits`}</span>
+        <span className="commit-meta">
+          {changes.single ? (
+            <>
+              <span className="commit-sha">{short(changes.to)}</span>
+              {changes.author && <span>{changes.author}</span>}
+              {changes.date && <span>{timeAgo(changes.date)}</span>}
+            </>
+          ) : (
+            <span className="commit-sha">
+              {short(changes.from)}…{short(changes.to)}
+            </span>
+          )}
+          <span className="d-add">+{changes.insertions}</span>
+          <span className="d-del">−{changes.deletions}</span>
+        </span>
+      </header>
+
+      {changes.body && <pre className="commit-body">{changes.body}</pre>}
+
+      <div className="commit-split">
+        <div className="commit-files">
+          {changes.files.map((entry) => (
+            <button
+              key={entry.path}
+              className={`git-file ${file === entry.path ? 'selected' : ''}`}
+              onClick={() => setFile(entry.path)}
+              title={entry.from ? `${entry.from} → ${entry.path}` : entry.path}
+            >
+              <span className={`git-status s${entry.status}`}>{entry.status}</span>
+              <PathLabel path={entry.path} className="git-path" />
+              <span className="commit-counts">
+                {entry.insertions > 0 && <span className="d-add">+{entry.insertions}</span>}
+                {entry.deletions > 0 && <span className="d-del">−{entry.deletions}</span>}
+              </span>
+            </button>
+          ))}
+          {changes.files.length === 0 && <p className="empty-note">No files — a merge commit.</p>}
+          {changes.truncated && <p className="empty-note">Showing the first {changes.files.length} files.</p>}
+        </div>
+
+        <div className="git-diff">
+          {diff ? <DiffView diff={diff.diff} empty="No textual changes — binary, or a mode change." /> : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function rowClass(sha: string, selection: Selection | null): string {
+  if (!selection) return ''
+  if (sha === selection.to || sha === selection.from) return 'selected'
+  return ''
+}
+
+function short(sha: string): string {
+  return sha.slice(0, 7)
+}

--- a/desktop/src/renderer/components/diff-view.tsx
+++ b/desktop/src/renderer/components/diff-view.tsx
@@ -1,0 +1,23 @@
+/** A unified patch, coloured. Shared by the working-tree and commit views. */
+export function DiffView({ diff, empty }: { diff: string; empty?: string }): JSX.Element {
+  if (!diff.trim()) return <p className="empty-note">{empty ?? 'No changes.'}</p>
+  return (
+    <pre>
+      {diff.split('\n').map((line, index) => (
+        <span key={index} className={diffClass(line)}>
+          {line || ' '}
+          {'\n'}
+        </span>
+      ))}
+    </pre>
+  )
+}
+
+export function diffClass(line: string): string {
+  if (line.startsWith('+++') || line.startsWith('---')) return 'd-meta'
+  if (line.startsWith('@@')) return 'd-hunk'
+  if (line.startsWith('+')) return 'd-add'
+  if (line.startsWith('-')) return 'd-del'
+  if (line.startsWith('diff --git') || line.startsWith('index ')) return 'd-meta'
+  return ''
+}

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -2,24 +2,31 @@ import { useEffect, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { store } from '../store.ts'
-import { CommitsView } from './commits.tsx'
+import { CommitChanges, ScopePicker, type Scope } from './commits.tsx'
 import { DiffView } from './diff-view.tsx'
 import { PathLabel } from './path-label.tsx'
 import { WorktreesView } from './worktrees.tsx'
 import type { GitChange, GitDiff, GitStatus } from '../../shared/models.ts'
 
-type View = 'changes' | 'commits' | 'worktrees'
-
 /**
  * The git panel: what is uncommitted, what has been committed on this branch,
  * and which worktrees the repository has.
+ *
+ * The working tree and history used to be separate tabs, which gave the commit
+ * view three columns — log, files, patch — and left none of them readable. They
+ * are one view now, files on the left and the patch on the right, with a
+ * dropdown choosing which set of changes fills it. The shape of the panel no
+ * longer depends on what you are looking at.
  *
  * Picking a worktree rescopes the whole panel to it, so a session started in
  * one checkout can still read the branch an agent is working in next door.
  */
 export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: string; revision?: string }): JSX.Element {
-  const [view, setView] = useState<View>('changes')
   const [worktree, setWorktree] = useState<string | null>(null)
+  const [scope, setScope] = useState<Scope>({ kind: 'working' })
+  const [worktrees, setWorktrees] = useState(false)
+  const [status, setStatus] = useState<GitStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
   const root = worktree ?? cwd
 
   // A different session is a different repository until proven otherwise.
@@ -27,51 +34,15 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
     setWorktree(null)
   }, [hostId, cwd])
 
-  return (
-    <div className="git">
-      <header className="git-head">
-        <div className="ws-side-head git-views">
-          {(['changes', 'commits', 'worktrees'] as View[]).map((name) => (
-            <button
-              key={name}
-              className={view === name ? 'ws-view on' : 'ws-view'}
-              onClick={() => setView(name)}
-            >
-              {name === 'changes' ? 'Changes' : name === 'commits' ? 'Commits' : 'Worktrees'}
-            </button>
-          ))}
-        </div>
-        {worktree && (
-          <button className="pill" title="Back to this session's own worktree" onClick={() => setWorktree(null)}>
-            ✕ {tail(worktree)}
-          </button>
-        )}
-      </header>
+  // A commit picked from one repository means nothing in the next.
+  useEffect(() => {
+    setScope({ kind: 'working' })
+    setWorktrees(false)
+    setStatus(null)
+  }, [hostId, root])
 
-      {view === 'changes' && <ChangesView hostId={hostId} root={root} revision={revision} />}
-      {view === 'commits' && <CommitsView hostId={hostId} root={root} />}
-      {view === 'worktrees' && (
-        <WorktreesView hostId={hostId} cwd={cwd} active={root} onPick={(path) => setWorktree(path)} />
-      )}
-    </div>
-  )
-}
-
-/** The working tree: staged, changed and untracked files, and their diffs. */
-function ChangesView({
-  hostId,
-  root,
-  revision,
-}: {
-  hostId: string
-  root: string
-  revision?: string
-}): JSX.Element {
-  const [status, setStatus] = useState<GitStatus | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [selected, setSelected] = useState<{ path: string; untracked: boolean } | null>(null)
-  const [diff, setDiff] = useState<GitDiff | null>(null)
-
+  // Status is fetched here rather than in the changes view because the header
+  // shows the branch in every scope — reading a commit is no reason to lose it.
   useEffect(() => {
     let cancelled = false
     setError(null)
@@ -89,6 +60,82 @@ function ChangesView({
     // Re-reads whenever the agent does something: a tool call is the usual way
     // the working tree changes here.
   }, [hostId, root, revision])
+
+  return (
+    <div className="git">
+      <header className="git-head">
+        <ScopePicker
+          hostId={hostId}
+          root={root}
+          scope={scope}
+          status={status}
+          onPick={(next) => {
+            setScope(next)
+            setWorktrees(false)
+          }}
+        />
+
+        {status && (
+          <>
+            <span className="branch">{status.branch}</span>
+            {status.ahead > 0 && <span className="pill">↑{status.ahead}</span>}
+            {status.behind > 0 && <span className="pill">↓{status.behind}</span>}
+          </>
+        )}
+
+        <button
+          className={worktrees ? 'ws-view on' : 'ws-view'}
+          title="Other checkouts of this repository"
+          onClick={() => setWorktrees((v) => !v)}
+        >
+          Worktrees
+        </button>
+
+        {worktree && (
+          <button className="pill" title="Back to this session's own worktree" onClick={() => setWorktree(null)}>
+            ✕ {tail(worktree)}
+          </button>
+        )}
+      </header>
+
+      {error ? (
+        <p className="empty-note">{error}</p>
+      ) : worktrees ? (
+        <WorktreesView
+          hostId={hostId}
+          cwd={cwd}
+          active={root}
+          onPick={(path) => {
+            setWorktree(path)
+            setWorktrees(false)
+          }}
+        />
+      ) : scope.kind === 'working' ? (
+        <ChangesView hostId={hostId} root={root} status={status} />
+      ) : (
+        <CommitChanges hostId={hostId} root={root} scope={scope} />
+      )}
+    </div>
+  )
+}
+
+/** The working tree: staged, changed and untracked files, and their diffs. */
+function ChangesView({
+  hostId,
+  root,
+  status,
+}: {
+  hostId: string
+  root: string
+  status: GitStatus | null
+}): JSX.Element {
+  const [selected, setSelected] = useState<{ path: string; untracked: boolean } | null>(null)
+  const [diff, setDiff] = useState<GitDiff | null>(null)
+
+  // A path from the previous repository would only produce a failed diff.
+  useEffect(() => {
+    setSelected(null)
+  }, [hostId, root])
 
   useEffect(() => {
     if (!selected) {
@@ -112,7 +159,6 @@ function ChangesView({
     }
   }, [hostId, root, selected?.path, selected?.untracked])
 
-  if (error) return <p className="empty-note">{error}</p>
   if (!status) return <p className="empty-note">Loading…</p>
 
   // An older daemon sends JSON null for an empty list rather than [].
@@ -123,49 +169,44 @@ function ChangesView({
   ]
 
   return (
-    <>
-      <div className="git-substatus">
-        <span className="branch">{status.branch}</span>
-        {status.ahead > 0 && <span className="pill">↑{status.ahead}</span>}
-        {status.behind > 0 && <span className="pill">↓{status.behind}</span>}
-        {!status.dirty && <span className="pill clean">clean</span>}
+    <div className="git-body">
+      <div className="git-files">
+        {groups.map(([name, files, untracked]) =>
+          files.length === 0 ? null : (
+            <div key={name} className="git-group">
+              <span className="git-group-head">{name}</span>
+              {files.map((file) => (
+                <button
+                  key={`${name}:${file.path}`}
+                  className={`git-file ${selected?.path === file.path ? 'selected' : ''}`}
+                  onClick={() => setSelected({ path: file.path, untracked })}
+                >
+                  <span className={`git-status s${file.status.trim() || 'x'}`}>
+                    {file.status.trim() || '?'}
+                  </span>
+                  <PathLabel path={file.path} className="git-path" />
+                </button>
+              ))}
+            </div>
+          ),
+        )}
+        {!status.dirty && <p className="empty-note">Working tree clean.</p>}
       </div>
 
-      <div className="git-body">
-        <div className="git-files">
-          {groups.map(([name, files, untracked]) =>
-            files.length === 0 ? null : (
-              <div key={name} className="git-group">
-                <span className="git-group-head">{name}</span>
-                {files.map((file) => (
-                  <button
-                    key={`${name}:${file.path}`}
-                    className={`git-file ${selected?.path === file.path ? 'selected' : ''}`}
-                    onClick={() => setSelected({ path: file.path, untracked })}
-                  >
-                    <span className={`git-status s${file.status.trim() || 'x'}`}>
-                      {file.status.trim() || '?'}
-                    </span>
-                    <PathLabel path={file.path} className="git-path" />
-                  </button>
-                ))}
-              </div>
-            ),
-          )}
-          {!status.dirty && <p className="empty-note">Working tree clean.</p>}
-        </div>
-
-        {diff && (
-          <div className="git-diff">
+      <div className="git-diff">
+        {diff ? (
+          <>
             <header>
               <span>{diff.file}</span>
               <span className="muted">{diff.stat}</span>
             </header>
             <DiffView diff={diff.diff} />
-          </div>
+          </>
+        ) : (
+          <p className="empty-note">{status.dirty ? 'Pick a file.' : 'Nothing to show.'}</p>
         )}
       </div>
-    </>
+    </div>
   )
 }
 

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -2,20 +2,81 @@ import { useEffect, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { store } from '../store.ts'
+import { CommitsView } from './commits.tsx'
+import { DiffView } from './diff-view.tsx'
 import { PathLabel } from './path-label.tsx'
+import { WorktreesView } from './worktrees.tsx'
 import type { GitChange, GitDiff, GitStatus } from '../../shared/models.ts'
 
+type View = 'changes' | 'commits' | 'worktrees'
+
+/**
+ * The git panel: what is uncommitted, what has been committed on this branch,
+ * and which worktrees the repository has.
+ *
+ * Picking a worktree rescopes the whole panel to it, so a session started in
+ * one checkout can still read the branch an agent is working in next door.
+ */
 export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: string; revision?: string }): JSX.Element {
+  const [view, setView] = useState<View>('changes')
+  const [worktree, setWorktree] = useState<string | null>(null)
+  const root = worktree ?? cwd
+
+  // A different session is a different repository until proven otherwise.
+  useEffect(() => {
+    setWorktree(null)
+  }, [hostId, cwd])
+
+  return (
+    <div className="git">
+      <header className="git-head">
+        <div className="ws-side-head git-views">
+          {(['changes', 'commits', 'worktrees'] as View[]).map((name) => (
+            <button
+              key={name}
+              className={view === name ? 'ws-view on' : 'ws-view'}
+              onClick={() => setView(name)}
+            >
+              {name === 'changes' ? 'Changes' : name === 'commits' ? 'Commits' : 'Worktrees'}
+            </button>
+          ))}
+        </div>
+        {worktree && (
+          <button className="pill" title="Back to this session's own worktree" onClick={() => setWorktree(null)}>
+            ✕ {tail(worktree)}
+          </button>
+        )}
+      </header>
+
+      {view === 'changes' && <ChangesView hostId={hostId} root={root} revision={revision} />}
+      {view === 'commits' && <CommitsView hostId={hostId} root={root} />}
+      {view === 'worktrees' && (
+        <WorktreesView hostId={hostId} cwd={cwd} active={root} onPick={(path) => setWorktree(path)} />
+      )}
+    </div>
+  )
+}
+
+/** The working tree: staged, changed and untracked files, and their diffs. */
+function ChangesView({
+  hostId,
+  root,
+  revision,
+}: {
+  hostId: string
+  root: string
+  revision?: string
+}): JSX.Element {
   const [status, setStatus] = useState<GitStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useState<{ path: string; untracked: boolean } | null>(null)
   const [diff, setDiff] = useState<GitDiff | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setError(null)
     api(hostId)
-      .gitStatus(cwd)
+      .gitStatus(root)
       .then((result) => {
         if (!cancelled) setStatus(result)
       })
@@ -27,7 +88,7 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
     }
     // Re-reads whenever the agent does something: a tool call is the usual way
     // the working tree changes here.
-  }, [hostId, cwd, revision])
+  }, [hostId, root, revision])
 
   useEffect(() => {
     if (!selected) {
@@ -36,7 +97,10 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
     }
     let cancelled = false
     api(hostId)
-      .gitDiff(cwd, selected)
+      // An untracked file has nothing to diff against, so it is diffed against
+      // nothing — otherwise git says the file is not in the index and the pane
+      // comes back empty.
+      .gitDiff(root, selected.path, { untracked: selected.untracked })
       .then((result) => {
         if (!cancelled) setDiff(result)
       })
@@ -46,40 +110,42 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
     return () => {
       cancelled = true
     }
-  }, [hostId, cwd, selected])
+  }, [hostId, root, selected?.path, selected?.untracked])
 
   if (error) return <p className="empty-note">{error}</p>
   if (!status) return <p className="empty-note">Loading…</p>
 
   // An older daemon sends JSON null for an empty list rather than [].
-  const groups: [string, GitChange[]][] = [
-    ['Staged', status.staged ?? []],
-    ['Changed', status.unstaged ?? []],
-    ['Untracked', status.untracked ?? []],
+  const groups: [string, GitChange[], boolean][] = [
+    ['Staged', status.staged ?? [], false],
+    ['Changed', status.unstaged ?? [], false],
+    ['Untracked', status.untracked ?? [], true],
   ]
 
   return (
-    <div className="git">
-      <header className="git-head">
+    <>
+      <div className="git-substatus">
         <span className="branch">{status.branch}</span>
         {status.ahead > 0 && <span className="pill">↑{status.ahead}</span>}
         {status.behind > 0 && <span className="pill">↓{status.behind}</span>}
         {!status.dirty && <span className="pill clean">clean</span>}
-      </header>
+      </div>
 
       <div className="git-body">
         <div className="git-files">
-          {groups.map(([name, files]) =>
+          {groups.map(([name, files, untracked]) =>
             files.length === 0 ? null : (
               <div key={name} className="git-group">
                 <span className="git-group-head">{name}</span>
                 {files.map((file) => (
                   <button
                     key={`${name}:${file.path}`}
-                    className={`git-file ${selected === file.path ? 'selected' : ''}`}
-                    onClick={() => setSelected(file.path)}
+                    className={`git-file ${selected?.path === file.path ? 'selected' : ''}`}
+                    onClick={() => setSelected({ path: file.path, untracked })}
                   >
-                    <span className={`git-status s${file.status.trim() || 'x'}`}>{file.status.trim() || '?'}</span>
+                    <span className={`git-status s${file.status.trim() || 'x'}`}>
+                      {file.status.trim() || '?'}
+                    </span>
                     <PathLabel path={file.path} className="git-path" />
                   </button>
                 ))}
@@ -95,25 +161,16 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
               <span>{diff.file}</span>
               <span className="muted">{diff.stat}</span>
             </header>
-            <pre>
-              {diff.diff.split('\n').map((line, index) => (
-                <span key={index} className={diffClass(line)}>
-                  {line || ' '}
-                  {'\n'}
-                </span>
-              ))}
-            </pre>
+            <DiffView diff={diff.diff} />
           </div>
         )}
       </div>
-    </div>
+    </>
   )
 }
 
-function diffClass(line: string): string {
-  if (line.startsWith('+++') || line.startsWith('---')) return 'd-meta'
-  if (line.startsWith('@@')) return 'd-hunk'
-  if (line.startsWith('+')) return 'd-add'
-  if (line.startsWith('-')) return 'd-del'
-  return ''
+/** The last two segments: the parent directory is what distinguishes them. */
+function tail(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts.length <= 2 ? path : `…/${parts.slice(-2).join('/')}`
 }

--- a/desktop/src/renderer/components/worktrees.tsx
+++ b/desktop/src/renderer/components/worktrees.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+
+import { api } from '../bridge.ts'
+import type { Worktree } from '../../shared/models.ts'
+
+interface Props {
+  hostId: string
+  /** The repository to list from — any path inside it will do. */
+  cwd: string
+  /** The worktree the panel is currently scoped to. */
+  active: string
+  onPick: (path: string) => void
+}
+
+/**
+ * Every worktree of this repository, with enough state to tell parallel agents
+ * apart. Read-only: Helios shows worktrees, it does not make them.
+ */
+export function WorktreesView({ hostId, cwd, active, onPick }: Props): JSX.Element {
+  const [worktrees, setWorktrees] = useState<Worktree[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    api(hostId)
+      .gitWorktrees(cwd)
+      .then((result) => {
+        if (!cancelled) setWorktrees(result)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, cwd])
+
+  if (error) return <p className="empty-note">{error}</p>
+  if (!worktrees) return <p className="empty-note">Loading…</p>
+  if (worktrees.length === 0) return <p className="empty-note">No worktrees.</p>
+
+  return (
+    <div className="worktrees">
+      {worktrees.map((worktree) => (
+        <button
+          key={worktree.path}
+          className={`worktree ${worktree.path === active ? 'selected' : ''}`}
+          onClick={() => onPick(worktree.path)}
+          title={worktree.path}
+        >
+          <span className="worktree-top">
+            <span className="branch">{worktree.branch || '(detached)'}</span>
+            {worktree.is_main && <span className="pill">main</span>}
+            {worktree.locked && <span className="pill">locked</span>}
+            {worktree.ahead > 0 && (
+              <span className="pill" title={`Ahead of ${worktree.base}`}>
+                ↑{worktree.ahead}
+              </span>
+            )}
+            {worktree.behind > 0 && (
+              <span className="pill" title={`Behind ${worktree.base}`}>
+                ↓{worktree.behind}
+              </span>
+            )}
+            {worktree.dirty > 0 ? (
+              <span className="pill" title={`${worktree.dirty} changed files`}>
+                ●{worktree.dirty}
+              </span>
+            ) : (
+              <span className="pill clean">clean</span>
+            )}
+          </span>
+          {worktree.subject && <span className="worktree-subject">{worktree.subject}</span>}
+          <span className="worktree-path">
+            <span className="commit-sha">{worktree.head}</span>
+            {tail(worktree.path)}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** The last two segments: the parent directory is what distinguishes them. */
+function tail(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts.length <= 2 ? path : `…/${parts.slice(-2).join('/')}`
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2162,3 +2162,218 @@ hr {
     transform: translate(-50%, 8px);
   }
 }
+
+/* ─── Git: commits and worktrees ────────────────────────────────────────── */
+
+.git-views {
+  flex: 1;
+  box-shadow: none;
+  padding: 0;
+}
+
+/* The branch line lives under the view switcher rather than beside it: the
+   switcher is the same in all three views and the branch is not. */
+.git-substatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+.commit-list {
+  width: clamp(220px, 42%, 380px);
+  flex: none;
+  overflow-y: auto;
+  padding: 6px;
+  background: color-mix(in srgb, var(--on-surface) 3%, transparent);
+}
+
+.commit-scope {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 4px 8px;
+}
+
+.commit-scope .muted {
+  margin-left: auto;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commit-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 9px;
+  border-radius: var(--r-sm);
+  color: var(--on-surface);
+  font-weight: 400;
+}
+
+.commit-row:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+}
+
+.commit-row.selected {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+}
+
+.commit-subject {
+  font-size: 12.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.commit-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+  min-width: 0;
+}
+
+.commit-row.selected .commit-meta {
+  color: inherit;
+  opacity: 0.75;
+}
+
+.commit-sha {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--primary);
+}
+
+.commit-row.selected .commit-sha {
+  color: inherit;
+}
+
+.commit-more {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  border-radius: var(--r-sm);
+  font-size: 12px;
+  color: var(--primary);
+  background: color-mix(in srgb, var(--on-surface) 5%, transparent);
+}
+
+.commit-detail {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.commit-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+.commit-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.commit-body {
+  margin: 0;
+  padding: 8px 14px;
+  max-height: 120px;
+  overflow: auto;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  color: var(--on-surface-variant);
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+/* Files above, patch below: the commit pane is already the narrow half, and
+   splitting it again sideways leaves neither side readable. */
+.commit-split {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.commit-files {
+  flex: none;
+  max-height: 38%;
+  overflow-y: auto;
+  padding: 6px;
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+.commit-counts {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+  padding-left: 8px;
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.worktrees {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.worktree {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: var(--r-md);
+  background: var(--surface-high);
+  color: var(--on-surface);
+  font-weight: 400;
+}
+
+.worktree:hover {
+  background: color-mix(in srgb, var(--on-surface) 10%, transparent);
+}
+
+.worktree.selected {
+  outline: 1px solid var(--primary);
+}
+
+.worktree-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.worktree-subject {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.worktree-path {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2165,28 +2165,126 @@ hr {
 
 /* ─── Git: commits and worktrees ────────────────────────────────────────── */
 
-.git-views {
-  flex: 1;
-  box-shadow: none;
-  padding: 0;
+/* The scope picker takes the header's spare width and the Worktrees toggle is
+   pushed to the far end, so the two controls never crowd each other. */
+.git-head .ws-view {
+  margin-left: auto;
 }
 
-/* The branch line lives under the view switcher rather than beside it: the
-   switcher is the same in all three views and the branch is not. */
+.scope {
+  position: relative;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.scope-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  padding: 5px 10px;
+  border-radius: var(--r-sm);
+  background: var(--surface-high);
+  color: var(--on-surface);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.scope-button:hover,
+.scope-button.on {
+  background: color-mix(in srgb, var(--on-surface) 10%, transparent);
+}
+
+.scope-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scope-caret {
+  font-size: 10px;
+  color: var(--on-surface-variant);
+}
+
+/* Catches the click that dismisses the menu: over the panel, under the menu. */
+.scope-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+}
+
+/* Fixed, and placed from a measured rect — see anchorFor in commits.tsx. */
+.scope-menu {
+  position: fixed;
+  z-index: 31;
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  border-radius: var(--r-md);
+  background: var(--surface-high);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 45%);
+}
+
+.scope-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 9px;
+  border-radius: var(--r-sm);
+  color: var(--on-surface);
+  font-size: 12.5px;
+  font-weight: 400;
+}
+
+.scope-row:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+}
+
+.scope-row.selected {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+}
+
+.scope-row-meta {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+.scope-row.selected .scope-row-meta {
+  color: inherit;
+  opacity: 0.75;
+}
+
+.scope-sep {
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--outline-variant);
+}
+
+.scope-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.scope-hint {
+  padding: 7px 9px 2px;
+  margin: 0;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+/* Commit metadata sits where the branch line sits for the working tree, so the
+   row below the header means the same thing in both scopes. */
 .git-substatus {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
   box-shadow: inset 0 -1px 0 var(--outline-variant);
-}
-
-.commit-list {
-  width: clamp(220px, 42%, 380px);
-  flex: none;
-  overflow-y: auto;
-  padding: 6px;
-  background: color-mix(in srgb, var(--on-surface) 3%, transparent);
 }
 
 .commit-scope {
@@ -2224,6 +2322,12 @@ hr {
 .commit-row.selected {
   background: var(--primary-container);
   color: var(--on-primary-container);
+}
+
+/* The commits a range covers between its two endpoints. Without this a range
+   selection looks like two unrelated picks. */
+.commit-row.in-range {
+  background: color-mix(in srgb, var(--primary-container) 40%, transparent);
 }
 
 .commit-subject {
@@ -2267,26 +2371,6 @@ hr {
   background: color-mix(in srgb, var(--on-surface) 5%, transparent);
 }
 
-.commit-detail {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.commit-head {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 10px 14px;
-  box-shadow: inset 0 -1px 0 var(--outline-variant);
-}
-
-.commit-title {
-  font-size: 13px;
-  font-weight: 600;
-}
-
 .commit-body {
   margin: 0;
   padding: 8px 14px;
@@ -2296,23 +2380,6 @@ hr {
   line-height: 1.5;
   white-space: pre-wrap;
   color: var(--on-surface-variant);
-  box-shadow: inset 0 -1px 0 var(--outline-variant);
-}
-
-/* Files above, patch below: the commit pane is already the narrow half, and
-   splitting it again sideways leaves neither side readable. */
-.commit-split {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.commit-files {
-  flex: none;
-  max-height: 38%;
-  overflow-y: auto;
-  padding: 6px;
   box-shadow: inset 0 -1px 0 var(--outline-variant);
 }
 

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -188,6 +188,62 @@ export interface Worktree {
   path: string
   branch: string
   is_main: boolean
+  head?: string
+  subject?: string
+  detached: boolean
+  locked: boolean
+  ahead: number
+  behind: number
+  /** A count of changed files, not a flag: "7 touched" says an agent is mid-flight. */
+  dirty: number
+  /** What ahead and behind were measured against. */
+  base?: string
+}
+
+/** internal/server/githistory.go:35 */
+export interface Commit {
+  sha: string
+  short: string
+  author: string
+  date: string
+  subject: string
+  files: number
+  insertions: number
+  deletions: number
+}
+
+export interface GitLog {
+  root: string
+  branch: string
+  base: string
+  /** 'branch' is base..HEAD; 'all' is the whole history. */
+  scope: 'branch' | 'all'
+  commits: Commit[]
+  has_more: boolean
+}
+
+export interface CommitFile {
+  path: string
+  /** Set on a rename or a copy. */
+  from?: string
+  status: string
+  insertions: number
+  deletions: number
+}
+
+export interface GitChanges {
+  from: string
+  to: string
+  single: boolean
+  subject?: string
+  body?: string
+  author?: string
+  date?: string
+  parents?: string[]
+  files: CommitFile[]
+  insertions: number
+  deletions: number
+  truncated: boolean
 }
 
 /** internal/server/files.go:16 */

--- a/docs/specs/35-git-history-and-worktrees.md
+++ b/docs/specs/35-git-history-and-worktrees.md
@@ -1,0 +1,203 @@
+# 35 — Git History and Worktree View
+
+## Problem
+
+Helios shows you what the agent has changed *right now* and nothing else. The
+git panel is a working-tree view: staged, changed, untracked, and a unified
+diff per file. The moment the agent commits, its work vanishes from the panel.
+
+That is the wrong shape for how these sessions actually run. An agent works for
+twenty minutes and leaves three commits behind; the question you want answered
+on your phone is "what did it do on this branch", and the panel can only answer
+"what is still uncommitted" — which, after a tidy agent, is nothing.
+
+The second half of the same gap is worktrees. Running several agents in
+parallel means one worktree per feature branch — the repo this spec was written
+in had four checked out at once, one per in-flight spec. The daemon lists them
+(`GET /api/git/worktrees`), mobile uses that list as a scope dropdown, and
+desktop does not surface them at all. There is nowhere to see, in one glance,
+which branch each agent is on and how far along it is.
+
+## Current State
+
+Three read-only endpoints in `internal/server/git.go`:
+
+| Endpoint | Returns | Clients |
+|---|---|---|
+| `GET /api/git/status` | branch, ahead/behind, staged/unstaged/untracked | mobile `git_status_screen.dart`, desktop `git.tsx` |
+| `GET /api/git/diff` | unified diff for one file, working tree only | both |
+| `GET /api/git/worktrees` | path, branch, is_main | mobile only, as a scope picker |
+
+Four defects found while reading, all fixed as part of this work:
+
+1. An untracked file has an empty diff. `git diff -- file` ignores untracked
+   files, so tapping one shows a blank pane on both clients.
+2. `parseStatLine` computes insertions and deletions, discards the result, and
+   recomputes them — dead code by any reading.
+3. `gitCmd` has no timeout. A git command that hangs on a lock file hangs the
+   request.
+4. `gitCmd` drops stderr, so every failure reaches the client as
+   "failed to get diff" with the reason thrown away.
+
+## Goals
+
+- See the commits on the current branch, on both clients.
+- See what one commit changed, and what changed between any two commits.
+- See every worktree of the repo with enough state to tell the agents apart.
+
+## Non-Goals
+
+- **Helios does not create, remove or switch worktrees.** You make them; Helios
+  shows them. This keeps the whole feature read-only, which is the reason it
+  needs no path confinement, no branch-name validation beyond argument safety,
+  and no new failure modes on someone else's repository.
+- No commit, stage, push, or any other mutation. The agent has a terminal for
+  that, and so do you.
+- No graph rendering. A list of commits, in order, is what the question needs.
+
+## Which Commits Are "This Branch"
+
+The useful default is `base..HEAD` — what this branch adds on top of where it
+started. Resolving `base` has no single right answer, so it is a fallback chain:
+
+1. the tracking branch, `@{upstream}`
+2. `origin/HEAD`, the remote's default branch
+3. a local `main`, then `master`
+
+The resolved base is returned in the response so the UI can name it, and can be
+overridden with `&base=`.
+
+One case breaks the default: on `main`, fully pushed, `origin/main..HEAD` is
+empty and the panel would show nothing at all — the worst possible answer to
+"what happened here". So an empty branch range silently falls back to full
+history and reports `scope: "all"`; the client shows a Branch/All toggle that
+does the same thing deliberately.
+
+## API
+
+Two new endpoints, two extended. All read-only, all on `protectedMux` behind
+bearer auth, all resolving their `path` through the same `resolveSafePath` as
+the existing file and git endpoints.
+
+### `GET /api/git/log`
+
+```
+?path=       required, anywhere inside the repo
+&base=       override the resolved base
+&all=true    full history instead of base..HEAD
+&limit=      default 50, max 200
+&skip=       for paging
+```
+
+```json
+{
+  "root": "/Users/x/repo", "branch": "feat/thing",
+  "base": "origin/main", "scope": "branch",
+  "commits": [{
+    "sha": "cd98e15…", "short": "cd98e15", "author": "Kamrul",
+    "date": "2026-08-11T21:03:11Z", "subject": "feat: …",
+    "files": 16, "insertions": 1204, "deletions": 88
+  }],
+  "has_more": true
+}
+```
+
+Parsed from a single `git log --format=…%x1e… --shortstat` call: one record
+per commit, separated by `0x1e`, fields by `0x1f`. `has_more` comes from asking
+for one commit more than the limit and dropping it.
+
+### `GET /api/git/changes`
+
+The file list for a commit or a range — the middle pane, before any patch is
+fetched.
+
+```
+?path=   required
+&to=     required; a sha or ref
+&from=   optional; when absent, `to` is compared against its parent
+```
+
+```json
+{
+  "from": "41986ae", "to": "cd98e15", "single": true,
+  "subject": "feat: …", "body": "…", "author": "Kamrul",
+  "date": "2026-08-11T21:03:11Z",
+  "files": [{"path": "internal/server/git.go", "status": "M",
+             "insertions": 210, "deletions": 14}],
+  "insertions": 1204, "deletions": 88, "truncated": false
+}
+```
+
+Status letters come from `--name-status`, counts from `--numstat`, zipped by
+path; a file present in one and not the other still appears, with whatever is
+known. Binary files report `-` counts as zero and are flagged by the diff
+endpoint, not here.
+
+### `GET /api/git/diff` (extended)
+
+Existing behaviour is unchanged when the new parameters are absent.
+
+```
+&from=&to=       patch for one file at that revision pair
+&untracked=true  diff an untracked file against nothing
+```
+
+`untracked` runs `git diff --no-index -- /dev/null <file>`, whose exit status 1
+means "there are differences" and is not an error — that is defect 1 above.
+
+### `GET /api/git/worktrees` (extended)
+
+Additive: the existing `path`, `branch` and `is_main` stay, so an older client
+keeps working.
+
+```json
+{"worktrees": [{
+  "path": "/Users/x/repo-feature", "branch": "feat/thing", "is_main": false,
+  "head": "1d1d745", "subject": "feat: …", "detached": false,
+  "ahead": 3, "behind": 12, "dirty": 7, "locked": false
+}]}
+```
+
+`dirty` is a file count, not a boolean: "7 files touched" tells you an agent is
+mid-flight where "dirty" does not. Each worktree costs a handful of git calls,
+so the list is capped and the calls are the same short-timeout `gitCmd` as
+everything else.
+
+## Revisions as Arguments
+
+The only real safety question in a read-only feature: `from`, `to` and `base`
+are user-supplied strings that become git arguments. A value beginning with `-`
+would be read as a flag, so revisions are validated against
+`[A-Za-z0-9._/^~@{}-]+` with a leading `-` rejected and a length cap, and are
+never concatenated into a range string — `from` and `to` are passed as separate
+arguments so `git diff A B` cannot be talked into being something else.
+
+## UI
+
+Both clients get the same three views over the same data.
+
+**Changes** — today's panel, unchanged, still the default.
+
+**Commits** — the commit list, with the base and scope named in the header and
+a Branch/All toggle. Selecting a commit shows its message and file list;
+selecting a file shows the patch. Selecting a second commit with ⌘ or shift
+compares the two, and the header says which range is being shown.
+
+**Worktrees** — one row per worktree: branch, ahead/behind, dirty count, head
+subject, and a marker on the one the current session is in. Selecting a row
+scopes the whole panel to that worktree, which is what mobile's picker already
+does; this only makes it visible and gives desktop the same thing.
+
+Desktop puts the three behind a segmented control in the git panel header.
+Mobile keeps `git_status_screen` as the Changes tab and adds the other two,
+reusing the existing diff renderer and its Ask AI bar. Having no modifier keys,
+mobile long-presses a commit to mark one end of the range and taps the other.
+
+## Testing
+
+Go tests build a real repository in `t.TempDir()` — a few commits, a rename, an
+untracked file, a second worktree — and assert against it, the same way
+`filesearch_test.go` does. Cases that matter: base resolution through each rung
+of the fallback, the empty-range fallback to full history, paging boundaries,
+a root commit (no parent), a merge commit (no shortstat), a rename, an
+untracked diff, and a revision argument beginning with `-` being refused.

--- a/internal/server/git.go
+++ b/internal/server/git.go
@@ -1,39 +1,54 @@
 package server
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// gitTimeout bounds every git call. A repository with a stale index.lock will
+// otherwise hang the request until the client gives up.
+const gitTimeout = 15 * time.Second
+
+// maxWorktreeDetail caps how many worktrees are enriched with branch state:
+// each one costs three more git calls.
+const maxWorktreeDetail = 30
 
 type gitChange struct {
 	Path   string `json:"path"`
 	Status string `json:"status"`
 }
 
+// gitRepoRoot resolves a client-supplied path and finds the repository holding it.
+func gitRepoRoot(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("missing path")
+	}
+	clean, err := resolveSafePath(path)
+	if err != nil {
+		return "", err
+	}
+	out, err := gitCmd(clean, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", errors.New("not a git repository")
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // handleGitStatus returns branch, ahead/behind, and changed file lists.
 func (s *PublicServer) handleGitStatus(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Query().Get("path")
-	if path == "" {
-		jsonError(w, "missing path", http.StatusBadRequest)
-		return
-	}
-
-	clean, err := resolveSafePath(path)
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	// Find repo root from the given path.
-	root, err := gitCmd(clean, "rev-parse", "--show-toplevel")
-	if err != nil {
-		jsonError(w, "not a git repository", http.StatusBadRequest)
-		return
-	}
-	root = strings.TrimSpace(root)
 
 	// Branch name.
 	branch, err := gitCmd(root, "rev-parse", "--abbrev-ref", "HEAD")
@@ -84,51 +99,31 @@ func (s *PublicServer) handleGitStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleGitDiff returns the unified diff for a single file.
+// handleGitDiff returns the unified diff for a single file, in the working tree
+// or at a revision.
 func (s *PublicServer) handleGitDiff(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Query().Get("path")
 	file := r.URL.Query().Get("file")
-	if path == "" || file == "" {
-		jsonError(w, "missing path or file", http.StatusBadRequest)
+	if file == "" {
+		jsonError(w, "missing file", http.StatusBadRequest)
 		return
 	}
-
-	clean, err := resolveSafePath(path)
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	root, err := gitCmd(clean, "rev-parse", "--show-toplevel")
-	if err != nil {
-		jsonError(w, "not a git repository", http.StatusBadRequest)
-		return
-	}
-	root = strings.TrimSpace(root)
-
-	staged := r.URL.Query().Get("staged") == "true"
-
-	// Get the diff.
-	var diff string
-	if staged {
-		diff, err = gitCmd(root, "diff", "--cached", "--", file)
-	} else {
-		diff, err = gitCmd(root, "diff", "--", file)
-	}
-	if err != nil {
-		jsonError(w, "failed to get diff", http.StatusInternalServerError)
+	from, to := r.URL.Query().Get("from"), r.URL.Query().Get("to")
+	if (from != "" && !validRevision(from)) || (to != "" && !validRevision(to)) {
+		jsonError(w, "invalid revision", http.StatusBadRequest)
 		return
 	}
 
-	// Get stat line.
-	var stat string
-	if staged {
-		stat, _ = gitCmd(root, "diff", "--cached", "--stat", "--", file)
-	} else {
-		stat, _ = gitCmd(root, "diff", "--stat", "--", file)
+	diff, err := fileDiff(root, file, from, to, r.URL.Query())
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
-	// Parse stat to "+N -M" format.
-	statLine := parseStatLine(stat)
 
 	// Infer language from extension.
 	ext := ""
@@ -140,36 +135,89 @@ func (s *PublicServer) handleGitDiff(w http.ResponseWriter, r *http.Request) {
 		"file":     file,
 		"language": ext,
 		"diff":     diff,
-		"stat":     statLine,
+		"stat":     statFromDiff(diff),
 	})
+}
+
+// fileDiff picks the comparison the query asked for: an untracked file against
+// nothing, a commit against its parent, one revision against another, or the
+// working tree.
+func fileDiff(root, file, from, to string, query map[string][]string) (string, error) {
+	value := func(name string) string {
+		if v := query[name]; len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	}
+
+	switch {
+	case value("untracked") == "true":
+		return diffNoIndex(root, file)
+	case to != "" && from == "":
+		return gitCmd(root, "show", "--format=", "--no-color", "--find-renames", to, "--", file)
+	case to != "" && from != "":
+		return gitCmd(root, "diff", "--no-color", "--find-renames", from, to, "--", file)
+	case value("staged") == "true":
+		return gitCmd(root, "diff", "--no-color", "--cached", "--", file)
+	default:
+		return gitCmd(root, "diff", "--no-color", "--", file)
+	}
+}
+
+// diffNoIndex diffs a file git does not track yet. --no-index exits 1 when the
+// files differ, which here is the expected outcome rather than a failure.
+func diffNoIndex(root, file string) (string, error) {
+	out, code, err := gitRun(root, "diff", "--no-color", "--no-index", "--", os.DevNull, file)
+	if err != nil && code != 1 {
+		return "", err
+	}
+	return out, nil
+}
+
+// statFromDiff counts the patch's own +/- lines, which is cheaper and more
+// honest than parsing the prose of `git diff --stat`.
+func statFromDiff(diff string) string {
+	insertions, deletions := 0, 0
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+		case strings.HasPrefix(line, "+"):
+			insertions++
+		case strings.HasPrefix(line, "-"):
+			deletions++
+		}
+	}
+	if insertions == 0 && deletions == 0 {
+		return ""
+	}
+	return fmt.Sprintf("+%d -%d", insertions, deletions)
 }
 
 type worktreeEntry struct {
 	Path   string `json:"path"`
 	Branch string `json:"branch"`
 	IsMain bool   `json:"is_main"`
+	// The rest describe how far along the branch in that worktree is — enough
+	// to tell several parallel agents apart at a glance.
+	Head     string `json:"head,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	Detached bool   `json:"detached"`
+	Locked   bool   `json:"locked"`
+	Ahead    int    `json:"ahead"`
+	Behind   int    `json:"behind"`
+	Dirty    int    `json:"dirty"`
+	// Base names what ahead and behind were measured against — the tracking
+	// branch when there is one, otherwise the repository's base branch.
+	Base string `json:"base,omitempty"`
 }
 
 // handleGitWorktrees lists all worktrees for the repo containing the given path.
 func (s *PublicServer) handleGitWorktrees(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Query().Get("path")
-	if path == "" {
-		jsonError(w, "missing path", http.StatusBadRequest)
-		return
-	}
-
-	clean, err := resolveSafePath(path)
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	root, err := gitCmd(clean, "rev-parse", "--show-toplevel")
-	if err != nil {
-		jsonError(w, "not a git repository", http.StatusBadRequest)
-		return
-	}
-	root = strings.TrimSpace(root)
 
 	out, err := gitCmd(root, "worktree", "list", "--porcelain")
 	if err != nil {
@@ -178,15 +226,87 @@ func (s *PublicServer) handleGitWorktrees(w http.ResponseWriter, r *http.Request
 	}
 
 	worktrees := parseWorktreeList(out, root)
+	for i := range worktrees {
+		if i >= maxWorktreeDetail {
+			break
+		}
+		describeWorktree(&worktrees[i])
+	}
 
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
 		"worktrees": worktrees,
 	})
 }
 
+// describeWorktree fills in branch state. A worktree whose directory has been
+// deleted but not pruned answers nothing, and is left as the porcelain had it.
+func describeWorktree(entry *worktreeEntry) {
+	if out, err := gitCmd(entry.Path, "log", "-1", "--format=%s"); err == nil {
+		entry.Subject = strings.TrimSpace(out)
+	}
+	if out, err := gitCmd(entry.Path, "status", "--porcelain"); err == nil {
+		entry.Dirty = countLines(out)
+	}
+
+	// A worktree cut for one feature usually has no upstream yet, and "0 ahead,
+	// 0 behind" would say nothing about it. Fall back to the base branch, and
+	// name whatever was compared against.
+	entry.Base = "@{upstream}"
+	ahead, behind, err := countAheadBehind(entry.Path, entry.Base)
+	if err != nil {
+		entry.Base = resolveBase(entry.Path)
+		if entry.Base == "" {
+			return
+		}
+		ahead, behind, err = countAheadBehind(entry.Path, entry.Base)
+		if err != nil {
+			entry.Base = ""
+			return
+		}
+	}
+	entry.Ahead, entry.Behind = ahead, behind
+}
+
+// countAheadBehind counts each side separately rather than asking for
+// "HEAD...base": the two-call form keeps the revision its own argument instead
+// of concatenating it into a range string.
+func countAheadBehind(dir, base string) (ahead, behind int, err error) {
+	ahead, err = countRevs(dir, "HEAD", base)
+	if err != nil {
+		return 0, 0, err
+	}
+	behind, err = countRevs(dir, base, "HEAD")
+	if err != nil {
+		return 0, 0, err
+	}
+	return ahead, behind, nil
+}
+
+// countRevs counts commits reachable from have but not from without.
+func countRevs(dir, have, without string) (int, error) {
+	out, err := gitCmd(dir, "rev-list", "--count", have, "--not", without)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse rev-list count %q: %w", out, err)
+	}
+	return n, nil
+}
+
+func countLines(out string) int {
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0
+	}
+	return len(strings.Split(trimmed, "\n"))
+}
+
 // parseWorktreeList parses `git worktree list --porcelain` output.
 func parseWorktreeList(out string, mainRoot string) []worktreeEntry {
-	var worktrees []worktreeEntry
+	// Not nil: a nil slice marshals to JSON null, and clients expect a list.
+	worktrees := []worktreeEntry{}
 	var current worktreeEntry
 
 	for _, line := range strings.Split(out, "\n") {
@@ -198,15 +318,21 @@ func parseWorktreeList(out string, mainRoot string) []worktreeEntry {
 			current = worktreeEntry{}
 			continue
 		}
-		if strings.HasPrefix(line, "worktree ") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
 			current.Path = strings.TrimPrefix(line, "worktree ")
 			current.IsMain = current.Path == mainRoot
-		} else if strings.HasPrefix(line, "branch ") {
+		case strings.HasPrefix(line, "HEAD "):
+			current.Head = shortSHA(strings.TrimPrefix(line, "HEAD "))
+		case strings.HasPrefix(line, "branch "):
 			// branch refs/heads/main -> main
 			ref := strings.TrimPrefix(line, "branch ")
 			current.Branch = strings.TrimPrefix(ref, "refs/heads/")
-		} else if line == "detached" {
+		case line == "detached":
 			current.Branch = "(detached)"
+			current.Detached = true
+		case line == "locked" || strings.HasPrefix(line, "locked "):
+			current.Locked = true
 		}
 	}
 	// Flush last entry.
@@ -216,14 +342,51 @@ func parseWorktreeList(out string, mainRoot string) []worktreeEntry {
 	return worktrees
 }
 
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
 // gitCmd runs a git command in the given directory and returns stdout.
 func gitCmd(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, _, err := gitRun(dir, args...)
+	return out, err
+}
+
+// gitRun also reports the exit status, for the callers where a non-zero one is
+// an answer rather than a failure.
+func gitRun(dir string, args ...string) (string, int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	if err == nil {
+		return string(out), 0, nil
 	}
-	return string(out), nil
+
+	code := -1
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		code = exit.ExitCode()
+	}
+	// git says why on stderr; without it every failure reads the same.
+	reason := strings.TrimSpace(stderr.String())
+	if reason == "" {
+		reason = err.Error()
+	}
+	return string(out), code, fmt.Errorf("git %s: %s", strings.Join(args, " "), firstLine(reason))
+}
+
+func firstLine(text string) string {
+	if idx := strings.IndexByte(text, '\n'); idx >= 0 {
+		return text[:idx]
+	}
+	return text
 }
 
 // parseNameStatus parses `git diff --name-status` output into gitChange slices.
@@ -254,43 +417,4 @@ func parseNameStatus(root string, extraArgs ...string) []gitChange {
 		changes = append(changes, gitChange{Path: p, Status: status})
 	}
 	return changes
-}
-
-// parseStatLine extracts "+N -M" from git diff --stat output.
-func parseStatLine(stat string) string {
-	lines := strings.Split(strings.TrimSpace(stat), "\n")
-	if len(lines) == 0 {
-		return ""
-	}
-	// Last line looks like: " 1 file changed, 5 insertions(+), 2 deletions(-)"
-	last := lines[len(lines)-1]
-	var ins, del int
-	for _, part := range strings.Fields(last) {
-		if n, err := strconv.Atoi(part); err == nil {
-			// First number after "changed" is insertions, second is deletions.
-			if strings.Contains(last[strings.Index(last, part):], "insertion") || strings.Contains(last[strings.Index(last, part):], "deletion") {
-				if ins == 0 && strings.Contains(last, "insertion") {
-					ins = n
-				} else {
-					del = n
-				}
-			}
-		}
-	}
-	// Simpler approach: just scan for numbers next to +/-.
-	ins = 0
-	del = 0
-	parts := strings.Fields(last)
-	for i, p := range parts {
-		if strings.HasPrefix(p, "insertion") && i > 0 {
-			ins, _ = strconv.Atoi(parts[i-1])
-		}
-		if strings.HasPrefix(p, "deletion") && i > 0 {
-			del, _ = strconv.Atoi(parts[i-1])
-		}
-	}
-	if ins == 0 && del == 0 {
-		return ""
-	}
-	return fmt.Sprintf("+%d -%d", ins, del)
 }

--- a/internal/server/githistory.go
+++ b/internal/server/githistory.go
@@ -1,0 +1,368 @@
+package server
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultLogLimit = 50
+	maxLogLimit     = 200
+	// maxChangedFiles bounds the file list for a commit or a range. A tree-wide
+	// refactor can touch thousands of files, and no one reads that list.
+	maxChangedFiles = 2000
+)
+
+// git will put these separators in a format string verbatim, and no commit
+// subject or author name contains them.
+const (
+	fieldSep  = "\x1f"
+	recordSep = "\x1e"
+)
+
+const logFormat = recordSep + "%H" + fieldSep + "%h" + fieldSep + "%an" + fieldSep + "%aI" + fieldSep + "%s"
+
+// revPattern is deliberately narrow: these strings become git arguments, and a
+// value beginning with "-" would be read as a flag rather than a revision.
+var revPattern = regexp.MustCompile(`^[A-Za-z0-9._/^~@{}-]{1,255}$`)
+
+func validRevision(rev string) bool {
+	return !strings.HasPrefix(rev, "-") && revPattern.MatchString(rev)
+}
+
+type logEntry struct {
+	SHA        string `json:"sha"`
+	Short      string `json:"short"`
+	Author     string `json:"author"`
+	Date       string `json:"date"`
+	Subject    string `json:"subject"`
+	Files      int    `json:"files"`
+	Insertions int    `json:"insertions"`
+	Deletions  int    `json:"deletions"`
+}
+
+type commitFile struct {
+	Path string `json:"path"`
+	// From is set on a rename or copy, so the UI can show "old → new".
+	From       string `json:"from,omitempty"`
+	Status     string `json:"status"`
+	Insertions int    `json:"insertions"`
+	Deletions  int    `json:"deletions"`
+}
+
+// handleGitLog returns the commits on the current branch, newest first.
+func (s *PublicServer) handleGitLog(w http.ResponseWriter, r *http.Request) {
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	base := r.URL.Query().Get("base")
+	if base != "" && !validRevision(base) {
+		jsonError(w, "invalid base", http.StatusBadRequest)
+		return
+	}
+	if base == "" {
+		base = resolveBase(root)
+	}
+
+	limit := queryInt(r, "limit", defaultLogLimit, maxLogLimit)
+	skip := queryInt(r, "skip", 0, 1<<20)
+	scope := "branch"
+	if r.URL.Query().Get("all") == "true" || base == "" {
+		scope = "all"
+	}
+
+	commits, hasMore, err := readLog(root, base, scope, limit, skip)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// On a branch that is level with its base — main, fully pushed — the branch
+	// range is empty, and an empty list is the least useful answer to "what
+	// happened here". Fall back to the whole history and say so.
+	if len(commits) == 0 && scope == "branch" && skip == 0 {
+		scope = "all"
+		commits, hasMore, err = readLog(root, base, scope, limit, skip)
+		if err != nil {
+			jsonError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	branch, _ := gitCmd(root, "rev-parse", "--abbrev-ref", "HEAD")
+	jsonResponse(w, http.StatusOK, map[string]interface{}{
+		"root":     root,
+		"branch":   strings.TrimSpace(branch),
+		"base":     base,
+		"scope":    scope,
+		"commits":  commits,
+		"has_more": hasMore,
+	})
+}
+
+// readLog asks for one commit more than the caller wants, which is how it knows
+// whether there is another page.
+func readLog(root, base, scope string, limit, skip int) ([]logEntry, bool, error) {
+	args := []string{"log", "--no-color", "--format=" + logFormat, "--shortstat",
+		"--max-count=" + strconv.Itoa(limit+1), "HEAD"}
+	if skip > 0 {
+		args = append(args, "--skip="+strconv.Itoa(skip))
+	}
+	// "--not base" rather than "base..HEAD": the revision stays its own argument
+	// instead of being concatenated into a range string.
+	if scope == "branch" && base != "" {
+		args = append(args, "--not", base)
+	}
+	out, err := gitCmd(root, append(args, "--")...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	commits := parseLog(out)
+	hasMore := len(commits) > limit
+	if hasMore {
+		commits = commits[:limit]
+	}
+	return commits, hasMore, nil
+}
+
+func parseLog(out string) []logEntry {
+	// Not nil: a nil slice marshals to JSON null, and clients expect a list.
+	commits := []logEntry{}
+	for _, record := range strings.Split(out, recordSep) {
+		lines := strings.Split(strings.Trim(record, "\n"), "\n")
+		fields := strings.Split(lines[0], fieldSep)
+		if len(fields) < 5 {
+			continue
+		}
+		entry := logEntry{SHA: fields[0], Short: fields[1], Author: fields[2], Date: fields[3], Subject: fields[4]}
+		// A merge commit has no shortstat line, and neither does the record
+		// separator's empty leading chunk.
+		for _, line := range lines[1:] {
+			if strings.Contains(line, "changed") {
+				entry.Files, entry.Insertions, entry.Deletions = parseShortStat(line)
+			}
+		}
+		commits = append(commits, entry)
+	}
+	return commits
+}
+
+// parseShortStat reads " 3 files changed, 10 insertions(+), 2 deletions(-)".
+func parseShortStat(line string) (files, insertions, deletions int) {
+	parts := strings.Fields(line)
+	for i, part := range parts {
+		if i == 0 {
+			continue
+		}
+		n, err := strconv.Atoi(parts[i-1])
+		if err != nil {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(part, "file"):
+			files = n
+		case strings.HasPrefix(part, "insertion"):
+			insertions = n
+		case strings.HasPrefix(part, "deletion"):
+			deletions = n
+		}
+	}
+	return files, insertions, deletions
+}
+
+// resolveBase answers "where did this branch start" — the tracking branch, then
+// the remote's default branch, then a local main or master.
+func resolveBase(root string) string {
+	if out, err := gitCmd(root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"); err == nil {
+		if base := strings.TrimSpace(out); base != "" {
+			return base
+		}
+	}
+	if out, err := gitCmd(root, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"); err == nil {
+		if base := strings.TrimPrefix(strings.TrimSpace(out), "refs/remotes/"); base != "" {
+			return base
+		}
+	}
+	current := ""
+	if out, err := gitCmd(root, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		current = strings.TrimSpace(out)
+	}
+	for _, name := range []string{"main", "master"} {
+		if name == current {
+			continue
+		}
+		if _, err := gitCmd(root, "rev-parse", "--verify", "--quiet", name+"^{commit}"); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+// handleGitChanges returns the files touched by one commit, or between two.
+func (s *PublicServer) handleGitChanges(w http.ResponseWriter, r *http.Request) {
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	to := r.URL.Query().Get("to")
+	from := r.URL.Query().Get("from")
+	if to == "" || !validRevision(to) || (from != "" && !validRevision(from)) {
+		jsonError(w, "missing or invalid revision", http.StatusBadRequest)
+		return
+	}
+
+	files, err := changedFiles(root, from, to)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	truncated := len(files) > maxChangedFiles
+	if truncated {
+		files = files[:maxChangedFiles]
+	}
+
+	insertions, deletions := 0, 0
+	for _, file := range files {
+		insertions += file.Insertions
+		deletions += file.Deletions
+	}
+
+	body := map[string]interface{}{
+		"from": from, "to": to, "single": from == "",
+		"files": files, "insertions": insertions, "deletions": deletions,
+		"truncated": truncated,
+	}
+	if from == "" {
+		describeCommit(root, to, body)
+	}
+	jsonResponse(w, http.StatusOK, body)
+}
+
+// changedFiles zips `--name-status` (which knows what happened to a file) with
+// `--numstat` (which knows how much). Both are asked for with -z so that a path
+// containing a space, a quote or a rename arrow still parses exactly.
+func changedFiles(root, from, to string) ([]commitFile, error) {
+	var nameArgs, numArgs []string
+	if from == "" {
+		// `show` rather than `diff to^ to`: it is also right for a root commit.
+		nameArgs = []string{"show", "--format=", "--name-status", "-z", "--find-renames", to}
+		numArgs = []string{"show", "--format=", "--numstat", "-z", "--find-renames", to}
+	} else {
+		nameArgs = []string{"diff", "--name-status", "-z", "--find-renames", from, to}
+		numArgs = []string{"diff", "--numstat", "-z", "--find-renames", from, to}
+	}
+
+	nameOut, err := gitCmd(root, append(nameArgs, "--")...)
+	if err != nil {
+		return nil, err
+	}
+	numOut, err := gitCmd(root, append(numArgs, "--")...)
+	if err != nil {
+		return nil, err
+	}
+
+	files := parseNameStatusZ(nameOut)
+	counts := parseNumstatZ(numOut)
+	for i := range files {
+		if count, ok := counts[files[i].Path]; ok {
+			files[i].Insertions, files[i].Deletions = count[0], count[1]
+		}
+	}
+	return files, nil
+}
+
+func describeCommit(root, sha string, body map[string]interface{}) {
+	format := "%s" + fieldSep + "%an" + fieldSep + "%aI" + fieldSep + "%P" + fieldSep + "%b"
+	out, err := gitCmd(root, "show", "-s", "--format="+format, sha)
+	if err != nil {
+		return
+	}
+	fields := strings.SplitN(strings.TrimRight(out, "\n"), fieldSep, 5)
+	if len(fields) < 5 {
+		return
+	}
+	body["subject"] = fields[0]
+	body["author"] = fields[1]
+	body["date"] = fields[2]
+	body["parents"] = strings.Fields(fields[3])
+	body["body"] = strings.TrimSpace(fields[4])
+}
+
+// parseNameStatusZ reads NUL-separated records: a status, then one path, or two
+// when the status is a rename or a copy.
+func parseNameStatusZ(out string) []commitFile {
+	fields := strings.Split(out, "\x00")
+	files := []commitFile{}
+	for i := 0; i < len(fields); i++ {
+		status := strings.TrimSpace(fields[i])
+		if status == "" {
+			continue
+		}
+		renamed := strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C")
+		if renamed && i+2 < len(fields) {
+			files = append(files, commitFile{Status: status[:1], From: fields[i+1], Path: fields[i+2]})
+			i += 2
+			continue
+		}
+		if i+1 >= len(fields) {
+			break
+		}
+		files = append(files, commitFile{Status: status[:1], Path: fields[i+1]})
+		i++
+	}
+	return files
+}
+
+// parseNumstatZ reads "insertions\tdeletions\tpath" records. On a rename the
+// path is empty and the old and new paths follow as two more records.
+func parseNumstatZ(out string) map[string][2]int {
+	counts := map[string][2]int{}
+	fields := strings.Split(out, "\x00")
+	for i := 0; i < len(fields); i++ {
+		parts := strings.Split(fields[i], "\t")
+		if len(parts) < 3 {
+			continue
+		}
+		path := parts[2]
+		if path == "" {
+			if i+2 >= len(fields) {
+				break
+			}
+			path = fields[i+2]
+			i += 2
+		}
+		counts[path] = [2]int{countOrZero(parts[0]), countOrZero(parts[1])}
+	}
+	return counts
+}
+
+// countOrZero reads a numstat count, which is "-" for a binary file.
+func countOrZero(field string) int {
+	n, err := strconv.Atoi(field)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func queryInt(r *http.Request, name string, fallback, max int) int {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return fallback
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/internal/server/githistory_test.go
+++ b/internal/server/githistory_test.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitRepo builds a small repository to read history from: three commits, a
+// rename, and an untracked file left in the working tree.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Tester", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=Tester", "GIT_COMMITTER_EMAIL=t@example.com",
+			"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z", "GIT_COMMITTER_DATE=2026-01-01T00:00:00Z")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	run("init", "--initial-branch=main")
+	write(t, filepath.Join(root, "one.txt"), "alpha\n")
+	run("add", ".")
+	run("commit", "-m", "first: add one")
+
+	write(t, filepath.Join(root, "two.txt"), "beta\ngamma\n")
+	run("add", ".")
+	run("commit", "-m", "second: add two")
+
+	run("mv", "one.txt", "renamed.txt")
+	write(t, filepath.Join(root, "two.txt"), "beta\ngamma\ndelta\n")
+	run("add", ".")
+	run("commit", "-m", "third: rename and extend")
+
+	// A branch to serve as a base, pointing at the first commit.
+	run("branch", "base-branch", "HEAD~2")
+	write(t, filepath.Join(root, "loose.txt"), "untracked\n")
+	return root
+}
+
+func gitSHAs(t *testing.T, root string) []string {
+	t.Helper()
+	out, err := gitCmd(root, "log", "--format=%H")
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	return strings.Fields(out)
+}
+
+func TestGitLogListsBranchCommits(t *testing.T) {
+	root := gitRepo(t)
+	body := gitJSON(t, gitServer(t), "/api/git/log?path="+root+"&base=base-branch")
+
+	if body["scope"] != "branch" {
+		t.Fatalf("scope = %v, want branch", body["scope"])
+	}
+	commits, _ := body["commits"].([]interface{})
+	if len(commits) != 2 {
+		t.Fatalf("got %d commits, want the 2 since base-branch", len(commits))
+	}
+	first, _ := commits[0].(map[string]interface{})
+	if subject, _ := first["subject"].(string); !strings.HasPrefix(subject, "third:") {
+		t.Fatalf("newest commit = %q, want the third one", subject)
+	}
+	if files, _ := first["files"].(float64); files == 0 {
+		t.Fatal("shortstat was not parsed: files = 0")
+	}
+}
+
+func TestGitLogFallsBackToFullHistory(t *testing.T) {
+	root := gitRepo(t)
+	// HEAD is its own base, so the branch range is empty.
+	body := gitJSON(t, gitServer(t), "/api/git/log?path="+root+"&base=main")
+
+	if body["scope"] != "all" {
+		t.Fatalf("scope = %v, want all after an empty branch range", body["scope"])
+	}
+	if commits, _ := body["commits"].([]interface{}); len(commits) != 3 {
+		t.Fatalf("got %d commits, want all 3", len(commits))
+	}
+}
+
+func TestGitLogPages(t *testing.T) {
+	root := gitRepo(t)
+	server := gitServer(t)
+
+	first := gitJSON(t, server, "/api/git/log?path="+root+"&all=true&limit=2")
+	if has, _ := first["has_more"].(bool); !has {
+		t.Fatal("has_more = false on the first of two pages")
+	}
+	if commits, _ := first["commits"].([]interface{}); len(commits) != 2 {
+		t.Fatalf("page one has %d commits, want 2", len(commits))
+	}
+
+	second := gitJSON(t, server, "/api/git/log?path="+root+"&all=true&limit=2&skip=2")
+	if has, _ := second["has_more"].(bool); has {
+		t.Fatal("has_more = true on the last page")
+	}
+	if commits, _ := second["commits"].([]interface{}); len(commits) != 1 {
+		t.Fatalf("page two has %d commits, want 1", len(commits))
+	}
+}
+
+func TestGitChangesForOneCommit(t *testing.T) {
+	root := gitRepo(t)
+	head := gitSHAs(t, root)[0]
+	body := gitJSON(t, gitServer(t), "/api/git/changes?path="+root+"&to="+head)
+
+	if single, _ := body["single"].(bool); !single {
+		t.Fatal("single = false for a lone revision")
+	}
+	if subject, _ := body["subject"].(string); !strings.HasPrefix(subject, "third:") {
+		t.Fatalf("subject = %q", subject)
+	}
+
+	files, _ := body["files"].([]interface{})
+	byPath := map[string]map[string]interface{}{}
+	for _, entry := range files {
+		file, _ := entry.(map[string]interface{})
+		path, _ := file["path"].(string)
+		byPath[path] = file
+	}
+	renamed, ok := byPath["renamed.txt"]
+	if !ok {
+		t.Fatalf("renamed.txt missing from %v", byPath)
+	}
+	if renamed["status"] != "R" || renamed["from"] != "one.txt" {
+		t.Fatalf("rename reported as %v", renamed)
+	}
+	if edited, ok := byPath["two.txt"]; !ok || edited["insertions"].(float64) != 1 {
+		t.Fatalf("two.txt counts wrong: %v", edited)
+	}
+}
+
+func TestGitChangesBetweenTwoCommits(t *testing.T) {
+	root := gitRepo(t)
+	shas := gitSHAs(t, root)
+	body := gitJSON(t, gitServer(t), "/api/git/changes?path="+root+"&from="+shas[2]+"&to="+shas[0])
+
+	if single, _ := body["single"].(bool); single {
+		t.Fatal("single = true for a range")
+	}
+	if files, _ := body["files"].([]interface{}); len(files) != 2 {
+		t.Fatalf("got %d files across the range, want 2", len(files))
+	}
+	if insertions, _ := body["insertions"].(float64); insertions != 3 {
+		t.Fatalf("insertions = %v, want 3", insertions)
+	}
+}
+
+func TestGitChangesRejectsFlagLikeRevision(t *testing.T) {
+	root := gitRepo(t)
+	res := gitGet(t, gitServer(t), "/api/git/changes?path="+root+"&to=--output=/tmp/pwned")
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a revision that starts with a dash", res.Code)
+	}
+}
+
+func TestGitDiffAtRevision(t *testing.T) {
+	root := gitRepo(t)
+	head := gitSHAs(t, root)[0]
+	body := gitJSON(t, gitServer(t), "/api/git/diff?path="+root+"&file=two.txt&to="+head)
+
+	diff, _ := body["diff"].(string)
+	if !strings.Contains(diff, "+delta") {
+		t.Fatalf("diff does not show the change: %q", diff)
+	}
+	if body["stat"] != "+1 -0" {
+		t.Fatalf("stat = %v, want +1 -0", body["stat"])
+	}
+}
+
+func TestGitDiffShowsUntrackedFile(t *testing.T) {
+	root := gitRepo(t)
+	body := gitJSON(t, gitServer(t), "/api/git/diff?path="+root+"&file=loose.txt&untracked=true")
+
+	if diff, _ := body["diff"].(string); !strings.Contains(diff, "+untracked") {
+		t.Fatalf("untracked file diffed to %q, want its contents", diff)
+	}
+}
+
+func TestGitWorktreesReportBranchState(t *testing.T) {
+	root := gitRepo(t)
+	body := gitJSON(t, gitServer(t), "/api/git/worktrees?path="+root)
+
+	worktrees, _ := body["worktrees"].([]interface{})
+	if len(worktrees) != 1 {
+		t.Fatalf("got %d worktrees, want 1", len(worktrees))
+	}
+	main, _ := worktrees[0].(map[string]interface{})
+	if main["branch"] != "main" || main["is_main"] != true {
+		t.Fatalf("main worktree = %v", main)
+	}
+	if subject, _ := main["subject"].(string); !strings.HasPrefix(subject, "third:") {
+		t.Fatalf("subject = %q, want the head commit", subject)
+	}
+	// One untracked file is left in the tree by gitRepo.
+	if dirty, _ := main["dirty"].(float64); dirty != 1 {
+		t.Fatalf("dirty = %v, want 1", dirty)
+	}
+}
+
+func TestResolveBasePrefersUpstream(t *testing.T) {
+	root := gitRepo(t)
+	// No upstream and no origin/HEAD: main is the last rung of the chain, and is
+	// skipped when it is the branch you are on.
+	if base := resolveBase(root); base != "" {
+		t.Fatalf("base = %q, want empty when only main exists and HEAD is main", base)
+	}
+
+	if out, err := gitCmd(root, "checkout", "-q", "base-branch"); err != nil {
+		t.Fatalf("checkout: %v %s", err, out)
+	}
+	if base := resolveBase(root); base != "main" {
+		t.Fatalf("base = %q, want main", base)
+	}
+}
+
+func TestParseShortStatReadsEachCount(t *testing.T) {
+	files, insertions, deletions := parseShortStat(" 3 files changed, 10 insertions(+), 2 deletions(-)")
+	if files != 3 || insertions != 10 || deletions != 2 {
+		t.Fatalf("got %d/%d/%d, want 3/10/2", files, insertions, deletions)
+	}
+	// A commit that only adds has no deletion clause.
+	if _, insertions, deletions = parseShortStat(" 1 file changed, 4 insertions(+)"); insertions != 4 || deletions != 0 {
+		t.Fatalf("got %d insertions and %d deletions, want 4 and 0", insertions, deletions)
+	}
+}
+
+func TestStatFromDiffIgnoresHeaders(t *testing.T) {
+	diff := "--- a/x\n+++ b/x\n@@ -1 +1,2 @@\n context\n+added\n-removed\n"
+	if got := statFromDiff(diff); got != "+1 -1" {
+		t.Fatalf("stat = %q, want +1 -1", got)
+	}
+	if got := statFromDiff(""); got != "" {
+		t.Fatalf("stat = %q, want empty for an empty diff", got)
+	}
+}
+
+// gitServer wires just the git routes, the way the daemon does.
+func gitServer(t *testing.T) http.Handler {
+	t.Helper()
+	server := &PublicServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/git/status", server.handleGitStatus)
+	mux.HandleFunc("GET /api/git/diff", server.handleGitDiff)
+	mux.HandleFunc("GET /api/git/log", server.handleGitLog)
+	mux.HandleFunc("GET /api/git/changes", server.handleGitChanges)
+	mux.HandleFunc("GET /api/git/worktrees", server.handleGitWorktrees)
+	return mux
+}
+
+func gitGet(t *testing.T, handler http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, target, nil))
+	return res
+}
+
+func gitJSON(t *testing.T, handler http.Handler, target string) map[string]interface{} {
+	t.Helper()
+	res := gitGet(t, handler, target)
+	if res.Code != http.StatusOK {
+		t.Fatalf("GET %s: status %d: %s", target, res.Code, res.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %s: %v", target, err)
+	}
+	return body
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,6 +134,8 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 	protectedMux.HandleFunc("PUT /api/file", s.handleWriteFile)
 	protectedMux.HandleFunc("GET /api/git/status", s.handleGitStatus)
 	protectedMux.HandleFunc("GET /api/git/diff", s.handleGitDiff)
+	protectedMux.HandleFunc("GET /api/git/log", s.handleGitLog)
+	protectedMux.HandleFunc("GET /api/git/changes", s.handleGitChanges)
 	protectedMux.HandleFunc("GET /api/git/worktrees", s.handleGitWorktrees)
 	protectedMux.HandleFunc("GET /api/notifications", s.handleListNotifications)
 	protectedMux.HandleFunc("POST /api/notifications/batch", s.handleBatchNotifications)

--- a/mobile/lib/screens/git_status_screen.dart
+++ b/mobile/lib/screens/git_status_screen.dart
@@ -20,9 +20,19 @@ class GitStatusScreen extends StatefulWidget {
   State<GitStatusScreen> createState() => _GitStatusScreenState();
 }
 
+enum _GitView { changes, commits, worktrees }
+
 class _GitStatusScreenState extends State<GitStatusScreen> {
   GitStatus? _status;
   bool _loading = true;
+  _GitView _view = _GitView.changes;
+
+  /// The worktree the screen is scoped to — the session's own until another is
+  /// picked from the Worktrees tab.
+  late String _root = widget.cwd;
+
+  /// Bumped by the refresh button so the commit and worktree tabs reload.
+  int _reload = 0;
 
   DaemonAPIService? get _svc =>
       context.read<HostManager>().serviceFor(widget.hostId);
@@ -35,7 +45,7 @@ class _GitStatusScreenState extends State<GitStatusScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final status = await _svc?.gitStatus(widget.cwd);
+    final status = await _svc?.gitStatus(_root);
     if (!mounted) return;
     setState(() {
       _status = status;
@@ -43,17 +53,52 @@ class _GitStatusScreenState extends State<GitStatusScreen> {
     });
   }
 
+  void _refresh() {
+    setState(() => _reload++);
+    _load();
+  }
+
+  void _scopeTo(String path) {
+    setState(() {
+      _root = path;
+      _view = _GitView.changes;
+    });
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final rescoped = _root != widget.cwd;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Git Status'),
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Git'),
+            if (rescoped)
+              Text(
+                _shortPath(_root),
+                style: TextStyle(
+                  fontSize: 11,
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
         actions: [
+          if (rescoped)
+            IconButton(
+              icon: const Icon(Icons.undo),
+              tooltip: "Back to this session's worktree",
+              onPressed: () => _scopeTo(widget.cwd),
+            ),
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'Refresh',
-            onPressed: _load,
+            onPressed: _refresh,
           ),
           IconButton(
             icon: const Icon(Icons.chat_bubble_outline),
@@ -61,25 +106,60 @@ class _GitStatusScreenState extends State<GitStatusScreen> {
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(40),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: SegmentedButton<_GitView>(
+              segments: const [
+                ButtonSegment(value: _GitView.changes, label: Text('Changes', style: TextStyle(fontSize: 12))),
+                ButtonSegment(value: _GitView.commits, label: Text('Commits', style: TextStyle(fontSize: 12))),
+                ButtonSegment(value: _GitView.worktrees, label: Text('Worktrees', style: TextStyle(fontSize: 12))),
+              ],
+              selected: {_view},
+              onSelectionChanged: (s) => setState(() => _view = s.first),
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
+          ),
+        ),
       ),
-      body: _loading
-          ? const _GitStatusSkeleton()
-          : _status == null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
-                      const SizedBox(height: 12),
-                      const Text('Not a git repository'),
-                    ],
-                  ),
-                )
-              : RefreshIndicator(
-                  onRefresh: _load,
-                  child: _buildContent(theme),
-                ),
+      body: switch (_view) {
+        _GitView.changes => _buildChanges(theme),
+        _GitView.commits => _CommitsTab(
+            key: ValueKey('commits:$_root:$_reload'),
+            hostId: widget.hostId,
+            root: _root,
+            sessionId: widget.sessionId,
+          ),
+        _GitView.worktrees => _WorktreesTab(
+            key: ValueKey('worktrees:$_root:$_reload'),
+            hostId: widget.hostId,
+            root: _root,
+            active: _root,
+            onPick: _scopeTo,
+          ),
+      },
     );
+  }
+
+  Widget _buildChanges(ThemeData theme) {
+    if (_loading) return const _GitStatusSkeleton();
+    if (_status == null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
+            const SizedBox(height: 12),
+            const Text('Not a git repository'),
+          ],
+        ),
+      );
+    }
+    return RefreshIndicator(onRefresh: _load, child: _buildContent(theme));
   }
 
   Widget _buildContent(ThemeData theme) {
@@ -301,6 +381,787 @@ class _ChangeTile extends StatelessWidget {
   }
 }
 
+/// The last two segments: the parent directory is what tells worktrees apart.
+String _shortPath(String path) {
+  final parts = path.split('/').where((p) => p.isNotEmpty).toList();
+  if (parts.length <= 2) return path;
+  return '.../${parts.sublist(parts.length - 2).join('/')}';
+}
+
+String _shortSha(String sha) => sha.length > 7 ? sha.substring(0, 7) : sha;
+
+Color _statusTint(String status) {
+  switch (status) {
+    case 'M':
+      return Colors.orange;
+    case 'A':
+      return Colors.green;
+    case 'D':
+      return Colors.red;
+    case 'R':
+    case 'C':
+      return Colors.blue;
+    default:
+      return Colors.grey;
+  }
+}
+
+/// Insertion and deletion counts, the way git writes them.
+List<Widget> _statChips(int insertions, int deletions) {
+  return [
+    if (insertions > 0)
+      Text(
+        '+$insertions',
+        style: const TextStyle(fontSize: 11, fontFamily: 'monospace', color: Colors.green),
+      ),
+    if (insertions > 0 && deletions > 0) const SizedBox(width: 6),
+    if (deletions > 0)
+      Text(
+        '-$deletions',
+        style: const TextStyle(fontSize: 11, fontFamily: 'monospace', color: Colors.red),
+      ),
+  ];
+}
+
+// ==================== Commits ====================
+
+/// The commit history of the current branch.
+///
+/// Tapping a commit shows what it changed; long-pressing one marks it, and the
+/// next tap shows everything between the two.
+class _CommitsTab extends StatefulWidget {
+  final String hostId;
+  final String root;
+  final String? sessionId;
+
+  const _CommitsTab({super.key, required this.hostId, required this.root, this.sessionId});
+
+  @override
+  State<_CommitsTab> createState() => _CommitsTabState();
+}
+
+class _CommitsTabState extends State<_CommitsTab> {
+  GitLog? _log;
+  final List<Commit> _commits = [];
+  bool _all = false;
+  bool _loading = true;
+  bool _loadingMore = false;
+  String? _compareFrom;
+
+  DaemonAPIService? get _svc =>
+      context.read<HostManager>().serviceFor(widget.hostId);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _compareFrom = null;
+    });
+    final log = await _svc?.gitLog(widget.root, all: _all);
+    if (!mounted) return;
+    setState(() {
+      _log = log;
+      _commits
+        ..clear()
+        ..addAll(log?.commits ?? []);
+      _loading = false;
+    });
+  }
+
+  Future<void> _loadMore() async {
+    if (_loadingMore) return;
+    setState(() => _loadingMore = true);
+    final next = await _svc?.gitLog(widget.root, all: _all, skip: _commits.length);
+    if (!mounted) return;
+    setState(() {
+      if (next != null) {
+        _commits.addAll(next.commits);
+        _log = next;
+      }
+      _loadingMore = false;
+    });
+  }
+
+  void _tap(Commit commit) {
+    final anchor = _compareFrom;
+    if (anchor == null || anchor == commit.sha) {
+      _open(to: commit.sha, subject: commit.subject);
+      return;
+    }
+    final a = _commits.indexWhere((c) => c.sha == anchor);
+    final b = _commits.indexWhere((c) => c.sha == commit.sha);
+    if (a < 0 || b < 0) {
+      _open(to: commit.sha, subject: commit.subject);
+      return;
+    }
+    // Lower in the list is older, and the older end is what we diff from.
+    final newer = a < b ? a : b;
+    final older = a < b ? b : a;
+    setState(() => _compareFrom = null);
+    _open(
+      to: _commits[newer].sha,
+      from: _commits[older].sha,
+      subject: '${older - newer + 1} commits',
+    );
+  }
+
+  void _open({required String to, String? from, required String subject}) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CommitDetailScreen(
+          hostId: widget.hostId,
+          root: widget.root,
+          to: to,
+          from: from,
+          title: subject,
+          sessionId: widget.sessionId,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_loading) return const _GitStatusSkeleton();
+    final log = _log;
+    if (log == null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
+            const SizedBox(height: 12),
+            const Text('Failed to load history'),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        _buildScopeBar(theme, log),
+        if (_compareFrom != null) _buildCompareBanner(theme),
+        Expanded(
+          child: _commits.isEmpty
+              ? Center(
+                  child: Text(
+                    'No commits',
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  child: ListView.builder(
+                    itemCount: _commits.length + (log.hasMore ? 1 : 0),
+                    itemBuilder: (ctx, i) {
+                      if (i == _commits.length) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          child: Center(
+                            child: _loadingMore
+                                ? const SizedBox(
+                                    width: 18,
+                                    height: 18,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : TextButton(
+                                    onPressed: _loadMore,
+                                    child: const Text('Load more', style: TextStyle(fontSize: 13)),
+                                  ),
+                          ),
+                        );
+                      }
+                      final commit = _commits[i];
+                      return _CommitTile(
+                        commit: commit,
+                        marked: commit.sha == _compareFrom,
+                        onTap: () => _tap(commit),
+                        onLongPress: () {
+                          HapticFeedback.lightImpact();
+                          setState(() => _compareFrom = commit.sha);
+                        },
+                      );
+                    },
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScopeBar(ThemeData theme, GitLog log) {
+    final label = log.scope == 'branch' && log.base.isNotEmpty
+        ? 'vs ${log.base}'
+        : 'full history';
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.fork_right, size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              log.branch,
+              style: TextStyle(
+                fontSize: 13,
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onSurface,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const Spacer(),
+          SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(value: false, label: Text('Branch', style: TextStyle(fontSize: 11))),
+              ButtonSegment(value: true, label: Text('All', style: TextStyle(fontSize: 11))),
+            ],
+            selected: {_all},
+            onSelectionChanged: (s) {
+              setState(() => _all = s.first);
+              _load();
+            },
+            showSelectedIcon: false,
+            style: ButtonStyle(
+              visualDensity: VisualDensity.compact,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCompareBanner(ThemeData theme) {
+    final short = _compareFrom!.substring(0, 7);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: theme.colorScheme.primaryContainer,
+      child: Row(
+        children: [
+          Icon(Icons.compare_arrows, size: 16, color: theme.colorScheme.onPrimaryContainer),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Comparing from $short — tap another commit',
+              style: TextStyle(fontSize: 12, color: theme.colorScheme.onPrimaryContainer),
+            ),
+          ),
+          GestureDetector(
+            onTap: () => setState(() => _compareFrom = null),
+            child: Icon(Icons.close, size: 16, color: theme.colorScheme.onPrimaryContainer),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CommitTile extends StatelessWidget {
+  final Commit commit;
+  final bool marked;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const _CommitTile({
+    required this.commit,
+    required this.marked,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: BoxDecoration(
+          color: marked ? theme.colorScheme.primaryContainer.withValues(alpha: 0.4) : null,
+          border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5))),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              commit.subject,
+              style: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Text(
+                  commit.short,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    commit.author,
+                    style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  commit.timeAgo,
+                  style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                ),
+                const Spacer(),
+                ..._statChips(commit.insertions, commit.deletions),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// What one commit changed, or everything between two.
+class CommitDetailScreen extends StatefulWidget {
+  final String hostId;
+  final String root;
+  final String to;
+  final String? from;
+  final String title;
+  final String? sessionId;
+
+  const CommitDetailScreen({
+    super.key,
+    required this.hostId,
+    required this.root,
+    required this.to,
+    this.from,
+    required this.title,
+    this.sessionId,
+  });
+
+  @override
+  State<CommitDetailScreen> createState() => _CommitDetailScreenState();
+}
+
+class _CommitDetailScreenState extends State<CommitDetailScreen> {
+  GitChanges? _changes;
+  bool _loading = true;
+
+  DaemonAPIService? get _svc =>
+      context.read<HostManager>().serviceFor(widget.hostId);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final changes = await _svc?.gitChanges(widget.root, widget.to, from: widget.from);
+    if (!mounted) return;
+    setState(() {
+      _changes = changes;
+      _loading = false;
+    });
+  }
+
+  void _openFile(CommitFile file) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => GitDiffScreen(
+          hostId: widget.hostId,
+          cwd: widget.root,
+          change: GitChange(path: file.path, status: file.status),
+          staged: false,
+          from: widget.from,
+          to: widget.to,
+          sessionId: widget.sessionId,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final changes = _changes;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          changes?.single == true && changes!.subject.isNotEmpty ? changes.subject : widget.title,
+          style: const TextStyle(fontSize: 15),
+          overflow: TextOverflow.ellipsis,
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.chat_bubble_outline),
+            tooltip: 'Back to chat',
+            onPressed: () => Navigator.of(context).popUntil(
+              (route) => route.settings.name != '/file-browser' && route.settings.name != '/git-status',
+            ),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const _GitStatusSkeleton()
+          : changes == null
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
+                      const SizedBox(height: 12),
+                      const Text('Failed to load commit'),
+                    ],
+                  ),
+                )
+              : _buildBody(theme, changes),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme, GitChanges changes) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    changes.single ? changes.shortTo : '${changes.shortFrom}...${changes.shortTo}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                  if (changes.author.isNotEmpty) ...[
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(
+                        changes.author,
+                        style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                  if (changes.date.isNotEmpty) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      changes.timeAgo,
+                      style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                    ),
+                  ],
+                  const Spacer(),
+                  ..._statChips(changes.insertions, changes.deletions),
+                ],
+              ),
+              if (changes.body.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                SelectableText(
+                  changes.body,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Text(
+            '${changes.files.length} ${changes.files.length == 1 ? 'FILE' : 'FILES'}',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.2,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        if (changes.files.isEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 16),
+            child: Center(
+              child: Text(
+                'No files — a merge commit',
+                style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ),
+          ),
+        ...changes.files.map((file) => _CommitFileTile(file: file, onTap: () => _openFile(file))),
+        if (changes.truncated)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Text(
+              'Showing the first ${changes.files.length} files.',
+              style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CommitFileTile extends StatelessWidget {
+  final CommitFile file;
+  final VoidCallback onTap;
+
+  const _CommitFileTile({required this.file, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 22,
+              child: Text(
+                file.status,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: 'monospace',
+                  color: _statusTint(file.status),
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    file.path,
+                    style: TextStyle(fontSize: 13, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (file.from.isNotEmpty)
+                    Text(
+                      'was ${file.from}',
+                      style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurfaceVariant),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            ..._statChips(file.insertions, file.deletions),
+            Icon(Icons.chevron_right, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ==================== Worktrees ====================
+
+/// Every worktree of this repository. Read-only: Helios shows worktrees, it
+/// does not make them. Tapping one points the whole screen at it.
+class _WorktreesTab extends StatefulWidget {
+  final String hostId;
+  final String root;
+  final String active;
+  final ValueChanged<String> onPick;
+
+  const _WorktreesTab({
+    super.key,
+    required this.hostId,
+    required this.root,
+    required this.active,
+    required this.onPick,
+  });
+
+  @override
+  State<_WorktreesTab> createState() => _WorktreesTabState();
+}
+
+class _WorktreesTabState extends State<_WorktreesTab> {
+  List<Worktree>? _worktrees;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final svc = context.read<HostManager>().serviceFor(widget.hostId);
+    final worktrees = await svc?.gitWorktrees(widget.root);
+    if (!mounted) return;
+    setState(() => _worktrees = worktrees ?? []);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final worktrees = _worktrees;
+    if (worktrees == null) return const _GitStatusSkeleton();
+    if (worktrees.isEmpty) {
+      return Center(
+        child: Text('No worktrees', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.builder(
+        itemCount: worktrees.length,
+        itemBuilder: (ctx, i) => _WorktreeTile(
+          worktree: worktrees[i],
+          selected: worktrees[i].path == widget.active,
+          onTap: () => widget.onPick(worktrees[i].path),
+        ),
+      ),
+    );
+  }
+}
+
+class _WorktreeTile extends StatelessWidget {
+  final Worktree worktree;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _WorktreeTile({required this.worktree, required this.selected, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: BoxDecoration(
+          color: selected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.35) : null,
+          border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5))),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                  size: 16,
+                  color: selected ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    worktree.branch.isEmpty ? '(detached)' : worktree.branch,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontFamily: 'monospace',
+                      fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                if (worktree.isMain) const _Pill(text: 'main'),
+                if (worktree.locked) const _Pill(text: 'locked'),
+                if (worktree.ahead > 0) _Pill(text: '↑${worktree.ahead}', color: Colors.green),
+                if (worktree.behind > 0) _Pill(text: '↓${worktree.behind}', color: Colors.orange),
+                if (worktree.dirty > 0)
+                  _Pill(text: '●${worktree.dirty}', color: Colors.orange)
+                else
+                  const _Pill(text: 'clean', color: Colors.green),
+              ],
+            ),
+            if (worktree.subject.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                worktree.subject,
+                style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            const SizedBox(height: 2),
+            Text(
+              '${worktree.head} ${_shortPath(worktree.path)}',
+              style: TextStyle(
+                fontSize: 11,
+                fontFamily: 'monospace',
+                color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  final String text;
+  final Color? color;
+
+  const _Pill({required this.text, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tint = color ?? theme.colorScheme.onSurfaceVariant;
+    return Container(
+      margin: const EdgeInsets.only(right: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: tint.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: tint),
+      ),
+    );
+  }
+}
+
 // ==================== Git Diff Screen ====================
 
 enum DiffViewMode { diff, unified, full }
@@ -310,6 +1171,11 @@ class GitDiffScreen extends StatefulWidget {
   final String cwd;
   final GitChange change;
   final bool staged;
+
+  /// The revisions to diff, when this is a committed change rather than a
+  /// working-tree one: [to] alone is that commit against its parent.
+  final String? from;
+  final String? to;
   final String? sessionId;
 
   const GitDiffScreen({
@@ -318,6 +1184,8 @@ class GitDiffScreen extends StatefulWidget {
     required this.cwd,
     required this.change,
     required this.staged,
+    this.from,
+    this.to,
     this.sessionId,
   });
 
@@ -385,19 +1253,29 @@ class _GitDiffScreenState extends State<GitDiffScreen> {
       setState(() => _loading = false);
       return;
     }
-    final diff = await svc.gitDiff(widget.cwd, widget.change.path, staged: widget.staged);
+    final diff = await svc.gitDiff(
+      widget.cwd,
+      widget.change.path,
+      staged: widget.staged,
+      from: widget.from,
+      to: widget.to,
+    );
     if (!mounted) return;
     setState(() {
       _diff = diff;
       _loading = false;
     });
-    // Preload full file for full-file mode.
+    // Preload full file for full-file mode. Only for the working tree: on disk
+    // is the current file, which is not what an old commit changed.
+    if (_atRevision) return;
     final fullPath = '${widget.cwd}/${widget.change.path}';
     final file = await svc.readFile(fullPath);
     if (mounted && file != null) {
       setState(() => _fullFile = file);
     }
   }
+
+  bool get _atRevision => widget.to != null && widget.to!.isNotEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -408,8 +1286,14 @@ class _GitDiffScreenState extends State<GitDiffScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(widget.change.fileName, style: const TextStyle(fontSize: 15), overflow: TextOverflow.ellipsis),
-            if (_diff?.stat.isNotEmpty == true)
-              Text(_diff!.stat, style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant)),
+            if (_diff?.stat.isNotEmpty == true || _atRevision)
+              Text(
+                [
+                  if (_diff?.stat.isNotEmpty == true) _diff!.stat,
+                  if (_atRevision) 'at ${_shortSha(widget.to!)}',
+                ].join(' · '),
+                style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+              ),
           ],
         ),
         actions: [
@@ -438,10 +1322,13 @@ class _GitDiffScreenState extends State<GitDiffScreen> {
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: SegmentedButton<DiffViewMode>(
-              segments: const [
-                ButtonSegment(value: DiffViewMode.diff, label: Text('Diff', style: TextStyle(fontSize: 12))),
-                ButtonSegment(value: DiffViewMode.unified, label: Text('Unified', style: TextStyle(fontSize: 12))),
-                ButtonSegment(value: DiffViewMode.full, label: Text('Full', style: TextStyle(fontSize: 12))),
+              segments: [
+                const ButtonSegment(value: DiffViewMode.diff, label: Text('Diff', style: TextStyle(fontSize: 12))),
+                const ButtonSegment(value: DiffViewMode.unified, label: Text('Unified', style: TextStyle(fontSize: 12))),
+                // The file on disk is the current one, so "full" only makes
+                // sense for a working-tree diff.
+                if (!_atRevision)
+                  const ButtonSegment(value: DiffViewMode.full, label: Text('Full', style: TextStyle(fontSize: 12))),
               ],
               selected: {_mode},
               onSelectionChanged: (s) => setState(() => _mode = s.first),
@@ -587,6 +1474,13 @@ class _GitDiffScreenState extends State<GitDiffScreen> {
     final svc = context.read<HostManager>().serviceFor(widget.hostId);
     if (svc == null || widget.sessionId == null) return;
 
+    // Say which commit, so the agent looks at the same thing you are.
+    final at = !_atRevision
+        ? ''
+        : widget.from == null || widget.from!.isEmpty
+            ? ' at ${_shortSha(widget.to!)}'
+            : ' between ${_shortSha(widget.from!)} and ${_shortSha(widget.to!)}';
+
     String prompt;
     if (_hasSelection) {
       final allLines = _parseDiff(_diff!.diff);
@@ -597,9 +1491,9 @@ class _GitDiffScreenState extends State<GitDiffScreen> {
         return '$prefix${l.text}';
       }).join('\n');
       final ext = _diff?.language ?? '';
-      prompt = 'Regarding diff of `${widget.change.path}` $_selLabel:\n```$ext\n$selectedTexts\n```\n${question.trim()}';
+      prompt = 'Regarding diff of `${widget.change.path}`$at $_selLabel:\n```$ext\n$selectedTexts\n```\n${question.trim()}';
     } else {
-      prompt = 'Regarding diff of `${widget.change.path}`:\n${question.trim()}';
+      prompt = 'Regarding diff of `${widget.change.path}`$at:\n${question.trim()}';
     }
 
     final nav = Navigator.of(context);

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -1602,7 +1602,9 @@ class _WorktreePickerSheetState extends State<_WorktreePickerSheet> {
                     wt.path == widget.effectiveCwd ||
                     (wt.isMain && widget.selectedWorktreePath == null);
                 final wtStatus = widget.worktreeStatuses[wt.path];
-                final changes = wtStatus?.totalChanges ?? 0;
+                // The worktree listing already carries a dirty count; the
+                // per-worktree status is more precise but arrives later.
+                final changes = wtStatus?.totalChanges ?? wt.dirty;
 
                 return ListTile(
                   leading: Icon(
@@ -1658,11 +1660,18 @@ class _WorktreePickerSheetState extends State<_WorktreePickerSheet> {
                     ],
                   ),
                   subtitle: Text(
-                    wt.shortPath,
+                    [
+                      wt.shortPath,
+                      if (wt.ahead > 0) '↑${wt.ahead}',
+                      if (wt.behind > 0) '↓${wt.behind}',
+                      if (wt.subject.isNotEmpty) wt.subject,
+                    ].join('  '),
                     style: TextStyle(
                       fontSize: 11,
                       color: widget.theme.colorScheme.onSurfaceVariant,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   trailing: wt.isMain
                       ? Text(

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -831,21 +831,76 @@ class DaemonAPIService extends ChangeNotifier {
     return null;
   }
 
+  /// The working-tree diff for a file, or its diff at a revision: [to] alone is
+  /// that commit against its parent, [from] and [to] together are a range.
   Future<GitDiff?> gitDiff(
     String path,
     String file, {
     bool staged = false,
+    String? from,
+    String? to,
+    bool untracked = false,
   }) async {
     try {
-      final stagedParam = staged ? '&staged=true' : '';
-      final resp = await _api.get(
-        '/api/git/diff?path=${Uri.encodeComponent(path)}&file=${Uri.encodeComponent(file)}$stagedParam',
-      );
+      final query = <String>[
+        'path=${Uri.encodeComponent(path)}',
+        'file=${Uri.encodeComponent(file)}',
+        if (staged) 'staged=true',
+        if (untracked) 'untracked=true',
+        if (from != null && from.isNotEmpty) 'from=${Uri.encodeComponent(from)}',
+        if (to != null && to.isNotEmpty) 'to=${Uri.encodeComponent(to)}',
+      ];
+      final resp = await _api.get('/api/git/diff?${query.join('&')}');
       if (resp.statusCode == 200) {
         return GitDiff.fromJson(jsonDecode(resp.body));
       }
     } catch (e) {
       debugPrint('[$hostId] Failed to get git diff for $file: $e');
+    }
+    return null;
+  }
+
+  /// Commit history. Defaults to what this branch added on top of its base;
+  /// pass [all] for the whole history.
+  Future<GitLog?> gitLog(
+    String path, {
+    String? base,
+    bool all = false,
+    int limit = 50,
+    int skip = 0,
+  }) async {
+    try {
+      final query = <String>[
+        'path=${Uri.encodeComponent(path)}',
+        'limit=$limit',
+        if (skip > 0) 'skip=$skip',
+        if (all) 'all=true',
+        if (base != null && base.isNotEmpty) 'base=${Uri.encodeComponent(base)}',
+      ];
+      final resp = await _api.get('/api/git/log?${query.join('&')}');
+      if (resp.statusCode == 200) {
+        return GitLog.fromJson(jsonDecode(resp.body));
+      }
+    } catch (e) {
+      debugPrint('[$hostId] Failed to get git log for $path: $e');
+    }
+    return null;
+  }
+
+  /// The files one commit touched, or everything between two.
+  Future<GitChanges?> gitChanges(String path, String to, {String? from}) async {
+    try {
+      final query = <String>[
+        'path=${Uri.encodeComponent(path)}',
+        'to=${Uri.encodeComponent(to)}',
+        if (from != null && from.isNotEmpty) 'from=${Uri.encodeComponent(from)}',
+      ];
+      final resp = await _api.get('/api/git/changes?${query.join('&')}');
+      if (resp.statusCode == 200) {
+        return GitChanges.fromJson(jsonDecode(resp.body));
+      }
+    } catch (e) {
+      debugPrint('[$hostId] Failed to get changes for $to: $e');
     }
     return null;
   }
@@ -1122,18 +1177,230 @@ class GitDiff {
   }
 }
 
+class Commit {
+  final String sha;
+  final String short;
+  final String author;
+  final String date;
+  final String subject;
+  final int files;
+  final int insertions;
+  final int deletions;
+
+  Commit({
+    required this.sha,
+    required this.short,
+    required this.author,
+    required this.date,
+    required this.subject,
+    required this.files,
+    required this.insertions,
+    required this.deletions,
+  });
+
+  factory Commit.fromJson(Map<String, dynamic> json) {
+    return Commit(
+      sha: json['sha'] as String? ?? '',
+      short: json['short'] as String? ?? '',
+      author: json['author'] as String? ?? '',
+      date: json['date'] as String? ?? '',
+      subject: json['subject'] as String? ?? '',
+      files: json['files'] as int? ?? 0,
+      insertions: json['insertions'] as int? ?? 0,
+      deletions: json['deletions'] as int? ?? 0,
+    );
+  }
+
+  String get timeAgo => _timeAgo(date);
+}
+
+/// Formats an ISO-8601 commit date the way the rest of the app formats times.
+String _timeAgo(String iso) {
+  if (iso.isEmpty) return '';
+  try {
+    final d = DateTime.parse(iso);
+    final diff = DateTime.now().toUtc().difference(d.toUtc());
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return '${d.month}/${d.day}';
+  } catch (_) {
+    return iso;
+  }
+}
+
+class GitLog {
+  final String root;
+  final String branch;
+
+  /// What the branch was compared against — empty when there was nothing to
+  /// compare against.
+  final String base;
+
+  /// 'branch' for base..HEAD, 'all' for the whole history.
+  final String scope;
+  final List<Commit> commits;
+  final bool hasMore;
+
+  GitLog({
+    required this.root,
+    required this.branch,
+    required this.base,
+    required this.scope,
+    required this.commits,
+    required this.hasMore,
+  });
+
+  factory GitLog.fromJson(Map<String, dynamic> json) {
+    return GitLog(
+      root: json['root'] as String? ?? '',
+      branch: json['branch'] as String? ?? '',
+      base: json['base'] as String? ?? '',
+      scope: json['scope'] as String? ?? 'all',
+      commits:
+          (json['commits'] as List?)?.map((e) => Commit.fromJson(e)).toList() ??
+          [],
+      hasMore: json['has_more'] as bool? ?? false,
+    );
+  }
+}
+
+class CommitFile {
+  final String path;
+
+  /// The old path, on a rename or a copy.
+  final String from;
+  final String status;
+  final int insertions;
+  final int deletions;
+
+  CommitFile({
+    required this.path,
+    required this.from,
+    required this.status,
+    required this.insertions,
+    required this.deletions,
+  });
+
+  factory CommitFile.fromJson(Map<String, dynamic> json) {
+    return CommitFile(
+      path: json['path'] as String? ?? '',
+      from: json['from'] as String? ?? '',
+      status: json['status'] as String? ?? 'M',
+      insertions: json['insertions'] as int? ?? 0,
+      deletions: json['deletions'] as int? ?? 0,
+    );
+  }
+
+  String get fileName => path.split('/').last;
+}
+
+class GitChanges {
+  final String from;
+  final String to;
+
+  /// True when this is one commit rather than a range — only then are the
+  /// commit's own subject, author, date and body filled in.
+  final bool single;
+  final List<CommitFile> files;
+  final int insertions;
+  final int deletions;
+  final bool truncated;
+  final String subject;
+  final String author;
+  final String date;
+  final String body;
+  final List<String> parents;
+
+  GitChanges({
+    required this.from,
+    required this.to,
+    required this.single,
+    required this.files,
+    required this.insertions,
+    required this.deletions,
+    required this.truncated,
+    required this.subject,
+    required this.author,
+    required this.date,
+    required this.body,
+    required this.parents,
+  });
+
+  factory GitChanges.fromJson(Map<String, dynamic> json) {
+    return GitChanges(
+      from: json['from'] as String? ?? '',
+      to: json['to'] as String? ?? '',
+      single: json['single'] as bool? ?? false,
+      files:
+          (json['files'] as List?)
+              ?.map((e) => CommitFile.fromJson(e))
+              .toList() ??
+          [],
+      insertions: json['insertions'] as int? ?? 0,
+      deletions: json['deletions'] as int? ?? 0,
+      truncated: json['truncated'] as bool? ?? false,
+      subject: json['subject'] as String? ?? '',
+      author: json['author'] as String? ?? '',
+      date: json['date'] as String? ?? '',
+      body: json['body'] as String? ?? '',
+      parents:
+          (json['parents'] as List?)?.map((e) => e.toString()).toList() ?? [],
+    );
+  }
+
+  String get timeAgo => _timeAgo(date);
+
+  String get shortTo => to.length > 7 ? to.substring(0, 7) : to;
+
+  String get shortFrom => from.length > 7 ? from.substring(0, 7) : from;
+}
+
 class Worktree {
   final String path;
   final String branch;
   final bool isMain;
+  final String head;
+  final String subject;
+  final bool detached;
+  final bool locked;
+  final int ahead;
+  final int behind;
 
-  Worktree({required this.path, required this.branch, required this.isMain});
+  /// Number of changed files in that worktree.
+  final int dirty;
+
+  /// What ahead/behind were measured against — empty when nothing was found.
+  final String base;
+
+  Worktree({
+    required this.path,
+    required this.branch,
+    required this.isMain,
+    this.head = '',
+    this.subject = '',
+    this.detached = false,
+    this.locked = false,
+    this.ahead = 0,
+    this.behind = 0,
+    this.dirty = 0,
+    this.base = '',
+  });
 
   factory Worktree.fromJson(Map<String, dynamic> json) {
     return Worktree(
       path: json['path'] as String,
       branch: json['branch'] as String? ?? '',
       isMain: json['is_main'] as bool? ?? false,
+      head: json['head'] as String? ?? '',
+      subject: json['subject'] as String? ?? '',
+      detached: json['detached'] as bool? ?? false,
+      locked: json['locked'] as bool? ?? false,
+      ahead: json['ahead'] as int? ?? 0,
+      behind: json['behind'] as int? ?? 0,
+      dirty: json['dirty'] as int? ?? 0,
+      base: json['base'] as String? ?? '',
     );
   }
 


### PR DESCRIPTION
Two commits, stacked. The first was sitting unpushed on local `main`; the second builds directly on it, so they travel together.

### `feat: add commit history and worktree views`
Adds the commit log and worktree list to the desktop git panel.

### `feat(desktop): unify the git panel behind a scope dropdown`
The commit view put the log, the file list and the patch in three columns, so none of them was readable — the files list sat in a narrow middle strip with the patch squeezed beside it.

Changes and Commits are one view now: **files on the left, diff on the right, always.** A dropdown picks what fills them, with the working tree pinned above the log as just another thing to look at. The shape of the panel no longer depends on what is being read.

Ranges survive the move. Shift/⌘-clicking a second commit in the popover extends the selection and leaves the menu open so it can be adjusted; a plain click picks one commit and closes. Commits between the endpoints are tinted, which the old endpoints-only highlight never showed.

The menu is fixed-positioned from a measured rect rather than absolute: `.panel-body` clips its overflow and the panel is shorter than the menu whenever a terminal is open below it, so an absolute popover lost its bottom half. A resize invalidates the rect, so it dismisses.

Status is fetched by the panel rather than the changes view, since the header shows the branch in every scope now. That drops a duplicate request, and the commit log is only fetched when the menu is first opened — most visits never touch history.

### Verification
- `npm run typecheck`, `npm run build`, `npm test` (22/22) all clean.
- Ran the app against the live daemon and confirmed the new header, the popover, the pinned working-tree row, the Branch/All scope and the range hint all render with real data.