### PR TITLE
fix: make AskUserQuestion answerable from the terminal and the phone

### DIFF
--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,0 +1,1 @@
+/Users/kamrul/workspace/helios/desktop/node_modules

--- a/desktop/src/renderer/components/approvals.tsx
+++ b/desktop/src/renderer/components/approvals.tsx
@@ -179,45 +179,48 @@ function QuestionCard({
   act: (body: Record<string, unknown>) => Promise<void>
 }): JSX.Element {
   const questions = (Array.isArray(payload.questions) ? payload.questions : []) as Question[]
-  const [answers, setAnswers] = useState<Record<string, string>>({})
+  // Question index → option index. Indices rather than labels: the daemon
+  // answers by moving the CLI's own highlight, so position is what it needs.
+  const [chosen, setChosen] = useState<Record<number, number>>({})
 
-  const toggle = (question: Question, option: string): void => {
-    setAnswers((current) => {
-      if (!question.multiSelect) return { ...current, [question.question]: option }
-      const chosen = new Set((current[question.question] ?? '').split(', ').filter(Boolean))
-      if (chosen.has(option)) chosen.delete(option)
-      else chosen.add(option)
-      return { ...current, [question.question]: [...chosen].join(', ') }
-    })
+  const submit = (): void => {
+    const selections = Object.entries(chosen)
+      .map(([questionIndex, optionIndex]) => ({
+        question_index: Number(questionIndex),
+        option_index: optionIndex,
+      }))
+      .sort((a, b) => a.question_index - b.question_index)
+    void act({ action: 'answer', selections })
   }
 
   return (
     <>
-      {questions.map((question) => (
-        <div key={question.question} className="question">
+      {questions.map((question, questionIndex) => (
+        <div key={questionIndex} className="question">
           {question.header && <span className="question-head">{question.header}</span>}
           <p>{question.question}</p>
-          {(question.options ?? []).map((option) => {
-            const chosen = (answers[question.question] ?? '').split(', ').includes(option.label)
-            return (
-              <button
-                key={option.label}
-                className={`option ${chosen ? 'chosen' : ''}`}
-                onClick={() => toggle(question, option.label)}
-              >
-                <span className="option-label">{option.label}</span>
-                {option.description && <span className="option-desc">{option.description}</span>}
-              </button>
-            )
-          })}
+          {(question.options ?? []).map((option, optionIndex) => (
+            <button
+              key={optionIndex}
+              className={`option ${chosen[questionIndex] === optionIndex ? 'chosen' : ''}`}
+              onClick={() => setChosen((current) => ({ ...current, [questionIndex]: optionIndex }))}
+            >
+              <span className="option-label">{option.label}</span>
+              {option.description && <span className="option-desc">{option.description}</span>}
+            </button>
+          ))}
+          {/* Answering drives the CLI's own list, which takes one highlighted
+              option per question. Picking several needs the terminal. */}
+          {question.multiSelect && (
+            <small className="option-desc">Pick one here, or answer in the terminal to choose several.</small>
+          )}
         </div>
       ))}
 
       <Actions busy={busy}>
-        <button
-          disabled={Object.keys(answers).length === 0}
-          onClick={() => void act({ action: 'answer', answers })}
-        >
+        {/* Every question, not just one: the daemon walks the CLI through them
+            in order and a gap would leave it stranded. */}
+        <button disabled={Object.keys(chosen).length !== questions.length} onClick={submit}>
           Submit
         </button>
         <button className="ghost" onClick={() => void act({ action: 'skip' })}>

--- a/docs/specs/34-askuserquestion-dual-answer.md
+++ b/docs/specs/34-askuserquestion-dual-answer.md
@@ -1,0 +1,385 @@
+# 34 — AskUserQuestion: Answerable From the Terminal *and* the Phone
+
+## Problem
+
+When Claude asks a question, it appears on the phone but the terminal is stuck
+showing a spinner with nothing to answer. In practice neither side answers it:
+**all four questions ever recorded on this machine expired unanswered.**
+
+```
+id                      created              resolved             source  response
+notif-e643ad5b02d3e559  2026-08-11 09:58:44  2026-08-11 10:00:32  claude  (empty)
+notif-a30c2a1b370b096c  2026-08-11 11:29:46  2026-08-11 11:34:46  claude  (empty)
+notif-6adfcaf3b84f1399  2026-08-11 12:05:21  2026-08-11 12:09:11  claude  (empty)
+notif-3cd48c61179265ff  2026-08-11 15:34:42  2026-08-11 15:46:10  claude  (empty)
+```
+
+Every one resolved with `resolved_source=claude` and an empty response — that is
+the cancellation path, not an answer. The feature has never once worked
+end to end.
+
+### 1. The hook blocks, so the CLI never renders its own UI
+
+`hookConfig` (`internal/daemon/hooks.go:39-49`) registers `/question` as a
+`PreToolUse` hook matching `AskUserQuestion`, with a 300-second timeout.
+`handleQuestion` (`hooks.go:162`) then blocks in `waitForDecision` for up to five
+minutes waiting for a **mobile** answer.
+
+While that hook is outstanding the tool has not been allowed to run, so the CLI
+has not rendered its question UI. There is no code path by which the terminal
+user can answer. The phone is the only possible answerer, and if it does not
+answer, the question is denied.
+
+### 2. Both PreToolUse matchers fire on the same event
+
+`hookConfig` registers `PreToolUse` twice — `AskUserQuestion` → `/question`, and
+`*` → `/tool/pre`. Both match `AskUserQuestion`. Confirmed in `daemon.log`:
+
+```
+15:58:44 hook: dispatching claude.question (2486 bytes)
+15:58:44 hook: dispatching claude.tool.pre (2486 bytes)
+```
+
+Identical payload size — the same event, delivered twice. `handleToolPre`
+(`hooks.go:667`) then writes status `active`, overwriting the
+`waiting_permission` that `handleQuestion` set moments earlier. So the session
+list never shows the session as needing an answer; only the notification hints
+at it.
+
+### 3. Two independent five-minute timeouts race
+
+`waitForDecision` runs a local 5-minute timer (`hooks.go:590`) while the hook
+config declares `"timeout": 300`. Whichever fires first decides how the event is
+recorded: the request context cancelling gives `resolved`/`claude`
+(`hooks.go:611`), the local timer gives `timeout`/`system` (`hooks.go:607`). The
+`notif-a30c2a1b370b096c` row above expired at exactly 5m00s — that is this race.
+
+## Design
+
+Invert the model. Today helios intercepts the question and tries to answer it on
+Claude's behalf. Instead, **let the CLI own the question** and have helios drive
+the CLI's own UI when the answer arrives from the phone.
+
+```
+AskUserQuestion
+  ├─ /question hook → returns {} immediately (no decision, no block)
+  │     └─ creates claude.question notification → phone
+  └─ CLI renders its OWN question UI          ← terminal answerable
+
+Phone answers    → backend.SendKey(session, ↓×k, Enter)
+                   → CLI UI resolves → PostToolUse → cancel notification
+Terminal answers → PostToolUse fires → cancel notification on phone
+```
+
+First answer wins; the other surface's notification is retracted.
+
+### Why PTY injection rather than a hook response
+
+Because it is the only way both surfaces can work. A blocking hook response is,
+by construction, an answer given *instead of* the CLI's UI — the terminal can
+never participate.
+
+This is not a novel mechanism here. `handleTrustAction` (`actions.go:96-134`)
+already answers Claude's workspace-trust dialog by sending `KeyEnter` into the
+PTY, and `StartTrustWatcher` (`server/trust_watcher.go:122`) already reads
+rendered screen text via `Backend.Capture` to detect that dialog. This spec
+applies the same two primitives to a dialog with more than one option.
+
+### Why the CLI's UI is trustworthy to drive
+
+`Backend.Capture` returns **emulator output**, not the raw PTY stream. Claude
+positions text with cursor-column jumps, so phrases never appear contiguously in
+the raw bytes — the trust watcher documents this precisely
+(`trust_watcher.go:94-98`). Capture gives the rendered screen, which is what the
+user sees and what can be matched against the question text.
+
+### Selection model
+
+`AskUserQuestion` carries a `questions` array; each entry has `question`,
+`header` and `options`. The CLI presents them one at a time with the first
+option highlighted. To pick option index `k`: send `KeyDown` `k` times, then
+`KeyEnter`.
+
+Before each injection, `Capture` must show the expected question. If it does
+not, abort rather than press keys blind — a stray Enter into a session that has
+moved on is a real action the user did not ask for. This is the single most
+important safety property in this spec.
+
+Free-text answers use `SendText`, which submits the text followed by Enter.
+
+### Concurrency
+
+One in-flight injection per session, guarded by a mutex keyed on session ID. Two
+devices answering simultaneously must not interleave keystrokes.
+
+## Changes
+
+### `internal/backend/backend.go` — arrow keys
+
+```go
+const (
+	KeyEnter  Key = "enter"
+	KeyEscape Key = "escape"
+	KeyCtrlC  Key = "ctrl-c"
+	KeyUp     Key = "up"
+	KeyDown   Key = "down"
+)
+```
+
+`internal/backend/host.go` `keySequence`:
+
+```go
+case KeyUp:
+	return []byte("\x1b[A"), nil
+case KeyDown:
+	return []byte("\x1b[B"), nil
+```
+
+### `internal/daemon/hooks.go` — stop the double dispatch
+
+Keep `/question` as a `PreToolUse` matcher but drop its `timeout`: it no longer
+blocks, so a 300-second budget is misleading.
+
+The `*` matcher stays — every other tool needs it. `handleToolPre` learns to
+skip the one tool that has a dedicated handler (below). Folding `/question` into
+`handleToolPre` entirely was considered and rejected: it would collapse two
+clean handlers into one branching one and lose the per-type hook registration
+the provider interface is built around.
+
+### `internal/provider/claude/hooks.go` — non-blocking question hook
+
+`handleQuestion` keeps everything up to and including `ctx.Notify`, then returns
+immediately:
+
+```go
+// Deliberately no decision and no block. Returning an empty object lets the
+// CLI run AskUserQuestion and render its own UI, which is the only way the
+// terminal user can answer. The phone answers by driving that same UI —
+// see handleQuestionAction.
+w.Header().Set("Content-Type", "application/json")
+fmt.Fprint(w, `{}`)
+```
+
+Drop the `ctx.Mgr.Register(notifID)` call: nothing waits on a decision channel
+any more. Resolution now happens through `Mgr.Resolve` from the action handler
+or `CancelPendingFromClaude` from the completion paths, neither of which needs a
+registered slot.
+
+The payload gains the session id, which the action handler needs to reach the
+terminal.
+
+`input.ToolInput` is **already** `{"questions": [...]}` — verified against a
+stored payload. So `session_id` must be spliced into that object, not wrapped
+around it. Wrapping would produce `{"questions": {"questions": [...]}}` and
+`notification_ext.dart`'s `questions` accessor (`payload?['questions'] as List?`)
+would cast a Map to a List and return null, silently emptying the card:
+
+```go
+// input.ToolInput is already {"questions": [...]}; splice session_id into it
+// rather than wrapping, which would nest questions under itself and break the
+// mobile card's payload['questions'] accessor.
+var payload map[string]json.RawMessage
+if err := json.Unmarshal(input.ToolInput, &payload); err != nil {
+    payload = map[string]json.RawMessage{}
+}
+sessionJSON, _ := json.Marshal(input.SessionID)
+payload["session_id"] = sessionJSON
+payloadJSON, _ := json.Marshal(payload)
+payloadStr := string(payloadJSON)
+```
+
+This replaces the bare `payloadStr := string(input.ToolInput)` at `hooks.go:176`
+and leaves `questions` exactly where the card already looks for it. A test
+asserts the stored payload has `questions` as a JSON array at the top level.
+
+`handleToolPre` skips the tool that has its own handler:
+
+```go
+// AskUserQuestion has a dedicated hook that sets waiting_permission. The
+// "*" PreToolUse matcher fires for it too, and writing "active" here is what
+// used to erase that status a millisecond after it was set.
+if input.ToolName == "AskUserQuestion" {
+    w.Header().Set("Content-Type", "application/json")
+    fmt.Fprint(w, `{}`)
+    return
+}
+```
+
+`handleToolPost` resolves the notification when the tool completes — whoever
+answered:
+
+```go
+// The tool finished, so the question is answered. Retract the notification on
+// every other surface. Which side answered does not matter.
+if input.ToolName == "AskUserQuestion" {
+    resolveSessionQuestions(ctx, input.SessionID)
+}
+```
+
+```go
+// resolveSessionQuestions clears pending claude.question notifications for a
+// session and tells clients to drop them.
+func resolveSessionQuestions(ctx *provider.HookContext, sessionID string)
+```
+
+Implemented over a new store query rather than `ResolveSessionNotifications`,
+which would also clear unrelated pending permissions for the session.
+
+Add the same call to the `idle_prompt` branch of `handleNotification`
+(`hooks.go:468`): pressing Escape at a question returns Claude to its prompt
+without a `PostToolUse`, and the phone should not keep offering to answer a
+question that is gone.
+
+### `internal/store/notifications.go`
+
+```go
+// ResolveSessionNotificationsByType is ResolveSessionNotifications narrowed to
+// one type, so clearing a question does not also clear a pending permission.
+func (s *Store) ResolveSessionNotificationsByType(sourceSession, nType, status, source string) ([]string, error)
+```
+
+Same body as `ResolveSessionNotifications` with `AND type = ?` in both
+statements.
+
+### `internal/provider/claude/actions.go` — answer by driving the CLI
+
+`handleQuestionAction` is rewritten. It no longer returns an answer for a
+blocked hook; it types into the terminal.
+
+```go
+// handleQuestionAction answers Claude's question by driving the CLI's own
+// question UI.
+//
+// The alternative — returning the answer from a blocking PreToolUse hook —
+// is what this replaces: it prevented the CLI from ever rendering the UI, so
+// the terminal user could not answer at all.
+func handleQuestionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error)
+```
+
+Request body, extending the existing shape so the mobile card's `answers` map
+still applies:
+
+```json
+{ "action": "answer", "selections": [{"question_index": 0, "option_index": 2}] }
+{ "action": "answer", "text": "something else" }
+{ "action": "skip" }
+```
+
+`skip` sends `KeyEscape` and returns `Decision{Status: "denied"}`.
+
+Injection, per selection:
+
+1. `terminalBackend.Alive(sessionID)` — error out if the terminal is gone.
+2. `Capture(sessionID)`; require the current question's text or header to be
+   present, matched case-insensitively the way `containsTrustPrompt` does. Abort
+   with an error if absent.
+3. `SendKey(KeyDown)` × `option_index`, with `keyDelay` between presses.
+4. `SendKey(KeyEnter)`.
+5. Wait for the screen to change before the next question, bounded by
+   `screenSettleTimeout`.
+
+Constants, in one place with the reasoning attached:
+
+```go
+// keyDelay spaces out injected keystrokes. The CLI redraws between them and
+// a burst can be coalesced into a single highlight move.
+const keyDelay = 40 * time.Millisecond
+
+// screenSettleTimeout bounds the wait for the next question to render.
+const screenSettleTimeout = 3 * time.Second
+```
+
+Per-session mutex:
+
+```go
+// answerLocks serialises injection per session. Two devices answering at once
+// must not interleave keystrokes into the same dialog.
+var answerLocks sync.Map // sessionID -> *sync.Mutex
+```
+
+On success return `Decision{Status: "answered"}` with the selections echoed in
+`Response`, so the notification records what was sent.
+
+### `mobile/lib/providers/claude/cards.dart`
+
+`ClaudeQuestionCard` posts `selections` (question index + option index) instead
+of the `answers` string map. The card already renders the options list, so this
+is a change to what the tap handler sends, not to the layout.
+
+Surface injection failure: `sendAction` returning non-200 currently just returns
+false (`daemon_api_service.dart:315`). The card should show the error — "Couldn't
+answer: session has no live terminal" — rather than silently doing nothing,
+which is indistinguishable from the bug being fixed.
+
+## Risks
+
+**The CLI's question UI changes shape.** Injection is coupled to how Claude
+renders options. If the layout changes, the `Capture` guard fails closed and the
+action returns an error — the phone reports it could not answer, and the
+terminal still works. Degradation, not breakage. This is the reason the guard is
+mandatory rather than best-effort.
+
+**Two questions in flight for one session.** Not currently possible — the tool
+blocks the turn — but the per-session mutex and the `Capture` check both hold if
+it becomes possible.
+
+**`PostToolUse` may not fire on every path.** `idle_prompt` and `Stop` are the
+backstops, and both already run.
+
+## Testing
+
+Go:
+
+1. `backend/host_test.go` — `KeyUp`/`KeyDown` map to `\x1b[A` / `\x1b[B`,
+   alongside the existing `keySequence` table test at `host_test.go:277`.
+2. `hooks_test.go` — `handleQuestion` returns `{}` without blocking and creates
+   a pending notification; it completes well inside a test timeout, which is the
+   direct regression guard for the five-minute block.
+3. `hooks_test.go` — `handleToolPre` with `tool_name: "AskUserQuestion"` leaves
+   status `waiting_permission` untouched.
+4. `hooks_test.go` — `handleToolPost` with `tool_name: "AskUserQuestion"`
+   resolves a pending question notification and leaves a pending permission for
+   the same session alone.
+5. `actions_test.go`, against a fake backend recording keystrokes — option index
+   2 sends exactly `↓ ↓ Enter`; a `Capture` that does not contain the question
+   sends **nothing** and returns an error; `skip` sends `Escape`; concurrent
+   answers do not interleave.
+6. `store/notifications_test.go` — `ResolveSessionNotificationsByType` clears
+   only the named type.
+7. `hooks_test.go` — the stored question payload has `questions` as a top-level
+   JSON **array** and a `session_id` string, guarding the double-nesting
+   mistake described above.
+
+Manual — the flows that have never worked:
+
+8. Ask a question, answer it **in the terminal**, confirm the phone notification
+   clears and no keystrokes are injected.
+9. Ask a question, answer it **on the phone**, confirm the terminal UI advances
+   to the chosen option and the turn continues.
+10. Multi-question payload answered entirely from the phone.
+11. Answer on the phone while the terminal sits at the question, then confirm
+    the CLI does not also wait for a second answer.
+12. Press Escape in the terminal; confirm the phone notification clears.
+
+## Implementation order
+
+1. Arrow keys in `backend` + test. Self-contained.
+2. `ResolveSessionNotificationsByType` + test.
+3. `handleQuestion` non-blocking; drop `Register`; hook config timeout removed.
+4. `handleToolPre` skip; `handleToolPost` + `idle_prompt` resolution.
+5. `handleQuestionAction` injection, with the `Capture` guard written before the
+   keystroke code, not after.
+6. Mobile card payload change and error surfacing.
+
+Steps 1-4 alone already fix the terminal (the question becomes answerable there)
+and the status clobbering. Step 5 restores the phone. Landing 1-4 without 5
+would regress phone answering, so they ship together.
+
+## Notes
+
+- `waitForDecision` stays for permission and elicitation, which genuinely do
+  block a waiting CLI request. Only the question path stops using it — so the
+  duplicate-timeout race disappears for questions and remains, harmlessly and
+  by design, for the two hooks that really are request-scoped.
+- The `denied` path for questions changes meaning: it used to mean "helios told
+  Claude no", it now means "helios pressed Escape". Same outcome for the agent.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -19,6 +19,8 @@ const (
 	KeyEnter  Key = "enter"
 	KeyEscape Key = "escape"
 	KeyCtrlC  Key = "ctrl-c"
+	KeyUp     Key = "up"
+	KeyDown   Key = "down"
 )
 
 // Status reports backend health for the doctor/status endpoints.

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -263,6 +263,10 @@ func keySequence(key Key) ([]byte, error) {
 		return []byte("\x1b"), nil
 	case KeyCtrlC:
 		return []byte("\x03"), nil
+	case KeyUp:
+		return []byte("\x1b[A"), nil
+	case KeyDown:
+		return []byte("\x1b[B"), nil
 	default:
 		return nil, fmt.Errorf("backend: unknown key %q", key)
 	}

--- a/internal/backend/host_test.go
+++ b/internal/backend/host_test.go
@@ -277,6 +277,10 @@ func TestKeySequence(t *testing.T) {
 		KeyEnter:  "\r",
 		KeyEscape: "\x1b",
 		KeyCtrlC:  "\x03",
+		// Arrows move the highlight in Claude's own question UI, which is how
+		// an answer from the phone reaches a dialog the CLI owns.
+		KeyUp:   "\x1b[A",
+		KeyDown: "\x1b[B",
 	}
 	for key, want := range cases {
 		got, err := keySequence(key)

--- a/internal/daemon/hooks.go
+++ b/internal/daemon/hooks.go
@@ -41,9 +41,8 @@ func hookConfig(port int) map[string]interface{} {
 					"matcher": "AskUserQuestion",
 					"hooks": []interface{}{
 						map[string]interface{}{
-							"type":    "http",
-							"url":     base + "/question",
-							"timeout": 300,
+							"type": "http",
+							"url":  base + "/question",
 						},
 					},
 				},

--- a/internal/provider/claude/actions.go
+++ b/internal/provider/claude/actions.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/notifications"
@@ -47,25 +51,209 @@ func handlePermissionAction(notif *store.Notification, body json.RawMessage) (no
 	return notifications.Decision{Status: "approved", Response: response}, nil
 }
 
+// keyDelay spaces out injected keystrokes. The CLI redraws between them and a
+// burst can be coalesced into a single highlight move.
+const keyDelay = 40 * time.Millisecond
+
+// screenSettleTimeout bounds the wait for a question to render before its
+// keystrokes are sent.
+const screenSettleTimeout = 3 * time.Second
+
+// answerLocks serialises injection per session. Two devices answering at once
+// must not interleave keystrokes into the same dialog.
+var answerLocks sync.Map // sessionID -> *sync.Mutex
+
+func sessionAnswerLock(sessionID string) *sync.Mutex {
+	lock, _ := answerLocks.LoadOrStore(sessionID, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+// questionSpec is one entry of the AskUserQuestion tool input.
+type questionSpec struct {
+	Question string            `json:"question"`
+	Header   string            `json:"header"`
+	Options  []json.RawMessage `json:"options"`
+}
+
+type questionPayload struct {
+	SessionID string         `json:"session_id"`
+	Questions []questionSpec `json:"questions"`
+}
+
+// handleQuestionAction answers Claude's question by driving the CLI's own
+// question UI.
+//
+// The alternative — returning the answer from a blocking PreToolUse hook — is
+// what this replaces: it prevented the CLI from ever rendering the UI, so the
+// terminal user could not answer at all.
 func handleQuestionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {
-		Action  string            `json:"action"`
-		Answers map[string]string `json:"answers"`
+		Action     string `json:"action"`
+		Selections []struct {
+			QuestionIndex int `json:"question_index"`
+			OptionIndex   int `json:"option_index"`
+		} `json:"selections"`
+		Text string `json:"text"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return notifications.Decision{}, fmt.Errorf("invalid body: %w", err)
 	}
+	if req.Action != "answer" && req.Action != "skip" {
+		return notifications.Decision{}, fmt.Errorf("action must be answer/skip")
+	}
+
+	var payload questionPayload
+	if notif.Payload != nil {
+		if err := json.Unmarshal([]byte(*notif.Payload), &payload); err != nil {
+			return notifications.Decision{}, fmt.Errorf("invalid payload: %w", err)
+		}
+	}
+	sessionID := payload.SessionID
+	if sessionID == "" {
+		sessionID = notif.SourceSession
+	}
+	if sessionID == "" {
+		return notifications.Decision{}, fmt.Errorf("missing session_id in notification payload")
+	}
+
+	// Reject rather than resolve when there is nothing to type into. Consuming
+	// the notification here would leave the CLI sitting at a question no
+	// surface can answer any more.
+	if terminalBackend == nil || !terminalBackend.Alive(sessionID) {
+		return notifications.Decision{}, fmt.Errorf("session %s has no live terminal", sessionID)
+	}
+
+	lock := sessionAnswerLock(sessionID)
+	lock.Lock()
+	defer lock.Unlock()
 
 	if req.Action == "skip" {
+		if err := terminalBackend.SendKey(sessionID, backend.KeyEscape); err != nil {
+			return notifications.Decision{}, fmt.Errorf("send Escape to session %s: %w", sessionID, err)
+		}
+		log.Printf("question-action: skipped question for session %s", sessionID)
 		return notifications.Decision{Status: "denied"}, nil
 	}
 
-	if len(req.Answers) == 0 {
-		return notifications.Decision{}, fmt.Errorf("missing answers")
+	if req.Text != "" {
+		if len(payload.Questions) > 0 {
+			if err := awaitQuestionOnScreen(sessionID, payload.Questions[0]); err != nil {
+				return notifications.Decision{}, err
+			}
+		}
+		if err := terminalBackend.SendText(sessionID, req.Text); err != nil {
+			return notifications.Decision{}, fmt.Errorf("send answer to session %s: %w", sessionID, err)
+		}
+		response, err := json.Marshal(map[string]interface{}{"text": req.Text})
+		if err != nil {
+			return notifications.Decision{}, fmt.Errorf("encode response: %w", err)
+		}
+		return notifications.Decision{Status: "answered", Response: response}, nil
 	}
 
-	response, _ := json.Marshal(map[string]interface{}{"answers": req.Answers})
+	if len(req.Selections) == 0 {
+		return notifications.Decision{}, fmt.Errorf("missing selections")
+	}
+
+	for _, sel := range req.Selections {
+		if sel.QuestionIndex < 0 || sel.QuestionIndex >= len(payload.Questions) {
+			return notifications.Decision{}, fmt.Errorf("question index %d out of range", sel.QuestionIndex)
+		}
+		q := payload.Questions[sel.QuestionIndex]
+		if sel.OptionIndex < 0 || sel.OptionIndex >= len(q.Options) {
+			return notifications.Decision{}, fmt.Errorf("option index %d out of range for question %d", sel.OptionIndex, sel.QuestionIndex)
+		}
+		if err := answerQuestion(sessionID, q, sel.OptionIndex); err != nil {
+			return notifications.Decision{}, err
+		}
+	}
+
+	response, err := json.Marshal(map[string]interface{}{"selections": req.Selections})
+	if err != nil {
+		return notifications.Decision{}, fmt.Errorf("encode response: %w", err)
+	}
+	log.Printf("question-action: answered %d question(s) for session %s", len(req.Selections), sessionID)
 	return notifications.Decision{Status: "answered", Response: response}, nil
+}
+
+// answerQuestion moves the CLI's highlight to optionIndex and confirms it.
+//
+// The screen check runs first and is mandatory: a stray Enter into a session
+// that has moved on is a real action the user did not ask for.
+func answerQuestion(sessionID string, q questionSpec, optionIndex int) error {
+	if err := awaitQuestionOnScreen(sessionID, q); err != nil {
+		return err
+	}
+	for i := 0; i < optionIndex; i++ {
+		if err := terminalBackend.SendKey(sessionID, backend.KeyDown); err != nil {
+			return fmt.Errorf("send Down to session %s: %w", sessionID, err)
+		}
+		time.Sleep(keyDelay)
+	}
+	if err := terminalBackend.SendKey(sessionID, backend.KeyEnter); err != nil {
+		return fmt.Errorf("send Enter to session %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+// awaitQuestionOnScreen polls the rendered screen until it shows q, and fails
+// closed when it never does. The poll covers the gap between one question
+// being confirmed and the next being drawn.
+func awaitQuestionOnScreen(sessionID string, q questionSpec) error {
+	needles := condenseAll(q.Question, q.Header)
+	if len(needles) == 0 {
+		return fmt.Errorf("question carries no text to match against the screen")
+	}
+
+	deadline := time.Now().Add(screenSettleTimeout)
+	var lastErr error
+	for {
+		screen, err := terminalBackend.Capture(sessionID)
+		if err != nil {
+			lastErr = fmt.Errorf("capture session %s: %w", sessionID, err)
+		} else {
+			lastErr = nil
+			haystack := condense(screen)
+			for _, needle := range needles {
+				if strings.Contains(haystack, needle) {
+					return nil
+				}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(keyDelay)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("session %s is not showing the question any more", sessionID)
+}
+
+// condense reduces text to lowercase letters and digits.
+//
+// The screen is emulator output, so a question is wrapped across lines and
+// boxed in border characters; nothing matches contiguously until the padding,
+// newlines and borders are gone.
+func condense(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func condenseAll(texts ...string) []string {
+	var out []string
+	for _, t := range texts {
+		if c := condense(t); c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func handleElicitationAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {

--- a/internal/provider/claude/actions_test.go
+++ b/internal/provider/claude/actions_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/kamrul1157024/helios/internal/store"
@@ -128,4 +129,207 @@ func TestErrorAction_MissingSessionID(t *testing.T) {
 	if _, err := handleErrorAction(notif, json.RawMessage(`{"action":"retry"}`)); err == nil {
 		t.Fatal("want an error when no session can be identified")
 	}
+}
+
+// ==================== Question injection ====================
+
+// questionNotif builds the notification handleQuestion stores: the tool input
+// with session_id spliced in at the top level.
+func questionNotif(sessionID string, questions string) *store.Notification {
+	payload := `{"questions":` + questions + `,"session_id":"` + sessionID + `"}`
+	return &store.Notification{
+		ID:            "notif-q",
+		Source:        "claude",
+		SourceSession: sessionID,
+		Type:          "claude.question",
+		Status:        "pending",
+		Payload:       &payload,
+	}
+}
+
+const twoOptions = `[{"question":"Which approach?","header":"Approach","options":[{"label":"Rewrite"},{"label":"Patch"},{"label":"Leave it"}]}]`
+
+// The rendered CLI wraps the question inside a box, so the text never appears
+// contiguously — the screen check has to survive that.
+const questionScreen = `
+╭──────────────────────────────────────╮
+│ Approach                             │
+│ Which approach should we take for    │
+│ the migration?                       │
+│                                      │
+│ ❯ 1. Rewrite                         │
+│   2. Patch                           │
+│   3. Leave it                        │
+╰──────────────────────────────────────╯
+`
+
+func TestQuestionAction_SelectsOptionByIndex(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	dec, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":2}]}`),
+	)
+	if err != nil {
+		t.Fatalf("handleQuestionAction: %v", err)
+	}
+	if dec.Status != "answered" {
+		t.Errorf("status = %q, want answered", dec.Status)
+	}
+	// Option 2 is two moves down from the highlighted first option.
+	want := []string{"sess-1:down", "sess-1:down", "sess-1:enter"}
+	if got := fb.sentKeys(); !equalStrings(got, want) {
+		t.Errorf("keys = %v, want %v", got, want)
+	}
+}
+
+func TestQuestionAction_FirstOptionSendsOnlyEnter(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	if _, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":0}]}`),
+	); err != nil {
+		t.Fatalf("handleQuestionAction: %v", err)
+	}
+	if got := fb.sentKeys(); !equalStrings(got, []string{"sess-1:enter"}) {
+		t.Errorf("keys = %v, want [sess-1:enter]", got)
+	}
+}
+
+// The single most important safety property: a stray Enter into a session that
+// has moved on is a real action the user did not ask for.
+func TestQuestionAction_AbortsWhenScreenDoesNotShowQuestion(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen("$ git status\nnothing to commit\n")
+
+	_, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":1}]}`),
+	)
+	if err == nil {
+		t.Fatal("want an error when the question is not on screen")
+	}
+	if got := fb.sentKeys(); len(got) != 0 {
+		t.Errorf("keys = %v, want none sent", got)
+	}
+}
+
+func TestQuestionAction_SkipSendsEscape(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	dec, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"skip"}`),
+	)
+	if err != nil {
+		t.Fatalf("handleQuestionAction: %v", err)
+	}
+	if dec.Status != "denied" {
+		t.Errorf("status = %q, want denied", dec.Status)
+	}
+	if got := fb.sentKeys(); !equalStrings(got, []string{"sess-1:escape"}) {
+		t.Errorf("keys = %v, want [sess-1:escape]", got)
+	}
+}
+
+func TestQuestionAction_DeadTerminalErrors(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.setScreen(questionScreen)
+
+	_, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":0}]}`),
+	)
+	if err == nil {
+		t.Fatal("want an error for a session with no live terminal")
+	}
+	if !strings.Contains(err.Error(), "no live terminal") {
+		t.Errorf("error = %v, want it to mention the missing terminal", err)
+	}
+}
+
+func TestQuestionAction_OptionIndexOutOfRange(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	if _, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":7}]}`),
+	); err == nil {
+		t.Fatal("want an error for an out-of-range option")
+	}
+	if got := fb.sentKeys(); len(got) != 0 {
+		t.Errorf("keys = %v, want none sent", got)
+	}
+}
+
+func TestQuestionAction_FreeTextIsSubmittedAsAPrompt(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	dec, err := handleQuestionAction(
+		questionNotif("sess-1", twoOptions),
+		json.RawMessage(`{"action":"answer","text":"something else"}`),
+	)
+	if err != nil {
+		t.Fatalf("handleQuestionAction: %v", err)
+	}
+	if dec.Status != "answered" {
+		t.Errorf("status = %q, want answered", dec.Status)
+	}
+	if len(fb.texts) != 1 || fb.texts[0] != "sess-1:something else" {
+		t.Errorf("texts = %v, want [sess-1:something else]", fb.texts)
+	}
+}
+
+// Two devices answering at once must not interleave keystrokes into the same
+// dialog: each answer's Downs have to stay contiguous with its own Enter.
+func TestQuestionAction_ConcurrentAnswersDoNotInterleave(t *testing.T) {
+	fb := withBackend(t, newFakeBackend())
+	fb.live("sess-1")
+	fb.setScreen(questionScreen)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handleQuestionAction(
+				questionNotif("sess-1", twoOptions),
+				json.RawMessage(`{"action":"answer","selections":[{"question_index":0,"option_index":2}]}`),
+			)
+		}()
+	}
+	wg.Wait()
+
+	got := fb.sentKeys()
+	want := []string{
+		"sess-1:down", "sess-1:down", "sess-1:enter",
+		"sess-1:down", "sess-1:down", "sess-1:enter",
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("keys = %v, want two uninterleaved runs %v", got, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -177,7 +177,26 @@ func handleQuestion(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 	notifID := notifications.GenerateNotificationID()
 	title := "Claude has a question"
 	detail := "Answer required to continue"
-	payloadStr := string(input.ToolInput)
+
+	// input.ToolInput is already {"questions": [...]}; splice session_id into it
+	// rather than wrapping, which would nest questions under itself and break
+	// the mobile card's payload['questions'] accessor.
+	payload := map[string]json.RawMessage{}
+	if err := json.Unmarshal(input.ToolInput, &payload); err != nil {
+		payload = map[string]json.RawMessage{}
+	}
+	sessionJSON, err := json.Marshal(input.SessionID)
+	if err != nil {
+		http.Error(w, "failed to encode session id", http.StatusInternalServerError)
+		return
+	}
+	payload["session_id"] = sessionJSON
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, "failed to encode question payload", http.StatusInternalServerError)
+		return
+	}
+	payloadStr := string(payloadJSON)
 
 	notif := &store.Notification{
 		ID:            notifID,
@@ -196,9 +215,9 @@ func handleQuestion(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Reserve the decision slot before publishing, so a client that answers
-	// immediately cannot beat this handler to WaitForDecision.
-	ctx.Mgr.Register(notifID)
+	// No Register: nothing waits on a decision channel for questions any more.
+	// Resolution comes from handleQuestionAction via Mgr.Resolve, or from the
+	// PostToolUse / idle_prompt paths, neither of which needs a reserved slot.
 
 	ctx.Notify("notification", notif)
 
@@ -221,39 +240,12 @@ func handleQuestion(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 		})
 	}
 
-	decision := waitForDecision(ctx, notifID, r)
-	if decision == nil {
-		return
-	}
-
-	type preToolUseResponse struct {
-		HookSpecificOutput struct {
-			HookEventName      string                 `json:"hookEventName"`
-			PermissionDecision string                 `json:"permissionDecision"`
-			UpdatedInput       map[string]interface{} `json:"updatedInput,omitempty"`
-		} `json:"hookSpecificOutput"`
-	}
-
-	resp := preToolUseResponse{}
-	resp.HookSpecificOutput.HookEventName = "PreToolUse"
-
-	if decision.Status == "answered" && len(decision.Response) > 0 {
-		resp.HookSpecificOutput.PermissionDecision = "allow"
-		var respData map[string]interface{}
-		json.Unmarshal(decision.Response, &respData)
-
-		var toolInput map[string]interface{}
-		json.Unmarshal(input.ToolInput, &toolInput)
-		for k, v := range respData {
-			toolInput[k] = v
-		}
-		resp.HookSpecificOutput.UpdatedInput = toolInput
-	} else {
-		resp.HookSpecificOutput.PermissionDecision = "deny"
-	}
-
+	// Deliberately no decision and no block. Returning an empty object lets the
+	// CLI run AskUserQuestion and render its own UI, which is the only way the
+	// terminal user can answer at all. The phone answers by driving that same
+	// UI — see handleQuestionAction.
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	fmt.Fprint(w, `{}`)
 }
 
 // ==================== Elicitation Hook ====================
@@ -516,6 +508,10 @@ func handleNotification(ctx *provider.HookContext, w http.ResponseWriter, r *htt
 			"session_id": input.SessionID,
 			"status":     "idle",
 		})
+		// Escaping out of a question returns Claude to its prompt without a
+		// PostToolUse, so this is the only signal that the question is gone.
+		// The phone must stop offering to answer it.
+		resolveSessionQuestions(ctx, input.SessionID)
 	}
 
 	if ctx.Report != nil {
@@ -701,10 +697,38 @@ func handlePromptSubmit(ctx *provider.HookContext, w http.ResponseWriter, r *htt
 	fmt.Fprint(w, `{}`)
 }
 
+// askUserQuestionTool is the tool whose PreToolUse has a dedicated handler.
+const askUserQuestionTool = "AskUserQuestion"
+
+// resolveSessionQuestions clears a session's pending claude.question
+// notifications and tells clients to drop them, whichever surface answered.
+//
+// Narrowed to the one type rather than reusing ResolveSessionNotifications,
+// which would also clear a permission request the session is still waiting on.
+func resolveSessionQuestions(ctx *provider.HookContext, sessionID string) {
+	ids, err := ctx.DB.ResolveSessionNotificationsByType(sessionID, "claude.question", "resolved", "claude")
+	if err != nil {
+		log.Printf("hook: resolve questions for %s: %v", sessionID, err)
+		return
+	}
+	for _, id := range ids {
+		ctx.Notify("notification_resolved", map[string]string{"id": id, "action": "resolved", "source": "claude"})
+	}
+}
+
 func handleToolPre(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	var input hookInput
 	if err := json.Unmarshal(raw, &input); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// AskUserQuestion has a dedicated hook that sets waiting_permission. The
+	// "*" PreToolUse matcher fires for it too, and writing "active" here is
+	// what used to erase that status a millisecond after it was set.
+	if input.ToolName == askUserQuestionTool {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
 		return
 	}
 
@@ -740,6 +764,12 @@ func handleToolPost(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 
 	ctx.DB.UpdateSessionStatus(input.SessionID, "active", "PostToolUse:"+input.ToolName)
 	updateSessionTranscript(ctx, &input)
+
+	// The tool finished, so the question is answered. Retract the notification
+	// on every other surface. Which side answered does not matter.
+	if input.ToolName == askUserQuestionTool {
+		resolveSessionQuestions(ctx, input.SessionID)
+	}
 
 	if ctx.Report != nil {
 		ctx.Report(provider.ReportEvent{

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,12 +30,18 @@ func openMemoryStore(t *testing.T) *store.Store {
 }
 
 // fakeBackend satisfies backend.Backend and records the calls hooks make.
+//
+// The recording fields are mutex-guarded: question answering is serialised per
+// session by the code under test, and the test that proves it drives two
+// answers at once.
 type fakeBackend struct {
+	mu      sync.Mutex
 	handles map[string]string
 	renames []string // "sessionID:name"
 	kills   []string
 	keys    []string // "sessionID:key"
 	texts   []string // "sessionID:text"
+	screen  string   // what Capture returns
 }
 
 func newFakeBackend() *fakeBackend {
@@ -77,13 +85,31 @@ func (f *fakeBackend) Snapshot() map[string]string {
 }
 
 func (f *fakeBackend) SendText(sessionID, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.texts = append(f.texts, sessionID+":"+text)
 	return nil
 }
 
 func (f *fakeBackend) SendKey(sessionID string, k backend.Key) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.keys = append(f.keys, sessionID+":"+string(k))
 	return nil
+}
+
+// setScreen sets what Capture reports, standing in for the rendered CLI.
+func (f *fakeBackend) setScreen(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.screen = s
+}
+
+// sentKeys returns a copy of the recorded keystrokes.
+func (f *fakeBackend) sentKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.keys...)
 }
 
 func (f *fakeBackend) Interrupt(sessionID string) error { return nil }
@@ -94,7 +120,11 @@ func (f *fakeBackend) Kill(sessionID string) error {
 	return nil
 }
 
-func (f *fakeBackend) Capture(sessionID string) (string, error) { return "", nil }
+func (f *fakeBackend) Capture(sessionID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.screen, nil
+}
 
 func (f *fakeBackend) Rename(sessionID, name string) error {
 	f.renames = append(f.renames, sessionID+":"+name)
@@ -960,92 +990,197 @@ func makeRequestWithCancel(body []byte) (*http.Request, context.CancelFunc) {
 
 // ==================== Question flow ====================
 
-func TestQuestion_TransitionsToWaitingPermission(t *testing.T) {
+// questionInput builds an AskUserQuestion tool input in the shape Claude
+// sends: {"questions": [...]}.
+func questionInput(t *testing.T, questions ...map[string]interface{}) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(map[string]interface{}{"questions": questions})
+	if err != nil {
+		t.Fatalf("marshal tool input: %v", err)
+	}
+	return raw
+}
+
+func oneQuestion(question, header string, options ...string) map[string]interface{} {
+	opts := make([]interface{}, 0, len(options))
+	for _, o := range options {
+		opts = append(opts, map[string]string{"label": o, "description": o})
+	}
+	return map[string]interface{}{"question": question, "header": header, "options": opts}
+}
+
+func notifsOfType(t *testing.T, db *store.Store, nType string) []store.Notification {
+	t.Helper()
+	notifs, err := db.ListNotifications("claude", "", nType)
+	if err != nil {
+		t.Fatalf("list %s notifications: %v", nType, err)
+	}
+	return notifs
+}
+
+func onlyQuestionNotif(t *testing.T, db *store.Store) *store.Notification {
+	t.Helper()
+	notifs := notifsOfType(t, db, "claude.question")
+	if len(notifs) != 1 {
+		t.Fatalf("want 1 claude.question notification, got %d", len(notifs))
+	}
+	return &notifs[0]
+}
+
+// The direct regression guard for the five-minute block: the hook used to wait
+// for a mobile answer, which is why the CLI never rendered its own question UI
+// and the terminal had nothing to answer.
+func TestQuestion_ReturnsImmediatelyWithoutBlocking(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 
-	notifIDs := captureNotifIDs(ctx)
-
-	toolInput, _ := json.Marshal(map[string]string{"question": "Are you sure?"})
-	done := make(chan struct{})
+	done := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
-		defer close(done)
-		callHook(handleQuestion, ctx, hookInput{
+		done <- callHook(handleQuestion, ctx, hookInput{
 			SessionID: "sess-1",
 			CWD:       "/tmp/proj",
-			ToolInput: toolInput,
+			ToolInput: questionInput(t, oneQuestion("Proceed?", "Plan", "Yes", "No")),
 		})
 	}()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		sess, _ := db.GetSession("sess-1")
-		if sess != nil && sess.Status == "waiting_permission" {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleQuestion blocked; it must return so the CLI can render its own UI")
+	}
+
+	if got := strings.TrimSpace(w.Body.String()); got != "{}" {
+		t.Errorf("body = %q, want {}", got)
 	}
 	assertStatus(t, db, "sess-1", "waiting_permission")
 
-	capturedNotifID := awaitNotifID(t, notifIDs)
-	ctx.Mgr.Resolve(capturedNotifID, notifications.Decision{Status: "answered"}, "mobile")
-	<-done
-}
-
-func TestQuestion_Answer_ReturnsAllow(t *testing.T) {
-	ctx, db, _ := setupCtx(t)
-	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-
-	notifIDs := captureNotifIDs(ctx)
-
-	toolInput, _ := json.Marshal(map[string]string{"question": "Proceed?"})
-	resultCh := make(chan *httptest.ResponseRecorder, 1)
-	go func() {
-		resultCh <- callHook(handleQuestion, ctx, hookInput{
-			SessionID: "sess-1",
-			CWD:       "/tmp/proj",
-			ToolInput: toolInput,
-		})
-	}()
-
-	capturedNotifID := awaitNotifID(t, notifIDs)
-	answerPayload, _ := json.Marshal(map[string]string{"answer": "yes"})
-	ctx.Mgr.Resolve(capturedNotifID, notifications.Decision{Status: "answered", Response: answerPayload}, "mobile")
-
-	w := <-resultCh
-	var resp map[string]interface{}
-	json.NewDecoder(w.Body).Decode(&resp)
-	output := resp["hookSpecificOutput"].(map[string]interface{})
-	if output["permissionDecision"] != "allow" {
-		t.Errorf("permissionDecision = %v, want allow", output["permissionDecision"])
+	notif := onlyQuestionNotif(t, db)
+	if notif.Status != "pending" {
+		t.Errorf("notification status = %q, want pending", notif.Status)
+	}
+	// Nothing waits on a decision channel any more, so no slot is reserved.
+	if ctx.Mgr.HasPending(notif.ID) {
+		t.Error("question registered a decision slot; nothing waits on one")
 	}
 }
 
-func TestQuestion_Skip_ReturnsDeny(t *testing.T) {
+// Wrapping rather than splicing would produce {"questions":{"questions":[...]}}
+// and the mobile card's payload['questions'] accessor would cast a Map to a
+// List, silently emptying the card.
+func TestQuestion_PayloadKeepsQuestionsAtTopLevel(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 
-	notifIDs := captureNotifIDs(ctx)
+	callHook(handleQuestion, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolInput: questionInput(t, oneQuestion("Proceed?", "Plan", "Yes", "No")),
+	})
 
-	toolInput, _ := json.Marshal(map[string]string{"question": "Proceed?"})
-	resultCh := make(chan *httptest.ResponseRecorder, 1)
-	go func() {
-		resultCh <- callHook(handleQuestion, ctx, hookInput{
-			SessionID: "sess-1",
-			CWD:       "/tmp/proj",
-			ToolInput: toolInput,
-		})
-	}()
+	payload := decodePayload(t, onlyQuestionNotif(t, db))
+	questions, ok := payload["questions"].([]interface{})
+	if !ok {
+		t.Fatalf("payload[questions] = %T, want a JSON array", payload["questions"])
+	}
+	if len(questions) != 1 {
+		t.Fatalf("questions length = %d, want 1", len(questions))
+	}
+	if payload["session_id"] != "sess-1" {
+		t.Errorf("payload[session_id] = %v, want sess-1", payload["session_id"])
+	}
+}
 
-	capturedNotifID := awaitNotifID(t, notifIDs)
-	ctx.Mgr.Resolve(capturedNotifID, notifications.Decision{Status: "denied"}, "mobile")
+// Both PreToolUse matchers fire for AskUserQuestion. Writing "active" from the
+// wildcard one is what used to erase waiting_permission a millisecond after
+// handleQuestion set it.
+func TestToolPre_LeavesQuestionStatusAlone(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "waiting_permission")
 
-	w := <-resultCh
-	var resp map[string]interface{}
-	json.NewDecoder(w.Body).Decode(&resp)
-	output := resp["hookSpecificOutput"].(map[string]interface{})
-	if output["permissionDecision"] != "deny" {
-		t.Errorf("permissionDecision = %v, want deny", output["permissionDecision"])
+	callHook(handleToolPre, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "AskUserQuestion",
+	})
+
+	assertStatus(t, db, "sess-1", "waiting_permission")
+}
+
+func TestToolPre_StillMarksOtherToolsActive(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "idle")
+
+	callHook(handleToolPre, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "Read",
+	})
+
+	assertStatus(t, db, "sess-1", "active")
+}
+
+// The tool completed, so whoever answered — terminal or phone — the question is
+// gone and the other surface must stop offering it.
+func TestToolPost_ResolvesQuestionButNotPermission(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleQuestion, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolInput: questionInput(t, oneQuestion("Proceed?", "Plan", "Yes", "No")),
+	})
+	perm := &store.Notification{
+		ID:            "notif-perm",
+		Source:        "claude",
+		SourceSession: "sess-1",
+		CWD:           "/tmp/proj",
+		Type:          "claude.permission",
+		Status:        "pending",
+	}
+	if err := db.CreateNotification(perm); err != nil {
+		t.Fatalf("create permission notification: %v", err)
+	}
+
+	callHook(handleToolPost, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "AskUserQuestion",
+	})
+
+	if got := onlyQuestionNotif(t, db).Status; got != "resolved" {
+		t.Errorf("question status = %q, want resolved", got)
+	}
+	stored, err := db.GetNotification("notif-perm")
+	if err != nil {
+		t.Fatalf("get permission notification: %v", err)
+	}
+	if stored.Status != "pending" {
+		t.Errorf("permission status = %q, want pending", stored.Status)
+	}
+}
+
+// Escaping out of a question returns Claude to its prompt without a
+// PostToolUse, so idle_prompt is the only signal the question is gone.
+func TestIdlePrompt_ResolvesPendingQuestion(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	callHook(handleQuestion, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolInput: questionInput(t, oneQuestion("Proceed?", "Plan", "Yes", "No")),
+	})
+
+	callHook(handleNotification, ctx, hookInput{
+		SessionID:     "sess-1",
+		CWD:           "/tmp/proj",
+		HookEventName: "idle_prompt",
+	})
+
+	if got := onlyQuestionNotif(t, db).Status; got != "resolved" {
+		t.Errorf("question status = %q, want resolved", got)
 	}
 }
 

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"time"
 )
 
@@ -143,6 +144,45 @@ func (s *Store) ResolveSessionNotifications(sourceSession, status, source string
 			`UPDATE notifications SET status = ?, resolved_at = ?, resolved_source = ? WHERE source_session = ? AND status = 'pending'`,
 			status, now, source, sourceSession,
 		)
+	}
+
+	return ids, nil
+}
+
+// ResolveSessionNotificationsByType is ResolveSessionNotifications narrowed to
+// a single notification type, so clearing a session's answered question does
+// not also clear a permission request the same session is still waiting on.
+func (s *Store) ResolveSessionNotificationsByType(sourceSession, nType, status, source string) ([]string, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows, err := s.db.Query(
+		`SELECT id FROM notifications WHERE source_session = ? AND type = ? AND status = 'pending'`,
+		sourceSession, nType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query pending %s notifications: %w", nType, err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan pending %s notifications: %w", nType, err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	if _, err := s.db.Exec(
+		`UPDATE notifications SET status = ?, resolved_at = ?, resolved_source = ? WHERE source_session = ? AND type = ? AND status = 'pending'`,
+		status, now, source, sourceSession, nType,
+	); err != nil {
+		return nil, fmt.Errorf("resolve pending %s notifications: %w", nType, err)
 	}
 
 	return ids, nil

--- a/internal/store/notifications_test.go
+++ b/internal/store/notifications_test.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"testing"
+)
+
+func seedNotification(t *testing.T, s *Store, id, session, nType, status string) {
+	t.Helper()
+	n := &Notification{
+		ID:            id,
+		Source:        "claude",
+		SourceSession: session,
+		CWD:           "/tmp/test",
+		Type:          nType,
+		Status:        status,
+	}
+	if err := s.CreateNotification(n); err != nil {
+		t.Fatalf("create notification %s: %v", id, err)
+	}
+}
+
+func statusOf(t *testing.T, s *Store, id string) string {
+	t.Helper()
+	n, err := s.GetNotification(id)
+	if err != nil {
+		t.Fatalf("get notification %s: %v", id, err)
+	}
+	return n.Status
+}
+
+// Answering a question must not also clear a permission the same session is
+// still blocked on — that is the whole reason this exists rather than reusing
+// ResolveSessionNotifications.
+func TestResolveSessionNotificationsByType_LeavesOtherTypes(t *testing.T) {
+	s := setupTestStore(t)
+	seedNotification(t, s, "n-question", "sess-1", "claude.question", "pending")
+	seedNotification(t, s, "n-permission", "sess-1", "claude.permission", "pending")
+
+	ids, err := s.ResolveSessionNotificationsByType("sess-1", "claude.question", "resolved", "claude")
+	if err != nil {
+		t.Fatalf("resolve by type: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "n-question" {
+		t.Fatalf("ids = %v, want [n-question]", ids)
+	}
+	if got := statusOf(t, s, "n-question"); got != "resolved" {
+		t.Errorf("question status = %q, want resolved", got)
+	}
+	if got := statusOf(t, s, "n-permission"); got != "pending" {
+		t.Errorf("permission status = %q, want pending", got)
+	}
+}
+
+func TestResolveSessionNotificationsByType_LeavesOtherSessions(t *testing.T) {
+	s := setupTestStore(t)
+	seedNotification(t, s, "n-mine", "sess-1", "claude.question", "pending")
+	seedNotification(t, s, "n-theirs", "sess-2", "claude.question", "pending")
+
+	if _, err := s.ResolveSessionNotificationsByType("sess-1", "claude.question", "resolved", "claude"); err != nil {
+		t.Fatalf("resolve by type: %v", err)
+	}
+	if got := statusOf(t, s, "n-theirs"); got != "pending" {
+		t.Errorf("other session status = %q, want pending", got)
+	}
+}
+
+// The PostToolUse and idle_prompt paths both call this, so a question that is
+// already answered goes through it a second time.
+func TestResolveSessionNotificationsByType_NoPendingIsNotAnError(t *testing.T) {
+	s := setupTestStore(t)
+	seedNotification(t, s, "n-done", "sess-1", "claude.question", "resolved")
+
+	ids, err := s.ResolveSessionNotificationsByType("sess-1", "claude.question", "resolved", "claude")
+	if err != nil {
+		t.Fatalf("resolve by type: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("ids = %v, want none", ids)
+	}
+}

--- a/mobile/lib/providers/claude/cards.dart
+++ b/mobile/lib/providers/claude/cards.dart
@@ -307,9 +307,32 @@ class ClaudeQuestionCard extends StatefulWidget {
 }
 
 class _ClaudeQuestionCardState extends State<ClaudeQuestionCard> {
-  final Map<String, String> _answers = {};
+  /// Question index → chosen option index. Indices rather than labels: the
+  /// daemon answers by moving the CLI's own highlight, so position is what it
+  /// needs, and two options can share a label.
+  final Map<int, int> _selections = {};
+  bool _submitting = false;
 
   HeliosNotification get n => widget.notification;
+
+  Future<void> _submit() async {
+    setState(() => _submitting = true);
+    final error = await widget.sse.sendActionError(n.id, {
+      'action': 'answer',
+      'selections': _selections.entries
+          .map((e) => {'question_index': e.key, 'option_index': e.value})
+          .toList()
+        ..sort((a, b) =>
+            (a['question_index'] as int).compareTo(b['question_index'] as int)),
+    });
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    if (error != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Couldn't answer: $error")),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -351,8 +374,10 @@ class _ClaudeQuestionCardState extends State<ClaudeQuestionCard> {
               ],
             ),
             const SizedBox(height: 12),
-            ...questions.map((q) {
+            ...questions.asMap().entries.map((qe) {
+              final q = qe.value;
               if (q is! Map) return const SizedBox.shrink();
+              final questionIndex = qe.key;
               final question = q['question']?.toString() ?? '';
               final header = q['header']?.toString();
               final options = (q['options'] as List?) ?? [];
@@ -369,62 +394,48 @@ class _ClaudeQuestionCardState extends State<ClaudeQuestionCard> {
                     ],
                     Text(question, style: const TextStyle(fontSize: 13)),
                     const SizedBox(height: 6),
-                    ...options.map((opt) {
+                    ...options.asMap().entries.map((oe) {
+                      final optionIndex = oe.key;
+                      final opt = oe.value;
                       final label = (opt is Map ? opt['label'] : opt)?.toString() ?? '';
-                      if (multiSelect) {
-                        final currentAnswers = (_answers[question] ?? '').split(', ').where((s) => s.isNotEmpty).toSet();
-                        final isSelected = currentAnswers.contains(label);
-                        return InkWell(
-                          onTap: () {
-                            setState(() {
-                              if (isSelected) {
-                                currentAnswers.remove(label);
-                              } else {
-                                currentAnswers.add(label);
-                              }
-                              _answers[question] = currentAnswers.join(', ');
-                            });
-                          },
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 2),
-                            child: Row(
-                              children: [
-                                Icon(
-                                  isSelected ? Icons.check_box : Icons.check_box_outline_blank,
-                                  size: 20,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                                const SizedBox(width: 8),
-                                Text(label, style: const TextStyle(fontSize: 13)),
-                              ],
-                            ),
+                      final isSelected = _selections[questionIndex] == optionIndex;
+                      return InkWell(
+                        onTap: _submitting
+                            ? null
+                            : () {
+                                setState(() {
+                                  _selections[questionIndex] = optionIndex;
+                                });
+                              },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Row(
+                            children: [
+                              Icon(
+                                isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                                size: 20,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(child: Text(label, style: const TextStyle(fontSize: 13))),
+                            ],
                           ),
-                        );
-                      } else {
-                        final isSelected = _answers[question] == label;
-                        return InkWell(
-                          onTap: () {
-                            setState(() {
-                              _answers[question] = label;
-                            });
-                          },
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 2),
-                            child: Row(
-                              children: [
-                                Icon(
-                                  isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
-                                  size: 20,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                                const SizedBox(width: 8),
-                                Text(label, style: const TextStyle(fontSize: 13)),
-                              ],
-                            ),
-                          ),
-                        );
-                      }
+                        ),
+                      );
                     }),
+                    // Answering drives the CLI's own list, which takes one
+                    // highlighted option per question. Picking several needs
+                    // the terminal.
+                    if (multiSelect) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        'Pick one here, or answer in the terminal to choose several.',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               );
@@ -455,9 +466,11 @@ class _ClaudeQuestionCardState extends State<ClaudeQuestionCard> {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: _answers.isNotEmpty
-                    ? () => widget.sse.sendAction(n.id, {'action': 'answer', 'answers': _answers})
-                    : null,
+                // Every question, not just one: the daemon walks the CLI
+                // through them in order and a gap would leave it stranded.
+                onPressed: _submitting || _selections.length != questions.length
+                    ? null
+                    : _submit,
                 child: Text(questions.length > 1 ? 'Submit Answers' : 'Submit Answer'),
               ),
             ),

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -332,16 +332,46 @@ class DaemonAPIService extends ChangeNotifier {
   }
 
   Future<bool> sendAction(String id, Map<String, dynamic> body) async {
+    return await sendActionError(id, body) == null;
+  }
+
+  /// [sendAction] that reports why it failed, so a card can tell the user
+  /// instead of silently doing nothing — indistinguishable, otherwise, from
+  /// the action never having been wired up. Returns null on success.
+  Future<String?> sendActionError(String id, Map<String, dynamic> body) async {
     try {
       final resp = await _api.post('/api/notifications/$id/action', body: body);
       if (resp.statusCode == 200) {
         await fetchNotifications();
-        return true;
+        return null;
       }
+      // 410 means someone else got there first — the terminal, or our own
+      // answer racing the hook that retracts the notification. Either way the
+      // question is answered, which is not a failure worth reporting.
+      if (resp.statusCode == 410) {
+        await fetchNotifications();
+        return null;
+      }
+      final message = _actionErrorMessage(resp.body);
+      debugPrint('[$hostId] Action failed (${resp.statusCode}): $message');
+      return message;
     } catch (e) {
       debugPrint('[$hostId] Failed to send action: $e');
+      return 'Could not reach the daemon';
     }
-    return false;
+  }
+
+  String _actionErrorMessage(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      // jsonError puts the reason in "message"; "error" holds the status text.
+      if (decoded is Map && decoded['message'] is String) {
+        return decoded['message'] as String;
+      }
+    } catch (_) {
+      // Fall through to the generic message.
+    }
+    return 'The daemon rejected the action';
   }
 
   Future<bool> dismissNotification(String id) async {


### PR DESCRIPTION
Spec: `docs/specs/34-askuserquestion-dual-answer.md`

## The bug

The `/question` `PreToolUse` hook blocked for up to five minutes waiting for a mobile answer. While it was outstanding the tool had not been allowed to run, so the CLI never rendered its own question UI — **there was no code path by which the terminal user could answer**. All four questions ever recorded on this machine expired unanswered, every one with `resolved_source=claude` and an empty response (the cancellation path).

Two smaller faults rode along:

- Both `PreToolUse` matchers (`AskUserQuestion` → `/question` and `*` → `/tool/pre`) fire on the same event. `handleToolPre` wrote status `active`, erasing the `waiting_permission` that `handleQuestion` had just set.
- `waitForDecision`'s local 5-minute timer raced the hook config's `"timeout": 300`, so how a question expired was a coin flip between `timeout`/`system` and `resolved`/`claude`.

## The fix

Let the CLI own the question, and drive its UI when an answer arrives from elsewhere.

```
AskUserQuestion
  ├─ /question hook → returns {} immediately
  │     └─ creates claude.question notification → phone + desktop
  └─ CLI renders its OWN question UI          ← terminal answerable

Remote answer   → SendKey(down x k, Enter) → CLI resolves → PostToolUse → retract
Terminal answer → PostToolUse fires        → retract on the other surfaces
```

PTY injection is not a new mechanism here: `handleTrustAction` already answers Claude's workspace-trust dialog with `KeyEnter`, and `StartTrustWatcher` already reads rendered screen text via `Backend.Capture`. This applies both primitives to a dialog with more than one option.

### Safety

Before any keystroke, `Capture` must show the question — matched on the condensed (letters-and-digits-only) form, because the screen is emulator output where the text is wrapped and boxed and never appears contiguously. If it does not match, the action **sends nothing** and returns an error. A stray Enter into a session that has moved on is a real action the user did not ask for. Injection is serialised per session so two devices cannot interleave keystrokes.

## Changes

**Go**
- `internal/backend`: `KeyUp`/`KeyDown` mapping to `\x1b[A` / `\x1b[B`
- `internal/daemon/hooks.go`: drop the now-misleading `timeout: 300` on `/question`
- `internal/provider/claude/hooks.go`: `handleQuestion` returns `{}` without blocking and no longer reserves a decision slot; `session_id` is **spliced into** the tool input rather than wrapping it (wrapping would give `{"questions":{"questions":[...]}}` and the clients' `payload['questions']` accessor would cast a Map to a List, silently emptying the card); `handleToolPre` skips `AskUserQuestion`; `handleToolPost` and the `idle_prompt` branch resolve the question
- `internal/store/notifications.go`: `ResolveSessionNotificationsByType`, so clearing a question does not also clear a pending permission
- `internal/provider/claude/actions.go`: `handleQuestionAction` rewritten to inject keystrokes

**Clients** — both, per the request that this work on desktop too
- `mobile/.../cards.dart` and `desktop/.../approvals.tsx`: post `selections` (question index + option index) instead of the label map, require every question answered, and surface the daemon's reason when an answer fails. `sendActionError` in `daemon_api_service.dart` reports why; the desktop already surfaced `ApiError.message` and treats 410 as "someone else answered".

## Tests

Go — `go test ./...` green, `-race` green on the claude package:
- `host_test.go`: `KeyUp`/`KeyDown` sequences
- `hooks_test.go`: the question hook returns `{}` well inside a timeout (the direct regression guard for the five-minute block) and reserves no decision slot; the payload keeps `questions` as a top-level array with a `session_id` string; `handleToolPre` leaves `waiting_permission` alone for `AskUserQuestion` and still marks other tools active; `handleToolPost` resolves the question but not a permission for the same session; `idle_prompt` resolves it too
- `actions_test.go`: option 2 sends exactly down-down-Enter; option 0 sends only Enter; a screen without the question sends **nothing** and errors; `skip` sends Escape; a dead terminal errors; an out-of-range option sends nothing; free text goes through `SendText`; two concurrent answers do not interleave
- `store/notifications_test.go`: the by-type resolve leaves other types, other sessions, and an already-resolved question alone

Flutter — `flutter test` 34/34, `flutter analyze` clean.
Desktop — `npm run typecheck` clean, `npm test` 22/22.

## Not done

**Manual verification has not been run.** Steps 8-12 of the spec are the flows that have never worked end to end — answer in the terminal, answer on the phone, multi-question, simultaneous answer, Escape — and they need a live session.

**Multi-select questions.** The injection model expresses one highlighted option per question, so both clients now render `multiSelect` questions as single-select with a note pointing at the terminal. Toggling several would need Space keystrokes into the CLI's list, which is unverified against the real UI and out of scope here.
