### PR TITLE
fix: let the daemon own notification resolution, and bring the desktop to parity

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -85,8 +85,26 @@ export function registerIpc(deps: IpcDeps): void {
   })
   handle('hosts:rename', async (_e, id: string, name: string) => hosts.rename(id, name))
 
+  /**
+   * Brings the tray in line with the daemon.
+   *
+   * Coming back online means whatever happened while offline was missed, and a
+   * missed `notification_resolved` leaves an approval on the tray that nothing
+   * else will ever take off it.
+   */
+  const reconcile = async (hostId: string): Promise<void> => {
+    try {
+      notifier.seed(hostId, await hosts.require(hostId).api.notifications({ status: 'pending' }))
+    } catch {
+      // Offline again already; the next status change tries once more.
+    }
+  }
+
   hosts.on('hosts', (list) => send('hosts:changed', list))
-  hosts.on('status', (status) => send('hosts:status', status))
+  hosts.on('status', (status: { id: string; state: string }) => {
+    send('hosts:status', status)
+    if (status.state === 'online') void reconcile(status.id)
+  })
   hosts.on('event', ({ hostId, event }: { hostId: string; event: { type: string; data: Record<string, unknown> } }) => {
     notifier.handleEvent(hostId, event.type, event.data)
     send('hosts:event', { hostId, event })

--- a/desktop/src/main/notify.ts
+++ b/desktop/src/main/notify.ts
@@ -27,6 +27,8 @@ export class Notifier {
   private tray: Tray | null = null
   private seen = new Set<string>()
   private pending = new Map<string, NotifyTarget>()
+  /** Notifications still on screen, so one answered elsewhere can be taken down. */
+  private shown = new Map<string, ElectronNotification>()
 
   constructor(
     private readonly hosts: HostRegistry,
@@ -48,10 +50,23 @@ export class Notifier {
     }
   }
 
-  /** Called after a poll, so notifications raised while the app was down still show. */
+  /**
+   * Called after a poll, so notifications raised while the app was down still
+   * show — and, just as importantly, so ones answered while the app was down
+   * stop showing. A reconnect can drop the `notification_resolved` event, and
+   * without this the tray would keep counting approvals that no longer exist.
+   *
+   * [notifications] must be the host's full pending set, not a delta.
+   */
   seed(hostId: string, notifications: Notification[]): void {
+    const stillPending = new Set<string>()
     for (const notif of notifications) {
-      if (notif.status === 'pending') this.present(hostId, notif)
+      if (notif.status !== 'pending') continue
+      stillPending.add(`${hostId}:${notif.id}`)
+      this.present(hostId, notif)
+    }
+    for (const key of [...this.pending.keys()]) {
+      if (key.startsWith(`${hostId}:`) && !stillPending.has(key)) this.retract(key)
     }
     this.refreshTray()
   }
@@ -81,18 +96,30 @@ export class Notifier {
       timeoutType: notif.type.endsWith('permission') ? 'never' : 'default',
     })
     notification.on('click', () => this.onActivate(target))
+    notification.on('close', () => this.shown.delete(key))
+    this.shown.set(key, notification)
     notification.show()
   }
 
   private resolve(hostId: string, notificationId: string): void {
-    const key = `${hostId}:${notificationId}`
-    if (this.pending.delete(key)) this.refreshTray()
+    if (this.retract(`${hostId}:${notificationId}`)) this.refreshTray()
+  }
+
+  /**
+   * Takes a notification down: off the tray and off the screen. Leaving the
+   * banner up offers an Approve button for a request that was already answered
+   * on the phone or auto-approved here.
+   */
+  private retract(key: string): boolean {
+    this.shown.get(key)?.close()
+    this.shown.delete(key)
+    return this.pending.delete(key)
   }
 
   /** Forgets a host's notifications when it is removed or goes offline for good. */
   clearHost(hostId: string): void {
     for (const key of [...this.pending.keys()]) {
-      if (key.startsWith(`${hostId}:`)) this.pending.delete(key)
+      if (key.startsWith(`${hostId}:`)) this.retract(key)
     }
     this.refreshTray()
   }
@@ -160,6 +187,8 @@ function titleFor(type: string): string {
       return 'Claude has a question'
     case 'claude.trust':
       return 'Trust this folder?'
+    case 'claude.error':
+      return 'Session error'
     default:
       return 'Helios'
   }

--- a/desktop/src/renderer/components/approvals.tsx
+++ b/desktop/src/renderer/components/approvals.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
@@ -70,6 +70,8 @@ function Card({ hostId, notif }: { hostId: string; notif: Notification }): JSX.E
         return <UrlCard payload={payload} busy={busy} act={act} />
       case 'claude.elicitation.form':
         return <FormCard payload={payload} busy={busy} act={act} />
+      case 'claude.error':
+        return <ErrorCard payload={payload} busy={busy} act={act} />
       default:
         return (
           <Actions busy={busy}>
@@ -298,6 +300,59 @@ function FormCard({
   )
 }
 
+/**
+ * A turn that died on an API error.
+ *
+ * Retry sends "continue", which is what a user types in the terminal after an
+ * API error: the CLI picks the turn up where it stopped. A rate limit with a
+ * known reset time disables the button until the window lifts — retrying
+ * before then just burns another failure.
+ */
+function ErrorCard({
+  payload,
+  busy,
+  act,
+}: {
+  payload: Record<string, unknown>
+  busy: boolean
+  act: (body: Record<string, unknown>) => Promise<void>
+}): JSX.Element {
+  const text = typeof payload.error === 'string' ? payload.error : ''
+  const resetAt = typeof payload.reset_at === 'string' ? Date.parse(payload.reset_at) : NaN
+  const [now, setNow] = useState(() => Date.now())
+
+  const blocked = !Number.isNaN(resetAt) && resetAt > now
+
+  useEffect(() => {
+    // Only a rate limit with a known reset time has anything to tick.
+    if (!blocked) return
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [blocked])
+
+  return (
+    <>
+      {text && <pre className="code">{text}</pre>}
+      <Actions busy={busy}>
+        <button disabled={blocked} onClick={() => void act({ action: 'retry' })}>
+          {blocked ? remainingLabel(resetAt - now) : 'Retry'}
+        </button>
+        <button className="ghost" onClick={() => void act({ action: 'dismiss' })}>
+          Dismiss
+        </button>
+      </Actions>
+    </>
+  )
+}
+
+/** Coarse on purpose: a second-by-second countdown on a multi-hour window is noise. */
+function remainingLabel(ms: number): string {
+  const seconds = Math.max(0, Math.ceil(ms / 1000))
+  if (seconds >= 3600) return `Retry in ${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+  if (seconds >= 60) return `Retry in ${Math.floor(seconds / 60)}m`
+  return `Retry in ${seconds}s`
+}
+
 function Actions({ busy, children }: { busy: boolean; children: React.ReactNode }): JSX.Element {
   return <div className={`card-actions ${busy ? 'busy' : ''}`}>{children}</div>
 }
@@ -342,6 +397,8 @@ function label(type: string): string {
       return 'Authentication required'
     case 'claude.trust':
       return 'Workspace trust'
+    case 'claude.error':
+      return 'Session error'
     default:
       return type
   }

--- a/internal/notifications/manager.go
+++ b/internal/notifications/manager.go
@@ -4,6 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -17,9 +20,10 @@ type Decision struct {
 }
 
 type Manager struct {
-	db      *store.Store
-	mu      sync.Mutex
-	pending map[string]chan Decision // notification ID -> channel awaiting decision
+	db        *store.Store
+	mu        sync.Mutex
+	pending   map[string]chan Decision                 // notification ID -> channel awaiting decision
+	broadcast func(eventType string, data interface{}) // SSE fan-out; nil until wired
 }
 
 func NewManager(db *store.Store) *Manager {
@@ -27,6 +31,20 @@ func NewManager(db *store.Store) *Manager {
 		db:      db,
 		pending: make(map[string]chan Decision),
 	}
+}
+
+// SetBroadcaster installs the fan-out used to announce resolutions.
+//
+// A notification's status lives here, in the database, and clients are only
+// ever a view of it. That only holds if every resolution announces itself, so
+// the announcement lives with the write rather than at each call site — which
+// is what let the hook timeout path mark a notification resolved and tell
+// nobody, leaving an approval on every phone and tray that nothing would ever
+// take down.
+func (m *Manager) SetBroadcaster(fn func(eventType string, data interface{})) {
+	m.mu.Lock()
+	m.broadcast = fn
+	m.mu.Unlock()
 }
 
 // Register reserves the pending slot for a notification. Call it before the
@@ -65,31 +83,82 @@ func (m *Manager) WaitForDecision(notifID string) (Decision, error) {
 	return decision, nil
 }
 
-// Resolve resolves a notification and unblocks any waiting hook handler.
+// Resolve resolves a notification, unblocks any waiting hook handler, and
+// tells every client it is gone.
+//
+// Returns store.ErrAlreadyResolved when another surface got there first; the
+// row is untouched and nothing is announced twice.
 func (m *Manager) Resolve(notifID string, decision Decision, source string) error {
 	// Store response in the notification record
 	if len(decision.Response) > 0 {
-		m.db.UpdateNotificationResponse(notifID, string(decision.Response))
+		if err := m.db.UpdateNotificationResponse(notifID, string(decision.Response)); err != nil {
+			return fmt.Errorf("store response for %s: %w", notifID, err)
+		}
 	}
 
 	if err := m.db.ResolveNotification(notifID, decision.Status, source); err != nil {
 		return err
 	}
 
+	m.unblock(notifID, decision)
+	m.announce(notifID, decision.Status, source)
+	return nil
+}
+
+// ResolveSession resolves every pending notification for a session, as when
+// the agent answers in its own terminal and the Stop hook fires.
+func (m *Manager) ResolveSession(sessionID, status, source string) ([]string, error) {
+	ids, err := m.db.ResolveSessionNotifications(sessionID, status, source)
+	if err != nil {
+		return nil, fmt.Errorf("resolve notifications for %s: %w", sessionID, err)
+	}
+	m.announceAll(ids, status, source)
+	return ids, nil
+}
+
+// ResolveSessionByType is ResolveSession narrowed to one notification type, so
+// clearing a session's answered question does not also clear a permission
+// request the same session is still waiting on.
+func (m *Manager) ResolveSessionByType(sessionID, nType, status, source string) ([]string, error) {
+	ids, err := m.db.ResolveSessionNotificationsByType(sessionID, nType, status, source)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s notifications for %s: %w", nType, sessionID, err)
+	}
+	m.announceAll(ids, status, source)
+	return ids, nil
+}
+
+func (m *Manager) announceAll(ids []string, status, source string) {
+	for _, id := range ids {
+		m.unblock(id, Decision{Status: status})
+		m.announce(id, status, source)
+	}
+}
+
+// unblock hands a decision to a waiting hook handler, if one is still there.
+// Non-blocking: a repeat resolve for the same notification must not wedge the
+// caller behind the already-buffered decision.
+func (m *Manager) unblock(notifID string, decision Decision) {
 	m.mu.Lock()
 	ch, ok := m.pending[notifID]
 	m.mu.Unlock()
-
-	if ok {
-		// Non-blocking: a repeat resolve for the same notification must not
-		// wedge the caller behind the already-buffered decision.
-		select {
-		case ch <- decision:
-		default:
-		}
+	if !ok {
+		return
 	}
+	select {
+	case ch <- decision:
+	default:
+	}
+}
 
-	return nil
+func (m *Manager) announce(notifID, status, source string) {
+	m.mu.Lock()
+	fn := m.broadcast
+	m.mu.Unlock()
+	if fn == nil {
+		return
+	}
+	fn("notification_resolved", map[string]string{"id": notifID, "action": status, "source": source})
 }
 
 func (m *Manager) CreateNotification(n *store.Notification) error {
@@ -126,21 +195,21 @@ func (m *Manager) CancelPendingFromClaude(notifID string) {
 }
 
 func (m *Manager) cancelPendingWithStatus(notifID, status, source string) {
-	m.mu.Lock()
-	ch, ok := m.pending[notifID]
-	m.mu.Unlock()
-
 	// Hand the waiter a dismissal rather than closing the channel: the slot may
 	// have been registered before the handler blocks on it, and the decision has
 	// to survive that gap. The waiter deletes the slot on its way out.
-	if ok {
-		select {
-		case ch <- Decision{Status: "dismissed"}:
-		default:
-		}
-	}
+	m.unblock(notifID, Decision{Status: "dismissed"})
 
-	m.db.ResolveNotification(notifID, status, source)
+	if err := m.db.ResolveNotification(notifID, status, source); err != nil {
+		// Already resolved is the ordinary race: another surface got there
+		// first and announced it then. Anything else means the row did not
+		// change, so there is nothing to announce either.
+		if !errors.Is(err, store.ErrAlreadyResolved) {
+			log.Printf("notifications: cancel %s: %v", notifID, err)
+		}
+		return
+	}
+	m.announce(notifID, status, source)
 }
 
 // Notification retention — keep only the latest N resolved notifications.

--- a/internal/notifications/manager_test.go
+++ b/internal/notifications/manager_test.go
@@ -1,6 +1,8 @@
 package notifications
 
 import (
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -120,6 +122,169 @@ func TestCancelPending_Dismisses(t *testing.T) {
 
 	if got := waitWithTimeout(t, m, id); got.Status != "dismissed" {
 		t.Errorf("status = %q, want dismissed", got.Status)
+	}
+}
+
+// ─── Announcements ─────────────────────────────────────────────────────────
+//
+// Clients are a view of the store, so nothing may change a notification's
+// status without saying so. A resolution nobody hears about leaves a stale
+// approval on every phone and tray until the client next reconnects.
+
+type announcement struct {
+	eventType string
+	id        string
+	action    string
+	source    string
+}
+
+// recordAnnouncements installs a broadcaster and returns the events it saw.
+func recordAnnouncements(m *Manager) *[]announcement {
+	var seen []announcement
+	var mu sync.Mutex
+	m.SetBroadcaster(func(eventType string, data interface{}) {
+		fields, _ := data.(map[string]string)
+		mu.Lock()
+		seen = append(seen, announcement{eventType, fields["id"], fields["action"], fields["source"]})
+		mu.Unlock()
+	})
+	return &seen
+}
+
+func TestResolve_Announces(t *testing.T) {
+	m := newTestManager(t)
+	seen := recordAnnouncements(m)
+	id := seedNotification(t, m, "notif-announce")
+
+	if err := m.Resolve(id, Decision{Status: "approved"}, "device:abc"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if len(*seen) != 1 {
+		t.Fatalf("announcements = %d, want 1", len(*seen))
+	}
+	want := announcement{"notification_resolved", id, "approved", "device:abc"}
+	if (*seen)[0] != want {
+		t.Errorf("announced %+v, want %+v", (*seen)[0], want)
+	}
+}
+
+// The row is already resolved, so nothing changed and nothing is announced —
+// otherwise two surfaces answering at once would retract it twice.
+func TestResolve_AlreadyResolvedStaysQuiet(t *testing.T) {
+	m := newTestManager(t)
+	id := seedNotification(t, m, "notif-twice")
+	if err := m.Resolve(id, Decision{Status: "approved"}, "browser"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	seen := recordAnnouncements(m)
+	if err := m.Resolve(id, Decision{Status: "denied"}, "device:abc"); !errors.Is(err, store.ErrAlreadyResolved) {
+		t.Fatalf("second resolve err = %v, want ErrAlreadyResolved", err)
+	}
+	if len(*seen) != 0 {
+		t.Errorf("announcements = %+v, want none", *seen)
+	}
+}
+
+// The regression this whole change exists for: a hook that times out server
+// side marked the notification resolved and told no one, so it sat on the
+// phone forever.
+func TestCancelPending_Announces(t *testing.T) {
+	m := newTestManager(t)
+	seen := recordAnnouncements(m)
+	id := seedNotification(t, m, "notif-timeout")
+
+	m.Register(id)
+	m.CancelPending(id)
+
+	if len(*seen) != 1 {
+		t.Fatalf("announcements = %d, want 1 (timeout must reach clients)", len(*seen))
+	}
+	want := announcement{"notification_resolved", id, "timeout", "system"}
+	if (*seen)[0] != want {
+		t.Errorf("announced %+v, want %+v", (*seen)[0], want)
+	}
+}
+
+func TestCancelPendingFromClaude_Announces(t *testing.T) {
+	m := newTestManager(t)
+	seen := recordAnnouncements(m)
+	id := seedNotification(t, m, "notif-claude")
+
+	m.CancelPendingFromClaude(id)
+
+	if len(*seen) != 1 {
+		t.Fatalf("announcements = %d, want 1", len(*seen))
+	}
+	if (*seen)[0].action != "resolved" || (*seen)[0].source != "claude" {
+		t.Errorf("announced %+v, want resolved/claude", (*seen)[0])
+	}
+}
+
+func TestResolveSession_AnnouncesEveryNotification(t *testing.T) {
+	m := newTestManager(t)
+	seedNotification(t, m, "notif-a")
+	seedNotification(t, m, "notif-b")
+	seen := recordAnnouncements(m)
+
+	ids, err := m.ResolveSession("sess-1", "resolved", "claude")
+	if err != nil {
+		t.Fatalf("resolve session: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("resolved %d, want 2", len(ids))
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("announcements = %d, want 2", len(*seen))
+	}
+	for _, a := range *seen {
+		if a.action != "resolved" || a.source != "claude" {
+			t.Errorf("announced %+v, want resolved/claude", a)
+		}
+	}
+}
+
+// Narrowed by type so answering a question does not also retract a permission
+// the same session is still blocked on.
+func TestResolveSessionByType_LeavesOtherTypes(t *testing.T) {
+	m := newTestManager(t)
+	seedNotification(t, m, "notif-perm") // claude.permission
+	if err := m.CreateNotification(&store.Notification{
+		ID: "notif-q", Source: "claude", SourceSession: "sess-1",
+		Type: "claude.question", Status: "pending",
+	}); err != nil {
+		t.Fatalf("create question: %v", err)
+	}
+	seen := recordAnnouncements(m)
+
+	ids, err := m.ResolveSessionByType("sess-1", "claude.question", "resolved", "claude")
+	if err != nil {
+		t.Fatalf("resolve by type: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "notif-q" {
+		t.Fatalf("resolved %v, want [notif-q]", ids)
+	}
+	if len(*seen) != 1 || (*seen)[0].id != "notif-q" {
+		t.Fatalf("announcements = %+v, want just notif-q", *seen)
+	}
+
+	perm, err := m.GetNotification("notif-perm")
+	if err != nil {
+		t.Fatalf("get permission: %v", err)
+	}
+	if perm.Status != "pending" {
+		t.Errorf("permission status = %q, want pending", perm.Status)
+	}
+}
+
+// A manager with no broadcaster wired must still resolve rather than panic;
+// the daemon sets one in NewShared, but nothing enforces ordering.
+func TestResolve_WithoutBroadcaster(t *testing.T) {
+	m := newTestManager(t)
+	id := seedNotification(t, m, "notif-quiet")
+	if err := m.Resolve(id, Decision{Status: "approved"}, "browser"); err != nil {
+		t.Fatalf("resolve: %v", err)
 	}
 }
 

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -355,11 +355,11 @@ func handleStop(ctx *provider.HookContext, w http.ResponseWriter, r *http.Reques
 	updateSessionTranscript(ctx, &input)
 	renameSessionWindow(ctx, input.SessionID, "idle", input.CWD)
 
-	// Resolve any pending notifications for this session (approved from CLI)
-	resolvedIDs, _ := ctx.DB.ResolveSessionNotifications(input.SessionID, "resolved", "claude")
-	for _, id := range resolvedIDs {
-		ctx.Mgr.CancelPendingFromClaude(id)
-		ctx.Notify("notification_resolved", map[string]string{"id": id, "action": "resolved", "source": "claude"})
+	// Resolve any pending notifications for this session (approved from CLI).
+	// The manager announces each one, so clients drop them without being told
+	// separately.
+	if _, err := ctx.Mgr.ResolveSession(input.SessionID, "resolved", "claude"); err != nil {
+		log.Printf("hook: resolve notifications for %s: %v", input.SessionID, err)
 	}
 
 	notifID := notifications.GenerateNotificationID()
@@ -649,7 +649,6 @@ func waitForDecision(ctx *provider.HookContext, notifID string, r *http.Request)
 		return &denied
 	case <-r.Context().Done():
 		ctx.Mgr.CancelPendingFromClaude(notifID)
-		ctx.Notify("notification_resolved", map[string]string{"id": notifID, "action": "resolved", "source": "claude"})
 		return nil
 	}
 }
@@ -701,18 +700,13 @@ func handlePromptSubmit(ctx *provider.HookContext, w http.ResponseWriter, r *htt
 const askUserQuestionTool = "AskUserQuestion"
 
 // resolveSessionQuestions clears a session's pending claude.question
-// notifications and tells clients to drop them, whichever surface answered.
+// notifications, whichever surface answered. The manager tells clients.
 //
-// Narrowed to the one type rather than reusing ResolveSessionNotifications,
-// which would also clear a permission request the session is still waiting on.
+// Narrowed to the one type rather than resolving the whole session, which
+// would also clear a permission request the session is still waiting on.
 func resolveSessionQuestions(ctx *provider.HookContext, sessionID string) {
-	ids, err := ctx.DB.ResolveSessionNotificationsByType(sessionID, "claude.question", "resolved", "claude")
-	if err != nil {
+	if _, err := ctx.Mgr.ResolveSessionByType(sessionID, "claude.question", "resolved", "claude"); err != nil {
 		log.Printf("hook: resolve questions for %s: %v", sessionID, err)
-		return
-	}
-	for _, id := range ids {
-		ctx.Notify("notification_resolved", map[string]string{"id": id, "action": "resolved", "source": "claude"})
 	}
 }
 

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -145,13 +145,18 @@ func setupCtx(t *testing.T) (*provider.HookContext, *store.Store, *[]string) {
 	mgr := notifications.NewManager(db)
 	var sseEvents []string
 
+	notify := func(eventType string, _ interface{}) {
+		sseEvents = append(sseEvents, eventType)
+	}
+	// Mirrors server.NewShared: the manager announces its own resolutions, so
+	// tests see the same events clients would.
+	mgr.SetBroadcaster(notify)
+
 	ctx := &provider.HookContext{
-		DB:       db,
-		Mgr:      mgr,
-		Terminal: newFakeBackend(),
-		Notify: func(eventType string, _ interface{}) {
-			sseEvents = append(sseEvents, eventType)
-		},
+		DB:             db,
+		Mgr:            mgr,
+		Terminal:       newFakeBackend(),
+		Notify:         notify,
 		Report:         func(provider.ReportEvent) {},
 		SessionStarted: func(string) {},
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -94,11 +94,7 @@ func (s *PublicServer) handleNotificationAction(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	s.shared.SSE.Broadcast(SSEEvent{
-		Type: "notification_resolved",
-		Data: map[string]string{"id": id, "action": decision.Status, "source": source},
-	})
-
+	// Mgr.Resolve broadcasts notification_resolved itself.
 	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
 }
 
@@ -119,11 +115,6 @@ func (s *PublicServer) handleDismissNotification(w http.ResponseWriter, r *http.
 		jsonError(w, "failed to dismiss", http.StatusInternalServerError)
 		return
 	}
-
-	s.shared.SSE.Broadcast(SSEEvent{
-		Type: "notification_resolved",
-		Data: map[string]string{"id": id, "action": "dismissed", "source": source},
-	})
 
 	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
 }
@@ -176,10 +167,6 @@ func (s *PublicServer) handleBatchNotifications(w http.ResponseWriter, r *http.R
 			result["error"] = "already_resolved"
 		} else {
 			result["success"] = true
-			s.shared.SSE.Broadcast(SSEEvent{
-				Type: "notification_resolved",
-				Data: map[string]string{"id": id, "action": decision.Status, "source": source},
-			})
 		}
 		results = append(results, result)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,7 +54,7 @@ func (sh *Shared) injectTerminal(sess *store.Session) {
 }
 
 func NewShared(db *store.Store, mgr *notifications.Manager, be backend.Backend) *Shared {
-	return &Shared{
+	sh := &Shared{
 		DB:       db,
 		Mgr:      mgr,
 		SSE:      NewSSEBroadcaster(),
@@ -63,6 +63,12 @@ func NewShared(db *store.Store, mgr *notifications.Manager, be backend.Backend) 
 		Signals:  NewSessionSignals(),
 		Reporter: reporter.New("claude", db),
 	}
+	// The manager owns notification state, so it announces its own writes. No
+	// caller has to remember to, and none can resolve one silently.
+	mgr.SetBroadcaster(func(eventType string, data interface{}) {
+		sh.SSE.Broadcast(SSEEvent{Type: eventType, Data: data})
+	})
+	return sh
 }
 
 // NewInternalServer creates the localhost-only server for hooks and admin API.

--- a/internal/store/notifications.go
+++ b/internal/store/notifications.go
@@ -126,7 +126,7 @@ func (s *Store) ResolveSessionNotifications(sourceSession, status, source string
 		sourceSession,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query pending notifications: %w", err)
 	}
 	defer rows.Close()
 
@@ -138,12 +138,20 @@ func (s *Store) ResolveSessionNotifications(sourceSession, status, source string
 		}
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan pending notifications: %w", err)
+	}
 
-	if len(ids) > 0 {
-		s.db.Exec(
-			`UPDATE notifications SET status = ?, resolved_at = ?, resolved_source = ? WHERE source_session = ? AND status = 'pending'`,
-			status, now, source, sourceSession,
-		)
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	// Returning ids for an update that failed would have the caller announce
+	// resolutions that never happened, and clients would drop live approvals.
+	if _, err := s.db.Exec(
+		`UPDATE notifications SET status = ?, resolved_at = ?, resolved_source = ? WHERE source_session = ? AND status = 'pending'`,
+		status, now, source, sourceSession,
+	); err != nil {
+		return nil, fmt.Errorf("resolve pending notifications: %w", err)
 	}
 
 	return ids, nil


### PR DESCRIPTION
Two commits: the backend change you asked for, then the desktop client catching up.

## 1. The daemon announces every resolution it makes

You are right that this belongs on the server, and there was a real hole.

The store was always the source of truth — `notifications.status` / `resolved_source`, `Mgr.Resolve`, the `notification_resolved` SSE event. What was not owned by the server was the **announcement**: every call site had to remember to broadcast after resolving, and one did not.

`waitForDecision`'s five-minute timer calls `Mgr.CancelPending`, which wrote `status = 'timeout'` and broadcast nothing. The row was resolved, no client was told, and the approval sat on the phone and the tray until that client next reconnected. That is the stale notification.

The fix moves the announcement to the write:

- `Manager.SetBroadcaster` installs the SSE fan-out, wired once in `NewShared`
- `Resolve` and `cancelPendingWithStatus` announce on a real transition, and stay silent when the row was already resolved — `ResolveNotification` is `WHERE status = 'pending'`, so two surfaces answering at once cannot retract it twice
- `Manager.ResolveSession` / `ResolveSessionByType` replace the resolve-then-notify loops that `handleStop` and `resolveSessionQuestions` were hand-rolling
- `api.go` drops three now-duplicate `SSE.Broadcast` calls

`cancelPendingWithStatus` and `store.ResolveSessionNotifications` also stopped discarding their database errors. `ResolveSessionNotifications` returned the ids it *intended* to resolve even when the `UPDATE` failed, so a caller would have announced resolutions that never happened and clients would have dropped live approvals.

### What stays on the clients, and why

The server cannot reach an OS notification tray. It can say "this is resolved"; only the process that raised the banner can call `close`/`cancel` on it. So each client keeps a map of *banners it has posted* — that is not a second source of truth, it is a handle table.

The reconcile-on-reconnect in both clients is a **pull of server state**, not client bookkeeping: exactly because the phone goes offline and the daemon does not, a client that missed the SSE event re-derives its tray from `GET /api/notifications?status=pending`.

## 2. Desktop parity

- **Error card.** `claude.error` hit the default branch and offered only Dismiss, so a turn killed by an API error could not be retried from the desktop. It now shows the error with a Retry button, disabled with a live countdown while `reset_at` is in the future — same behaviour as the mobile card.
- **Notification retraction.** `Notifier.seed` was commented as the poll path but **nothing ever called it**; the tray had no correction path at all. It is now wired to `hosts.on('status')` when a host comes online and reconciles against the host's full pending set. `retract` also closes the OS banner, not just the badge count.

## Tests

Go — `go build`, `go vet`, `go test ./...` all green:
- `notifications`: announce on resolve; silence on an already-resolved row; announce on **both** cancel paths, the timeout one being the regression above; per-id announcements across a whole session; by-type resolve leaving other types pending; no broadcaster wired does not panic
- the claude hook harness wires the broadcaster the way `NewShared` does, so hook tests observe the production path

Desktop — `npm run typecheck` clean, `npm test` 22/22.

## Not done

Manual verification. The timeout retraction needs a hook to actually sit for five minutes, and the desktop reconcile needs the app taken offline and back while an approval is answered elsewhere. Neither has been run against a live daemon.
