### PR TITLE
fix: derive the tray from the daemon's pending set on mobile and desktop

### DIFF
--- a/desktop/src/main/notify.ts
+++ b/desktop/src/main/notify.ts
@@ -62,7 +62,13 @@ export class Notifier {
     const stillPending = new Set<string>()
     for (const notif of notifications) {
       if (notif.status !== 'pending') continue
-      stillPending.add(`${hostId}:${notif.id}`)
+      const key = `${hostId}:${notif.id}`
+      stillPending.add(key)
+      // Tracked here rather than left to present(): the badge counts what the
+      // daemon says is pending, while `seen` only decides whether to raise a
+      // banner. present() skips anything seen before, so an approval that has
+      // already alerted once would otherwise never come back onto the tray.
+      this.pending.set(key, { hostId, notificationId: notif.id, sessionId: notif.source_session })
       this.present(hostId, notif)
     }
     for (const key of [...this.pending.keys()]) {

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -214,6 +214,10 @@ class DaemonAPIService extends ChangeNotifier {
       // SSE is healthy — stop fallback polling
       _pollTimer?.cancel();
       _pollTimer = null;
+      // A dead stream is exactly when notification_resolved events go missing,
+      // so re-sync the tray against the daemon before trusting the stream
+      // again. Resuming the app already does this; a network flap does not.
+      fetchNotifications();
       notifyListeners();
 
       String buffer = '';
@@ -319,16 +323,18 @@ class DaemonAPIService extends ChangeNotifier {
     }
   }
 
-  /// Retract OS notifications for anything the daemon no longer considers
-  /// pending. This is the only thing that clears a notification answered while
-  /// the SSE stream was dead, which is every approval made while the phone was
-  /// dozing.
+  /// Bring the tray in line with the daemon, which owns notification status.
+  ///
+  /// This is the only thing that clears a notification answered while the SSE
+  /// stream was dead, which is every approval made while the phone was dozing.
+  /// Driven by the pending set rather than by the resolved rows: the daemon
+  /// prunes old notifications, so one resolved a while back is absent from the
+  /// response entirely and no per-row sweep would ever reach it.
   void _reconcilePostedNotifications() {
-    for (final n in _notifications) {
-      if (n.isPending) continue;
-      NotificationService.instance
-          .cancel(NotificationService.notifKey(hostId, n.id));
-    }
+    NotificationService.instance.retainOnly(
+      hostId,
+      _notifications.where((n) => n.isPending).map((n) => n.id).toSet(),
+    );
   }
 
   Future<bool> sendAction(String id, Map<String, dynamic> body) async {

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -97,6 +97,27 @@ class NotificationService {
     }
   }
 
+  /// Retract every notification posted for [hostId] that is not in
+  /// [pendingIds], so the tray matches what the daemon still considers pending.
+  ///
+  /// Set-based rather than cancelling the ids the daemon reported as resolved:
+  /// the daemon keeps only its most recent notifications, so one resolved long
+  /// enough ago is not in the list at all, and cancelling only what is listed
+  /// would leave it in the tray forever.
+  Future<void> retainOnly(String hostId, Set<String> pendingIds) async {
+    final prefix = '$hostId:';
+    final stale = _posted.keys
+        .where(
+          (key) =>
+              key.startsWith(prefix) &&
+              !pendingIds.contains(key.substring(prefix.length)),
+        )
+        .toList();
+    for (final key in stale) {
+      await cancel(key);
+    }
+  }
+
   /// Retract every notification this service has posted.
   Future<void> cancelAll() async {
     final ids = _posted.values.toList();

--- a/mobile/test/notification_service_test.dart
+++ b/mobile/test/notification_service_test.dart
@@ -134,6 +134,68 @@ void main() {
     expect(NotificationService.instance.isPosted('host-b:n2'), isFalse);
   });
 
+  // The daemon owns notification status; the tray is only a view of it. So the
+  // sweep is driven by the pending set, not by the rows the daemon reported as
+  // resolved — the daemon prunes old notifications, and one that ages out of
+  // the response entirely would never be reached by a per-row sweep.
+  group('retainOnly', () {
+    Future<void> post(String host, String id) =>
+        NotificationService.instance.showNotification(
+          id: '{"hostId":"$host","notificationId":"$id"}',
+          key: NotificationService.notifKey(host, id),
+          title: id,
+          body: id,
+          silent: true,
+        );
+
+    test('retracts a posted notification the daemon no longer lists', () async {
+      await post('host-a', 'n1');
+      await post('host-a', 'n2');
+
+      // n1 is gone from the response altogether, not merely marked resolved.
+      await NotificationService.instance.retainOnly('host-a', {'n2'});
+
+      expect(NotificationService.instance.isPosted('host-a:n1'), isFalse);
+      expect(NotificationService.instance.isPosted('host-a:n2'), isTrue);
+    });
+
+    test('leaves other hosts alone', () async {
+      await post('host-a', 'n1');
+      await post('host-b', 'n1');
+
+      await NotificationService.instance.retainOnly('host-a', {});
+
+      expect(NotificationService.instance.isPosted('host-a:n1'), isFalse);
+      expect(NotificationService.instance.isPosted('host-b:n1'), isTrue);
+    });
+
+    test('an empty pending set clears the host', () async {
+      await post('host-a', 'n1');
+      await post('host-a', 'n2');
+      calls.clear();
+
+      await NotificationService.instance.retainOnly('host-a', {});
+
+      expect(calls.where((c) => c.method == 'cancel').length, 2);
+    });
+
+    test('everything still pending is left posted and nothing is cancelled',
+        () async {
+      await post('host-a', 'n1');
+      calls.clear();
+
+      await NotificationService.instance.retainOnly('host-a', {'n1'});
+
+      expect(calls.where((c) => c.method == 'cancel'), isEmpty);
+      expect(NotificationService.instance.isPosted('host-a:n1'), isTrue);
+    });
+
+    test('a host with nothing posted is a no-op', () async {
+      await NotificationService.instance.retainOnly('host-z', {'n1'});
+      expect(calls.where((c) => c.method == 'cancel'), isEmpty);
+    });
+  });
+
   test('notifKey is stable and host-scoped', () {
     expect(NotificationService.notifKey('h', 'n'), 'h:n');
     expect(


### PR DESCRIPTION
Follow-up to #18. That PR made the daemon announce every resolution; this one makes both clients actually derive their tray from the daemon's state instead of keeping their own tally.

## The problem

Both clients reconciled by walking the notifications the daemon reported as **resolved** and cancelling those. That is not the same as "show exactly what the daemon says is pending", and the difference bites: the store prunes to the most recent 200, so a notification resolved a while ago is not in the response at all. A per-row sweep never reaches it, and the banner sits in the tray permanently.

The rule that actually follows from the daemon owning status is the set one: **anything posted for a host that the daemon does not list as pending comes down.**

## Mobile

- `NotificationService.retainOnly(hostId, pendingIds)` retracts by absence, scoped to one host so another host's approvals are untouched.
- `_reconcilePostedNotifications` now passes the pending set rather than sweeping resolved rows.
- `fetchNotifications()` also runs when the SSE stream connects. A dead stream is precisely when `notification_resolved` events go missing. Resuming the app already re-synced (`resumeAll`), but a network flap with the app in the foreground did not — the stream came back and the tray was never corrected.

## Desktop

`Notifier.seed` now records a notification as pending *before* calling `present()`. `present()` early-returns on anything in `seen`, so it never re-added an already-alerted approval to the `pending` map — one reconcile would drop it off the badge and nothing could put it back. The badge counts what the daemon says is pending; `seen` only decides whether to raise a banner. Those were conflated.

## What is still client-side, and why it has to be

The server cannot reach an OS tray. It can say "this is resolved"; only the process that raised the banner can call `cancel`/`close` on it. So each client keeps a map of *banners it has posted* — a handle table, not a second source of truth. Every decision about what belongs on screen now comes from the daemon.

## Tests

Dart — five new cases for `retainOnly`: retracts a notification absent from the response entirely, leaves other hosts alone, an empty pending set clears the host, a fully pending set cancels nothing, an unknown host is a no-op. `flutter test` 39/39, `flutter analyze` clean.

Desktop — `npm run typecheck` clean, `npm test` 22/22. Go untouched; `go build` and the notifications/server packages still green.

## Not done

Manual verification. The case worth doing by hand is: answer an approval on the laptop while the phone is in airplane mode long enough for the notification to age out of the daemon's list, then bring the phone back — the banner should disappear on reconnect.
