### PR TITLE
feat(desktop): resume parity with mobile, and fix the New session directory list

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -2,6 +2,7 @@ import { signJWT, type DeviceKey } from './keys.ts'
 import type {
   CommandInfo,
   DeviceInfo,
+  DirectoryInfo,
   FileContent,
   FileEntry,
   FileSearchResult,
@@ -123,8 +124,11 @@ export class ApiClient {
     return this.request('GET', `/api/sessions/${encodeURIComponent(id)}`)
   }
 
-  async listDirectories(): Promise<string[]> {
-    const res = await this.request<{ directories?: string[] }>('GET', '/api/sessions/directories')
+  async listDirectories(): Promise<DirectoryInfo[]> {
+    const res = await this.request<{ directories?: DirectoryInfo[] }>(
+      'GET',
+      '/api/sessions/directories',
+    )
     return res.directories ?? []
   }
 

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -1,6 +1,7 @@
 import type {
   CommandInfo,
   DeviceInfo,
+  DirectoryInfo,
   FileContent,
   FileEntry,
   FileSearchResult,
@@ -106,7 +107,7 @@ export class HostApi {
   getSession(id: string): Promise<{ session: Session; pending_permissions: number }> {
     return this.call('getSession', id)
   }
-  listDirectories(): Promise<string[]> {
+  listDirectories(): Promise<DirectoryInfo[]> {
     return this.call('listDirectories')
   }
   transcript(id: string, limit?: number, offset?: number): Promise<TranscriptPage> {

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -9,7 +9,13 @@ import {
   resolveFilePath,
 } from '../markdown.ts'
 import { store } from '../store.ts'
-import { BUSY_STATUSES, type Session, type TranscriptMessage } from '../../shared/models.ts'
+import {
+  BUSY_STATUSES,
+  canResume,
+  needsRecovery,
+  type Session,
+  type TranscriptMessage,
+} from '../../shared/models.ts'
 
 const PAGE = 200
 
@@ -24,6 +30,8 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
 
   const status = session.status
   const busy = BUSY_STATUSES.has(status)
+  const terminated = canResume(session)
+  const cold = needsRecovery(session)
 
   useEffect(() => {
     let cancelled = false
@@ -73,12 +81,17 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
       void store.refreshSessions(hostId)
     } catch (err) {
       // 409 is an answer, not a fault: the session is busy without a queue, or
-      // it has ended. Saying which is more use than "request failed".
+      // it ended between this render and the click. Refreshing swaps the
+      // composer for the resume banner, so the second attempt is not the same
+      // dead end as the first.
       if (statusOf(err) === 409) {
         store.notify(
-          status === 'terminated' ? 'Session has ended' : 'Session is busy and cannot queue prompts',
+          status === 'terminated'
+            ? 'Session has ended — resume to continue'
+            : 'Session is busy and cannot queue prompts',
           'error',
         )
+        void store.refreshSessions(hostId)
       } else {
         store.fail(err)
       }
@@ -114,30 +127,50 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
         {busy && <div className="typing">agent is working…</div>}
       </div>
 
-      <div className="composer">
-        <textarea
-          value={draft}
-          rows={3}
-          placeholder={session.supports_prompt_queue ? 'Send a prompt (⌘↵)' : 'Send a prompt'}
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-              event.preventDefault()
-              void send()
-            }
-          }}
-        />
-        <div className="composer-actions">
-          {busy && (
-            <button className="ghost" onClick={() => void api(hostId).stop(session.session_id)}>
-              Stop
-            </button>
-          )}
-          <button disabled={!draft.trim() || sending} onClick={() => void send()}>
-            {sending ? 'Sending…' : 'Send'}
+      {/* No composer for a terminated session: the daemon refuses its prompts,
+          so offering the box only trades a typed prompt for a 409. */}
+      {terminated ? (
+        <div className="composer ended">
+          <span className="ended-note">Session terminated — resume to continue</span>
+          <button
+            className="filled"
+            onClick={() => void store.resumeSession(hostId, session.session_id)}
+          >
+            Resume
           </button>
         </div>
-      </div>
+      ) : (
+        <div className="composer">
+          <textarea
+            value={draft}
+            rows={3}
+            placeholder={
+              cold
+                ? 'Send a prompt — the session wakes first'
+                : session.supports_prompt_queue
+                  ? 'Send a prompt (⌘↵)'
+                  : 'Send a prompt'
+            }
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault()
+                void send()
+              }
+            }}
+          />
+          <div className="composer-actions">
+            {busy && (
+              <button className="ghost" onClick={() => void api(hostId).stop(session.session_id)}>
+                Stop
+              </button>
+            )}
+            <button disabled={!draft.trim() || sending} onClick={() => void send()}>
+              {sending ? 'Sending…' : cold ? 'Wake and send' : 'Send'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -7,7 +7,15 @@ import { ChatPanel } from './chat.tsx'
 import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
 import { GitPanel } from './git.tsx'
-import { BUSY_STATUSES, sessionLabel, statusLabel, type Session } from '../../shared/models.ts'
+import {
+  BUSY_STATUSES,
+  canResume,
+  hasTerminal,
+  needsRecovery,
+  sessionLabel,
+  statusLabel,
+  type Session,
+} from '../../shared/models.ts'
 
 const PANELS: RightPanel[] = ['chat', 'approvals', 'git', 'files']
 
@@ -74,8 +82,10 @@ export function Detail(): JSX.Element {
 function SessionHeader({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(session.title ?? '')
-  const live = Boolean(session.terminal)
+  const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
+  const terminated = canResume(session)
+  const cold = needsRecovery(session)
 
   const run = async (fn: () => Promise<unknown>): Promise<void> => {
     try {
@@ -122,11 +132,32 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
           {statusLabel(session.status)}
         </span>
 
+        {cold && (
+          <button
+            className="ghost cold"
+            title="Cold — no live terminal. Resume brings the agent back."
+            onClick={() => void store.resumeSession(hostId, session.session_id)}
+          >
+            ⚯ Cold
+          </button>
+        )}
+
         <PermissionMode hostId={hostId} session={session} />
 
-        <button className="filled" onClick={() => void store.openTerminal(hostId, session, !live)}>
-          {live ? 'Terminal' : 'Wake'}
-        </button>
+        {/* Resume, not Wake: waking a terminated session starts its host but
+            leaves the daemon refusing every prompt. */}
+        {terminated ? (
+          <button
+            className="filled"
+            onClick={() => void store.resumeSession(hostId, session.session_id)}
+          >
+            Resume
+          </button>
+        ) : (
+          <button className="filled" onClick={() => void store.openTerminal(hostId, session, !live)}>
+            {live ? 'Terminal' : 'Wake'}
+          </button>
+        )}
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}
 
@@ -152,9 +183,6 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
             >
               {session.archived ? 'Unarchive' : 'Archive'}
             </button>
-            {!live && (
-              <button onClick={() => void run(() => api(hostId).resume(session.session_id))}>Resume</button>
-            )}
             <button onClick={() => void run(() => api(hostId).terminate(session.session_id))}>
               Terminate
             </button>

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
-import type { ModelInfo, ProviderInfo } from '../../shared/models.ts'
+import type { DirectoryInfo, ModelInfo, ProviderInfo } from '../../shared/models.ts'
 
 export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const [hostId, setHostId] = useState(hosts[0]?.id ?? '')
   const [providers, setProviders] = useState<ProviderInfo[]>([])
   const [models, setModels] = useState<ModelInfo[]>([])
-  const [directories, setDirectories] = useState<string[]>([])
+  const [directories, setDirectories] = useState<DirectoryInfo[]>([])
   const [provider, setProvider] = useState('claude')
   const [model, setModel] = useState('')
   const [cwd, setCwd] = useState('')
@@ -28,7 +28,7 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
         setDirectories(dirs)
         const first = providerList[0]
         if (first && !providerList.some((p) => p.id === provider)) setProvider(first.id)
-        if (!cwd && dirs[0]) setCwd(dirs[0])
+        if (!cwd && dirs[0]) setCwd(dirs[0].cwd)
       })
       .catch((err: unknown) => store.fail(err))
     return () => {
@@ -119,9 +119,12 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
           spellCheck={false}
           onChange={(event) => setCwd(event.target.value)}
         />
+        {/* The daemon sends objects, not paths: cwd is the value, and the
+            project name is the label that tells two checkouts of the same
+            repository apart. */}
         <datalist id="known-directories">
           {directories.map((dir) => (
-            <option key={dir} value={dir} />
+            <option key={dir.cwd} value={dir.cwd} label={dir.project || undefined} />
           ))}
         </datalist>
       </label>

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -3,6 +3,9 @@ import { useMemo, useState } from 'react'
 import { store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
+  canResume,
+  hasTerminal,
+  needsRecovery,
   sessionLabel,
   shortCwd,
   statusLabel,
@@ -142,13 +145,21 @@ function SessionRow({
   pending: number
   selected: boolean
 }): JSX.Element {
-  const live = Boolean(session.terminal)
+  const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
+  const terminated = canResume(session)
+  const cold = needsRecovery(session)
   return (
     <article
       className={`session-card ${session.status} ${selected ? 'selected' : ''}`}
       onClick={() => store.select(hostId, session.session_id)}
-      onDoubleClick={() => void store.openTerminal(hostId, session, !live)}
+      // A terminated session has to be resumed before it has a terminal worth
+      // opening, so the shortcut resumes instead of waking one it will refuse.
+      onDoubleClick={() =>
+        void (terminated
+          ? store.resumeSession(hostId, session.session_id)
+          : store.openTerminal(hostId, session, !live))
+      }
     >
       <div className="card-inner">
         <div className="card-top">
@@ -156,6 +167,11 @@ function SessionRow({
             <span className={busy ? 'dot pulse' : 'dot'} />
             {statusLabel(session.status)}
           </span>
+          {cold && (
+            <span className="cold-mark" title="Cold — no live terminal">
+              ⚯
+            </span>
+          )}
           {session.pinned && (
             <span className="pin" title="Pinned">
               ★
@@ -177,14 +193,21 @@ function SessionRow({
             {session.permission_mode ? ` · ${shortMode(session.permission_mode)}` : ''}
           </span>
           <button
-            className="row-btn"
-            title={live ? 'Open terminal' : 'Wake and open terminal'}
+            className={terminated ? 'row-btn resume' : 'row-btn'}
+            title={
+              terminated
+                ? 'Resume — bring the agent back'
+                : live
+                  ? 'Open terminal'
+                  : 'Cold — wake and open terminal'
+            }
             onClick={(event) => {
               event.stopPropagation()
-              void store.openTerminal(hostId, session, !live)
+              if (terminated) void store.resumeSession(hostId, session.session_id)
+              else void store.openTerminal(hostId, session, !live)
             }}
           >
-            {live ? 'Terminal' : 'Wake'}
+            {terminated ? 'Resume' : live ? 'Terminal' : 'Wake'}
           </button>
         </div>
       </div>
@@ -196,8 +219,8 @@ function SessionRow({
 function compareRows(a: Row, b: Row): number {
   if (a.pending !== b.pending) return b.pending - a.pending
   if (a.session.pinned !== b.session.pinned) return a.session.pinned ? -1 : 1
-  const aLive = Boolean(a.session.terminal)
-  const bLive = Boolean(b.session.terminal)
+  const aLive = hasTerminal(a.session)
+  const bLive = hasTerminal(b.session)
   if (aLive !== bLive) return aLive ? -1 : 1
   return (b.session.last_event_at ?? b.session.created_at).localeCompare(
     a.session.last_event_at ?? a.session.created_at,

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react'
 
-import { api, bridge } from './bridge.ts'
+import { api, bridge, statusOf } from './bridge.ts'
 import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
 
 export interface Tab {
@@ -180,7 +180,12 @@ class Store {
         const id = str(event.data.session_id)
         const status = str(event.data.status)
         if (!id || !status) return
-        this.patchSession(hostId, id, { status } as Partial<Session>)
+        // A resume carries the new host handle. Taking it matters: the session
+        // is cold in this client's copy until something says otherwise, and
+        // most session_status events say nothing about the terminal at all —
+        // so an absent handle is no evidence the host went away.
+        const terminal = str(event.data.terminal)
+        this.patchSession(hostId, id, (terminal ? { status, terminal } : { status }) as Partial<Session>)
         return
       }
       case 'session_updated':
@@ -288,6 +293,25 @@ class Store {
       this.set((s) => ({ tabs: s.tabs.filter((t) => t.id !== tab.id) }))
       this.fail(err)
     }
+  }
+
+  /**
+   * Brings a terminated session's agent back and moves the daemon's record out
+   * of `terminated`, which is what re-enables prompts. Distinct from waking:
+   * a wake starts the host but leaves the status alone, so a woken terminated
+   * session looks alive and refuses everything.
+   */
+  async resumeSession(hostId: string, sessionId: string): Promise<void> {
+    try {
+      await api(hostId).resume(sessionId)
+      this.notify('Session resumed')
+    } catch (err) {
+      // The daemon refuses to resume a session that is already running its
+      // turn, which is not a failure worth a red error from the user's side.
+      if (statusOf(err) === 409) this.notify('Session is already running', 'error')
+      else this.fail(err)
+    }
+    await this.refreshSessions(hostId)
   }
 
   setActiveTab(activeTab: string | null): void {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -146,6 +146,15 @@ button.link {
   padding: 4px 8px;
 }
 
+/* Cold, not broken: amber rather than red, as on the mobile app bar. */
+button.cold {
+  color: var(--s-waiting);
+}
+
+button.cold:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--s-waiting) 14%, transparent);
+}
+
 button.danger {
   color: var(--error);
 }
@@ -599,6 +608,13 @@ small {
   font-size: 12px;
 }
 
+/* No live host behind the status: the card says idle, this says it will take a
+   moment to prove it. */
+.cold-mark {
+  color: var(--s-waiting);
+  font-size: 12px;
+}
+
 .card-title {
   margin-top: 8px;
   font-size: 14px;
@@ -645,7 +661,10 @@ small {
 }
 
 .session-card:hover .row-btn,
-.session-card.selected .row-btn {
+.session-card.selected .row-btn,
+/* The only move a terminated session has left, so it does not wait for a
+   hover to admit it exists. */
+.row-btn.resume {
   opacity: 1;
 }
 
@@ -1217,6 +1236,19 @@ small {
 
 .composer {
   padding: 12px 16px 14px;
+}
+
+/* What replaces the composer once the session has ended. */
+.composer.ended {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ended-note {
+  font-size: 13px;
+  color: var(--on-surface-variant);
 }
 
 .composer textarea {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -45,8 +45,35 @@ export const BUSY_STATUSES: ReadonlySet<string> = new Set([
   'waiting_permission',
 ])
 
-export function isLive(session: Session): boolean {
-  return session.status !== 'ended' && session.status !== 'terminated'
+/** A live terminal host is attached. Absent means the session is cold. */
+export function hasTerminal(session: Session): boolean {
+  return Boolean(session.terminal)
+}
+
+/**
+ * The one final state. The daemon refuses prompts for a terminated session
+ * outright (internal/server/api.go, session-send returns 409 session_terminated)
+ * and POST /resume is the only way back — waking it would revive the process
+ * but leave the record terminated, so every prompt would still be refused.
+ */
+export function isTerminated(session: Session): boolean {
+  return session.status === 'terminated'
+}
+
+/**
+ * Alive on paper with no host to run in: evicted, or the daemon restarted
+ * under it. Nothing resurrects a host on its own, but anything that needs one
+ * — a prompt, a terminal, a resume — brings it back in place.
+ *
+ * Mirrors Session.needsRecovery in mobile/lib/models/session.dart.
+ */
+export function needsRecovery(session: Session): boolean {
+  return !hasTerminal(session) && !isTerminated(session)
+}
+
+/** Resume relaunches the agent and moves the session back to idle. */
+export function canResume(session: Session): boolean {
+  return isTerminated(session)
 }
 
 /** Display label: the generated title, else the last prompt, else the directory. */

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -117,6 +117,14 @@ export function shortCwd(cwd: string): string {
   return parts.length <= 2 ? cwd : `…/${parts.slice(-2).join('/')}`
 }
 
+/** internal/store/sessions.go:258 — one directory Helios has seen sessions in. */
+export interface DirectoryInfo {
+  cwd: string
+  project: string
+  session_count: number
+  active_count: number
+}
+
 /** internal/store/notifications.go:8. `type` is provider-scoped, e.g. claude.permission. */
 export interface Notification {
   id: string

--- a/desktop/test/session-state.test.ts
+++ b/desktop/test/session-state.test.ts
@@ -1,0 +1,67 @@
+// The state a session is in decides which action the UI offers, and getting it
+// wrong is not cosmetic: offering Wake on a terminated session starts a host
+// the daemon still refuses every prompt for. These rules mirror
+// mobile/lib/models/session.dart, so a change here is a change to both clients.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { canResume, hasTerminal, needsRecovery, type Session } from '../src/shared/models.ts'
+
+function session(patch: Partial<Session>): Session {
+  return {
+    session_id: 's1',
+    source: 'claude',
+    cwd: '/tmp/repo',
+    project: 'repo',
+    status: 'idle',
+    pinned: false,
+    archived: false,
+    managed: true,
+    created_at: '2026-01-01T00:00:00Z',
+    supports_prompt_queue: true,
+    ...patch,
+  }
+}
+
+test('a session with a host handle is warm', () => {
+  const warm = session({ terminal: '/tmp/helios/s1.sock' })
+  assert.equal(hasTerminal(warm), true)
+  assert.equal(needsRecovery(warm), false)
+  assert.equal(canResume(warm), false)
+})
+
+test('an empty handle is no handle', () => {
+  // The daemon omits the field, but an older one has sent "" for a dead host.
+  assert.equal(hasTerminal(session({ terminal: '' })), false)
+})
+
+test('idle with no host needs a wake, not a resume', () => {
+  const cold = session({ status: 'idle' })
+  assert.equal(needsRecovery(cold), true)
+  assert.equal(canResume(cold), false)
+})
+
+test('terminated is the one state a wake cannot fix', () => {
+  const dead = session({ status: 'terminated' })
+  assert.equal(canResume(dead), true)
+  // Not "cold": a wake would start the host and leave the record terminated.
+  assert.equal(needsRecovery(dead), false)
+})
+
+test('a terminated session with a stale handle still only offers resume', () => {
+  const dead = session({ status: 'terminated', terminal: '/tmp/helios/s1.sock' })
+  assert.equal(canResume(dead), true)
+  assert.equal(needsRecovery(dead), false)
+})
+
+test('ended is cold, not terminated: the daemon wakes it to take a prompt', () => {
+  const ended = session({ status: 'ended' })
+  assert.equal(canResume(ended), false)
+  assert.equal(needsRecovery(ended), true)
+})
+
+test('a busy session is neither cold nor resumable', () => {
+  const busy = session({ status: 'active', terminal: '/tmp/helios/s1.sock' })
+  assert.equal(needsRecovery(busy), false)
+  assert.equal(canResume(busy), false)
+})


### PR DESCRIPTION
Two desktop fixes, both cases of the desktop client disagreeing with what the daemon actually does.

## 1. Resume parity with mobile

Desktop had one notion of "not running" — no terminal handle — and offered **Wake** for all of it. Mobile distinguishes two states, and so does the daemon:

| | cold (`!terminal && status != terminated`) | terminated |
|---|---|---|
| daemon | a prompt, a terminal or a resume wakes it in place | `session-send` returns `409 session_terminated`; only `POST /resume` clears it |
| mobile | amber `link_off`, "Cold — tap to resume" | `play_arrow` Resume, and the composer becomes a "Session terminated — resume to continue" banner |
| desktop (before) | primary button "Wake" | primary button **still "Wake"**, Resume buried in `⋯`, composer enabled and failing with a 409 |

Waking a terminated session was the actual bug: it starts the host, leaves the record `terminated`, and the session then looks alive while refusing everything typed into it.

- `shared/models.ts`: `hasTerminal`, `isTerminated`, `needsRecovery`, `canResume`, mirroring `Session` in `mobile/lib/models/session.dart`. Replaces `isLive`, which nothing called.
- `detail.tsx`: Resume replaces Wake as the primary action for a terminated session; a cold session gets an amber chip that resumes in place. The now-duplicate `⋯` item is gone.
- `chat.tsx`: the composer becomes the resume banner for a terminated session, says "Wake and send" for a cold one, and refreshes on a 409 so a session that died mid-render swaps to the banner instead of failing twice.
- `sidebar.tsx`: cards carry a cold mark; the row button and double-click resume rather than wake.
- `store.ts`: `resumeSession` (409 → "already running", then refresh), and `session_status` now takes the terminal handle a resume carries — without it the session reads as cold until the next full refresh.

## 2. New session directory list

`GET /api/sessions/directories` returns `[]DirectoryInfo` (cwd, project, counts); the client typed it `[]string`. Every suggestion rendered as `[object Object]`, and the first entry was written straight into the cwd field — so **starting a session sent `"[object Object]"` as the working directory**. Typed as the Go struct does, seeded from `.cwd`, labelled with the project name. Mobile has parsed this correctly all along.

## Verification

- `npm run typecheck`, `npm run build`, `npm test` — 29 pass, including 7 new cases in `test/session-state.test.ts` covering the states the two clients have to agree on (empty handle, terminated-with-stale-handle, `ended` vs `terminated`).
- Ran the app against the live daemon: terminated cards show Resume without a hover, and the Directory field now reads `/Users/kamrul/workspace/helios` instead of `[object Object]`.