### PR TITLE
feat(desktop): terminal as a panel tab, plus a one-command install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean install uninstall test
 .PHONY: apk apk-release apk-install apk-run apk-debug apk-clean apk-device mobile
 .PHONY: dmg dmg-dev changelog release
-.PHONY: desktop desktop-dev desktop-test desktop-app desktop-clean
+.PHONY: desktop desktop-dev desktop-test desktop-app desktop-install desktop-clean
 
 VERSION = 0.2.5
 REPO = kamrul1157024/helios
@@ -134,6 +134,9 @@ dmg-dev:
 DESKTOP_VERSION = $(shell sed -n 's/.*"version": "\(.*\)".*/\1/p' desktop/package.json | head -1)
 DESKTOP_ARCH = $(if $(filter arm64,$(shell uname -m)),arm64,x64)
 DESKTOP_DMG = desktop/release/helios-desktop-$(DESKTOP_VERSION)-$(DESKTOP_ARCH).dmg
+# electron-builder suffixes the staging directory with the arch, except on the
+# x64 build, where it is bare `mac`.
+DESKTOP_APP = desktop/release/$(if $(filter arm64,$(DESKTOP_ARCH)),mac-arm64,mac)/Helios.app
 
 # make runs recipes under /bin/sh, which never sources a profile, so an nvm
 # install is invisible unless the parent shell already exported it.
@@ -167,6 +170,21 @@ desktop-app: desktop
 	else \
 		echo "Built, but $(DESKTOP_DMG) is missing — see desktop/release"; \
 	fi
+
+## Build the desktop app and install it into /Applications (macOS)
+desktop-install: desktop-app
+ifneq ($(UNAME_S),Darwin)
+	@echo "make desktop-install is macOS-only; on Linux install the AppImage or .deb from desktop/release" >&2
+	@exit 1
+else
+	@test -d "$(DESKTOP_APP)" || (echo "$(DESKTOP_APP) not found — see desktop/release" >&2 && exit 1)
+	# Replaced rather than copied over: a copy leaves the previous build's files
+	# behind inside the bundle.
+	rm -rf /Applications/Helios.app
+	cp -R "$(DESKTOP_APP)" /Applications/Helios.app
+	xattr -dr com.apple.quarantine /Applications/Helios.app 2>/dev/null || true
+	@echo "Helios.app installed to /Applications"
+endif
 
 desktop-clean:
 	rm -rf desktop/dist desktop/release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 **A platform that orchestrates AI coding agents on your machine.**
 
+## Install
+
+```bash
+git clone https://github.com/kamrul1157024/helios.git && cd helios
+
+make install           # daemon + CLI  → /usr/local/bin/helios   (needs Go 1.26+)
+make desktop-install   # desktop app   → /Applications/Helios.app (macOS, needs Node 20+)
+make apk-install       # Android app   → the device on adb        (needs Flutter 3.32+)
+
+helios start           # the TUI checks your setup and walks you through the rest
+```
+
+Only `make install` is required — the daemon is the product, and the apps are
+clients for it. Everything after that happens in the TUI: pick a tunnel, show a
+QR code, pair a device.
+
+| Command | Builds | Installs to |
+| --- | --- | --- |
+| `make install` | Go binary | `/usr/local/bin/helios` |
+| `make desktop-install` | Electron app | `/Applications/Helios.app` |
+| `make desktop-app` | Electron app | `desktop/release/*.dmg` (no install) |
+| `make apk-install` | Debug APK | the connected Android device |
+| `make apk-release` | Release APK | `~/.helios/helios.apk` |
+
+Pick one tunnel provider so your phone can reach the daemon —
+`brew install cloudflared` (recommended, no account) or `brew install ngrok`.
+
+The full walkthrough, with screenshots of each step, is in the
+[Setup Guide](#setup-guide) below.
+
+---
+
 You run 5 Claude sessions across 3 projects. One needs permission to run a test. Another finished refactoring and is waiting for your next instruction. A third hit a rate limit 20 minutes ago. You don't know any of this because you're in a different terminal tab.
 
 Helios fixes this. It's a daemon that sits between you and your AI coding tools. It runs each session in a terminal of its own, watches for events via hooks, and notifies you the moment any session needs attention — on your desktop, your phone, your browser, wherever you are. It also narrates what your agents are doing in real time via voice reporting, so you can stay informed hands-free without watching the screen.
@@ -487,7 +519,7 @@ helios resume 1
 
 ## Requirements
 
-- Go 1.22+
+- Go 1.26+ (the version in go.mod)
 - At least one AI CLI tool (claude, aider, codex, etc.)
 - Flutter 3.32+ (only if building the mobile/desktop app from source)
 

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useState } from 'react'
 
-import { store, useStore } from './store.ts'
+import { store, terminalId, useStore } from './store.ts'
 import { Detail } from './components/detail.tsx'
 import { HostsDialog } from './components/hosts.tsx'
 import { NewSessionDialog } from './components/newsession.tsx'
 import { Sidebar } from './components/sidebar.tsx'
-import { TerminalTabs } from './components/terminal.tsx'
 
 export function App(): JSX.Element {
   const loading = useStore((s) => s.loading)
   const toast = useStore((s) => s.toast)
-  const tabs = useStore((s) => s.tabs)
   const pairingLink = useStore((s) => s.pairingLink)
   const [dialog, setDialog] = useState<'new' | 'hosts' | null>(null)
 
@@ -29,10 +27,15 @@ export function App(): JSX.Element {
         event.preventDefault()
         setDialog('new')
       }
-      if ((event.metaKey || event.ctrlKey) && event.key === 'w' && store.getSnapshot().activeTab) {
-        event.preventDefault()
-        const active = store.getSnapshot().activeTab
-        if (active) store.closeTab(active)
+      // ⌘W closes the selected session's terminal, not the window: the
+      // terminal is the only thing in this layout that can be closed.
+      if ((event.metaKey || event.ctrlKey) && event.key === 'w') {
+        const { selection, tabs } = store.getSnapshot()
+        const id = selection ? terminalId(selection.hostId, selection.sessionId) : null
+        if (id && tabs.some((t) => t.id === id)) {
+          event.preventDefault()
+          store.closeTab(id)
+        }
       }
     }
     window.addEventListener('keydown', onKey)
@@ -52,9 +55,8 @@ export function App(): JSX.Element {
       <div className="titlebar" />
       <div className="body">
         <Sidebar onNewSession={() => setDialog('new')} onAddHost={() => setDialog('hosts')} />
-        <main className={tabs.length > 0 ? 'main split' : 'main'}>
+        <main className="main">
           <Detail />
-          <TerminalTabs />
         </main>
       </div>
 

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
-import { store, useStore, type RightPanel } from '../store.ts'
+import { store, terminalId, useStore, type RightPanel } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { ChatPanel } from './chat.tsx'
 import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
 import { GitPanel } from './git.tsx'
+import { TerminalPanes } from './terminal.tsx'
 import {
   BUSY_STATUSES,
   canResume,
@@ -17,63 +18,84 @@ import {
   type Session,
 } from '../../shared/models.ts'
 
-const PANELS: RightPanel[] = ['chat', 'approvals', 'git', 'files']
+const PANELS: RightPanel[] = ['chat', 'terminal', 'approvals', 'git', 'files']
 
 export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const sessions = useStore((s) => s.sessions)
   const notifications = useStore((s) => s.notifications)
   const panel = useStore((s) => s.panel)
+  const tabs = useStore((s) => s.tabs)
 
-  if (!selection) {
-    return (
-      <div className="detail empty">
-        <p>Select a session.</p>
-      </div>
-    )
-  }
+  const hostId = selection?.hostId ?? null
+  const session =
+    (selection && sessions[selection.hostId]?.find((s) => s.session_id === selection.sessionId)) ?? null
 
-  const session = sessions[selection.hostId]?.find((s) => s.session_id === selection.sessionId)
-  if (!session) {
-    return (
-      <div className="detail empty">
-        <p>That session is no longer listed.</p>
-      </div>
-    )
-  }
-
-  const pending = (notifications[selection.hostId] ?? []).filter(
-    (n) => n.source_session === session.session_id,
-  ).length
+  const pending = session
+    ? (notifications[hostId ?? ''] ?? []).filter((n) => n.source_session === session.session_id).length
+    : 0
+  const term = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
 
   return (
     <div className="detail">
-      <SessionHeader hostId={selection.hostId} session={session} />
+      {hostId && session && (
+        <>
+          <SessionHeader hostId={hostId} session={session} />
 
-      <nav className="panel-tabs">
-        {PANELS.map((name) => (
-          <button
-            key={name}
-            className={panel === name ? 'active' : ''}
-            onClick={() => store.setPanel(name)}
-          >
-            {name}
-            {name === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
-          </button>
-        ))}
-      </nav>
+          <nav className="panel-tabs">
+            {PANELS.map((name) => (
+              <button
+                key={name}
+                className={panel === name ? 'active' : ''}
+                onClick={() => (name === 'terminal' ? store.showTerminal(hostId, session) : store.setPanel(name))}
+              >
+                {/* The old tabstrip carried the connection state, and it is
+                    still the one thing about a terminal worth seeing from
+                    another panel. */}
+                {name === 'terminal' && term && <span className={`dot ${term.status.state}`} />}
+                {name}
+                {name === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
+                {name === 'terminal' && term && (
+                  <span
+                    className="tab-close"
+                    role="button"
+                    aria-label="Close terminal"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      store.closeTab(term.id)
+                    }}
+                  >
+                    ×
+                  </span>
+                )}
+              </button>
+            ))}
+          </nav>
+        </>
+      )}
 
       <div className="panel-body">
-        <PanelBoundary resetKey={`${selection.hostId}:${session.session_id}:${panel}`}>
-          {panel === 'chat' && <ChatPanel hostId={selection.hostId} session={session} />}
-          {panel === 'approvals' && (
-            <ApprovalsPanel hostId={selection.hostId} sessionId={session.session_id} />
-          )}
-          {panel === 'git' && (
-            <GitPanel hostId={selection.hostId} cwd={session.cwd} revision={session.last_event_at} />
-          )}
-          {panel === 'files' && <FilesPanel hostId={selection.hostId} cwd={session.cwd} />}
-        </PanelBoundary>
+        {!session && (
+          <div className="panel-empty">
+            <p>{selection ? 'That session is no longer listed.' : 'Select a session.'}</p>
+          </div>
+        )}
+
+        {hostId && session && panel !== 'terminal' && (
+          <PanelBoundary resetKey={`${hostId}:${session.session_id}:${panel}`}>
+            {panel === 'chat' && <ChatPanel hostId={hostId} session={session} />}
+            {panel === 'approvals' && <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />}
+            {panel === 'git' && (
+              <GitPanel hostId={hostId} cwd={session.cwd} revision={session.last_event_at} />
+            )}
+            {panel === 'files' && <FilesPanel hostId={hostId} cwd={session.cwd} />}
+          </PanelBoundary>
+        )}
+
+        {/* Outside the switch above, and outside the boundary: the panes stay
+            mounted whatever is selected, or every terminal would lose its
+            scrollback the moment the user looked at another panel. */}
+        <TerminalPanes hostId={hostId} session={session} visible={panel === 'terminal' && Boolean(session)} />
       </div>
     </div>
   )

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -5,7 +5,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 
 import { bridge } from '../bridge.ts'
-import { store, useStore, type Tab } from '../store.ts'
+import { store, terminalId, useStore, type Tab } from '../store.ts'
+import { canResume, hasTerminal, type Session } from '../../shared/models.ts'
 
 /**
  * Output arrives on one channel for every tab, so it is dispatched here rather
@@ -39,43 +40,65 @@ const THEME = {
   brightWhite: '#ffffff',
 }
 
-export function TerminalTabs(): JSX.Element | null {
+/**
+ * The terminal panel: the selected session's terminal, and every other open one
+ * kept mounted behind it.
+ *
+ * Mounted, not rendered on demand, because an xterm that unmounts loses its
+ * scrollback and neither the daemon nor the main process can replay it — only
+ * the visible pane is `active`, and the rest sit hidden and silent.
+ */
+export function TerminalPanes({
+  hostId,
+  session,
+  visible,
+}: {
+  hostId: string | null
+  session: Session | null
+  visible: boolean
+}): JSX.Element {
   const tabs = useStore((s) => s.tabs)
-  const activeTab = useStore((s) => s.activeTab)
+  const current = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
 
-  if (tabs.length === 0) return null
+  useEffect(() => {
+    if (!visible || current || !hostId || !session) return
+    // Warm sessions attach as soon as the panel is shown: the host is already
+    // running, so opening the tab is the whole of the request. A cold one waits
+    // for the button below, because attaching would start an agent.
+    if (hasTerminal(session)) void store.openTerminal(hostId, session, false)
+  }, [visible, current, hostId, session])
 
   return (
-    <div className="terminals">
-      <div className="tabstrip">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            className={`tab ${tab.id === activeTab ? 'active' : ''} ${tab.status.state}`}
-            onClick={() => store.setActiveTab(tab.id)}
-          >
-            <span className={`dot ${tab.status.state}`} />
-            <span className="tab-title">{tab.title}</span>
-            <span
-              className="tab-close"
-              role="button"
-              aria-label="Close tab"
-              onClick={(event) => {
-                event.stopPropagation()
-                store.closeTab(tab.id)
-              }}
-            >
-              ×
-            </span>
-          </button>
-        ))}
-      </div>
+    <div className={visible ? 'panes' : 'panes hidden'}>
+      {tabs.map((tab) => (
+        <TerminalPane key={tab.id} tab={tab} active={visible && tab.id === current?.id} />
+      ))}
 
-      <div className="panes">
-        {tabs.map((tab) => (
-          <TerminalPane key={tab.id} tab={tab} active={tab.id === activeTab} />
-        ))}
-      </div>
+      {visible && !current && hostId && session && (
+        <div className="pane-empty">
+          {/* Resume, not wake, for a terminated session: a wake would start the
+              host and attach to a session the daemon still refuses prompts for.
+              Resuming moves it back to idle, and the effect above attaches as
+              soon as the handle lands. */}
+          <p>
+            {canResume(session)
+              ? 'Session terminated — resume to bring the agent back.'
+              : 'No terminal attached to this session.'}
+          </p>
+          {canResume(session) ? (
+            <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
+              Resume
+            </button>
+          ) : (
+            <button
+              className="filled"
+              onClick={() => void store.openTerminal(hostId, session, !hasTerminal(session))}
+            >
+              {hasTerminal(session) ? 'Attach' : 'Wake and attach'}
+            </button>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
 
 import { api, bridge, statusOf } from './bridge.ts'
+import { hasTerminal } from '../shared/models.ts'
 import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
 
 export interface Tab {
@@ -11,12 +12,17 @@ export interface Tab {
   status: TabStatus
 }
 
+/** One terminal per session, so the session it belongs to is its identity. */
+export function terminalId(hostId: string, sessionId: string): string {
+  return `${hostId}:${sessionId}`
+}
+
 export interface Selection {
   hostId: string
   sessionId: string
 }
 
-export type RightPanel = 'chat' | 'approvals' | 'git' | 'files'
+export type RightPanel = 'chat' | 'terminal' | 'approvals' | 'git' | 'files'
 
 /**
  * A file the user asked to see, from a chip in the transcript. The counter is
@@ -34,8 +40,8 @@ export interface State {
   hostStatus: Record<string, HostStatus>
   sessions: Record<string, Session[]>
   notifications: Record<string, Notification[]>
+  /** Open terminal connections, one per session, keyed by `terminalId`. */
   tabs: Tab[]
-  activeTab: string | null
   selection: Selection | null
   panel: RightPanel
   fileTarget: FileTarget | null
@@ -53,7 +59,6 @@ const initial: State = {
   sessions: {},
   notifications: {},
   tabs: [],
-  activeTab: null,
   selection: null,
   panel: 'chat',
   fileTarget: null,
@@ -255,28 +260,29 @@ class Store {
     this.set({ pairingLink })
   }
 
-  // ─── Tabs ──────────────────────────────────────────────────────────────
+  // ─── Terminals ─────────────────────────────────────────────────────────
 
   /**
-   * Opens (or focuses) a terminal for a session. Waking is explicit: attaching
-   * to a cold session would otherwise spawn an agent process every time someone
-   * clicked through a list.
+   * Shows a session's terminal panel, attaching if nothing is attached yet.
+   * Waking is explicit: attaching to a cold session would otherwise spawn an
+   * agent process every time someone clicked through a list.
    */
   async openTerminal(hostId: string, session: Session, wake: boolean): Promise<void> {
-    const existing = this.state.tabs.find((t) => t.hostId === hostId && t.sessionId === session.session_id)
-    if (existing) {
-      this.setActiveTab(existing.id)
-      return
-    }
+    // The panel belongs to whichever session is selected, so showing one
+    // session's terminal means selecting it.
+    this.set({ selection: { hostId, sessionId: session.session_id }, panel: 'terminal' })
+
+    const id = terminalId(hostId, session.session_id)
+    if (this.state.tabs.some((t) => t.id === id)) return
 
     const tab: Tab = {
-      id: `${hostId}:${session.session_id}`,
+      id,
       hostId,
       sessionId: session.session_id,
       title: session.title ?? session.project ?? session.session_id.slice(0, 8),
       status: { state: 'connecting' },
     }
-    this.set((s) => ({ tabs: [...s.tabs, tab], activeTab: tab.id }))
+    this.set((s) => ({ tabs: [...s.tabs, tab] }))
 
     try {
       // Geometry is a placeholder; the tab reports its real size once xterm has
@@ -314,18 +320,20 @@ class Store {
     await this.refreshSessions(hostId)
   }
 
-  setActiveTab(activeTab: string | null): void {
-    this.set({ activeTab })
+  /**
+   * Shows the terminal panel for a session, attaching only if the host is
+   * already running. A cold session is left alone — moving between tabs should
+   * not start an agent process — and the panel offers the wake instead.
+   */
+  showTerminal(hostId: string, session: Session): void {
+    this.set({ panel: 'terminal' })
+    if (this.state.tabs.some((t) => t.id === terminalId(hostId, session.session_id))) return
+    if (hasTerminal(session)) void this.openTerminal(hostId, session, false)
   }
 
   closeTab(tabId: string): void {
     void bridge.term.close(tabId)
-    this.set((s) => {
-      const tabs = s.tabs.filter((t) => t.id !== tabId)
-      const activeTab =
-        s.activeTab === tabId ? (tabs[tabs.length - 1]?.id ?? null) : s.activeTab
-      return { tabs, activeTab }
-    })
+    this.set((s) => ({ tabs: s.tabs.filter((t) => t.id !== tabId) }))
   }
 
   // ─── Feedback ──────────────────────────────────────────────────────────

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -383,10 +383,6 @@ small {
   gap: 8px;
 }
 
-.main.split .detail {
-  flex: 0 0 44%;
-}
-
 .boot {
   display: grid;
   place-items: center;
@@ -696,7 +692,8 @@ small {
   overflow: hidden;
 }
 
-.detail.empty {
+.panel-empty {
+  flex: 1;
   display: grid;
   place-items: center;
   color: var(--on-surface-variant);
@@ -1930,47 +1927,9 @@ small {
 
 /* ─── Terminals ─────────────────────────────────────────────────────────── */
 
-.terminals {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  background: var(--surface-low);
-  border-radius: var(--r-lg);
-  overflow: hidden;
-}
-
-.tabstrip {
-  display: flex;
-  gap: 4px;
-  padding: 8px 8px 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-
-.tab {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px 6px 14px;
-  border-radius: var(--r-sm) var(--r-sm) 0 0;
-  background: transparent;
-  color: var(--on-surface-variant);
-  max-width: 230px;
-  font-size: 12.5px;
-  font-weight: 500;
-}
-
-.tab:hover {
-  background: color-mix(in srgb, var(--on-surface) 6%, transparent);
-}
-
-.tab.active {
-  background: var(--surface-container);
-  color: var(--on-surface);
-}
-
-.tab .dot {
+/* The connection state and the close affordance the old tabstrip carried, now
+   on the terminal entry in .panel-tabs. */
+.panel-tabs .dot {
   width: 7px;
   height: 7px;
   border-radius: 50%;
@@ -1978,28 +1937,22 @@ small {
   background: var(--s-off);
 }
 
-.tab .dot.live {
+.panel-tabs .dot.live {
   background: var(--s-active);
 }
 
-.tab .dot.connecting,
-.tab .dot.reconnecting {
+.panel-tabs .dot.connecting,
+.panel-tabs .dot.reconnecting {
   background: var(--s-waiting);
 }
 
-.tab .dot.closed {
+.panel-tabs .dot.closed {
   background: var(--error);
 }
 
-.tab-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .tab-close {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   padding: 0;
   border-radius: 50%;
   font-size: 12px;
@@ -2018,6 +1971,26 @@ small {
   position: relative;
   min-height: 0;
   background: var(--surface-container);
+}
+
+/* Still mounted, just out of the layout, so the panes it holds keep their
+   scrollback while the user reads another panel. */
+.panes.hidden {
+  display: none;
+}
+
+.pane-empty {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  color: var(--on-surface-variant);
+}
+
+.pane-empty p {
+  margin: 0;
 }
 
 /* Hidden rather than unmounted: an unmounted xterm loses its scrollback, and


### PR DESCRIPTION
Two unrelated changes, one per commit.

## `make desktop-install` + README Install section

There was no single command that installed anything but the Go binary. `make install` puts `helios` in `/usr/local/bin`; `make desktop-app` built a DMG and copied it to `~/.helios`, but left the bundle for the user to drag; `make dmg` is the Flutter macOS app, not the Electron one.

`make desktop-install` builds and replaces `/Applications/Helios.app`, then strips quarantine so the ad-hoc signature does not trip Gatekeeper. It replaces rather than copies over — copying into an existing bundle leaves the previous build's files inside it. macOS-only, with a Linux message pointing at the AppImage.

The README opened on prose about what Helios is, with install steps 120 lines down; the three commands now sit at the top, with a table of what each builds and where it lands. The stated Go floor was also stale — go.mod has required 1.26 for a while.

## Terminal as a panel tab

The terminal lived in a split below the detail view, taking 56% of the height whenever any terminal was open — including while reading chat for a different session. It is now a tab beside `chat`, and gets the full body when selected.

- **One terminal per session**, so the selected session picks the pane and the tabstrip is redundant. The two things it carried that were not — connection state and the close control — moved onto the tab itself (a live/connecting/closed dot, and a `×`).
- **Every pane stays mounted** whatever is selected. An unmounted xterm loses its scrollback and nothing can replay it: the daemon sends a snapshot on attach and the main process only coalesces. Hidden panes report 0×0 to abstain from the host's size negotiation, exactly as they did when hidden behind another tab.
- **Attaching follows what the session can do.** Warm: attaches when the tab opens, the host is already running. Cold: waits for a click, because attaching starts an agent. Terminated: offers Resume, not a wake — a wake would attach you to a session the daemon still refuses every prompt for, which is the trap #20 removed everywhere else.
- `activeTab` is gone from the store; the selection *is* the active terminal. ⌘W now closes the selected session's terminal.

Unchanged: remote hosts. `resolveEndpoint` still dials a unix socket only for local hosts and `wss://<host>/api/sessions/<id>/terminal` for everything else.

**Trade-off:** you can no longer watch session A's terminal while chatting in session B. That was the split's one advantage.

## Verification

`npm run typecheck`, `npm test` (29/29), `npm run build` all clean. Checked against the live daemon: a warm session auto-attaches with the live dot on the tab; a terminated one shows the Resume placeholder. `make desktop-install` is dry-run verified (`make -n`) — it resolves to `desktop/release/mac-arm64/Helios.app` — but has not been executed end to end.