### PR TITLE
fix: three bugs in the remote session lifecycle

### DIFF
--- a/cmd/apiprobe/main.go
+++ b/cmd/apiprobe/main.go
@@ -1,0 +1,289 @@
+// Command apiprobe creates one session and dumps what its terminal is showing,
+// so a session stuck in "starting" can be diagnosed. Scratch tooling.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/kamrul1157024/helios/internal/terminal"
+)
+
+var (
+	baseURL = flag.String("base", "http://localhost:7655", "public API base URL")
+	keyPath = flag.String("key", "/tmp/helios-apitest-key.json", "cached device key")
+	cwd     = flag.String("cwd", "", "session cwd (default: a fresh temp dir)")
+	prompt  = flag.String("prompt", "Reply with exactly PROBEOK and nothing else.", "initial prompt")
+	watch   = flag.Duration("watch", 25*time.Second, "how long to let it run before dumping the screen")
+	keep    = flag.Bool("keep", false, "leave the session running")
+	attach  = flag.String("attach", "", "attach to an existing session id instead of creating one")
+	mode    = flag.String("mode", "", "permission mode for a new session (default: the launch default)")
+)
+
+type device struct {
+	KID  string `json:"kid"`
+	Seed string `json:"seed"`
+	priv ed25519.PrivateKey
+}
+
+func b64(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+func load() (*device, error) {
+	raw, err := os.ReadFile(*keyPath)
+	if err != nil {
+		return nil, err
+	}
+	var d device
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, err
+	}
+	seed, err := base64.RawURLEncoding.DecodeString(d.Seed)
+	if err != nil {
+		return nil, err
+	}
+	d.priv = ed25519.NewKeyFromSeed(seed)
+	return &d, nil
+}
+
+func (d *device) token() string {
+	header, _ := json.Marshal(map[string]any{"alg": "EdDSA", "typ": "JWT", "kid": d.KID})
+	now := time.Now().Unix()
+	payload, _ := json.Marshal(map[string]any{"iat": now, "exp": now + 3600, "sub": "helios-client"})
+	input := b64(header) + "." + b64(payload)
+	return input + "." + b64(ed25519.Sign(d.priv, []byte(input)))
+}
+
+func (d *device) do(method, path string, body any) (int, []byte, error) {
+	var rdr io.Reader
+	if body != nil {
+		raw, _ := json.Marshal(body)
+		rdr = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, *baseURL+path, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 60 * time.Second}).Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, out, err
+}
+
+// pending returns the notifications still awaiting an answer for sessionID.
+func (d *device) pending(sessionID string) []map[string]any {
+	_, body, err := d.do("GET", "/api/notifications", nil)
+	if err != nil {
+		return nil
+	}
+	var parsed struct {
+		Notifications []map[string]any `json:"notifications"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	var out []map[string]any
+	for _, n := range parsed.Notifications {
+		if n["source_session"] == sessionID && n["status"] == "pending" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func main() {
+	flag.Parse()
+	dev, err := load()
+	if err != nil {
+		fmt.Println("load device key:", err, "— run apitest once first")
+		os.Exit(1)
+	}
+
+	id := *attach
+	if id == "" {
+		dir := *cwd
+		if dir == "" {
+			dir, err = os.MkdirTemp("", "helios-probe-")
+			if err != nil {
+				panic(err)
+			}
+			if err := os.WriteFile(dir+"/hello.txt", []byte("helios probe\n"), 0o644); err != nil {
+				panic(err)
+			}
+		}
+		req := map[string]any{"provider": "claude", "cwd": dir, "prompt": *prompt}
+		if *mode != "" {
+			req["permission_mode"] = *mode
+		}
+		code, body, err := dev.do("POST", "/api/sessions", req)
+		if err != nil || code != 200 {
+			fmt.Printf("create failed: %d %s %v\n", code, body, err)
+			os.Exit(1)
+		}
+		var created map[string]any
+		_ = json.Unmarshal(body, &created)
+		id, _ = created["session_id"].(string)
+		fmt.Printf("created %s in %s\n", id, dir)
+	}
+
+	deadline := time.Now().Add(*watch)
+	for time.Now().Before(deadline) {
+		code, body, err := dev.do("GET", "/api/sessions/"+id, nil)
+		if err == nil {
+			var m map[string]any
+			_ = json.Unmarshal(body, &m)
+			if inner, ok := m["session"].(map[string]any); ok {
+				m = inner
+			}
+			fmt.Printf("  t+%02.0fs http=%d status=%v last_event=%v mode=%v\n",
+				time.Until(deadline).Seconds(), code, m["status"], m["last_event"],
+				m["permission_mode"])
+		}
+		for _, n := range dev.pending(id) {
+			fmt.Printf("        notif %v type=%v title=%v\n", n["id"], n["type"], n["title"])
+			// A new directory is untrusted and the agent is blocked until someone
+			// says so; answer it the way a client would rather than hang here.
+			if n["type"] == "claude.trust" {
+				c, b, _ := dev.do("POST", "/api/notifications/"+fmt.Sprint(n["id"])+"/action",
+					map[string]any{"action": "trust"})
+				fmt.Printf("        → trusted (%d %s)\n", c, b)
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+
+	fmt.Println("\n=== notifications ===")
+	_, notifs, _ := dev.do("GET", "/api/notifications", nil)
+	var parsed struct {
+		Notifications []map[string]any `json:"notifications"`
+	}
+	_ = json.Unmarshal(notifs, &parsed)
+	for _, n := range parsed.Notifications {
+		if n["source_session"] == id {
+			fmt.Printf("  %v type=%v status=%v title=%v\n", n["id"], n["type"], n["status"], n["title"])
+		}
+	}
+
+	fmt.Println("\n=== terminal screen ===")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	wsURL := strings.Replace(strings.Replace(*baseURL, "https://", "wss://", 1), "http://", "ws://", 1)
+	conn, _, err := websocket.Dial(ctx, wsURL+"/api/sessions/"+id+"/terminal",
+		&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer " + dev.token()}}})
+	if err != nil {
+		fmt.Println("attach failed:", err)
+	} else {
+		conn.SetReadLimit(-1)
+		readCtx, readCancel := context.WithTimeout(ctx, 10*time.Second)
+		stream := websocket.NetConn(readCtx, conn, websocket.MessageBinary)
+
+		// The WebSocket handler is a byte relay, not a translator, so a viewer
+		// speaks the ptyhost's frame protocol over it exactly as the desktop
+		// does over the unix socket.
+		if err := terminal.WriteJSONFrame(stream, terminal.FrameHello, terminal.Hello{
+			Role: terminal.RoleObserver, Cols: 120, Rows: 40, Name: "apiprobe",
+		}); err != nil {
+			fmt.Println("hello:", err)
+		}
+
+		var screen bytes.Buffer
+		for i := 0; i < 8; i++ {
+			f, err := terminal.ReadFrame(stream)
+			if err != nil {
+				fmt.Printf("(stream ended after %d bytes: %v)\n", screen.Len(), err)
+				break
+			}
+			switch f.Type {
+			case terminal.FrameSnapshot:
+				seq, ansi, err := terminal.DecodeSnapshot(f.Payload)
+				if err != nil {
+					fmt.Println("bad snapshot:", err)
+					continue
+				}
+				fmt.Printf("(snapshot seq=%d, %d bytes)\n", seq, len(ansi))
+				screen.Write(ansi)
+			case terminal.FrameOutput:
+				screen.Write(f.Payload)
+			case terminal.FrameStatus:
+				fmt.Printf("(status %s)\n", f.Payload)
+			default:
+				fmt.Printf("(frame %s, %d bytes)\n", f.Type, len(f.Payload))
+			}
+			if screen.Len() > 0 && f.Type == terminal.FrameStatus {
+				i = 8 // snapshot and status both seen; that is the handshake
+			}
+		}
+		readCancel()
+		conn.Close(websocket.StatusNormalClosure, "")
+		fmt.Println(visible(screen.String()))
+	}
+
+	if !*keep && *attach == "" {
+		if _, _, err := dev.do("POST", "/api/sessions/"+id+"/terminate", nil); err != nil {
+			fmt.Println("terminate:", err)
+		}
+		if _, _, err := dev.do("DELETE", "/api/sessions/"+id, nil); err != nil {
+			fmt.Println("delete:", err)
+		}
+		fmt.Println("\ncleaned up", id)
+	} else {
+		fmt.Println("\nleft running:", id)
+	}
+}
+
+// visible strips escape sequences so the screen is readable in a log.
+func visible(s string) string {
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == 0x1b {
+			// Skip CSI / OSC until a terminator.
+			j := i + 1
+			if j < len(s) && (s[j] == '[' || s[j] == ']' || s[j] == '(') {
+				for j < len(s) && !strings.ContainsRune("@ABCDEFGHJKSTfmnsulhpqrt\a\\", rune(s[j])) {
+					j++
+				}
+			}
+			i = j
+			continue
+		}
+		if c == '\r' {
+			continue
+		}
+		if c >= 0x20 || c == '\n' || c == '\t' {
+			out.WriteByte(c)
+		}
+	}
+	// Collapse the runs of blank lines a TUI redraw leaves behind.
+	lines := strings.Split(out.String(), "\n")
+	var kept []string
+	blank := 0
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			blank++
+			if blank > 1 {
+				continue
+			}
+		} else {
+			blank = 0
+		}
+		kept = append(kept, strings.TrimRight(l, " "))
+	}
+	return strings.Join(kept, "\n")
+}

--- a/cmd/apitest/main.go
+++ b/cmd/apitest/main.go
@@ -1,0 +1,986 @@
+// Command apitest drives the daemon's public API the way a remote client does:
+// pair a local device, sign an EdDSA JWT per request, then walk the whole
+// session lifecycle over REST, SSE and the terminal WebSocket.
+//
+// It exists to exercise the paths the desktop and mobile apps take against a
+// running daemon, including over the tunnel URL, where TLS and a proxy sit
+// between the client and the handler. Scratch tooling; not part of the build.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/kamrul1157024/helios/internal/terminal"
+)
+
+var (
+	baseURL     = flag.String("base", "http://localhost:7655", "public API base URL")
+	internalURL = flag.String("internal", "http://localhost:7654", "internal API base URL (pairing only)")
+	keyPath     = flag.String("key", "/tmp/helios-apitest-key.json", "where to cache the paired device key")
+	skipAgent   = flag.Bool("skip-agent", false, "skip tests that launch a real agent session")
+)
+
+// ─── Device ────────────────────────────────────────────────────────────────
+
+type device struct {
+	KID  string `json:"kid"`
+	Seed string `json:"seed"` // base64url ed25519 seed
+	priv ed25519.PrivateKey
+}
+
+func b64(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// loadOrPair reuses a cached device so a remote run does not need the internal
+// port, which is loopback-only and unreachable over a tunnel.
+func loadOrPair() (*device, error) {
+	if raw, err := os.ReadFile(*keyPath); err == nil {
+		var d device
+		if json.Unmarshal(raw, &d) == nil && d.KID != "" {
+			seed, err := base64.RawURLEncoding.DecodeString(d.Seed)
+			if err == nil && len(seed) == ed25519.SeedSize {
+				d.priv = ed25519.NewKeyFromSeed(seed)
+				return &d, nil
+			}
+		}
+	}
+	d, err := pair()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(*keyPath, raw, 0o600); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// pair reproduces HostRegistry.pairLocal from desktop/src/main/hosts.ts.
+func pair() (*device, error) {
+	var created struct {
+		Token string `json:"token"`
+	}
+	if err := postJSON(*internalURL+"/internal/device/create", map[string]any{}, &created); err != nil {
+		return nil, fmt.Errorf("device create: %w", err)
+	}
+	if created.Token == "" {
+		return nil, fmt.Errorf("daemon issued no pairing token")
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	kid := fmt.Sprintf("apitest-%d", time.Now().UnixNano())
+
+	var paired map[string]any
+	if err := postJSON(*baseURL+"/api/auth/pair", map[string]any{
+		"token": created.Token, "kid": kid, "public_key": b64(pub),
+	}, &paired); err != nil {
+		return nil, fmt.Errorf("pair: %w", err)
+	}
+	if e, ok := paired["error"]; ok {
+		return nil, fmt.Errorf("pairing rejected: %v", e)
+	}
+	if err := postJSON(*internalURL+"/internal/device/activate", map[string]any{"kid": kid}, nil); err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+	return &device{KID: kid, Seed: b64(priv.Seed()), priv: priv}, nil
+}
+
+// token mirrors signJWT in desktop/src/main/keys.ts.
+func (d *device) token() string {
+	header, _ := json.Marshal(map[string]any{"alg": "EdDSA", "typ": "JWT", "kid": d.KID})
+	now := time.Now().Unix()
+	payload, _ := json.Marshal(map[string]any{"iat": now, "exp": now + 3600, "sub": "helios-client"})
+	input := b64(header) + "." + b64(payload)
+	return input + "." + b64(ed25519.Sign(d.priv, []byte(input)))
+}
+
+func (d *device) req(method, path string, body any) (*http.Request, error) {
+	var rdr io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		rdr = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, *baseURL+path, rdr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token())
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+type reply struct {
+	code int
+	body []byte
+}
+
+func (r reply) json() map[string]any {
+	var m map[string]any
+	_ = json.Unmarshal(r.body, &m)
+	return m
+}
+
+func (r reply) String() string { return fmt.Sprintf("HTTP %d: %s", r.code, trunc(r.body, 300)) }
+
+func (d *device) do(method, path string, body any) (reply, error) {
+	req, err := d.req(method, path, body)
+	if err != nil {
+		return reply{}, err
+	}
+	resp, err := (&http.Client{Timeout: 60 * time.Second}).Do(req)
+	if err != nil {
+		return reply{}, err
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	return reply{resp.StatusCode, out}, err
+}
+
+func postJSON(url string, body, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(url, "application/json", bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if out != nil {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+// ─── SSE ───────────────────────────────────────────────────────────────────
+
+type sseEvent struct {
+	Type string
+	Data map[string]any
+}
+
+// sseTap holds an open /api/events stream, the way every client keeps one.
+type sseTap struct {
+	mu     sync.Mutex
+	events []sseEvent
+	cancel context.CancelFunc
+	opened chan struct{}
+	err    error
+}
+
+func (d *device) tapEvents() *sseTap {
+	ctx, cancel := context.WithCancel(context.Background())
+	tap := &sseTap{cancel: cancel, opened: make(chan struct{})}
+	go func() {
+		req, err := d.req("GET", "/api/events", nil)
+		if err != nil {
+			tap.fail(err)
+			return
+		}
+		req = req.WithContext(ctx)
+		req.Header.Set("Accept", "text/event-stream")
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			tap.fail(err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			tap.fail(fmt.Errorf("events stream returned HTTP %d", resp.StatusCode))
+			return
+		}
+		close(tap.opened)
+
+		var evType string
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				evType = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				var data map[string]any
+				_ = json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &data)
+				tap.mu.Lock()
+				tap.events = append(tap.events, sseEvent{evType, data})
+				tap.mu.Unlock()
+			}
+		}
+	}()
+	return tap
+}
+
+func (t *sseTap) fail(err error) {
+	t.mu.Lock()
+	t.err = err
+	t.mu.Unlock()
+	select {
+	case <-t.opened:
+	default:
+		close(t.opened)
+	}
+}
+
+func (t *sseTap) wait(d time.Duration) error {
+	select {
+	case <-t.opened:
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		return t.err
+	case <-time.After(d):
+		return fmt.Errorf("events stream did not open within %s", d)
+	}
+}
+
+// seek waits for an event matching pred, so a test does not race the stream.
+func (t *sseTap) seek(timeout time.Duration, pred func(sseEvent) bool) (sseEvent, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		t.mu.Lock()
+		for _, e := range t.events {
+			if pred(e) {
+				t.mu.Unlock()
+				return e, true
+			}
+		}
+		t.mu.Unlock()
+		if time.Now().After(deadline) {
+			return sseEvent{}, false
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (t *sseTap) types() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	seen := map[string]int{}
+	var out []string
+	for _, e := range t.events {
+		if seen[e.Type] == 0 {
+			out = append(out, e.Type)
+		}
+		seen[e.Type]++
+	}
+	for i, s := range out {
+		out[i] = fmt.Sprintf("%s×%d", s, seen[s])
+	}
+	return out
+}
+
+// ─── Reporting ─────────────────────────────────────────────────────────────
+
+var (
+	passes   int
+	failures []string
+)
+
+func check(name string, ok bool, detail string) bool {
+	if ok {
+		passes++
+		fmt.Printf("  \033[32mPASS\033[0m  %s\n", name)
+		return true
+	}
+	failures = append(failures, name+" — "+detail)
+	fmt.Printf("  \033[31mFAIL\033[0m  %s\n        %s\n", name, detail)
+	return false
+}
+
+func step(name string) { fmt.Printf("\n\033[1m%s\033[0m\n", name) }
+
+func infof(format string, args ...any) {
+	fmt.Printf("  ....  "+format+"\n", args...)
+}
+
+func trunc(b []byte, n int) string {
+	s := strings.TrimSpace(string(b))
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}
+
+// ─── Session helpers ───────────────────────────────────────────────────────
+
+func (d *device) session(id string) (map[string]any, error) {
+	r, err := d.do("GET", "/api/sessions/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	if r.code != 200 {
+		return nil, fmt.Errorf("%s", r)
+	}
+	m := r.json()
+	if inner, ok := m["session"].(map[string]any); ok {
+		return inner, nil
+	}
+	return m, nil
+}
+
+func str(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// awaitStatus polls until the session reaches one of want, mirroring what a
+// client does between SSE events.
+func (d *device) awaitStatus(id string, timeout time.Duration, want ...string) (string, error) {
+	deadline := time.Now().Add(timeout)
+	last := ""
+	for time.Now().Before(deadline) {
+		sess, err := d.session(id)
+		if err != nil {
+			return last, err
+		}
+		status := str(sess, "status")
+		if status != last {
+			infof("status → %s", status)
+			last = status
+		}
+		for _, w := range want {
+			if status == w {
+				return status, nil
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return last, fmt.Errorf("still %q after %s, wanted one of %v", last, timeout, want)
+}
+
+func (d *device) transcriptText(id string) (string, int, error) {
+	r, err := d.do("GET", "/api/sessions/"+id+"/transcript?limit=200", nil)
+	if err != nil {
+		return "", 0, err
+	}
+	if r.code != 200 {
+		return "", 0, fmt.Errorf("%s", r)
+	}
+	var parsed struct {
+		Messages []map[string]any `json:"messages"`
+		Total    int              `json:"total"`
+	}
+	if err := json.Unmarshal(r.body, &parsed); err != nil {
+		return "", 0, err
+	}
+	var sb strings.Builder
+	for _, m := range parsed.Messages {
+		raw, _ := json.Marshal(m)
+		sb.Write(raw)
+	}
+	return sb.String(), parsed.Total, nil
+}
+
+func (d *device) pendingNotifications() ([]map[string]any, error) {
+	r, err := d.do("GET", "/api/notifications?status=pending", nil)
+	if err != nil {
+		return nil, err
+	}
+	if r.code != 200 {
+		return nil, fmt.Errorf("%s", r)
+	}
+	var parsed struct {
+		Notifications []map[string]any `json:"notifications"`
+	}
+	if err := json.Unmarshal(r.body, &parsed); err != nil {
+		return nil, err
+	}
+	return parsed.Notifications, nil
+}
+
+// belongsTo reports whether a notification is for sessionID.
+//
+// source_session is the column every server-side lifecycle sweep keys on, but
+// some producers only record the session inside the payload, so both are
+// checked here — a client has no other way to route the tap.
+func belongsTo(n map[string]any, sessionID string) bool {
+	if str(n, "source_session") == sessionID {
+		return true
+	}
+	var payload struct {
+		SessionID string `json:"session_id"`
+	}
+	if raw := str(n, "payload"); raw != "" {
+		_ = json.Unmarshal([]byte(raw), &payload)
+	}
+	return payload.SessionID == sessionID
+}
+
+// awaitNotification waits for a pending notification belonging to sessionID.
+func (d *device) awaitNotification(sessionID string, timeout time.Duration, ofType ...string) (map[string]any, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		notifs, err := d.pendingNotifications()
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range notifs {
+			if !belongsTo(n, sessionID) {
+				continue
+			}
+			if len(ofType) == 0 {
+				return n, nil
+			}
+			for _, t := range ofType {
+				if str(n, "type") == t {
+					return n, nil
+				}
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return nil, fmt.Errorf("no pending %v notification for %s within %s", ofType, sessionID, timeout)
+}
+
+// ─── Suite ─────────────────────────────────────────────────────────────────
+
+func main() {
+	flag.Parse()
+	fmt.Printf("\033[1mHelios API suite\033[0m  base=%s\n", *baseURL)
+
+	dev, err := loadOrPair()
+	if err != nil {
+		fmt.Println("pairing failed:", err)
+		os.Exit(1)
+	}
+	infof("device %s", dev.KID)
+
+	sessionID := ""
+	defer func() {
+		if sessionID != "" {
+			cleanup(dev, sessionID)
+		}
+		summarize()
+	}()
+
+	// ── Unauthenticated surface ──
+	step("Health and auth")
+	resp, err := http.Get(*baseURL + "/api/health")
+	if err == nil {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		check("GET /api/health is reachable without a token", resp.StatusCode == 200,
+			fmt.Sprintf("HTTP %d: %s", resp.StatusCode, trunc(body, 200)))
+		infof("health %s", trunc(body, 200))
+	} else {
+		check("GET /api/health is reachable without a token", false, err.Error())
+	}
+
+	noAuth, err := http.Get(*baseURL + "/api/sessions")
+	if err == nil {
+		noAuth.Body.Close()
+		check("GET /api/sessions rejects an unauthenticated caller", noAuth.StatusCode == 401,
+			fmt.Sprintf("HTTP %d, expected 401", noAuth.StatusCode))
+	} else {
+		check("GET /api/sessions rejects an unauthenticated caller", false, err.Error())
+	}
+
+	bad, err := http.NewRequest("GET", *baseURL+"/api/sessions", nil)
+	if err == nil {
+		bad.Header.Set("Authorization", "Bearer not.a.jwt")
+		if r, err := (&http.Client{Timeout: 10 * time.Second}).Do(bad); err == nil {
+			r.Body.Close()
+			check("a malformed bearer token is rejected", r.StatusCode == 401,
+				fmt.Sprintf("HTTP %d, expected 401", r.StatusCode))
+		}
+	}
+
+	// ── Read-only surface ──
+	step("Read-only endpoints")
+	for _, path := range []string{
+		"/api/sessions", "/api/sessions/directories", "/api/providers",
+		"/api/commands", "/api/settings", "/api/notifications", "/api/auth/devices",
+	} {
+		r, err := dev.do("GET", path, nil)
+		if err != nil {
+			check("GET "+path, false, err.Error())
+			continue
+		}
+		check("GET "+path, r.code == 200, r.String())
+	}
+
+	// ── SSE ──
+	step("Event stream")
+	tap := dev.tapEvents()
+	if err := tap.wait(10 * time.Second); err != nil {
+		check("GET /api/events opens", false, err.Error())
+	} else {
+		check("GET /api/events opens", true, "")
+	}
+	defer tap.cancel()
+
+	if *skipAgent {
+		infof("skipping agent tests (-skip-agent)")
+		return
+	}
+
+	// ── Session lifecycle ──
+	step("Create a session")
+	cwd, err := os.MkdirTemp("", "helios-e2e-")
+	if err != nil {
+		check("scratch directory", false, err.Error())
+		return
+	}
+	defer os.RemoveAll(cwd)
+	if err := os.WriteFile(filepath.Join(cwd, "hello.txt"), []byte("helios e2e\n"), 0o644); err != nil {
+		check("scratch directory", false, err.Error())
+		return
+	}
+	infof("cwd %s", cwd)
+
+	const marker = "HELIOSOK"
+	create, err := dev.do("POST", "/api/sessions", map[string]any{
+		"provider": "claude",
+		"cwd":      cwd,
+		// "manual" rather than the launch default: "auto" waves through the
+		// safe tools, so an approval would never be raised to test.
+		"permission_mode": "manual",
+		"prompt":          "Reply with exactly " + marker + " and nothing else. Do not use any tools.",
+	})
+	if err != nil {
+		check("POST /api/sessions", false, err.Error())
+		return
+	}
+	if !check("POST /api/sessions returns 200", create.code == 200, create.String()) {
+		return
+	}
+	created := create.json()
+	sessionID = str(created, "session_id")
+	if !check("the response carries a session_id", sessionID != "", create.String()) {
+		return
+	}
+	infof("session %s", sessionID)
+	check("the response echoes the requested cwd", str(created, "cwd") == cwd,
+		fmt.Sprintf("got %q, want %q", str(created, "cwd"), cwd))
+
+	step("The new session appears everywhere a client looks")
+	if sess, err := dev.session(sessionID); err != nil {
+		check("GET /api/sessions/{id} finds it", false, err.Error())
+	} else {
+		check("GET /api/sessions/{id} finds it", true, "")
+		check("it is marked managed", sess["managed"] == true, fmt.Sprintf("managed=%v", sess["managed"]))
+		check("its cwd is recorded", str(sess, "cwd") == cwd,
+			fmt.Sprintf("got %q, want %q", str(sess, "cwd"), cwd))
+	}
+	if list, err := dev.do("GET", "/api/sessions", nil); err == nil {
+		check("it is in the session list", strings.Contains(string(list.body), sessionID),
+			"the list did not mention the new session id")
+	}
+
+	// A fresh directory is untrusted, so Claude opens its trust dialog before it
+	// will run anything. Answering it is part of creating a session from a
+	// client — the agent is blocked until someone does.
+	step("The workspace-trust dialog is answerable from a client")
+	trust, err := dev.awaitNotification(sessionID, 60*time.Second, "claude.trust")
+	if !check("a claude.trust notification is raised for a new directory", err == nil, fmt.Sprintf("%v", err)) {
+		return
+	}
+	trustID := str(trust, "id")
+	infof("trust notification %s", trustID)
+	check("the trust notification names its session in source_session",
+		str(trust, "source_session") == sessionID,
+		fmt.Sprintf("source_session=%q, want %q — clients cannot route it, and no "+
+			"session-scoped sweep will ever resolve it",
+			str(trust, "source_session"), sessionID))
+	if r, err := dev.do("POST", "/api/notifications/"+trustID+"/action",
+		map[string]any{"action": "trust"}); err == nil {
+		check("trusting the workspace is accepted", r.code == 200, r.String())
+	}
+
+	step("The agent starts and answers")
+	if _, err := dev.awaitStatus(sessionID, 90*time.Second, "active", "idle", "waiting_permission"); err != nil {
+		check("the session leaves \"starting\"", false, err.Error())
+	} else {
+		check("the session leaves \"starting\"", true, "")
+	}
+	if _, err := dev.awaitStatus(sessionID, 180*time.Second, "idle"); err != nil {
+		check("the agent finishes the first prompt", false, err.Error())
+	} else {
+		check("the agent finishes the first prompt", true, "")
+	}
+
+	text, total, err := dev.transcriptText(sessionID)
+	if err != nil {
+		check("GET transcript", false, err.Error())
+	} else {
+		infof("transcript has %d messages", total)
+		check("the transcript is populated", total > 0, "transcript is empty")
+		check("the agent's reply is in the transcript", strings.Contains(text, marker),
+			"no "+marker+" in the transcript")
+	}
+
+	if _, ok := tap.seek(5*time.Second, func(e sseEvent) bool {
+		return e.Type == "session_status" && str(e.Data, "session_id") == sessionID
+	}); ok {
+		check("clients were told the status changed over SSE", true, "")
+	} else {
+		check("clients were told the status changed over SSE", false,
+			"no session_status event for this session; saw "+strings.Join(tap.types(), ", "))
+	}
+
+	step("Send a follow-up, the way the desktop composer does")
+	const marker2 = "SECONDOK"
+	send, err := dev.do("POST", "/api/sessions/"+sessionID+"/send", map[string]any{
+		"message": "Reply with exactly " + marker2 + " and nothing else. Do not use any tools.",
+	})
+	if err != nil {
+		check("POST /send", false, err.Error())
+	} else if check("POST /send is accepted", send.code == 200, send.String()) {
+		if _, err := dev.awaitStatus(sessionID, 180*time.Second, "idle"); err != nil {
+			check("the follow-up completes", false, err.Error())
+		} else {
+			check("the follow-up completes", true, "")
+			text, _, err := dev.transcriptText(sessionID)
+			if err != nil {
+				check("the follow-up reply reaches the transcript", false, err.Error())
+			} else {
+				check("the follow-up reply reaches the transcript", strings.Contains(text, marker2),
+					"no "+marker2+" in the transcript")
+			}
+		}
+	}
+
+	step("Empty and malformed sends are refused")
+	if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/send", map[string]any{"message": ""}); err == nil {
+		check("an empty message is a 400", r.code == 400, r.String())
+	}
+	if r, err := dev.do("POST", "/api/sessions/deadbeef-not-a-session/send",
+		map[string]any{"message": "hi"}); err == nil {
+		check("sending to an unknown session is a 404", r.code == 404, r.String())
+	}
+
+	step("A tool request raises an approval, and answering it releases the agent")
+	// A command that writes, not one that reads: the CLI classifies read-only
+	// shell commands as safe and runs them without asking even in manual mode,
+	// so `cat` would never produce the approval this step exists to answer.
+	perm, err := dev.do("POST", "/api/sessions/"+sessionID+"/send", map[string]any{
+		"message": "Use the Bash tool to run exactly: cp hello.txt copied.txt",
+	})
+	if err != nil || perm.code != 200 {
+		check("POST /send for the tool prompt", false, fmt.Sprintf("%v %v", err, perm))
+	} else {
+		notif, err := dev.awaitNotification(sessionID, 120*time.Second)
+		if !check("a pending notification is raised", err == nil, fmt.Sprintf("%v", err)) {
+			goto teardown
+		}
+		notifID := str(notif, "id")
+		infof("notification %s type=%s", notifID, str(notif, "type"))
+		check("it is pending", str(notif, "status") == "pending",
+			fmt.Sprintf("status=%q", str(notif, "status")))
+
+		if _, ok := tap.seek(10*time.Second, func(e sseEvent) bool {
+			return e.Type == "notification" && str(e.Data, "id") == notifID
+		}); ok {
+			check("the notification arrived over SSE", true, "")
+		} else {
+			check("the notification arrived over SSE", false,
+				"no notification event carrying "+notifID)
+		}
+
+		act, err := dev.do("POST", "/api/notifications/"+notifID+"/action",
+			map[string]any{"action": "approve"})
+		if err != nil {
+			check("approving it succeeds", false, err.Error())
+		} else {
+			check("approving it succeeds", act.code == 200, act.String())
+		}
+
+		if ev, ok := tap.seek(10*time.Second, func(e sseEvent) bool {
+			return e.Type == "notification_resolved" && str(e.Data, "id") == notifID
+		}); ok {
+			check("the daemon announces the resolution to every client", true, "")
+			check("the announcement names the device that answered",
+				strings.HasPrefix(str(ev.Data, "source"), "device:"),
+				fmt.Sprintf("source=%q", str(ev.Data, "source")))
+			check("the announcement carries the action", str(ev.Data, "action") == "approved",
+				fmt.Sprintf("action=%q", str(ev.Data, "action")))
+		} else {
+			check("the daemon announces the resolution to every client", false,
+				"no notification_resolved for "+notifID)
+		}
+
+		// The second phone to tap Approve must be told it lost the race rather
+		// than getting a silent success.
+		if again, err := dev.do("POST", "/api/notifications/"+notifID+"/action",
+			map[string]any{"action": "approve"}); err == nil {
+			check("approving twice reports already_resolved", again.code == 410, again.String())
+		}
+
+		if notifs, err := dev.pendingNotifications(); err == nil {
+			still := false
+			for _, n := range notifs {
+				if str(n, "id") == notifID {
+					still = true
+				}
+			}
+			check("it is gone from the pending list", !still, "still listed as pending")
+		}
+
+		if _, err := dev.awaitStatus(sessionID, 180*time.Second, "idle"); err != nil {
+			check("the agent runs the tool and returns to idle", false, err.Error())
+		} else {
+			check("the agent runs the tool and returns to idle", true, "")
+			// On disk rather than in the transcript: this is the whole point of
+			// answering an approval remotely — the tool the phone released has
+			// to have actually run.
+			_, statErr := os.Stat(filepath.Join(cwd, "copied.txt"))
+			check("the approved tool actually ran", statErr == nil,
+				"copied.txt was never created in the session's cwd")
+		}
+	}
+
+	// One question, one card. The PermissionRequest hook fires for
+	// AskUserQuestion alongside the question hook, and raising an approval from
+	// each put two cards on the phone for a single question.
+	step("AskUserQuestion raises exactly one card")
+	if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/send", map[string]any{
+		"message": "Use the AskUserQuestion tool to ask me whether to proceed, " +
+			"with the options Yes and No. Ask only one question.",
+	}); err != nil || r.code != 200 {
+		check("POST /send for the question prompt", false, fmt.Sprintf("%v %v", err, r))
+	} else {
+		question, err := dev.awaitNotification(sessionID, 120*time.Second, "claude.question")
+		if check("a claude.question notification is raised", err == nil, fmt.Sprintf("%v", err)) {
+			questionID := str(question, "id")
+			infof("question notification %s", questionID)
+
+			// Give the permission hook every chance to raise its own card.
+			time.Sleep(3 * time.Second)
+			notifs, err := dev.pendingNotifications()
+			if err != nil {
+				check("only one card is pending for the question", false, err.Error())
+			} else {
+				var pending []string
+				for _, n := range notifs {
+					if belongsTo(n, sessionID) {
+						pending = append(pending, fmt.Sprintf("%s/%s", str(n, "type"), str(n, "id")))
+					}
+				}
+				check("only one card is pending for the question", len(pending) == 1,
+					fmt.Sprintf("%d pending: %s", len(pending), strings.Join(pending, ", ")))
+			}
+
+			answer, err := dev.do("POST", "/api/notifications/"+questionID+"/action", map[string]any{
+				"action":     "answer",
+				"selections": []map[string]int{{"question_index": 0, "option_index": 0}},
+			})
+			if err != nil {
+				check("answering the question is accepted", false, err.Error())
+			} else if check("answering the question is accepted", answer.code == 200, answer.String()) {
+				if _, ok := tap.seek(10*time.Second, func(e sseEvent) bool {
+					return e.Type == "notification_resolved" && str(e.Data, "id") == questionID
+				}); ok {
+					check("the answered question is retracted everywhere", true, "")
+				} else {
+					check("the answered question is retracted everywhere", false,
+						"no notification_resolved for "+questionID)
+				}
+				if _, err := dev.awaitStatus(sessionID, 120*time.Second, "idle"); err != nil {
+					check("the agent continues after the answer", false, err.Error())
+				} else {
+					check("the agent continues after the answer", true, "")
+				}
+			}
+		}
+	}
+
+	// ── Terminal WebSocket ──
+	step("Attach to the terminal, the way the session screen does")
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		wsURL := strings.Replace(strings.Replace(*baseURL, "https://", "wss://", 1), "http://", "ws://", 1)
+		conn, _, err := websocket.Dial(ctx, wsURL+"/api/sessions/"+sessionID+"/terminal",
+			&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer " + dev.token()}}})
+		if err != nil {
+			check("the terminal WebSocket connects", false, err.Error())
+		} else {
+			check("the terminal WebSocket connects", true, "")
+			conn.SetReadLimit(-1)
+			readCtx, readCancel := context.WithTimeout(ctx, 15*time.Second)
+			// The handler is a byte relay, not a translator, so a viewer speaks
+			// the ptyhost's frame protocol over the socket exactly as the
+			// desktop does over the unix one.
+			stream := websocket.NetConn(readCtx, conn, websocket.MessageBinary)
+			if err := terminal.WriteJSONFrame(stream, terminal.FrameHello, terminal.Hello{
+				Role: terminal.RoleObserver, Cols: 120, Rows: 40, Name: "apitest",
+			}); err != nil {
+				check("the viewer handshake is accepted", false, err.Error())
+			} else {
+				check("the viewer handshake is accepted", true, "")
+			}
+			f, err := terminal.ReadFrame(stream)
+			if err != nil {
+				check("it replays the session's screen", false, err.Error())
+			} else if f.Type != terminal.FrameSnapshot {
+				check("it replays the session's screen", false,
+					fmt.Sprintf("first frame is %s, want snapshot", f.Type))
+			} else {
+				_, ansi, err := terminal.DecodeSnapshot(f.Payload)
+				check("it replays the session's screen", err == nil && len(ansi) > 0,
+					fmt.Sprintf("snapshot decode err=%v, %d bytes", err, len(ansi)))
+				infof("snapshot %d bytes", len(ansi))
+			}
+			readCancel()
+			conn.Close(websocket.StatusNormalClosure, "")
+		}
+		cancel()
+	}
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		wsURL := strings.Replace(strings.Replace(*baseURL, "https://", "wss://", 1), "http://", "ws://", 1)
+		conn, resp, err := websocket.Dial(ctx, wsURL+"/api/sessions/"+sessionID+"/terminal", nil)
+		if conn != nil {
+			conn.Close(websocket.StatusNormalClosure, "")
+		}
+		code := 0
+		if resp != nil {
+			code = resp.StatusCode
+		}
+		check("an unauthenticated terminal attach is refused", err != nil && code == 401,
+			fmt.Sprintf("err=%v status=%d", err, code))
+		cancel()
+	}
+
+	// ── Mutations ──
+	step("Rename, permission mode, and stop")
+	if r, err := dev.do("PATCH", "/api/sessions/"+sessionID,
+		map[string]any{"title": "e2e probe"}); err == nil {
+		if check("PATCH renames the session", r.code == 200, r.String()) {
+			if sess, err := dev.session(sessionID); err == nil {
+				check("the new title is persisted", str(sess, "title") == "e2e probe",
+					fmt.Sprintf("title=%q", str(sess, "title")))
+			}
+		}
+	}
+	if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/permission-mode",
+		map[string]any{"mode": "acceptEdits"}); err == nil {
+		if check("the permission mode can be changed", r.code == 200, r.String()) {
+			if sess, err := dev.session(sessionID); err == nil {
+				check("the new mode is persisted", str(sess, "permission_mode") == "acceptEdits",
+					fmt.Sprintf("permission_mode=%q", str(sess, "permission_mode")))
+			}
+		}
+	}
+	// Stop is an interrupt, so there has to be something to interrupt: on an idle
+	// session the daemon deliberately answers 409 rather than pretending. Give it
+	// a running turn to cut short, which is the case a client's Stop button is for.
+	if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/stop", nil); err == nil {
+		check("stopping an idle session is refused, not silently accepted", r.code == 409, r.String())
+	}
+	// Changing the mode restarts the session, so wait for it to come back before
+	// prompting it — otherwise the send races the relaunch.
+	if _, err := dev.awaitStatus(sessionID, 90*time.Second, "idle", "active"); err != nil {
+		check("the session comes back after a permission-mode change", false, err.Error())
+	} else {
+		check("the session comes back after a permission-mode change", true, "")
+	}
+	{
+		send, err := dev.do("POST", "/api/sessions/"+sessionID+"/send", map[string]any{
+			"message": "Count slowly from 1 to 500, one number per line.",
+		})
+		if check("POST /send for the long prompt", err == nil && send.code == 200,
+			fmt.Sprintf("%v %v", err, send)) {
+			if _, err := dev.awaitStatus(sessionID, 60*time.Second, "active"); err != nil {
+				check("the long prompt starts running", false, err.Error())
+			} else if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/stop", nil); err != nil {
+				check("POST /stop is accepted while the agent is working", false, err.Error())
+			} else if check("POST /stop is accepted while the agent is working", r.code == 200, r.String()) {
+				if _, err := dev.awaitStatus(sessionID, 60*time.Second, "idle"); err != nil {
+					check("the interrupted session settles back to idle", false, err.Error())
+				} else {
+					check("the interrupted session settles back to idle", true, "")
+				}
+			}
+		}
+	}
+
+teardown:
+	step("Terminate and delete")
+	if r, err := dev.do("POST", "/api/sessions/"+sessionID+"/terminate", nil); err == nil {
+		check("POST /terminate is accepted", r.code == 200, r.String())
+	}
+	// Nothing may outlive the session it belongs to: a pending row here is an
+	// approval every tray and phone keeps counting for a session that is gone,
+	// with no surface left that could ever answer it.
+	time.Sleep(2 * time.Second)
+	if notifs, err := dev.pendingNotifications(); err == nil {
+		var leaked []string
+		for _, n := range notifs {
+			if belongsTo(n, sessionID) {
+				leaked = append(leaked, fmt.Sprintf("%s (%s)", str(n, "id"), str(n, "type")))
+			}
+		}
+		check("terminating the session leaves nothing pending", len(leaked) == 0,
+			"still pending: "+strings.Join(leaked, ", "))
+	}
+	if _, err := dev.awaitStatus(sessionID, 30*time.Second, "terminated"); err != nil {
+		check("the session reports terminated", false, err.Error())
+	} else {
+		check("the session reports terminated", true, "")
+	}
+	if r, err := dev.do("DELETE", "/api/sessions/"+sessionID, nil); err == nil {
+		if check("DELETE removes the session", r.code == 200, r.String()) {
+			if r, err := dev.do("GET", "/api/sessions/"+sessionID, nil); err == nil {
+				check("it is a 404 afterwards", r.code == 404, r.String())
+			}
+			sessionID = ""
+		}
+	}
+
+	infof("events seen: %s", strings.Join(tap.types(), ", "))
+}
+
+// cleanup makes a best effort not to leave a live agent behind on failure.
+func cleanup(dev *device, sessionID string) {
+	step("Cleanup")
+	if _, err := dev.do("POST", "/api/sessions/"+sessionID+"/terminate", nil); err != nil {
+		infof("terminate %s: %v", sessionID, err)
+	}
+	if _, err := dev.do("DELETE", "/api/sessions/"+sessionID, nil); err != nil {
+		infof("delete %s: %v", sessionID, err)
+	}
+	infof("removed leftover session %s", sessionID)
+}
+
+func summarize() {
+	fmt.Printf("\n\033[1m%d passed, %d failed\033[0m\n", passes, len(failures))
+	for _, f := range failures {
+		fmt.Println("  ✗", f)
+	}
+	if len(failures) > 0 {
+		os.Exit(1)
+	}
+}

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -42,10 +42,54 @@ type hookInput struct {
 
 // ==================== Permission Hook ====================
 
+// permResponse is the PermissionRequest hook's reply to the CLI.
+type permResponse struct {
+	HookSpecificOutput struct {
+		HookEventName string `json:"hookEventName"`
+		Decision      struct {
+			Behavior           string                 `json:"behavior"`
+			Message            string                 `json:"message,omitempty"`
+			UpdatedInput       map[string]interface{} `json:"updatedInput,omitempty"`
+			UpdatedPermissions json.RawMessage        `json:"updatedPermissions,omitempty"`
+		} `json:"decision"`
+	} `json:"hookSpecificOutput"`
+}
+
+func newPermResponse() permResponse {
+	resp := permResponse{}
+	resp.HookSpecificOutput.HookEventName = "PermissionRequest"
+	return resp
+}
+
+func writePermResponse(w http.ResponseWriter, resp permResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("hook: encode permission response: %v", err)
+	}
+}
+
+// allowTool lets a tool run without asking anyone.
+func allowTool(w http.ResponseWriter) {
+	resp := newPermResponse()
+	resp.HookSpecificOutput.Decision.Behavior = "allow"
+	writePermResponse(w, resp)
+}
+
 func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	var input hookInput
 	if err := json.Unmarshal(raw, &input); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// AskUserQuestion is not an approval, and it already has a surface: the
+	// PreToolUse hook raises claude.question for it. Raising a second,
+	// blocking notification here put two cards on the phone for one question —
+	// and because this hook blocks the tool, the CLI never rendered the
+	// question UI that answering the other card drives, so neither card could
+	// be answered correctly. Let the tool run; claude.question owns it.
+	if input.ToolName == askUserQuestionTool {
+		allowTool(w)
 		return
 	}
 
@@ -108,20 +152,7 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 	ctx.DB.UpdateSessionStatus(input.SessionID, "active", "PermissionResolved")
 	renameSessionWindow(ctx, input.SessionID, "active", input.CWD)
 
-	type permResponse struct {
-		HookSpecificOutput struct {
-			HookEventName string `json:"hookEventName"`
-			Decision      struct {
-				Behavior           string                 `json:"behavior"`
-				Message            string                 `json:"message,omitempty"`
-				UpdatedInput       map[string]interface{} `json:"updatedInput,omitempty"`
-				UpdatedPermissions json.RawMessage        `json:"updatedPermissions,omitempty"`
-			} `json:"decision"`
-		} `json:"hookSpecificOutput"`
-	}
-
-	resp := permResponse{}
-	resp.HookSpecificOutput.HookEventName = "PermissionRequest"
+	resp := newPermResponse()
 
 	if decision.Status == "approved" {
 		resp.HookSpecificOutput.Decision.Behavior = "allow"
@@ -157,8 +188,7 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 		resp.HookSpecificOutput.Decision.Message = "Denied via helios"
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	writePermResponse(w, resp)
 }
 
 // ==================== AskUserQuestion Hook ====================

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -1070,6 +1070,71 @@ func TestQuestion_ReturnsImmediatelyWithoutBlocking(t *testing.T) {
 	}
 }
 
+// AskUserQuestion trips both the PermissionRequest hook and the PreToolUse
+// question hook. Raising a card from each put two approvals on the phone for
+// one question — and since the permission hook blocks the tool, the CLI never
+// rendered the question UI that answering the other card is supposed to drive.
+func TestPermission_AskUserQuestionRaisesNoSecondApproval(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- callHook(handlePermission, ctx, hookInput{
+			SessionID: "sess-1",
+			CWD:       "/tmp/proj",
+			ToolName:  askUserQuestionTool,
+			ToolInput: questionInput(t, oneQuestion("Proceed?", "Plan", "Yes", "No")),
+		})
+	}()
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handlePermission blocked on AskUserQuestion; the CLI can never render its question UI")
+	}
+
+	if notifs := notifsOfType(t, db, "claude.permission"); len(notifs) != 0 {
+		t.Fatalf("AskUserQuestion raised %d permission notifications, want 0 — "+
+			"claude.question is the only surface for a question", len(notifs))
+	}
+
+	// The tool has to be allowed through, or the question is never asked at all.
+	var resp permResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %q: %v", w.Body.String(), err)
+	}
+	if got := resp.HookSpecificOutput.Decision.Behavior; got != "allow" {
+		t.Errorf("decision behavior = %q, want allow", got)
+	}
+	if got := resp.HookSpecificOutput.HookEventName; got != "PermissionRequest" {
+		t.Errorf("hookEventName = %q, want PermissionRequest", got)
+	}
+}
+
+// The bypass is scoped to AskUserQuestion; every other tool still asks.
+func TestPermission_OtherToolsStillRaiseAnApproval(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+
+	notifIDs := captureNotifIDs(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		callHook(handlePermission, ctx, hookInput{
+			SessionID: "sess-1", CWD: "/tmp/proj", ToolName: "Bash",
+		})
+	}()
+
+	notifID := awaitNotifID(t, notifIDs)
+	if notifs := notifsOfType(t, db, "claude.permission"); len(notifs) != 1 {
+		t.Fatalf("Bash raised %d permission notifications, want 1", len(notifs))
+	}
+	ctx.Mgr.Resolve(notifID, notifications.Decision{Status: "approved"}, "mobile")
+	<-done
+}
+
 // Wrapping rather than splicing would produce {"questions":{"questions":[...]}}
 // and the mobile card's payload['questions'] accessor would cast a Map to a
 // List, silently emptying the card.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -647,9 +647,10 @@ func (sh *Shared) setPermissionMode(w http.ResponseWriter, id, mode string) {
 	}
 
 	// Cold sessions need no restart: the stored mode is read when they wake.
-	restarted := false
+	restarted, ready := false, true
 	if sh.Backend.Alive(id) {
-		if err := sh.restartForPermissionMode(id, session.CWD); err != nil {
+		var err error
+		if ready, err = sh.restartForPermissionMode(id, session.CWD); err != nil {
 			jsonError(w, fmt.Sprintf("failed to restart session: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -665,27 +666,50 @@ func (sh *Shared) setPermissionMode(w http.ResponseWriter, id, mode string) {
 	})
 
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
-		"success": true, "permission_mode": mode, "restarted": restarted,
+		"success": true, "permission_mode": mode, "restarted": restarted, "ready": ready,
 	})
 }
 
 // restartForPermissionMode cycles a session's terminal so the agent relaunches
-// under the mode just stored.
+// under the mode just stored, and reports whether it came back up.
 //
 // Kill before Wake, not Wake alone: Wake adopts a live host, so without the
 // kill the old process would keep running in the old mode and report success.
-func (sh *Shared) restartForPermissionMode(id, cwd string) error {
+//
+// Waiting for the agent is not politeness. Wake returns once the host's socket
+// is listening, seconds before the agent inside it is reading its terminal, and
+// throughout that gap the session is idle with a live terminal — which is
+// exactly what the send path takes as "type into it now". A client that changes
+// the mode and immediately sends a prompt therefore loses it: the keystrokes go
+// into a booting CLI, no hook ever acknowledges them, and the send fails.
+// Returning only once the agent has reported in closes the gap.
+//
+// Subscribed before the kill, because the agent can report in while Wake is
+// still returning and a signal fired with nobody listening is gone.
+func (sh *Shared) restartForPermissionMode(id, cwd string) (bool, error) {
 	waker, ok := sh.Backend.(backend.Waker)
 	if !ok {
-		return fmt.Errorf("backend %s cannot resume sessions", sh.Backend.Name())
+		return false, fmt.Errorf("backend %s cannot resume sessions", sh.Backend.Name())
 	}
+
+	ready := sh.Signals.Await(SignalAgentReady, id)
+	defer ready.Release()
+
 	if err := sh.Backend.Kill(id); err != nil {
-		return fmt.Errorf("kill terminal: %w", err)
+		return false, fmt.Errorf("kill terminal: %w", err)
 	}
 	if _, err := waker.Wake(id, cwd); err != nil {
-		return fmt.Errorf("restart terminal: %w", err)
+		return false, fmt.Errorf("restart terminal: %w", err)
 	}
-	return nil
+
+	// A slow boot is not a failed switch: the mode is stored and the terminal is
+	// up, so the change stands and the caller is told it is not usable yet
+	// rather than being handed an error for work that did happen.
+	if !ready.Wait(agentBootTimeout) {
+		log.Printf("permission-mode: session %s did not report ready within %s", id, agentBootTimeout)
+		return false, nil
+	}
+	return true, nil
 }
 
 // settleInterrupted moves a stopped session back to idle and tells every client.

--- a/internal/server/permission_mode_test.go
+++ b/internal/server/permission_mode_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/store"
@@ -16,6 +17,10 @@ type wakingBackend struct {
 	*stubBackend
 	killed []string
 	woken  []string
+	// onWake stands in for the relaunched agent's SessionStart hook. A real
+	// wake returns before the agent is up, so the restart path waits for this;
+	// leaving it nil is how a test plays an agent that never boots.
+	onWake func(sessionID string)
 }
 
 func (b *wakingBackend) Kill(sessionID string) error {
@@ -27,6 +32,9 @@ func (b *wakingBackend) Kill(sessionID string) error {
 func (b *wakingBackend) Wake(sessionID, cwd string) (bool, error) {
 	b.woken = append(b.woken, sessionID)
 	b.handles[sessionID] = "sock-" + sessionID
+	if b.onWake != nil {
+		b.onWake(sessionID)
+	}
 	return true, nil
 }
 
@@ -47,7 +55,9 @@ func newPermModeEnv(t *testing.T) *permModeEnv {
 	t.Cleanup(func() { db.Close() })
 
 	be := &wakingBackend{stubBackend: newStubBackend()}
-	return &permModeEnv{t: t, db: db, be: be, shared: NewShared(db, notifications.NewManager(db), be)}
+	shared := NewShared(db, notifications.NewManager(db), be)
+	be.onWake = func(sessionID string) { shared.Signals.Fire(SignalAgentReady, sessionID) }
+	return &permModeEnv{t: t, db: db, be: be, shared: shared}
 }
 
 // session inserts a claude session in the given status. warm decides whether
@@ -112,6 +122,82 @@ func TestSetPermissionModeRestartsWarmSession(t *testing.T) {
 	}
 	if len(e.be.killed) != 1 || len(e.be.woken) != 1 {
 		t.Errorf("killed = %v, woken = %v, want one of each", e.be.killed, e.be.woken)
+	}
+	if body["ready"] != true {
+		t.Errorf("ready = %v, want true once the agent has reported in", body["ready"])
+	}
+}
+
+// The restart must not return until the relaunched agent has reported in.
+//
+// Wake returns as soon as the host's socket is listening, but the session is
+// idle with a live terminal for the seconds the CLI spends booting — which is
+// precisely the state the send path reads as "type into it". A client that
+// changes the mode and sends the next prompt straight after would have that
+// prompt typed into a booting CLI and lost, with the send failing on a timeout
+// no one can act on.
+func TestSetPermissionModeWaitsForTheAgentToComeBack(t *testing.T) {
+	e := newPermModeEnv(t)
+	e.session("s1", "idle", true)
+
+	// The agent reports in only after Wake has returned, as a real one does.
+	ready := make(chan struct{})
+	e.be.onWake = func(sessionID string) {
+		go func() {
+			<-ready
+			e.shared.Signals.Fire(SignalAgentReady, sessionID)
+		}()
+	}
+
+	done := make(chan map[string]interface{}, 1)
+	go func() {
+		_, body := e.set("s1", "plan")
+		done <- body
+	}()
+
+	select {
+	case body := <-done:
+		t.Fatalf("the switch returned before the agent was up: %v — the next prompt "+
+			"would be typed into a booting CLI and lost", body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(ready)
+	select {
+	case body := <-done:
+		if body["ready"] != true {
+			t.Errorf("ready = %v, want true", body["ready"])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the switch never returned after the agent reported in")
+	}
+}
+
+// A boot that never finishes is not a failed switch: the mode is stored and the
+// terminal is up, so the caller is told the session is not usable yet rather
+// than handed an error for work that did happen.
+func TestSetPermissionModeReportsAnAgentThatNeverBoots(t *testing.T) {
+	restore := agentBootTimeout
+	agentBootTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { agentBootTimeout = restore })
+
+	e := newPermModeEnv(t)
+	e.session("s1", "idle", true)
+	e.be.onWake = nil // nothing ever reports in
+
+	w, body := e.set("s1", "plan")
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200: the mode was stored and the terminal restarted", w.Code)
+	}
+	if body["restarted"] != true {
+		t.Errorf("restarted = %v, want true", body["restarted"])
+	}
+	if body["ready"] != false {
+		t.Errorf("ready = %v, want false: no agent ever reported in", body["ready"])
+	}
+	if got := e.storedMode("s1"); got != "plan" {
+		t.Errorf("stored mode = %q, want plan", got)
 	}
 }
 

--- a/internal/server/trust_watcher.go
+++ b/internal/server/trust_watcher.go
@@ -168,15 +168,21 @@ func createTrustNotification(shared *Shared, p *PendingSession) {
 	detail := "Claude needs permission to access this workspace"
 	payloadStr := `{"session_id":"` + p.SessionID + `","cwd":"` + p.CWD + `"}`
 
+	// SourceSession, not just the payload: it is the column every
+	// session-scoped sweep keys on. Without it the dialog stays pending after
+	// the session is answered, terminated or deleted — a permanent approval on
+	// every tray for a session that no longer exists — and a client has nothing
+	// to route a tap on it to.
 	notif := &store.Notification{
-		ID:      notifications.GenerateNotificationID(),
-		Source:  "claude",
-		CWD:     p.CWD,
-		Type:    "claude.trust",
-		Status:  "pending",
-		Title:   &title,
-		Detail:  &detail,
-		Payload: &payloadStr,
+		ID:            notifications.GenerateNotificationID(),
+		Source:        "claude",
+		SourceSession: p.SessionID,
+		CWD:           p.CWD,
+		Type:          "claude.trust",
+		Status:        "pending",
+		Title:         &title,
+		Detail:        &detail,
+		Payload:       &payloadStr,
 	}
 
 	if err := shared.Mgr.CreateNotification(notif); err != nil {

--- a/internal/server/trust_watcher_test.go
+++ b/internal/server/trust_watcher_test.go
@@ -1,9 +1,91 @@
 package server
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/store"
 )
+
+// The trust dialog blocks a brand new session until someone answers it, so its
+// notification is the one surface a client has. Recording the session only in
+// the payload left source_session empty, and every session-scoped sweep —
+// Stop, terminate, delete — keys on that column. The row therefore stayed
+// pending forever: a permanent approval on every tray and phone for a session
+// that had long since finished or been deleted, with nothing left to answer it.
+func TestCreateTrustNotification_RecordsItsSession(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	shared := NewShared(db, notifications.NewManager(db), newStubBackend())
+	p := &PendingSession{SessionID: "sess-trust", CWD: "/tmp/untrusted"}
+	createTrustNotification(shared, p)
+
+	notifs, err := db.ListNotifications("claude", "", "claude.trust")
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	if len(notifs) != 1 {
+		t.Fatalf("got %d trust notifications, want 1", len(notifs))
+	}
+	notif := notifs[0]
+
+	if notif.SourceSession != "sess-trust" {
+		t.Errorf("source_session = %q, want sess-trust", notif.SourceSession)
+	}
+	if notif.CWD != "/tmp/untrusted" {
+		t.Errorf("cwd = %q, want /tmp/untrusted", notif.CWD)
+	}
+
+	// The action handler reads the session from the payload, so both carry it.
+	var payload struct {
+		SessionID string `json:"session_id"`
+	}
+	if notif.Payload == nil {
+		t.Fatal("notification has no payload")
+	}
+	if err := json.Unmarshal([]byte(*notif.Payload), &payload); err != nil {
+		t.Fatalf("decode payload %q: %v", *notif.Payload, err)
+	}
+	if payload.SessionID != "sess-trust" {
+		t.Errorf("payload session_id = %q, want sess-trust", payload.SessionID)
+	}
+}
+
+// The consequence the column exists for: once the session reports in or ends,
+// the sweep must be able to find and retract the dialog.
+func TestTrustNotification_IsResolvedByItsSession(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	mgr := notifications.NewManager(db)
+	shared := NewShared(db, mgr, newStubBackend())
+	createTrustNotification(shared, &PendingSession{SessionID: "sess-trust", CWD: "/tmp/untrusted"})
+
+	ids, err := mgr.ResolveSession("sess-trust", "resolved", "claude")
+	if err != nil {
+		t.Fatalf("resolve session notifications: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("resolved %d notifications, want 1 — the trust dialog would stay pending forever", len(ids))
+	}
+
+	notifs, err := db.ListNotifications("claude", "pending", "claude.trust")
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(notifs) != 0 {
+		t.Errorf("%d trust notifications still pending after the session resolved", len(notifs))
+	}
+}
 
 func TestPendingSessionMapAddRemove(t *testing.T) {
 	m := NewPendingSessionMap()


### PR DESCRIPTION
Found by driving the public API the way the mobile and desktop clients do — create a session, answer its dialogs, send prompts, attach to its terminal, change its settings, stop it — over both loopback and the tailscale tunnel.

## The bugs

**Trust notifications never recorded their session.** `createTrustNotification` put the session id only inside the payload JSON, leaving `source_session` empty. That is the column every session-scoped sweep keys on, so Stop, terminate and delete all missed the row and it stayed `pending` forever — a permanent approval on every tray and phone for a session that no longer exists. It also left clients with nothing to route a tap on the banner to. The live DB had three such orphans, all for sessions already deleted.

**AskUserQuestion raised two cards.** The `PermissionRequest` hook matches every tool, so it created a blocking `claude.permission` notification alongside the `claude.question` the PreToolUse hook raises — two approvals on the phone for one question. Worse, because the permission hook *blocks* the tool, the CLI never rendered the question UI that answering the `claude.question` card is designed to drive, so neither card could be answered correctly. AskUserQuestion is not an approval; it is now let through and `claude.question` is its only surface.

**A prompt sent straight after a permission-mode change was lost.** The switch works by killing and re-waking the terminal, and `Wake` returns as soon as the host's socket is listening — seconds before the agent inside it is reading its terminal. The session is `idle` with a live terminal for that whole gap, which is exactly what the send path reads as "type into it now", so the keystrokes went into a booting CLI and the send came back `504 the session did not accept the message`. The restart now waits for the agent to report in (`SignalAgentReady`, the same discipline the send path already uses for a cold wake) and reports `ready` in the response.

## Tests

Each fix has a test that fails without it — verified by reverting the fix and watching it go red:

- `TestCreateTrustNotification_RecordsItsSession` / `TestTrustNotification_IsResolvedByItsSession`
- `TestPermission_AskUserQuestionRaisesNoSecondApproval` / `TestPermission_OtherToolsStillRaiseAnApproval`
- `TestSetPermissionModeWaitsForTheAgentToComeBack` / `TestSetPermissionModeReportsAnAgentThatNeverBoots`

`go build ./... && go vet ./... && go test ./...` clean.

## Tooling

`cmd/apitest` is the suite that found them. It pairs a device the way the desktop does, then runs the whole lifecycle against a live daemon: health and auth, the read-only endpoints, SSE, create, the trust dialog, prompt and follow-up, an approval answered remotely (checking on disk that the released tool actually ran), AskUserQuestion, the terminal WebSocket including the ptyhost frame handshake, rename, permission mode, stop, terminate, delete. `cmd/apiprobe` is its single-session counterpart for looking at one thing closely.

65 checks pass against `http://localhost:7655` and the same 65 against the tunnel at `http://mds-macbook-air.tail20015d.ts.net:7655` — the path mobile and remote clients use.