### PR TITLE
fix(desktop): give the deb build the metadata it requires

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -26,8 +26,9 @@ protocols:
 mac:
   category: public.app-category.developer-tools
   icon: assets/icon.png
-  # Host arch only; a universal or cross-arch build is `--arm64 --x64` and pulls
-  # down a second Electron for the privilege.
+  # Host arch only; both slices are `--mac --arm64 --x64`, which pulls down a
+  # second Electron for the privilege. The platform flag is required — the arch
+  # flags are scoped to one, and on their own they are ignored.
   target:
     - dmg
   # Ad-hoc signing, matching the Go binary: enough for Gatekeeper to run it

--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,1 +1,0 @@
-/Users/kamrul/workspace/helios/desktop/node_modules

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "description": "Helios desktop client — session sidebar and live terminal tabs",
+  "homepage": "https://github.com/kamrul1157024/helios",
+  "author": {
+    "name": "Md Kamrul Hassan",
+    "email": "kamrul1157024@gmail.com"
+  },
   "main": "dist/main/main.js",
   "scripts": {
     "build": "node build.mjs",


### PR DESCRIPTION
The first run of the new release workflow failed on the Linux job: `fpm` refuses to build a `.deb` without a maintainer and a homepage, and `desktop/package.json` had neither — the same gap electron-builder warns about on every mac build ("author is missed in the package.json").

Verified by building the deb locally: it now gets past metadata validation and only stops at downloading `fpm`, which this machine cannot reach.

Also drops `desktop/node_modules`. It is a symlink to an absolute path on one machine; #24 said it was untracked, but a pathspec on that commit quietly dropped the staged deletion, so it is still in the tree.

The mac comment in `electron-builder.yml` was stale — the arch flags need a platform flag beside them or electron-builder ignores them.