### PR TITLE
fix(tui): show pairing and tunnel URLs as text, not only as QR codes

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -220,6 +220,20 @@ func (m StartModel) viewTunnelSelect() string {
 
 	b.WriteString(titleStyle.Render("helios — Tunnel Setup"))
 	b.WriteString("\n\n")
+
+	// Reached with a tunnel already up, this screen is "change the tunnel", so
+	// it has to say what the current one is — otherwise the only place the URL
+	// appears is the main screen the user just left.
+	if m.tunnelOK {
+		name := m.tunnelProv
+		if m.tunnelMode != "" {
+			name = m.tunnelProv + " " + m.tunnelMode
+		}
+		b.WriteString(fmt.Sprintf("  %s %s\n", dimStyle.Render("Current:"), urlStyle.Render(m.tunnelURL)))
+		b.WriteString(dimStyle.Render("  · via " + name))
+		b.WriteString("\n\n")
+	}
+
 	b.WriteString(subtitleStyle.Render("  How will your phone connect?"))
 	b.WriteString("\n\n")
 
@@ -389,6 +403,8 @@ func (m StartModel) viewMain() string {
 			b.WriteString(dimStyle.Render("  · " + exposure))
 			b.WriteString("\n")
 		}
+	} else {
+		b.WriteString(cross("No tunnel configured"))
 	}
 	if m.notifyBin != "" {
 		b.WriteString(check(fmt.Sprintf("Desktop notifications (%s)", filepath.Base(m.notifyBin))))
@@ -464,6 +480,14 @@ func (m StartModel) viewMain() string {
 		} else {
 			b.WriteString(fmt.Sprintf("  %s  %s\n", dimStyle.Render("Expires in "+countdown), dimStyle.Render("(auto-refreshes)")))
 		}
+
+		// The same link the QR encodes, in text. Scanning is not always an
+		// option — the terminal may be over SSH, the QR may not fit the window
+		// — and the app's manual field accepts this URL verbatim.
+		b.WriteString(dimStyle.Render("  · Or paste this into the app:"))
+		b.WriteString("\n")
+		b.WriteString("  " + urlStyle.Render(m.setupURL))
+		b.WriteString("\n")
 	} else if m.pairingToken == "" {
 		b.WriteString("\n")
 		b.WriteString(fmt.Sprintf("  Generating pairing code... %s\n", m.spinner.View()))


### PR DESCRIPTION
## Problem

In the tunnel/pairing area of `helios start`, the URLs were effectively invisible:

- The **pairing QR** was the *only* representation of the `helios://pair?url=...&token=...` link. If scanning wasn't an option — terminal over SSH, window too small for the QR to render legibly — there was no way to get the link. The mobile app's manual input field accepts that URL verbatim (`mobile/lib/screens/setup_screen.dart:54`), so the text form is directly usable.
- The main screen printed **nothing at all** about the tunnel when `tunnelOK` was false, so a failed/absent tunnel looked identical to a missing status line.
- The provider picker doubles as "change tunnel" (`t` from the main screen), but never showed the tunnel it was about to replace.

## Changes

`internal/tui/view.go`:

- Print `m.setupURL` as text below the pairing QR, labelled "Or paste this into the app:".
- Add an `else` branch on the main screen: `✗ No tunnel configured`.
- Show `Current: <url>` + `· via <provider>` at the top of the tunnel picker when a tunnel is already active.

## Testing

`go build ./...`, `gofmt -l`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)