### PR TITLE
fix: surface fatal server errors and unreachable local tunnels

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -178,6 +178,7 @@ func startDaemon(cfg *Config) error {
 
 	// Create both servers
 	publicBind := ResolvePublicBind(cfg)
+	server.PublicBind = publicBind
 	internalSrv := server.NewInternalServer(cfg.Server.InternalPort, shared)
 	publicSrv := server.NewPublicServer(publicBind, cfg.Server.PublicPort, shared)
 
@@ -269,11 +270,12 @@ func startDaemon(cfg *Config) error {
 	}()
 
 	// Wait for shutdown or error
+	var srvErr error
 	select {
 	case <-ctx.Done():
 		fmt.Println("\nShutting down...")
-	case err := <-errCh:
-		fmt.Printf("Server error: %v\n", err)
+	case srvErr = <-errCh:
+		fmt.Printf("Server error: %v\n", srvErr)
 	}
 
 	// Graceful shutdown (3 second timeout to avoid hanging on open SSE connections)
@@ -286,7 +288,7 @@ func startDaemon(cfg *Config) error {
 
 	log.Printf("helios daemon stopped")
 	fmt.Println("helios daemon stopped")
-	return nil
+	return srvErr
 }
 
 func Stop() error {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1237,6 +1237,10 @@ var TunnelManager interface {
 // Set by daemon to save tunnel provider to config.yaml.
 var OnTunnelConfigChanged func(provider, customURL, tailscaleMode string)
 
+// PublicBind is the interface the public server is listening on. Set by the
+// daemon at startup; the bind is fixed for the life of the process.
+var PublicBind string
+
 func (s *InternalServer) handleTunnelStatus(w http.ResponseWriter, r *http.Request) {
 	if TunnelManager == nil {
 		jsonResponse(w, http.StatusOK, map[string]interface{}{
@@ -1280,9 +1284,20 @@ func (s *InternalServer) handleTunnelStart(w http.ResponseWriter, r *http.Reques
 		OnTunnelConfigChanged(req.Provider, req.CustomURL, req.TailscaleMode)
 	}
 
-	jsonResponse(w, http.StatusOK, map[string]interface{}{
-		"public_url": url,
-	})
+	resp := map[string]interface{}{"public_url": url}
+	if restartRequiredForBind(req.Provider, PublicBind) {
+		resp["restart_required"] = true
+		resp["message"] = fmt.Sprintf("public API is bound to %s; restart the daemon so it listens on the LAN", PublicBind)
+	}
+	jsonResponse(w, http.StatusOK, resp)
+}
+
+// restartRequiredForBind reports whether the running listener can serve the URL
+// the provider just handed out. The bind is chosen once at startup from the
+// configured provider, so switching to "local" mid-run yields a LAN URL that
+// nothing is listening on.
+func restartRequiredForBind(provider, bind string) bool {
+	return provider == "local" && (bind == "127.0.0.1" || bind == "localhost" || bind == "::1")
 }
 
 func (s *InternalServer) handleTunnelStop(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/tunnel_test.go
+++ b/internal/server/tunnel_test.go
@@ -1,0 +1,25 @@
+package server
+
+import "testing"
+
+func TestRestartRequiredForBind(t *testing.T) {
+	tests := []struct {
+		provider string
+		bind     string
+		want     bool
+	}{
+		{"local", "127.0.0.1", true},
+		{"local", "localhost", true},
+		{"local", "::1", true},
+		{"local", "0.0.0.0", false},
+		{"tailscale", "127.0.0.1", false},
+		{"cloudflare", "127.0.0.1", false},
+		{"custom", "localhost", false},
+	}
+
+	for _, tt := range tests {
+		if got := restartRequiredForBind(tt.provider, tt.bind); got != tt.want {
+			t.Errorf("restartRequiredForBind(%q, %q) = %v, want %v", tt.provider, tt.bind, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -67,8 +67,9 @@ type tunnelStartRequest struct {
 }
 
 type tunnelStartResponse struct {
-	PublicURL string `json:"public_url"`
-	Message   string `json:"message"`
+	PublicURL       string `json:"public_url"`
+	Message         string `json:"message"`
+	RestartRequired bool   `json:"restart_required"`
 }
 
 func (c *client) tunnelStart(provider, customURL string, localPort int, tailscaleMode string) (*tunnelStartResponse, error) {

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -93,8 +93,9 @@ type statusCheckDone struct {
 }
 
 type tunnelStarted struct {
-	url string
-	err error
+	url  string
+	warn string
+	err  error
 }
 
 // tailscaleDetected carries the result of a readiness probe. Detection failures
@@ -168,6 +169,7 @@ type StartModel struct {
 	tunnelURL     string
 	tunnelProv    string
 	tunnelMode    string // tailscale exposure mode of the running tunnel; empty otherwise
+	tunnelWarn    string // daemon-reported caveat about the tunnel just started
 	deviceCount   int
 	devices       []deviceInfo
 	notifyBin     string // path to terminal-notifier/notify-send, empty if not found
@@ -620,6 +622,7 @@ func (m StartModel) handleTunnelStarted(msg tunnelStarted) (tea.Model, tea.Cmd) 
 	}
 	m.tunnelOK = true
 	m.tunnelURL = msg.url
+	m.tunnelWarn = msg.warn
 	m.tunnelProv = tunnelProviders[m.tunnelCursor].id
 	m.tunnelMode = tunnelProviders[m.tunnelCursor].mode
 
@@ -808,7 +811,14 @@ func startTunnel(c *client, provider, customURL string, localPort int, tailscale
 		if err != nil {
 			return tunnelStarted{err: err}
 		}
-		return tunnelStarted{url: resp.PublicURL}
+		warn := ""
+		if resp.RestartRequired {
+			warn = resp.Message
+			if warn == "" {
+				warn = "restart the daemon for this tunnel to be reachable"
+			}
+		}
+		return tunnelStarted{url: resp.PublicURL, warn: warn}
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -416,6 +416,9 @@ func (m StartModel) viewMain() string {
 			b.WriteString(dimStyle.Render("  · " + exposure))
 			b.WriteString("\n")
 		}
+		if m.tunnelWarn != "" {
+			b.WriteString(cross(m.tunnelWarn))
+		}
 	} else {
 		b.WriteString(cross("No tunnel configured"))
 	}


### PR DESCRIPTION
## Summary

Two bugs found while diagnosing a local daemon that had been dead for 21 hours without saying so.

**1. Fatal server errors were swallowed.** `Start` printed the error from `errCh` and returned `nil` anyway. The supervisor read that as `daemon exited cleanly` and exited; launchd respawned it 10s later, forever. On my machine a stale daemon held 7654, so every respawn hit `bind: address already in use` and the loop ran silently for hours — `supervisor.log` claimed clean exits the whole time. Now the error is returned after graceful shutdown, so the supervisor's existing backoff and max-restart logic actually engages.

**2. Switching to the `local` tunnel provider hands out a dead URL.** `ResolvePublicBind` maps provider `local` to `0.0.0.0` and is read once at startup. Starting a `local` tunnel at runtime writes the config and returns `http://<lan-ip>:7655`, but the listener is still on loopback until the next restart. The endpoint now returns `restart_required` with an explanatory message, and the TUI shows it beside the tunnel line.

## Test plan

- [ ] `go test ./...`
- [ ] Occupy 7654, start the daemon: `supervisor.log` shows `daemon exited with error` and backs off instead of looping every 10s
- [ ] With a loopback bind, switch the tunnel to `local` in the TUI: the restart warning renders under the tunnel URL
- [ ] Restart the daemon with `provider: local`: bind is `0.0.0.0`, no warning