### PR TITLE
fix: make the daemon's environment and failures legible

### DIFF
--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -45,7 +45,14 @@ export function App(): JSX.Element {
   if (loading) {
     return (
       <div className="boot">
-        <span className="spinner" />
+        {/* The window is frameless, so without a drag region the splash is a
+            surface the user cannot move while it is up. */}
+        <div className="titlebar" />
+        <div className="boot-card">
+          <span className="boot-mark">helios</span>
+          <span className="spinner" />
+          <span className="boot-caption">Connecting to your daemons…</span>
+        </div>
       </div>
     )
   }

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -21,6 +21,10 @@ const PAGE = 200
 
 export function ChatPanel({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
   const [messages, setMessages] = useState<TranscriptMessage[]>([])
+  // Which session the messages belong to. Switching sessions would otherwise
+  // show the previous transcript until the new one arrives, and "No transcript
+  // yet." for a session whose transcript is merely still loading.
+  const [loadedFor, setLoadedFor] = useState('')
   const [hasMore, setHasMore] = useState(false)
   const [total, setTotal] = useState(0)
   const [draft, setDraft] = useState('')
@@ -42,6 +46,7 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
         setMessages(page.messages)
         setTotal(page.total)
         setHasMore(page.has_more)
+        setLoadedFor(session.session_id)
       } catch (err) {
         if (!cancelled) store.fail(err)
       }
@@ -110,21 +115,30 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
           pinnedToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40
         }}
       >
-        {hasMore && (
-          <button className="link load-more" onClick={() => void loadOlder()}>
-            Load older ({total - messages.length} more)
-          </button>
+        {loadedFor !== session.session_id ? (
+          <div className="panel-loading">
+            <span className="spinner" />
+            <span>Loading transcript…</span>
+          </div>
+        ) : (
+          <>
+            {hasMore && (
+              <button className="link load-more" onClick={() => void loadOlder()}>
+                Load older ({total - messages.length} more)
+              </button>
+            )}
+            {messages.length === 0 && <p className="empty-note">No transcript yet.</p>}
+            {messages.map((message, index) => (
+              <Message
+                key={`${message.timestamp}-${index}`}
+                message={message}
+                hostId={hostId}
+                cwd={session.cwd}
+              />
+            ))}
+            {busy && <div className="typing">agent is working…</div>}
+          </>
         )}
-        {messages.length === 0 && <p className="empty-note">No transcript yet.</p>}
-        {messages.map((message, index) => (
-          <Message
-            key={`${message.timestamp}-${index}`}
-            message={message}
-            hostId={hostId}
-            cwd={session.cwd}
-          />
-        ))}
-        {busy && <div className="typing">agent is working…</div>}
       </div>
 
       {/* No composer for a terminated session: the daemon refuses its prompts,

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -30,6 +30,7 @@ export function Detail(): JSX.Element {
   const hostId = selection?.hostId ?? null
   const session =
     (selection && sessions[selection.hostId]?.find((s) => s.session_id === selection.sessionId)) ?? null
+  const pendingList = Boolean(selection) && sessions[selection?.hostId ?? ''] === undefined
 
   const pending = session
     ? (notifications[hostId ?? ''] ?? []).filter((n) => n.source_session === session.session_id).length
@@ -75,11 +76,20 @@ export function Detail(): JSX.Element {
       )}
 
       <div className="panel-body">
-        {!session && (
-          <div className="panel-empty">
-            <p>{selection ? 'That session is no longer listed.' : 'Select a session.'}</p>
-          </div>
-        )}
+        {!session &&
+          (pendingList ? (
+            // An unfetched host has no entry at all, an empty one has []. Without
+            // that distinction a selected session reads as deleted for as long as
+            // its host takes to answer.
+            <div className="panel-loading">
+              <span className="spinner" />
+              <span>Loading session…</span>
+            </div>
+          ) : (
+            <div className="panel-empty">
+              <p>{selection ? 'That session is no longer listed.' : 'Select a session.'}</p>
+            </div>
+          ))}
 
         {hostId && session && panel !== 'terminal' && (
           <PanelBoundary resetKey={`${hostId}:${session.session_id}:${panel}`}>

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -28,14 +28,17 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
         setDirectories(dirs)
         const first = providerList[0]
         if (first && !providerList.some((p) => p.id === provider)) setProvider(first.id)
-        if (!cwd && dirs[0]) setCwd(dirs[0].cwd)
+        // Reset rather than preserve: a directory is meaningful only on the
+        // host it came from, and carrying one across a host switch starts the
+        // session in a path that does not exist there.
+        setCwd(dirs[0]?.cwd ?? '')
       })
       .catch((err: unknown) => store.fail(err))
     return () => {
       cancelled = true
     }
-    // provider/cwd are seeded here but owned by the user afterwards, so they
-    // are deliberately not dependencies.
+    // Runs on host change only, so edits the user makes while staying on one
+    // host survive; provider and cwd are deliberately not dependencies.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hostId])
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -384,9 +384,30 @@ small {
 }
 
 .boot {
-  display: grid;
-  place-items: center;
+  display: flex;
+  flex-direction: column;
   height: 100%;
+}
+
+.boot-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+
+.boot-mark {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+}
+
+.boot-caption {
+  font-size: 12px;
+  color: var(--on-surface-variant);
 }
 
 /* ─── Sidebar ───────────────────────────────────────────────────────────── */
@@ -696,6 +717,18 @@ small {
   flex: 1;
   display: grid;
   place-items: center;
+  color: var(--on-surface-variant);
+}
+
+.panel-loading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px 0;
+  font-size: 12px;
   color: var(--on-surface-variant);
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -107,6 +107,8 @@ func startDaemon(cfg *Config) error {
 	defer logFile.Close()
 	log.SetOutput(logFile)
 
+	log.Printf("PATH: %s", importLoginPATH())
+
 	db, err := store.Open(cfg.DB.Path)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)

--- a/internal/daemon/path.go
+++ b/internal/daemon/path.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// loginPATHTimeout bounds the shell probe. A user's profile can do arbitrary
+// work — version managers, network calls — and none of it is worth delaying
+// the daemon for.
+const loginPATHTimeout = 5 * time.Second
+
+// importLoginPATH widens the process PATH with the one a login shell reports.
+//
+// launchd starts agents with PATH=/usr/bin:/bin:/usr/sbin:/sbin, so a daemon
+// launched at boot cannot see /opt/homebrew/bin and every agent it spawns
+// fails with "executable file not found in $PATH". The same daemon started
+// from a terminal works, which makes the failure look like anything but what
+// it is. Ask the login shell once at startup and inherit what it knows.
+//
+// Failures are silent by design: the PATH already in the environment is a
+// working default for anyone who started the daemon by hand.
+func importLoginPATH() string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return os.Getenv("PATH")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), loginPATHTimeout)
+	defer cancel()
+
+	merged := mergePATH(os.Getenv("PATH"), loginShellPATH(ctx, shell))
+	os.Setenv("PATH", merged)
+	return merged
+}
+
+// loginShellPATH asks a login shell for its PATH. It is deliberately not an
+// interactive shell: -i sources rc files that expect a terminal, and some of
+// them block forever without one.
+func loginShellPATH(ctx context.Context, shell string) string {
+	out, err := exec.CommandContext(ctx, shell, "-lc", "printf %s \"$PATH\"").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// mergePATH appends entries of extra that current does not already list,
+// preserving the order of both. current keeps priority: an operator who set
+// PATH explicitly outranks whatever a profile happens to say.
+func mergePATH(current, extra string) string {
+	if extra == "" {
+		return current
+	}
+
+	seen := make(map[string]bool)
+	var out []string
+	for _, dir := range strings.Split(current, string(os.PathListSeparator)) {
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	for _, dir := range strings.Split(extra, string(os.PathListSeparator)) {
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	return strings.Join(out, string(os.PathListSeparator))
+}

--- a/internal/daemon/path_test.go
+++ b/internal/daemon/path_test.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMergePATH(t *testing.T) {
+	sep := string(os.PathListSeparator)
+
+	tests := []struct {
+		name    string
+		current string
+		extra   string
+		want    string
+	}{
+		{
+			name:    "launchd default gains the profile's directories",
+			current: "/usr/bin" + sep + "/bin",
+			extra:   "/opt/homebrew/bin" + sep + "/usr/bin",
+			want:    "/usr/bin" + sep + "/bin" + sep + "/opt/homebrew/bin",
+		},
+		{
+			name:    "no extra leaves the current PATH untouched",
+			current: "/usr/bin" + sep + "/bin",
+			extra:   "",
+			want:    "/usr/bin" + sep + "/bin",
+		},
+		{
+			name:    "duplicates within either side collapse",
+			current: "/usr/bin" + sep + "/usr/bin",
+			extra:   "/bin" + sep + "/bin",
+			want:    "/usr/bin" + sep + "/bin",
+		},
+		{
+			name:    "empty segments are dropped",
+			current: "/usr/bin" + sep + sep + "/bin",
+			extra:   sep + "/opt/homebrew/bin",
+			want:    "/usr/bin" + sep + "/bin" + sep + "/opt/homebrew/bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergePATH(tt.current, tt.extra); got != tt.want {
+				t.Errorf("mergePATH(%q, %q) = %q, want %q", tt.current, tt.extra, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMergePATHKeepsCurrentFirst pins the precedence rule: an explicitly set
+// PATH must not be reordered by whatever the user's profile prefers.
+func TestMergePATHKeepsCurrentFirst(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	got := mergePATH("/custom/bin", "/opt/homebrew/bin"+sep+"/custom/bin")
+	want := "/custom/bin" + sep + "/opt/homebrew/bin"
+	if got != want {
+		t.Errorf("mergePATH = %q, want %q", got, want)
+	}
+}
+
+func TestLoginShellPATH(t *testing.T) {
+	dir := t.TempDir()
+	shell := filepath.Join(dir, "fakeshell")
+	script := "#!/bin/sh\nprintf %s \"/opt/homebrew/bin:/usr/bin\"\n"
+	if err := os.WriteFile(shell, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := loginShellPATH(context.Background(), shell)
+	if got != "/opt/homebrew/bin:/usr/bin" {
+		t.Errorf("loginShellPATH = %q, want %q", got, "/opt/homebrew/bin:/usr/bin")
+	}
+}
+
+// TestLoginShellPATHFailureIsEmpty covers the case that matters most: a shell
+// that cannot run must leave the caller with the PATH it already had.
+func TestLoginShellPATHFailureIsEmpty(t *testing.T) {
+	if got := loginShellPATH(context.Background(), filepath.Join(t.TempDir(), "missing")); got != "" {
+		t.Errorf("loginShellPATH = %q, want empty", got)
+	}
+}
+
+// TestImportLoginPATHWidensLaunchdDefault exercises the whole path with a
+// stub shell, since that is the launchd case the daemon actually hits.
+func TestImportLoginPATHWidensLaunchdDefault(t *testing.T) {
+	dir := t.TempDir()
+	shell := filepath.Join(dir, "fakeshell")
+	script := "#!/bin/sh\nprintf %s \"/opt/homebrew/bin:/usr/bin:/bin\"\n"
+	if err := os.WriteFile(shell, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SHELL", shell)
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+	got := importLoginPATH()
+	if !strings.Contains(got, "/opt/homebrew/bin") {
+		t.Errorf("importLoginPATH = %q, want it to contain /opt/homebrew/bin", got)
+	}
+	if got != os.Getenv("PATH") {
+		t.Errorf("importLoginPATH returned %q but set PATH to %q", got, os.Getenv("PATH"))
+	}
+	if !strings.HasPrefix(got, "/usr/bin:/bin:/usr/sbin:/sbin") {
+		t.Errorf("importLoginPATH = %q, want the inherited PATH to keep priority", got)
+	}
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1049,6 +1049,13 @@ func (s *InternalServer) handleInternalCreateSession(w http.ResponseWriter, r *h
 		req.CWD = cwd
 	}
 
+	resolved, err := resolveCWD(req.CWD)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.CWD = resolved
+
 	sessionID := uuid.New().String()
 	spec := provider.SessionSpec{
 		SessionID:       sessionID,
@@ -1658,6 +1665,13 @@ func (s *PublicServer) handleCreateSession(w http.ResponseWriter, r *http.Reques
 		}
 		req.CWD = home
 	}
+
+	resolved, err := resolveCWD(req.CWD)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.CWD = resolved
 
 	sessionID := uuid.New().String()
 	spec := provider.SessionSpec{

--- a/internal/server/cwd.go
+++ b/internal/server/cwd.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveCWD turns a client-supplied working directory into one the daemon can
+// hand to a terminal host.
+//
+// Clients send what the user typed, and "~/src/app" is what people type. Left
+// alone it reaches exec as a literal directory name, which fails as
+// "fork/exec /usr/local/bin/helios: no such file or directory" — exec blames
+// the binary for a missing Dir — so the error points at everything except the
+// path that is wrong.
+func resolveCWD(raw string) (string, error) {
+	cwd := strings.TrimSpace(raw)
+	if cwd == "" {
+		return "", fmt.Errorf("working directory is required")
+	}
+
+	if cwd == "~" || strings.HasPrefix(cwd, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot expand ~: %w", err)
+		}
+		cwd = filepath.Join(home, strings.TrimPrefix(cwd[1:], "/"))
+	}
+
+	if !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("working directory must be an absolute path: %s", raw)
+	}
+
+	cwd = filepath.Clean(cwd)
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("working directory does not exist: %s", cwd)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working directory is not a directory: %s", cwd)
+	}
+	return cwd, nil
+}

--- a/internal/server/cwd_test.go
+++ b/internal/server/cwd_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveCWDExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	got, err := resolveCWD("~")
+	if err != nil {
+		t.Fatalf("resolveCWD(~) = %v", err)
+	}
+	if got != filepath.Clean(home) {
+		t.Errorf("resolveCWD(~) = %q, want %q", got, home)
+	}
+}
+
+func TestResolveCWDRejectsRelativePaths(t *testing.T) {
+	_, err := resolveCWD("workspace/helios")
+	if err == nil {
+		t.Fatal("expected an error for a relative path")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("error = %q, want it to mention absolute paths", err)
+	}
+}
+
+func TestResolveCWDNamesTheMissingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "gone")
+
+	_, err := resolveCWD(missing)
+	if err == nil {
+		t.Fatal("expected an error for a missing directory")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error = %q, want it to name %q", err, missing)
+	}
+}
+
+func TestResolveCWDRejectsAFile(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := resolveCWD(file); err == nil {
+		t.Fatal("expected an error for a file")
+	}
+}
+
+func TestResolveCWDCleansAndKeepsValidPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := resolveCWD(dir + "/./")
+	if err != nil {
+		t.Fatalf("resolveCWD = %v", err)
+	}
+	if got != filepath.Clean(dir) {
+		t.Errorf("resolveCWD = %q, want %q", got, filepath.Clean(dir))
+	}
+}
+
+// Whitespace is what a paste into a text field leaves behind.
+func TestResolveCWDTrimsSurroundingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := resolveCWD("  " + dir + "  ")
+	if err != nil {
+		t.Fatalf("resolveCWD = %v", err)
+	}
+	if got != filepath.Clean(dir) {
+		t.Errorf("resolveCWD = %q, want %q", got, filepath.Clean(dir))
+	}
+}

--- a/internal/terminal/spawn.go
+++ b/internal/terminal/spawn.go
@@ -48,6 +48,13 @@ func SpawnHost(heliosDir, sessionID, cwd string, argv []string) error {
 		cmd.Stderr = logFile
 	}
 	if cwd != "" {
+		// Checked up front because exec blames the binary for a missing Dir:
+		// a deleted working directory surfaces as "fork/exec
+		// /usr/local/bin/helios: no such file or directory", which sends
+		// whoever reads it hunting for a broken install.
+		if info, err := os.Stat(cwd); err != nil || !info.IsDir() {
+			return fmt.Errorf("working directory does not exist: %s", cwd)
+		}
 		cmd.Dir = cwd
 	}
 	if err := cmd.Start(); err != nil {

--- a/internal/terminal/spawn_test.go
+++ b/internal/terminal/spawn_test.go
@@ -1,9 +1,44 @@
 package terminal
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
+
+// A missing working directory must be named as such. Left to exec, it reports
+// the helios binary as the missing file instead, which reads as a broken
+// install and sends the reader looking in entirely the wrong place.
+func TestSpawnHostRejectsMissingCwd(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "deleted-worktree")
+
+	err := SpawnHost(dir, "sess-1", missing, []string{"/bin/echo"})
+	if err == nil {
+		t.Fatal("expected an error for a missing working directory")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error = %q, want it to name %q", err, missing)
+	}
+	if strings.Contains(err.Error(), "fork/exec") {
+		t.Errorf("error = %q, want the directory blamed rather than the binary", err)
+	}
+}
+
+// A path that exists but is a file is the same failure with a different shape.
+func TestSpawnHostRejectsFileAsCwd(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SpawnHost(dir, "sess-1", file, []string{"/bin/echo"}); err == nil {
+		t.Fatal("expected an error for a file used as the working directory")
+	}
+}
 
 // Empty argv is the resume path: the host picks the agent and its --resume
 // flag itself, so nothing is passed down.


### PR DESCRIPTION
## Summary

Three failures that all reported something other than their cause.

**1. launchd's PATH.** A daemon started at login gets `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, and everything it spawns inherits it. On a Homebrew machine every session dies with `exec: "claude": executable file not found in $PATH`, and tunnel detection misses the real CLI and falls back to the `.app` bundle, failing with `parse tailscale status: invalid character 'T' …`. Started from a terminal the same daemon works. Fixed by asking the login shell for its PATH once at startup and merging it in — `-lc` not `-lic`, since an interactive shell sources rc files that expect a terminal and some block without one. The inherited PATH keeps priority; a shell that fails or hangs leaves the environment untouched.

**2. exec blames the binary for a missing Dir.** Starting a session in a directory that does not exist produces `failed to start terminal: spawn terminal host for …: start ptyhost: fork/exec /usr/local/bin/helios: no such file or directory`. Nothing is wrong with the binary. Now the directory is checked first and named, and client input is resolved: `~/src/app` previously reached exec as a literal path because nothing expanded it, and relative paths were accepted and then failed the same opaque way.

**3. The bad directory came from the other host.** The new-session dialog reloads the directory list when the host changes but kept the previous selection, so switching hosts started the session in a path that only exists on the host you left.

Plus the loading states that let all of this stay confusing: the app booted to a bare spinner, a selected session read as "That session is no longer listed." until its host answered, and a transcript still loading was reported as "No transcript yet."

## Test plan

Verified against the real launchd agent with **no** `EnvironmentVariables` in the plist:

- [x] `ps -Ewww` confirms launchd handed the daemon `PATH=/usr/bin:/bin:/usr/sbin:/sbin`
- [x] `daemon.log` shows the widened PATH: `/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:…`
- [x] `POST /internal/sessions` returns `success:true` where it previously failed with `did not come up`; the ptyhost has a live `claude` child
- [x] tunnel start resolves the real CLI: `http://mdkamrulhassan.tail20015d.ts.net:7655`
- [x] the old error reproduced on demand with a missing cwd, and again with `~/workspace/helios` and a relative path — all three now return a message naming the directory
- [x] `go test ./...` and `tsc --noEmit`; unit tests cover the PATH merge rules, a stub login shell, cwd resolution, and spawn refusing a missing or non-directory cwd

Not verified: the loading screens were exercised by running the app, not by an automated test — the desktop suite needs `--experimental-strip-types`, which this machine's Node 20.19 does not accept (pre-existing, untouched here).