### PR TITLE
feat(desktop): hide terminated sessions behind a per-host toggle

### DIFF
--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   BUSY_STATUSES,
   canResume,
   hasTerminal,
+  isTerminated,
   needsRecovery,
   sessionLabel,
   shortCwd,
@@ -20,6 +21,13 @@ interface Row {
   pending: number
 }
 
+interface Group {
+  host: HostRecord
+  rows: Row[]
+  /** Terminated sessions withheld from rows, so the host can offer them. */
+  hidden: number
+}
+
 export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void; onAddHost: () => void }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
@@ -29,8 +37,11 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
   const query = useStore((s) => s.query)
   const showArchived = useStore((s) => s.showArchived)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  // Per host, not global: a machine kept for finished work and one being
+  // worked in want opposite answers, and the setting is one click away.
+  const [showTerminated, setShowTerminated] = useState<Record<string, boolean>>({})
 
-  const grouped = useMemo(() => {
+  const grouped = useMemo<Group[]>(() => {
     const needle = query.trim().toLowerCase()
     return hosts.map((host) => {
       const pendingByCwd = new Map<string, number>()
@@ -38,7 +49,7 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
         pendingByCwd.set(notif.source_session, (pendingByCwd.get(notif.source_session) ?? 0) + 1)
       }
 
-      const rows: Row[] = (sessions[host.id] ?? [])
+      const visible = (sessions[host.id] ?? [])
         .filter((session) => showArchived || !session.archived)
         .filter((session) => {
           if (!needle) return true
@@ -46,12 +57,19 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
             .toLowerCase()
             .includes(needle)
         })
+
+      // A terminated session the user searched for is a session they asked to
+      // see, so the filter yields to an explicit query.
+      const hideTerminated = !showTerminated[host.id] && !needle
+      const rows: Row[] = visible
+        .filter((session) => !hideTerminated || !isTerminated(session))
         .map((session) => ({ host, session, pending: pendingByCwd.get(session.session_id) ?? 0 }))
         .sort(compareRows)
 
-      return { host, rows }
+      const hidden = hideTerminated ? visible.filter(isTerminated).length : 0
+      return { host, rows, hidden }
     })
-  }, [hosts, sessions, notifications, query, showArchived])
+  }, [hosts, sessions, notifications, query, showArchived, showTerminated])
 
   return (
     <aside className="sidebar">
@@ -73,7 +91,7 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
       </header>
 
       <div className="sidebar-list">
-        {grouped.map(({ host, rows }) => {
+        {grouped.map(({ host, rows, hidden }) => {
           const status = hostStatus[host.id]?.state ?? 'connecting'
           const isCollapsed = collapsed[host.id] ?? false
           return (
@@ -101,7 +119,22 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
                   />
                 ))}
 
-              {!isCollapsed && rows.length === 0 && <p className="empty-note">No sessions</p>}
+              {!isCollapsed && rows.length === 0 && hidden === 0 && (
+                <p className="empty-note">No sessions</p>
+              )}
+
+              {!isCollapsed && (hidden > 0 || showTerminated[host.id]) && (
+                <button
+                  className="link show-terminated"
+                  onClick={() =>
+                    setShowTerminated((current) => ({ ...current, [host.id]: !current[host.id] }))
+                  }
+                >
+                  {showTerminated[host.id]
+                    ? 'Hide terminated'
+                    : `Show ${hidden} terminated`}
+                </button>
+              )}
             </section>
           )
         })}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -245,6 +245,14 @@ small {
   font-size: 13px;
 }
 
+.show-terminated {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 16px 10px;
+  font-size: 12px;
+}
+
 .error-text {
   color: var(--error);
   font-size: 12px;


### PR DESCRIPTION
## Summary

Terminated sessions accumulate faster than live ones and push everything still worth looking at out of view. The sidebar now leaves them out by default.

- Hidden per host, not globally — a host kept around for finished work and one being actively worked in want opposite answers, and the control sits with the group it affects.
- The host group shows `Show N terminated` when any are hidden, and `Hide terminated` once revealed.
- A search overrides the filter: a session whose name the user typed is one they asked to see.
- `No sessions` no longer appears for a host whose only sessions are hidden — the toggle takes its place.

## Test plan

- [x] `tsc --noEmit` and `node build.mjs`
- [ ] Eyeball the sidebar: terminated sessions absent by default, the toggle reveals and hides them per host, and searching a terminated session's name finds it

I could not verify this one visually — the dev instance launches (menu bar shows it) but its window lands on a Space this environment cannot capture, so screenshots come back empty. The desktop test suite is no help either: `npm test` needs `--experimental-strip-types`, which Node 20.19 on this machine rejects. Worth a look before trusting the layout.