### PR TITLE
feat(desktop): make the agent panel usable on a wide window

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -161,16 +161,17 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
             placeholder={
               cold
                 ? 'Send a prompt — the session wakes first'
-                : session.supports_prompt_queue
-                  ? 'Send a prompt (⌘↵)'
-                  : 'Send a prompt'
+                : 'Send a prompt (↵ to send, ⇧↵ for a new line)'
             }
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-                event.preventDefault()
-                void send()
-              }
+              if (event.key !== 'Enter') return
+              // An IME uses Enter to accept a candidate; sending there would
+              // post half a word and swallow the rest.
+              if (event.nativeEvent.isComposing) return
+              if (event.shiftKey) return
+              event.preventDefault()
+              void send()
             }}
           />
           <div className="composer-actions">

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -20,6 +20,16 @@ import {
 
 const PANELS: RightPanel[] = ['chat', 'terminal', 'approvals', 'git', 'files']
 
+// The transcript is the agent's side of the session, not a chat room. The
+// store key stays 'chat' — it is persisted and referenced from elsewhere.
+const PANEL_LABELS: Record<RightPanel, string> = {
+  chat: 'agent',
+  terminal: 'terminal',
+  approvals: 'approvals',
+  git: 'git',
+  files: 'files',
+}
+
 export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const sessions = useStore((s) => s.sessions)
@@ -54,7 +64,7 @@ export function Detail(): JSX.Element {
                     still the one thing about a terminal worth seeing from
                     another panel. */}
                 {name === 'terminal' && term && <span className={`dot ${term.status.state}`} />}
-                {name}
+                {PANEL_LABELS[name]}
                 {name === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
                 {name === 'terminal' && term && (
                   <span
@@ -93,7 +103,23 @@ export function Detail(): JSX.Element {
 
         {hostId && session && panel !== 'terminal' && (
           <PanelBoundary resetKey={`${hostId}:${session.session_id}:${panel}`}>
-            {panel === 'chat' && <ChatPanel hostId={hostId} session={session} />}
+            {/* Approvals ride alongside the transcript instead of behind their
+                own tab: an agent that stops for permission stops the panel the
+                user is already looking at, and a tab round-trip per approval
+                is the whole interaction. */}
+            {panel === 'chat' && (
+              <div className="agent-split">
+                <ChatPanel hostId={hostId} session={session} />
+                {pending > 0 && (
+                  <aside className="approvals-dock">
+                    <h3 className="dock-title">
+                      Approvals <span className="badge">{pending}</span>
+                    </h3>
+                    <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
+                  </aside>
+                )}
+              </div>
+            )}
             {panel === 'approvals' && <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />}
             {panel === 'git' && (
               <GitPanel hostId={hostId} cwd={session.cwd} revision={session.last_event_at} />

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -41,6 +41,9 @@
   --r-lg: 16px;
   --r-xl: 28px;
   --sidebar: 320px;
+  /* Reading width for the transcript and its composer. Wider than this and a
+     reply and the prompt above it end up at opposite edges of the window. */
+  --chat-column: 860px;
 
   font-synthesis: none;
   color-scheme: dark;
@@ -901,6 +904,45 @@ small {
 
 /* ─── Chat ──────────────────────────────────────────────────────────────── */
 
+.agent-split {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+}
+
+.approvals-dock {
+  width: 380px;
+  flex: none;
+  overflow-y: auto;
+  padding: 12px 12px 16px;
+  border-left: 1px solid var(--outline-variant);
+}
+
+.dock-title {
+  margin: 0 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--on-surface-variant);
+}
+
+/* Too narrow to sit beside the transcript: fold underneath it, still without
+   a tab switch. */
+@media (max-width: 1240px) {
+  .agent-split {
+    flex-direction: column;
+  }
+
+  .approvals-dock {
+    width: auto;
+    max-height: 45%;
+    border-left: none;
+    border-top: 1px solid var(--outline-variant);
+  }
+}
+
 .chat {
   flex: 1;
   display: flex;
@@ -918,9 +960,13 @@ small {
   padding: 16px;
 }
 
+/* A centred column rather than the full window: on a wide display the reply
+   sits at the left edge and the prompt that produced it at the right, far
+   enough apart to read as unrelated. */
 .msg {
-  margin-bottom: 14px;
-  max-width: 780px;
+  margin: 0 auto 14px;
+  width: 100%;
+  max-width: var(--chat-column);
 }
 
 .msg-role {
@@ -943,7 +989,6 @@ small {
 .msg.user {
   display: flex;
   justify-content: flex-end;
-  margin-left: auto;
 }
 
 .msg.user .msg-body {
@@ -1276,6 +1321,13 @@ small {
   padding: 12px 16px 14px;
 }
 
+/* Aligned with the transcript column, so the box the prompt is typed into
+   lines up with the messages it produces. */
+.composer > * {
+  max-width: var(--chat-column);
+  margin: 0 auto;
+}
+
 /* What replaces the composer once the session has ended. */
 .composer.ended {
   display: flex;
@@ -1290,6 +1342,8 @@ small {
 }
 
 .composer textarea {
+  /* Inline-block by default, and auto margins do not centre one. */
+  display: block;
   width: 100%;
   resize: vertical;
   min-height: 60px;


### PR DESCRIPTION
## Summary

Four things about the transcript panel, all of them visible the moment the window is wide.

- **A reading column.** The transcript used the full window width, so a reply sat against the left edge and the user bubble that prompted it against the right — 1400px apart on a large display. Messages and the composer now share a centred 860px column.
- **Enter sends, shift-enter breaks the line.** The composer wanted ⌘↵ and nothing on screen said so. Enter during IME composition is deliberately left alone: sending there posts half a word and swallows the rest.
- **Approvals beside the transcript.** Behind their own tab, answering one approval meant switching tabs, approving, and switching back — once per approval — while the agent that asked was waiting in the panel the user had just left. They now dock to the right of the transcript, and fold underneath it below 1240px. The tab stays for when nothing is pending.
- **The tab is "agent".** It is one side of a session, not a chat room. The `RightPanel` key stays `chat`, since it is persisted and referenced elsewhere.

## Test plan

The Electron window opens on a Space this environment cannot screenshot, so the layout was measured against the real built stylesheet in Chrome instead — same CSS, same markup structure.

At 1600px:
- [x] assistant text `180…1040`, user bubble right edge `1040`, composer `180…1040` — one column, all three aligned
- [x] approvals dock `1212…1592`, beside the transcript rather than over it

At 1100px:
- [x] the dock folds beneath the composer, full width, approvals still one click each

- [x] `tsc --noEmit` and `node build.mjs`
- [ ] Worth confirming in the app itself: Enter sends, ⇧Enter breaks, and the dock appears the moment an approval arrives