### PR TITLE
feat(desktop): diffs for edits, send in the composer, sidebar toggle on top

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
+import { multiEditDiff, unifiedDiff } from '../diff.ts'
+import { DiffView } from './diff-view.tsx'
 import {
   extractFilePaths,
   highlightCode,
@@ -155,35 +157,43 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
         </div>
       ) : (
         <div className="composer">
-          <textarea
-            value={draft}
-            rows={3}
-            placeholder={
-              cold
-                ? 'Send a prompt — the session wakes first'
-                : 'Send a prompt (↵ to send, ⇧↵ for a new line)'
-            }
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter') return
-              // An IME uses Enter to accept a candidate; sending there would
-              // post half a word and swallow the rest.
-              if (event.nativeEvent.isComposing) return
-              if (event.shiftKey) return
-              event.preventDefault()
-              void send()
-            }}
-          />
-          <div className="composer-actions">
-            {busy && (
+          <div className="composer-input">
+            <textarea
+              value={draft}
+              rows={3}
+              placeholder={
+                cold
+                  ? 'Send a prompt — the session wakes first'
+                  : 'Send a prompt (↵ to send, ⇧↵ for a new line)'
+              }
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter') return
+                // An IME uses Enter to accept a candidate; sending there would
+                // post half a word and swallow the rest.
+                if (event.nativeEvent.isComposing) return
+                if (event.shiftKey) return
+                event.preventDefault()
+                void send()
+              }}
+            />
+            <button
+              className="filled send-btn"
+              disabled={!draft.trim() || sending}
+              title={cold ? 'Wake and send' : 'Send (↵)'}
+              aria-label={cold ? 'Wake and send' : 'Send'}
+              onClick={() => void send()}
+            >
+              {sending ? <span className="spinner" /> : '↑'}
+            </button>
+          </div>
+          {busy && (
+            <div className="composer-actions">
               <button className="ghost" onClick={() => void api(hostId).stop(session.session_id)}>
                 Stop
               </button>
-            )}
-            <button disabled={!draft.trim() || sending} onClick={() => void send()}>
-              {sending ? 'Sending…' : cold ? 'Wake and send' : 'Send'}
-            </button>
-          </div>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -311,16 +321,21 @@ const CODE_FIELDS: { key: string; label?: string }[] = [
   { key: 'old_string', label: 'old' },
 ]
 
+/** Tools whose call changes a file, and whose diff is the point of the row. */
+const WRITING_TOOLS = new Set(['Edit', 'MultiEdit', 'Write'])
+
 /**
  * A tool call: one line collapsed, the input expanded. The expansion is
  * tool-aware because a Bash command and an Edit's replacement text want
  * different treatment, and a raw JSON dump serves neither.
  */
 function ToolUse({ message, hostId, cwd }: MessageProps): JSX.Element {
-  const [open, setOpen] = useState(false)
   const tool = message.tool ?? 'tool'
   const input = (message.metadata ?? {}) as Record<string, unknown>
   const filePath = typeof input.file_path === 'string' ? input.file_path : null
+  // A write is the part of a session worth reading, and a collapsed row names
+  // the tool without saying what it did to the file.
+  const [open, setOpen] = useState(WRITING_TOOLS.has(tool))
 
   return (
     <div className="msg tool">
@@ -358,6 +373,21 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
     )
   }
 
+  // What changed, as a patch. Two code blocks — the text searched for and the
+  // text written — leave the reader diffing them by eye.
+  const diff = diffFor(tool, input)
+  if (diff) {
+    const coded = new Set([...CODE_FIELDS.map((f) => f.key), 'edits'])
+    return (
+      <>
+        <KeyValues entries={entries.filter(([key]) => !coded.has(key))} />
+        <div className="tool-diff">
+          <DiffView diff={diff} />
+        </div>
+      </>
+    )
+  }
+
   if (tool === 'Read' || tool === 'Write' || tool === 'Edit' || tool === 'MultiEdit') {
     const language = languageForPath(str(input.file_path))
     const coded = new Set(CODE_FIELDS.map((f) => f.key))
@@ -375,6 +405,21 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
   }
 
   return <KeyValues entries={entries} />
+}
+
+/** The patch a tool call implies, or "" for calls that changed no file. */
+function diffFor(tool: string, input: Record<string, unknown>): string {
+  if (tool === 'MultiEdit') return multiEditDiff(input.edits)
+  if (tool === 'Edit') {
+    const before = str(input.old_string)
+    const after = str(input.new_string)
+    return before || after ? unifiedDiff(before, after) : ''
+  }
+  if (tool === 'Write') {
+    const content = str(input.content) || str(input.new_content)
+    return content ? unifiedDiff('', content) : ''
+  }
+  return ''
 }
 
 function KeyValues({ entries }: { entries: [string, unknown][] }): JSX.Element | null {

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -106,6 +106,20 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
                 <span className="chevron">{isCollapsed ? '▸' : '▾'}</span>
               </button>
 
+              {/* Above the list, not below it: revealed sessions are appended,
+                  so a toggle under them walks further down the page with every
+                  use and the way back is a scroll. */}
+              {!isCollapsed && (hidden > 0 || showTerminated[host.id]) && (
+                <button
+                  className="link show-terminated"
+                  onClick={() =>
+                    setShowTerminated((current) => ({ ...current, [host.id]: !current[host.id] }))
+                  }
+                >
+                  {showTerminated[host.id] ? 'Hide terminated' : `Show ${hidden} terminated`}
+                </button>
+              )}
+
               {!isCollapsed &&
                 rows.map(({ session, pending }) => (
                   <SessionRow
@@ -121,19 +135,6 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
 
               {!isCollapsed && rows.length === 0 && hidden === 0 && (
                 <p className="empty-note">No sessions</p>
-              )}
-
-              {!isCollapsed && (hidden > 0 || showTerminated[host.id]) && (
-                <button
-                  className="link show-terminated"
-                  onClick={() =>
-                    setShowTerminated((current) => ({ ...current, [host.id]: !current[host.id] }))
-                  }
-                >
-                  {showTerminated[host.id]
-                    ? 'Hide terminated'
-                    : `Show ${hidden} terminated`}
-                </button>
               )}
             </section>
           )

--- a/desktop/src/renderer/diff.ts
+++ b/desktop/src/renderer/diff.ts
@@ -1,0 +1,61 @@
+/**
+ * A unified patch for an edit the agent made, built from the strings the tool
+ * call carried. The daemon does not send one: Edit reports the text it looked
+ * for and the text it wrote, and reading those as two code blocks means
+ * spotting the difference by eye.
+ *
+ * The output is the format DiffView already colours, so the transcript and the
+ * git panel render changes the same way.
+ */
+export function unifiedDiff(before: string, after: string): string {
+  const a = before === '' ? [] : before.split('\n')
+  const b = after === '' ? [] : after.split('\n')
+
+  // Both sides come from one tool call, so they are small. A quadratic LCS is
+  // fine here and stays exact, which a heuristic would not.
+  if (a.length * b.length > 250_000) {
+    return [...a.map((line) => `-${line}`), ...b.map((line) => `+${line}`)].join('\n')
+  }
+
+  const lcs: number[][] = Array.from({ length: a.length + 1 }, () => new Array<number>(b.length + 1).fill(0))
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i]![j] = a[i] === b[j] ? lcs[i + 1]![j + 1]! + 1 : Math.max(lcs[i + 1]![j]!, lcs[i]![j + 1]!)
+    }
+  }
+
+  const out: string[] = []
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      out.push(` ${a[i]}`)
+      i++
+      j++
+    } else if (lcs[i + 1]![j]! >= lcs[i]![j + 1]!) {
+      out.push(`-${a[i]}`)
+      i++
+    } else {
+      out.push(`+${b[j]}`)
+      j++
+    }
+  }
+  while (i < a.length) out.push(`-${a[i++]}`)
+  while (j < b.length) out.push(`+${b[j++]}`)
+
+  return out.join('\n')
+}
+
+/** The edits a MultiEdit call carried, in the order it applied them. */
+export function multiEditDiff(edits: unknown): string {
+  if (!Array.isArray(edits)) return ''
+  return edits
+    .map((edit) => {
+      if (typeof edit !== 'object' || edit === null) return ''
+      const { old_string: before, new_string: after } = edit as Record<string, unknown>
+      if (typeof before !== 'string' || typeof after !== 'string') return ''
+      return unifiedDiff(before, after)
+    })
+    .filter(Boolean)
+    .join('\n@@\n')
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -41,9 +41,11 @@
   --r-lg: 16px;
   --r-xl: 28px;
   --sidebar: 320px;
-  /* Reading width for the transcript and its composer. Wider than this and a
-     reply and the prompt above it end up at opposite edges of the window. */
-  --chat-column: 860px;
+  /* Reading width for the transcript and its composer. It exists to stop a
+     reply and the prompt above it drifting to opposite edges of the window,
+     not to hold prose to a paragraph width — code blocks and diffs want the
+     room. */
+  --chat-column: 1100px;
 
   font-synthesis: none;
   color-scheme: dark;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -960,11 +960,12 @@ small {
   padding: 16px;
 }
 
-/* A centred column rather than the full window: on a wide display the reply
-   sits at the left edge and the prompt that produced it at the right, far
-   enough apart to read as unrelated. */
+/* A column rather than the full window: on a wide display the reply sits at
+   the left edge and the prompt that produced it at the right, far enough
+   apart to read as unrelated. Left aligned, not centred — the transcript
+   stays put as the window widens. */
 .msg {
-  margin: 0 auto 14px;
+  margin: 0 0 14px;
   width: 100%;
   max-width: var(--chat-column);
 }
@@ -1241,6 +1242,17 @@ small {
   margin-bottom: 0;
 }
 
+.tool-diff pre {
+  margin: 0;
+  padding: 10px 12px;
+  max-height: 420px;
+  overflow: auto;
+  background: var(--surface-container);
+  border-radius: var(--r-sm);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .tool-code-label {
   display: inline-block;
   margin-bottom: 4px;
@@ -1325,7 +1337,7 @@ small {
    lines up with the messages it produces. */
 .composer > * {
   max-width: var(--chat-column);
-  margin: 0 auto;
+  margin: 0;
 }
 
 /* What replaces the composer once the session has ended. */
@@ -1341,10 +1353,42 @@ small {
   color: var(--on-surface-variant);
 }
 
+.composer-input {
+  position: relative;
+}
+
+/* Inside the box rather than under it: the button belongs to the text being
+   typed, and the row it used to sit in was empty most of the time. */
+.send-btn {
+  position: absolute;
+  right: 10px;
+  bottom: 12px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 15px;
+  line-height: 1;
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+}
+
+.send-btn .spinner {
+  width: 14px;
+  height: 14px;
+  border-width: 2px;
+}
+
 .composer textarea {
   /* Inline-block by default, and auto margins do not centre one. */
   display: block;
   width: 100%;
+  /* Room for the send button, so a long line does not run under it. */
+  padding-right: 48px;
   resize: vertical;
   min-height: 60px;
   border-radius: var(--r-md);

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -252,7 +252,7 @@ small {
   display: block;
   width: 100%;
   text-align: left;
-  padding: 6px 16px 10px;
+  padding: 2px 16px 8px;
   font-size: 12px;
 }
 


### PR DESCRIPTION
## Summary

- **Terminated toggle above the list.** Revealing terminated sessions appends them to the group, so a toggle underneath moved down by exactly what it had just revealed — hiding them again meant scrolling to find the control that did it. It now sits under the host header and stays put.
- **Transcript is left-aligned again.** The column stays, the centring goes: a centred column slides sideways as the window widens, which is worse than empty space on the right.
- **Edit / MultiEdit / Write render as a patch.** They showed the text searched for and the text written as two code blocks, leaving the reader to diff them by eye. The daemon sends no patch, so it is built in the renderer — an exact LCS over lines, which inputs this size can afford — and drawn by the same `DiffView` the git panel uses. These calls also start expanded: what a write did to a file is the part of a transcript worth reading, and a collapsed row shows only the tool's name.
- **Send is an arrow inside the text box.** It belongs to the text being typed, and the row it used to occupy was empty whenever the agent was idle. Stop still appears there while the agent works.

## Test plan

The Electron window opens on a Space this environment cannot screenshot, so layout was measured and rendered against the real built stylesheet in Chrome.

- [x] `unifiedDiff` / `multiEditDiff` checked against 7 cases — replacement, pure insert, pure delete, empty-before, identical input, multi-edit joining, and non-array input
- [x] at 1500px: transcript, bubbles and composer share one left-aligned column; an `Edit` row renders red `-` / green `+` with its context line; the send arrow sits inside the textarea, bottom right
- [x] `tsc --noEmit` and `node build.mjs`
- [ ] Worth confirming live: Enter still sends with the arrow present, and the sidebar toggle does not move when clicked