### PR TITLE
feat(desktop): keep panels mounted across tab switches

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -21,7 +21,16 @@ import {
 
 const PAGE = 200
 
-export function ChatPanel({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
+export function ChatPanel({
+  hostId,
+  session,
+  active = true,
+}: {
+  hostId: string
+  session: Session
+  /** False while another tab is showing: a hidden panel must not poll. */
+  active?: boolean
+}): JSX.Element {
   const [messages, setMessages] = useState<TranscriptMessage[]>([])
   // Which session the messages belong to. Switching sessions would otherwise
   // show the previous transcript until the new one arrives, and "No transcript
@@ -40,6 +49,10 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
   const cold = needsRecovery(session)
 
   useEffect(() => {
+    // last_event_at moves with every hook the agent fires, so an unwatched
+    // transcript would refetch itself all day. Reading it again on the way
+    // back costs one request instead.
+    if (!active) return
     let cancelled = false
     const load = async (): Promise<void> => {
       try {
@@ -59,7 +72,7 @@ export function ChatPanel({ hostId, session }: { hostId: string; session: Sessio
     }
     // Reloads as the agent works: last_event_at moves on every hook, and the
     // transcript is a file the daemon re-reads rather than a stream.
-  }, [hostId, session.session_id, session.last_event_at, status])
+  }, [hostId, session.session_id, session.last_event_at, status, active])
 
   useEffect(() => {
     if (pinnedToBottom.current && scroller.current) {

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
 import { store, terminalId, useStore, type RightPanel } from '../store.ts'
@@ -30,6 +30,20 @@ const PANEL_LABELS: Record<RightPanel, string> = {
   files: 'files',
 }
 
+/**
+ * Every panel but the terminal, which keeps itself mounted a level up.
+ *
+ * A panel holds work as much as it displays it — a file open in the editor, a
+ * diff scrolled to the hunk being read, a transcript scrolled back through —
+ * and unmounting on a tab switch throws all of it away. Once opened they stay
+ * mounted and hidden.
+ */
+const KEEP_MOUNTED: RightPanel[] = ['chat', 'approvals', 'git', 'files']
+
+/** How long an unseen panel keeps its state before it is unmounted. */
+const PANEL_TTL = 5 * 60 * 1000
+const SWEEP_INTERVAL = 60 * 1000
+
 export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const sessions = useStore((s) => s.sessions)
@@ -46,6 +60,39 @@ export function Detail(): JSX.Element {
     ? (notifications[hostId ?? ''] ?? []).filter((n) => n.source_session === session.session_id).length
     : 0
   const term = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
+
+  // When each panel was last on screen, for the idle sweep below.
+  const [kept, setKept] = useState<Partial<Record<RightPanel, number>>>({})
+  const sessionKey = hostId && session ? `${hostId}:${session.session_id}` : ''
+  // A terminated session's file and diff describe a working tree nobody is
+  // changing any more, so they close with it. Switching sessions drops them
+  // too: they belong to the tree they were opened from.
+  const terminated = session ? canResume(session) : false
+
+  useEffect(() => {
+    setKept({})
+  }, [sessionKey, terminated])
+
+  useEffect(() => {
+    if (!KEEP_MOUNTED.includes(panel) || terminated) return
+    setKept((current) => ({ ...current, [panel]: Date.now() }))
+  }, [panel, terminated])
+
+  // Held state is worth memory for as long as the user is moving between
+  // panels, and not much longer. A panel untouched for the timeout is
+  // unmounted, and comes back fetched fresh.
+  useEffect(() => {
+    const sweep = setInterval(() => {
+      setKept((current) => {
+        const cutoff = Date.now() - PANEL_TTL
+        const next = Object.fromEntries(
+          Object.entries(current).filter(([name, seen]) => name === panel || seen > cutoff),
+        ) as Partial<Record<RightPanel, number>>
+        return Object.keys(next).length === Object.keys(current).length ? current : next
+      })
+    }, SWEEP_INTERVAL)
+    return () => clearInterval(sweep)
+  }, [panel])
 
   return (
     <div className="detail">
@@ -101,32 +148,43 @@ export function Detail(): JSX.Element {
             </div>
           ))}
 
-        {hostId && session && panel !== 'terminal' && (
-          <PanelBoundary resetKey={`${hostId}:${session.session_id}:${panel}`}>
-            {/* Approvals ride alongside the transcript instead of behind their
-                own tab: an agent that stops for permission stops the panel the
-                user is already looking at, and a tab round-trip per approval
-                is the whole interaction. */}
-            {panel === 'chat' && (
-              <div className="agent-split">
-                <ChatPanel hostId={hostId} session={session} />
-                {pending > 0 && (
-                  <aside className="approvals-dock">
-                    <h3 className="dock-title">
-                      Approvals <span className="badge">{pending}</span>
-                    </h3>
-                    <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
-                  </aside>
+        {hostId &&
+          session &&
+          KEEP_MOUNTED.filter((name) => name === panel || kept[name]).map((name) => (
+            <div key={name} className="panel-keep" hidden={name !== panel}>
+              <PanelBoundary resetKey={`${hostId}:${session.session_id}:${name}`}>
+                {/* Approvals ride alongside the transcript instead of behind
+                    their own tab: an agent that stops for permission stops the
+                    panel the user is already looking at, and a tab round-trip
+                    per approval is the whole interaction. */}
+                {name === 'chat' && (
+                  <div className="agent-split">
+                    <ChatPanel hostId={hostId} session={session} active={name === panel} />
+                    {pending > 0 && (
+                      <aside className="approvals-dock">
+                        <h3 className="dock-title">
+                          Approvals <span className="badge">{pending}</span>
+                        </h3>
+                        <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
+                      </aside>
+                    )}
+                  </div>
                 )}
-              </div>
-            )}
-            {panel === 'approvals' && <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />}
-            {panel === 'git' && (
-              <GitPanel hostId={hostId} cwd={session.cwd} revision={session.last_event_at} />
-            )}
-            {panel === 'files' && <FilesPanel hostId={hostId} cwd={session.cwd} />}
-          </PanelBoundary>
-        )}
+                {name === 'approvals' && (
+                  <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
+                )}
+                {name === 'git' && (
+                  <GitPanel
+                    hostId={hostId}
+                    cwd={session.cwd}
+                    revision={session.last_event_at}
+                    active={name === panel}
+                  />
+                )}
+                {name === 'files' && <FilesPanel hostId={hostId} cwd={session.cwd} />}
+              </PanelBoundary>
+            </div>
+          ))}
 
         {/* Outside the switch above, and outside the boundary: the panes stay
             mounted whatever is selected, or every terminal would lose its

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -44,6 +44,14 @@ const KEEP_MOUNTED: RightPanel[] = ['chat', 'approvals', 'git', 'files']
 const PANEL_TTL = 5 * 60 * 1000
 const SWEEP_INTERVAL = 60 * 1000
 
+/**
+ * Panels the sweep leaves alone. What they hold is a place the user chose —
+ * the file they were reading, the diff they were working through — and losing
+ * it to a timer means finding it again by hand. They cost nothing while
+ * hidden, so they stay until the session does.
+ */
+const NO_TTL: RightPanel[] = ['git', 'files']
+
 export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const sessions = useStore((s) => s.sessions)
@@ -86,7 +94,10 @@ export function Detail(): JSX.Element {
       setKept((current) => {
         const cutoff = Date.now() - PANEL_TTL
         const next = Object.fromEntries(
-          Object.entries(current).filter(([name, seen]) => name === panel || seen > cutoff),
+          Object.entries(current).filter(
+            ([name, seen]) =>
+              name === panel || NO_TTL.includes(name as RightPanel) || seen > cutoff,
+          ),
         ) as Partial<Record<RightPanel, number>>
         return Object.keys(next).length === Object.keys(current).length ? current : next
       })
@@ -181,7 +192,9 @@ export function Detail(): JSX.Element {
                     active={name === panel}
                   />
                 )}
-                {name === 'files' && <FilesPanel hostId={hostId} cwd={session.cwd} />}
+                {name === 'files' && (
+                  <FilesPanel hostId={hostId} cwd={session.cwd} visible={name === panel} />
+                )}
               </PanelBoundary>
             </div>
           ))}

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -34,7 +34,16 @@ interface OpenFile {
  * the machine Helios runs on is just another host — so a remote session browses
  * exactly like a local one.
  */
-export function FilesPanel({ hostId, cwd }: { hostId: string; cwd: string }): JSX.Element {
+export function FilesPanel({
+  hostId,
+  cwd,
+  visible = true,
+}: {
+  hostId: string
+  cwd: string
+  /** False while another tab is showing. */
+  visible?: boolean
+}): JSX.Element {
   const root = useMemo(() => cwd.replace(/\/+$/, '') || '/', [cwd])
   const [files, setFiles] = useState<OpenFile[]>([])
   const [activePath, setActivePath] = useState<string | null>(null)
@@ -150,6 +159,20 @@ export function FilesPanel({ hostId, cwd }: { hostId: string; cwd: string }): JS
     },
     [hostId],
   )
+
+  // The agent edits the tree while the user is elsewhere, so the buffer that
+  // was accurate on the way out is stale on the way back. Unsaved edits
+  // outrank what is on disk and are left alone; the file keeps its unsaved
+  // marker and the user can revert deliberately.
+  const wasVisible = useRef(visible)
+  useEffect(() => {
+    const returning = visible && !wasVisible.current
+    wasVisible.current = visible
+    if (!returning || !activePath) return
+    const file = filesRef.current.find((f) => f.path === activePath)
+    if (!file || file.dirty) return
+    void reload(activePath)
+  }, [visible, activePath, reload])
 
   const close = (path: string): void => {
     const file = filesRef.current.find((f) => f.path === path)

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -21,7 +21,18 @@ import type { GitChange, GitDiff, GitStatus } from '../../shared/models.ts'
  * Picking a worktree rescopes the whole panel to it, so a session started in
  * one checkout can still read the branch an agent is working in next door.
  */
-export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: string; revision?: string }): JSX.Element {
+export function GitPanel({
+  hostId,
+  cwd,
+  revision,
+  active = true,
+}: {
+  hostId: string
+  cwd: string
+  revision?: string
+  /** False while another tab is showing: a hidden panel must not poll. */
+  active?: boolean
+}): JSX.Element {
   const [worktree, setWorktree] = useState<string | null>(null)
   const [scope, setScope] = useState<Scope>({ kind: 'working' })
   const [worktrees, setWorktrees] = useState(false)
@@ -44,6 +55,9 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
   // Status is fetched here rather than in the changes view because the header
   // shows the branch in every scope — reading a commit is no reason to lose it.
   useEffect(() => {
+    // revision moves with every hook the agent fires; behind another tab that
+    // is a status call per tool call, for a panel nobody is looking at.
+    if (!active) return
     let cancelled = false
     setError(null)
     api(hostId)
@@ -59,7 +73,7 @@ export function GitPanel({ hostId, cwd, revision }: { hostId: string; cwd: strin
     }
     // Re-reads whenever the agent does something: a tool call is the usual way
     // the working tree changes here.
-  }, [hostId, root, revision])
+  }, [hostId, root, revision, active])
 
   return (
     <div className="git">

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -733,6 +733,20 @@ small {
   color: var(--on-surface-variant);
 }
 
+/* A mounted panel waiting its turn. hidden alone would be overridden by the
+   flex display its contents need. */
+.panel-keep {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.panel-keep[hidden] {
+  display: none;
+}
+
 .panel-loading {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary

Switching tabs unmounted whatever panel was showing. A file open in the editor, a diff scrolled to the hunk being read, a transcript scrolled back through — discarded, then refetched on the way back. Moving between a diff and the file that produced it meant finding your place twice.

Panels now mount on first use and hide when another tab is selected, which is what the terminal already did for the same reason. Mounting stays lazy: a session whose git panel is never opened makes no git calls.

Kept state is bounded so that keeping it costs nothing:

- **A hidden panel does not fetch.** The transcript and git status both re-read on `last_event_at`, which moves with every hook the agent fires — behind another tab that is one request per tool call for something nobody is looking at. Both skip while hidden and read once on the way back.
- **Five-minute TTL, for the cheap panels only.** Agent and approvals rebuild themselves from one request, so an untouched one is unmounted after five minutes (swept once a minute). Git and files are exempt: a file open in the editor and a diff scrolled to a hunk are places the user chose, and losing them to a timer means finding them by hand.
- **Returning to files re-reads the open file.** The agent edits the tree while the user is elsewhere, so the buffer that was accurate on the way out is stale on the way back. A file with unsaved edits is left alone — what is in the editor outranks what is on disk, and reverting stays the user's call.
- Everything is dropped when the session changes or terminates: a panel describes one working tree, and a terminated session's is not being changed any more.

Terminals are untouched — they are explicit tabs with a close button, and dropping one silently would cost its scrollback and its writer role.

## Test plan

- [x] `tsc --noEmit` and `node build.mjs`
- [ ] Open a file in Files, switch to Git and back — same file, same scroll position
- [ ] Have the agent edit that file while you are on another tab, come back — content is current
- [ ] Do the same with unsaved edits in the buffer — they survive, still marked unsaved
- [ ] Leave the Agent tab while the agent works, return — one transcript fetch, not one per tool call
- [ ] Leave Agent five minutes — it reloads; leave Files five minutes — it does not