### PR TITLE
fix: retract a permission card when its tool runs

### DIFF
--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -740,6 +740,52 @@ func resolveSessionQuestions(ctx *provider.HookContext, sessionID string) {
 	}
 }
 
+// resolveToolPermissions retracts the pending permission card for a tool call
+// that has finished, whichever surface answered it.
+//
+// Answering in the CLI leaves no trace the daemon can see: the permission hook
+// stays blocked on a request Claude has stopped waiting for, so the card
+// outlived the decision by as long as the turn had left to run — minutes of a
+// phone and a desktop offering to approve something already approved. A
+// PostToolUse for the tool is the missing evidence: the tool ran, so the
+// question is settled.
+//
+// Matched by tool name because a turn can have several calls in flight, and
+// clearing the session's cards wholesale would retract one still being waited
+// on.
+func resolveToolPermissions(ctx *provider.HookContext, sessionID, toolName string) {
+	if toolName == "" {
+		return
+	}
+	pending, err := ctx.Mgr.ListNotifications("claude", "pending", "claude.permission")
+	if err != nil {
+		log.Printf("hook: list pending permissions for %s: %v", sessionID, err)
+		return
+	}
+	for i := range pending {
+		notif := &pending[i]
+		if notif.SourceSession != sessionID || permissionToolName(notif) != toolName {
+			continue
+		}
+		// The same call the blocked handler makes when Claude drops the
+		// request, so a decision that arrives late still finds the slot gone.
+		ctx.Mgr.CancelPendingFromClaude(notif.ID)
+	}
+}
+
+func permissionToolName(notif *store.Notification) string {
+	if notif.Payload == nil {
+		return ""
+	}
+	var payload struct {
+		ToolName string `json:"tool_name"`
+	}
+	if err := json.Unmarshal([]byte(*notif.Payload), &payload); err != nil {
+		return ""
+	}
+	return payload.ToolName
+}
+
 func handleToolPre(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	var input hookInput
 	if err := json.Unmarshal(raw, &input); err != nil {
@@ -794,6 +840,7 @@ func handleToolPost(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 	if input.ToolName == askUserQuestionTool {
 		resolveSessionQuestions(ctx, input.SessionID)
 	}
+	resolveToolPermissions(ctx, input.SessionID, input.ToolName)
 
 	if ctx.Report != nil {
 		ctx.Report(provider.ReportEvent{
@@ -818,6 +865,8 @@ func handleToolPostFailure(ctx *provider.HookContext, w http.ResponseWriter, r *
 
 	ctx.DB.UpdateSessionStatus(input.SessionID, "active", "PostToolUseFailure:"+input.ToolName)
 	updateSessionTranscript(ctx, &input)
+	// A tool that ran and failed was still permitted by somebody.
+	resolveToolPermissions(ctx, input.SessionID, input.ToolName)
 
 	if ctx.Report != nil {
 		ctx.Report(provider.ReportEvent{

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1228,6 +1229,99 @@ func TestToolPost_ResolvesQuestionButNotPermission(t *testing.T) {
 	}
 	if stored.Status != "pending" {
 		t.Errorf("permission status = %q, want pending", stored.Status)
+	}
+}
+
+// Answering in the CLI tells the daemon nothing. The tool running afterwards
+// does: the permission card must not outlive the tool call it was asking
+// about, or the phone keeps offering to approve work already done.
+func TestToolPost_ResolvesPermissionForTheSameTool(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	seedPermission(t, db, "notif-perm", "sess-1", "Bash")
+
+	callHook(handleToolPost, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "Bash",
+	})
+
+	assertNotificationStatus(t, db, "notif-perm", "resolved")
+}
+
+// A turn can have several tool calls in flight, so a finished one must not
+// retract the card for a different tool still waiting on an answer.
+func TestToolPost_LeavesOtherToolsPermissionPending(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	seedPermission(t, db, "notif-perm", "sess-1", "Write")
+
+	callHook(handleToolPost, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "Bash",
+	})
+
+	assertNotificationStatus(t, db, "notif-perm", "pending")
+}
+
+// Another session's card is another session's business.
+func TestToolPost_LeavesOtherSessionsPermissionPending(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	seedSession(t, db, "sess-2", "/tmp/other", "active")
+	seedPermission(t, db, "notif-perm", "sess-2", "Bash")
+
+	callHook(handleToolPost, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "Bash",
+	})
+
+	assertNotificationStatus(t, db, "notif-perm", "pending")
+}
+
+// A tool that ran and failed was still permitted by somebody.
+func TestToolPostFailure_ResolvesPermissionForTheSameTool(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	seedPermission(t, db, "notif-perm", "sess-1", "Bash")
+
+	callHook(handleToolPostFailure, ctx, hookInput{
+		SessionID: "sess-1",
+		CWD:       "/tmp/proj",
+		ToolName:  "Bash",
+	})
+
+	assertNotificationStatus(t, db, "notif-perm", "resolved")
+}
+
+func seedPermission(t *testing.T, db *store.Store, id, sessionID, toolName string) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"tool_name":%q,"tool_input":{}}`, toolName)
+	notif := &store.Notification{
+		ID:            id,
+		Source:        "claude",
+		SourceSession: sessionID,
+		CWD:           "/tmp/proj",
+		Type:          "claude.permission",
+		Status:        "pending",
+		Title:         &toolName,
+		Payload:       &payload,
+	}
+	if err := db.CreateNotification(notif); err != nil {
+		t.Fatalf("create permission notification: %v", err)
+	}
+}
+
+func assertNotificationStatus(t *testing.T, db *store.Store, id, want string) {
+	t.Helper()
+	stored, err := db.GetNotification(id)
+	if err != nil {
+		t.Fatalf("get notification %s: %v", id, err)
+	}
+	if stored.Status != want {
+		t.Errorf("notification %s status = %q, want %q", id, stored.Status, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Approving or denying in the CLI left the card standing on the phone and the desktop, and answering there did nothing.

The daemon has no way to see a CLI answer. `handlePermission` blocks on `waitForDecision`, and when the user answers in the terminal Claude simply proceeds — it does not close the hook request, so `r.Context().Done()` never fires. The card stays `pending` until the Stop hook sweeps the session at the end of the turn.

This machine's database shows the gap plainly — permissions resolved by `claude` versus by a device:

```
id        status    resolved_source   created_at            resolved_at
fa1bbcf3  resolved  claude            2026-08-12 17:41:46   2026-08-12T17:43:33Z   +1m47s
bcdeb558  resolved  claude            2026-08-12 16:11:50   2026-08-12T16:16:51Z   +5m01s
be13b76d  approved  device:6f2e865f   2026-08-12 16:00:06   2026-08-12T16:01:26Z   +1m20s
```

Every `claude`-resolved row lands exactly on that session's next `claude.done`. That is the Stop sweep, not the answer.

`PostToolUse` is the evidence that was going unused: the tool ran, so the question is settled regardless of which surface settled it. The card is now retracted there, through the same `CancelPendingFromClaude` path the abandoned-request case already uses, so a decision arriving late still finds the slot gone.

Matched on tool name, not swept per session: a turn can have several calls in flight, and clearing them wholesale would retract a card still legitimately waiting. `PostToolUse` failures count too — a tool that ran and failed was still permitted by somebody.

A denial in the CLI still waits for Stop. The tool never runs, so no hook fires to notice; the wait is short because the agent responds to the refusal and ends the turn.

## Test plan

- [x] `go test ./...`
- [x] Four new hook tests: same tool resolves the card, a different tool leaves it, another session's card is untouched, and a failed tool resolves it too
- [x] The existing `TestToolPost_ResolvesQuestionButNotPermission` still passes — an `AskUserQuestion` PostToolUse must not clear an unrelated permission
- [ ] Live: approve in the CLI and watch the desktop card disappear within a second instead of at end of turn