### PR TITLE
feat(desktop): review the branch the agent is working on

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -234,7 +234,14 @@ export class ApiClient {
   gitDiff(
     path: string,
     file: string,
-    at: { from?: string; to?: string; staged?: boolean; untracked?: boolean } = {},
+    at: {
+      from?: string
+      to?: string
+      staged?: boolean
+      untracked?: boolean
+      /** Compare against where the two revisions parted, as a review does. */
+      mergeBase?: boolean
+    } = {},
   ): Promise<GitDiff> {
     return this.request(
       'GET',
@@ -245,6 +252,7 @@ export class ApiClient {
         to: at.to,
         staged: at.staged ? 'true' : undefined,
         untracked: at.untracked ? 'true' : undefined,
+        merge_base: at.mergeBase ? 'true' : undefined,
       })}`,
     )
   }
@@ -262,8 +270,11 @@ export class ApiClient {
     )
   }
 
-  gitChanges(path: string, to: string, from?: string): Promise<GitChanges> {
-    return this.request('GET', `/api/git/changes${queryString({ path, to, from })}`)
+  gitChanges(path: string, to: string, from?: string, mergeBase?: boolean): Promise<GitChanges> {
+    return this.request(
+      'GET',
+      `/api/git/changes${queryString({ path, to, from, merge_base: mergeBase ? 'true' : undefined })}`,
+    )
   }
 
   async gitWorktrees(path: string): Promise<Worktree[]> {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -168,15 +168,15 @@ export class HostApi {
   gitDiff(
     path: string,
     file: string,
-    at?: { from?: string; to?: string; staged?: boolean; untracked?: boolean },
+    at?: { from?: string; to?: string; staged?: boolean; untracked?: boolean; mergeBase?: boolean },
   ): Promise<GitDiff> {
     return this.call('gitDiff', path, file, at)
   }
   gitLog(path: string, opts?: { base?: string; all?: boolean; limit?: number; skip?: number }): Promise<GitLog> {
     return this.call('gitLog', path, opts)
   }
-  gitChanges(path: string, to: string, from?: string): Promise<GitChanges> {
-    return this.call('gitChanges', path, to, from)
+  gitChanges(path: string, to: string, from?: string, mergeBase?: boolean): Promise<GitChanges> {
+    return this.call('gitChanges', path, to, from, mergeBase)
   }
   gitWorktrees(path: string): Promise<Worktree[]> {
     return this.call('gitWorktrees', path)

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -18,8 +18,19 @@ export interface CommitScope {
   label: string
 }
 
+/**
+ * Everything this branch changed against the branch it left — the review a
+ * pull request would show, before there is a pull request to show it.
+ */
+export interface ReviewScope {
+  kind: 'review'
+  base: string
+  span: number
+  label: string
+}
+
 /** What the git panel is looking at: the working tree, or some history. */
-export type Scope = { kind: 'working' } | CommitScope
+export type Scope = { kind: 'working' } | CommitScope | ReviewScope
 
 /**
  * The control that chooses what the panel shows. Closed it is a one-line
@@ -244,6 +255,31 @@ function ScopeMenu({
             </span>
           )}
         </button>
+
+        {/* The whole branch, offered before the individual commits: reviewing
+            what an agent did is a question about the branch, and picking the
+            commits one at a time is a worse way to ask it. */}
+        {log?.scope === 'branch' && log.base && commits.length > 0 && (
+          <button
+            className={`scope-row ${scope.kind === 'review' ? 'selected' : ''}`}
+            onClick={() =>
+              onPick(
+                {
+                  kind: 'review',
+                  base: log.base,
+                  span: commits.length,
+                  label: `Review vs ${log.base}`,
+                },
+                true,
+              )
+            }
+          >
+            <span>Review vs {log.base}</span>
+            <span className="scope-row-meta">
+              {commits.length} commit{commits.length === 1 ? '' : 's'}
+            </span>
+          </button>
+        )}
 
         <div className="scope-sep" />
 

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -189,6 +189,7 @@ export function Detail(): JSX.Element {
                     hostId={hostId}
                     cwd={session.cwd}
                     revision={session.last_event_at}
+                    sessionId={session.session_id}
                     active={name === panel}
                   />
                 )}

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -5,6 +5,7 @@ import { store } from '../store.ts'
 import { CommitChanges, ScopePicker, type Scope } from './commits.tsx'
 import { DiffView } from './diff-view.tsx'
 import { PathLabel } from './path-label.tsx'
+import { ReviewView } from './review.tsx'
 import { WorktreesView } from './worktrees.tsx'
 import type { GitChange, GitDiff, GitStatus } from '../../shared/models.ts'
 
@@ -25,32 +26,85 @@ export function GitPanel({
   hostId,
   cwd,
   revision,
+  sessionId,
   active = true,
 }: {
   hostId: string
   cwd: string
   revision?: string
+  /** Whose agent a review comment is addressed to. */
+  sessionId?: string
   /** False while another tab is showing: a hidden panel must not poll. */
   active?: boolean
 }): JSX.Element {
   const [worktree, setWorktree] = useState<string | null>(null)
-  const [scope, setScope] = useState<Scope>({ kind: 'working' })
+  // Null until resolved: the default depends on the branch, which takes a
+  // request, and rendering the working tree in the meantime would make the
+  // panel flip scopes under the reader.
+  const [scope, setScope] = useState<Scope | null>(null)
   const [worktrees, setWorktrees] = useState(false)
   const [status, setStatus] = useState<GitStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
   const root = worktree ?? cwd
+  const scopeKey = `helios.git.scope.${hostId}.${sessionId ?? root}`
 
   // A different session is a different repository until proven otherwise.
   useEffect(() => {
     setWorktree(null)
   }, [hostId, cwd])
 
-  // A commit picked from one repository means nothing in the next.
+  /**
+   * What the panel opens on. The question the user has when they open git
+   * during a session is "what has the agent done to this branch", so that is
+   * the default — the uncommitted-only view answers a narrower question and
+   * was the wrong one to answer first.
+   *
+   * A choice made afterwards is remembered per session: two sessions on two
+   * branches are two separate reviews, and one's scope means nothing in the
+   * other.
+   */
   useEffect(() => {
-    setScope({ kind: 'working' })
     setWorktrees(false)
     setStatus(null)
-  }, [hostId, root])
+
+    const stored = readScope(scopeKey)
+    if (stored) {
+      setScope(stored)
+      return
+    }
+
+    setScope(null)
+    let cancelled = false
+    api(hostId)
+      .gitLog(root, { limit: SCOPE_PROBE })
+      .then((log) => {
+        if (cancelled) return
+        const reviewable = log.scope === 'branch' && log.base && log.commits.length > 0
+        setScope(
+          reviewable
+            ? {
+                kind: 'review',
+                base: log.base,
+                span: log.commits.length,
+                label: `Review vs ${log.base}`,
+              }
+            : { kind: 'working' },
+        )
+      })
+      .catch(() => {
+        // No history, no base branch, not a repository — the working tree is
+        // the answer that needs nothing to be true.
+        if (!cancelled) setScope({ kind: 'working' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, root, scopeKey])
+
+  const pickScope = (next: Scope): void => {
+    setScope(next)
+    writeScope(scopeKey, next)
+  }
 
   // Status is fetched here rather than in the changes view because the header
   // shows the branch in every scope — reading a commit is no reason to lose it.
@@ -75,6 +129,15 @@ export function GitPanel({
     // the working tree changes here.
   }, [hostId, root, revision, active])
 
+  if (!scope) {
+    return (
+      <div className="panel-loading">
+        <span className="spinner" />
+        <span>Reading the branch…</span>
+      </div>
+    )
+  }
+
   return (
     <div className="git">
       <header className="git-head">
@@ -84,7 +147,7 @@ export function GitPanel({
           scope={scope}
           status={status}
           onPick={(next) => {
-            setScope(next)
+            pickScope(next)
             setWorktrees(false)
           }}
         />
@@ -126,6 +189,8 @@ export function GitPanel({
         />
       ) : scope.kind === 'working' ? (
         <ChangesView hostId={hostId} root={root} status={status} />
+      ) : scope.kind === 'review' ? (
+        <ReviewView hostId={hostId} root={root} scope={scope} sessionId={sessionId} />
       ) : (
         <CommitChanges hostId={hostId} root={root} scope={scope} />
       )}
@@ -222,6 +287,37 @@ function ChangesView({
       </div>
     </div>
   )
+}
+
+/** How far back to look when deciding whether the branch has anything to review. */
+const SCOPE_PROBE = 50
+
+/**
+ * The scope the user last chose for this session, if it still parses. Stored
+ * rather than derived because it is a preference, and dropped silently when it
+ * is not readable — a bad entry is not worth an error over a panel that has a
+ * perfectly good default.
+ */
+function readScope(key: string): Scope | null {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Scope
+    if (parsed.kind === 'working') return parsed
+    if (parsed.kind === 'review' && typeof parsed.base === 'string') return parsed
+    if (parsed.kind === 'commit' && typeof parsed.to === 'string') return parsed
+    return null
+  } catch {
+    return null
+  }
+}
+
+function writeScope(key: string, scope: Scope): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(scope))
+  } catch {
+    // A full or disabled store costs the preference, nothing else.
+  }
 }
 
 /** The last two segments: the parent directory is what distinguishes them. */

--- a/desktop/src/renderer/components/review.tsx
+++ b/desktop/src/renderer/components/review.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { api } from '../bridge.ts'
+import { store } from '../store.ts'
+import { diffClass } from './diff-view.tsx'
+import { PathLabel } from './path-label.tsx'
+import type { ReviewScope } from './commits.tsx'
+import type { CommitFile, GitChanges } from '../../shared/models.ts'
+
+/**
+ * Everything the branch changed, in one page: the review a pull request would
+ * give, for work that has not been pushed anywhere yet.
+ *
+ * The panel's other views answer "what is in this commit". This one answers
+ * "is what the agent did any good", which is a question about the whole branch
+ * and is unanswerable one file at a time behind a picker.
+ */
+export function ReviewView({
+  hostId,
+  root,
+  scope,
+  sessionId,
+}: {
+  hostId: string
+  root: string
+  scope: ReviewScope
+  /** Absent when the panel outlives its session; disables commenting. */
+  sessionId?: string
+}): JSX.Element {
+  const [changes, setChanges] = useState<GitChanges | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [viewed, setViewed] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    let cancelled = false
+    setChanges(null)
+    setError(null)
+    setViewed(new Set())
+    api(hostId)
+      // Merge base, not the branch tip: commits landed on the base since this
+      // branch was cut are not this branch's work, and a two-dot diff reports
+      // them as changes it undid.
+      .gitChanges(root, 'HEAD', scope.base, true)
+      .then((result) => {
+        if (!cancelled) setChanges(result)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, root, scope.base])
+
+  const toggleViewed = (path: string): void => {
+    setViewed((current) => {
+      const next = new Set(current)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  if (error) return <p className="empty-note">{error}</p>
+  if (!changes) {
+    return (
+      <div className="panel-loading">
+        <span className="spinner" />
+        <span>Loading review…</span>
+      </div>
+    )
+  }
+  if (changes.files.length === 0) {
+    return <p className="empty-note">Nothing to review — this branch matches {scope.base}.</p>
+  }
+
+  return (
+    <div className="review">
+      <header className="review-head">
+        <span className="review-count">
+          {changes.files.length} file{changes.files.length === 1 ? '' : 's'} changed
+        </span>
+        <span className="commit-counts">
+          <span className="d-add">+{changes.insertions}</span>
+          <span className="d-del">−{changes.deletions}</span>
+        </span>
+        <span className="muted">
+          {scope.base} ← {scope.span} commit{scope.span === 1 ? '' : 's'}
+        </span>
+        <span className="review-progress">
+          {viewed.size}/{changes.files.length} viewed
+        </span>
+      </header>
+
+      <div className="review-body">
+        <nav className="review-files">
+          {changes.files.map((file) => (
+            <button
+              key={file.path}
+              className={viewed.has(file.path) ? 'review-file done' : 'review-file'}
+              onClick={() => document.getElementById(anchorFor(file.path))?.scrollIntoView()}
+            >
+              <PathLabel path={file.path} />
+              <span className="review-file-stat">
+                {file.insertions > 0 && <span className="d-add">+{file.insertions}</span>}
+                {file.deletions > 0 && <span className="d-del">−{file.deletions}</span>}
+              </span>
+            </button>
+          ))}
+        </nav>
+
+        <div className="review-diffs">
+          {changes.files.map((file) => (
+            <FileReview
+              key={file.path}
+              hostId={hostId}
+              root={root}
+              base={scope.base}
+              file={file}
+              sessionId={sessionId}
+              viewed={viewed.has(file.path)}
+              onToggleViewed={() => toggleViewed(file.path)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function anchorFor(path: string): string {
+  return `review-${path.replace(/[^a-zA-Z0-9]/g, '-')}`
+}
+
+/**
+ * One file's patch. The diff is fetched when the card first comes into view:
+ * a branch of forty files is forty requests if they all load at once, and the
+ * reader is looking at one of them.
+ */
+function FileReview({
+  hostId,
+  root,
+  base,
+  file,
+  sessionId,
+  viewed,
+  onToggleViewed,
+}: {
+  hostId: string
+  root: string
+  base: string
+  file: CommitFile
+  sessionId?: string
+  viewed: boolean
+  onToggleViewed: () => void
+}): JSX.Element {
+  const [diff, setDiff] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [wanted, setWanted] = useState(false)
+  const card = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const el = card.current
+    if (!el || wanted) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setWanted(true)
+      },
+      { rootMargin: '400px' },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [wanted])
+
+  useEffect(() => {
+    if (!wanted || viewed) return
+    let cancelled = false
+    api(hostId)
+      .gitDiff(root, file.path, { from: base, to: 'HEAD', mergeBase: true })
+      .then((result) => {
+        if (!cancelled) setDiff(result.diff)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [wanted, viewed, hostId, root, base, file.path])
+
+  return (
+    <section className="review-card" id={anchorFor(file.path)} ref={card}>
+      <header className="review-card-head">
+        <span className={`review-status s-${file.status.toLowerCase()}`}>{file.status}</span>
+        <PathLabel path={file.path} />
+        <span className="review-file-stat">
+          {file.insertions > 0 && <span className="d-add">+{file.insertions}</span>}
+          {file.deletions > 0 && <span className="d-del">−{file.deletions}</span>}
+        </span>
+        <label className="check review-viewed">
+          <input type="checkbox" checked={viewed} onChange={onToggleViewed} />
+          Viewed
+        </label>
+      </header>
+
+      {!viewed &&
+        (error ? (
+          <p className="empty-note">{error}</p>
+        ) : diff === null ? (
+          <p className="empty-note">Loading…</p>
+        ) : (
+          <ReviewDiff hostId={hostId} path={file.path} diff={diff} sessionId={sessionId} />
+        ))}
+    </section>
+  )
+}
+
+/**
+ * A patch whose lines can be picked out and handed back to the agent.
+ *
+ * This is the part a hosted review cannot do: the author is still at the
+ * keyboard, so a comment is not a note for later — it is the next prompt.
+ */
+function ReviewDiff({
+  hostId,
+  path,
+  diff,
+  sessionId,
+}: {
+  hostId: string
+  path: string
+  diff: string
+  sessionId?: string
+}): JSX.Element {
+  const lines = useMemo(() => diff.split('\n'), [diff])
+  const [anchor, setAnchor] = useState<number | null>(null)
+  const [head, setHead] = useState<number | null>(null)
+  const [comment, setComment] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const from = anchor !== null && head !== null ? Math.min(anchor, head) : null
+  const to = anchor !== null && head !== null ? Math.max(anchor, head) : null
+
+  const clear = (): void => {
+    setAnchor(null)
+    setHead(null)
+    setComment('')
+  }
+
+  const select = (index: number, extend: boolean): void => {
+    if (extend && anchor !== null) {
+      setHead(index)
+      return
+    }
+    setAnchor(index)
+    setHead(index)
+  }
+
+  const send = async (): Promise<void> => {
+    if (!sessionId || from === null || to === null || sending) return
+    const text = comment.trim()
+    if (!text) return
+    setSending(true)
+    try {
+      const excerpt = lines.slice(from, to + 1).join('\n')
+      await api(hostId).sendPrompt(
+        sessionId,
+        `Review comment on ${path} (diff lines ${from + 1}–${to + 1}):\n\n` +
+          '```diff\n' +
+          `${excerpt}\n` +
+          '```\n\n' +
+          text,
+      )
+      store.notify('Sent to the agent')
+      clear()
+    } catch (err) {
+      store.fail(err)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="review-diff">
+      <pre>
+        {lines.map((line, index) => {
+          const picked = from !== null && to !== null && index >= from && index <= to
+          return (
+            <span
+              key={index}
+              className={`review-line ${diffClass(line)} ${picked ? 'picked' : ''}`}
+              onMouseDown={(event) => {
+                if (!sessionId) return
+                event.preventDefault()
+                select(index, event.shiftKey)
+              }}
+            >
+              {line || ' '}
+              {'\n'}
+            </span>
+          )
+        })}
+      </pre>
+
+      {sessionId && from !== null && to !== null && (
+        <div className="review-comment">
+          <span className="muted">
+            Lines {from + 1}–{to + 1} · ⇧-click to extend
+          </span>
+          <textarea
+            autoFocus
+            rows={2}
+            value={comment}
+            placeholder="What should the agent change here?"
+            onChange={(event) => setComment(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') clear()
+              if (event.key !== 'Enter' || event.nativeEvent.isComposing || event.shiftKey) return
+              event.preventDefault()
+              void send()
+            }}
+          />
+          <div className="review-comment-actions">
+            <button className="ghost" onClick={clear}>
+              Cancel
+            </button>
+            <button className="filled" disabled={!comment.trim() || sending} onClick={() => void send()}>
+              {sending ? 'Sending…' : 'Send to agent'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2604,3 +2604,163 @@ hr {
   font-size: 11px;
   color: var(--on-surface-variant);
 }
+
+/* ─── Branch review ─────────────────────────────────────────────────────── */
+
+.review {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.review-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  font-size: 12px;
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+.review-count {
+  font-weight: 600;
+}
+
+.review-progress {
+  margin-left: auto;
+  color: var(--on-surface-variant);
+}
+
+.review-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.review-files {
+  width: clamp(180px, 32%, 280px);
+  flex: none;
+  overflow-y: auto;
+  padding: 8px;
+  background: color-mix(in srgb, var(--on-surface) 3%, transparent);
+}
+
+.review-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 8px;
+  font-size: 12px;
+  text-align: left;
+  color: var(--on-surface);
+}
+
+/* A file already read stays listed — it is still part of the change — but
+   stops competing for attention with the ones that are not. */
+.review-file.done {
+  opacity: 0.45;
+}
+
+.review-file-stat {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.review-diffs {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 32px;
+  min-width: 0;
+}
+
+.review-card {
+  margin-bottom: 16px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.review-card-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  background: var(--surface-container);
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+}
+
+.review-status {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--on-surface) 10%, transparent);
+}
+
+.review-status.s-a {
+  color: var(--s-active);
+}
+
+.review-status.s-d {
+  color: var(--error);
+}
+
+.review-viewed {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+.review-diff pre {
+  margin: 0;
+  padding: 8px 0;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.review-line {
+  display: block;
+  padding: 0 12px;
+  cursor: text;
+}
+
+.review-line:hover {
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+}
+
+.review-line.picked {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+/* Anchored to the file rather than the selection: a comment box that follows
+   the cursor lands off-screen for a selection made at the bottom edge. */
+.review-comment {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--outline-variant);
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+}
+
+.review-comment textarea {
+  width: 100%;
+  resize: vertical;
+  border-radius: var(--r-sm);
+}
+
+.review-comment-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/internal/server/git.go
+++ b/internal/server/git.go
@@ -156,7 +156,7 @@ func fileDiff(root, file, from, to string, query map[string][]string) (string, e
 	case to != "" && from == "":
 		return gitCmd(root, "show", "--format=", "--no-color", "--find-renames", to, "--", file)
 	case to != "" && from != "":
-		return gitCmd(root, "diff", "--no-color", "--find-renames", from, to, "--", file)
+		return gitCmd(root, "diff", "--no-color", "--find-renames", mergeBaseFrom(root, from, to, query), to, "--", file)
 	case value("staged") == "true":
 		return gitCmd(root, "diff", "--no-color", "--cached", "--", file)
 	default:

--- a/internal/server/githistory.go
+++ b/internal/server/githistory.go
@@ -32,6 +32,31 @@ func validRevision(rev string) bool {
 	return !strings.HasPrefix(rev, "-") && revPattern.MatchString(rev)
 }
 
+// mergeBaseFrom answers "what has this branch changed", where the plain
+// two-dot form answers "how do these two revisions differ".
+//
+// The two part company as soon as the base branch moves: commits landed on
+// main after the branch was cut appear in a two-dot diff as changes the branch
+// undid — somebody else's work, rendered backwards, in the middle of a review.
+// Callers opt in with merge_base=true.
+//
+// Histories with no common ancestor keep the revision they were given: there
+// is no better answer for unrelated trees, and failing would take the diff
+// away entirely.
+func mergeBaseFrom(root, from, to string, query map[string][]string) string {
+	if from == "" || len(query["merge_base"]) == 0 || query["merge_base"][0] != "true" {
+		return from
+	}
+	out, err := gitCmd(root, "merge-base", from, to)
+	if err != nil {
+		return from
+	}
+	if base := strings.TrimSpace(out); base != "" {
+		return base
+	}
+	return from
+}
+
 type logEntry struct {
 	SHA        string `json:"sha"`
 	Short      string `json:"short"`
@@ -218,7 +243,7 @@ func (s *PublicServer) handleGitChanges(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	files, err := changedFiles(root, from, to)
+	files, err := changedFiles(root, mergeBaseFrom(root, from, to, r.URL.Query()), to)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/server/githistory_test.go
+++ b/internal/server/githistory_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -155,6 +156,92 @@ func TestGitChangesBetweenTwoCommits(t *testing.T) {
 	}
 	if insertions, _ := body["insertions"].(float64); insertions != 3 {
 		t.Fatalf("insertions = %v, want 3", insertions)
+	}
+}
+
+// divergedRepo leaves main one commit ahead of where the feature branch was
+// cut, which is the state every review runs into and the only one where the
+// two comparisons disagree.
+func divergedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Tester", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=Tester", "GIT_COMMITTER_EMAIL=t@example.com",
+			"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z", "GIT_COMMITTER_DATE=2026-01-01T00:00:00Z")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	run("init", "--initial-branch=main")
+	write(t, filepath.Join(root, "shared.txt"), "shared\n")
+	run("add", ".")
+	run("commit", "-m", "first")
+
+	run("checkout", "-b", "feature")
+	write(t, filepath.Join(root, "feature.txt"), "from the agent\n")
+	run("add", ".")
+	run("commit", "-m", "feature work")
+
+	run("checkout", "main")
+	write(t, filepath.Join(root, "elsewhere.txt"), "somebody else\n")
+	run("add", ".")
+	run("commit", "-m", "unrelated work on main")
+
+	run("checkout", "feature")
+	return root
+}
+
+func changedPaths(t *testing.T, body map[string]interface{}) []string {
+	t.Helper()
+	raw, _ := body["files"].([]interface{})
+	paths := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		file, _ := entry.(map[string]interface{})
+		path, _ := file["path"].(string)
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// Without merge_base the reviewer sees main's own commits inverted — work the
+// branch never touched, reported as deletions it made.
+func TestGitChangesTwoDotIncludesTheBaseBranchesOwnWork(t *testing.T) {
+	root := divergedRepo(t)
+	body := gitJSON(t, gitServer(t), "/api/git/changes?path="+root+"&from=main&to=HEAD")
+
+	if got := changedPaths(t, body); !slices.Contains(got, "elsewhere.txt") {
+		t.Fatalf("files = %v, want the two-dot diff to include main's own elsewhere.txt", got)
+	}
+}
+
+func TestGitChangesMergeBaseShowsOnlyTheBranchesWork(t *testing.T) {
+	root := divergedRepo(t)
+	body := gitJSON(t, gitServer(t), "/api/git/changes?path="+root+"&from=main&to=HEAD&merge_base=true")
+
+	got := changedPaths(t, body)
+	if !slices.Equal(got, []string{"feature.txt"}) {
+		t.Fatalf("files = %v, want only feature.txt", got)
+	}
+}
+
+func TestGitDiffMergeBaseIgnoresTheBaseBranchesOwnWork(t *testing.T) {
+	root := divergedRepo(t)
+	res := gitGet(t, gitServer(t), "/api/git/diff?path="+root+"&file=elsewhere.txt&from=main&to=HEAD&merge_base=true")
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", res.Code, res.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if diff, _ := body["diff"].(string); diff != "" {
+		t.Fatalf("diff = %q, want empty: the branch never touched that file", diff)
 	}
 }
 

--- a/internal/server/wrap_test.go
+++ b/internal/server/wrap_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -254,7 +255,10 @@ func TestCreateSession_RecordsTheModeItLaunchedWith(t *testing.T) {
 	claude.Register()
 	srv, shared, _ := newInternalTestServer(t)
 
-	resp := postJSON(t, srv.URL+"/internal/sessions", `{"provider":"claude","cwd":"/tmp/proj"}`)
+	// A real directory: creating a session resolves its cwd, and a path that
+	// does not exist is refused before anything is launched in it.
+	resp := postJSON(t, srv.URL+"/internal/sessions",
+		fmt.Sprintf(`{"provider":"claude","cwd":%q}`, t.TempDir()))
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -274,7 +278,7 @@ func TestCreateSession_RecordsTheRequestedMode(t *testing.T) {
 	srv, shared, _ := newInternalTestServer(t)
 
 	postJSON(t, srv.URL+"/internal/sessions",
-		`{"provider":"claude","cwd":"/tmp/proj","permission_mode":"plan"}`)
+		fmt.Sprintf(`{"provider":"claude","cwd":%q,"permission_mode":"plan"}`, t.TempDir()))
 
 	sessions, err := shared.DB.ListSessions()
 	if err != nil || len(sessions) != 1 {


### PR DESCRIPTION
## Summary

The git panel could show a commit, a range, or the working tree — one file at a time, behind a picker. None of those is the question you have after an agent has been running for an hour: *what has this branch done, and is it any good.*

That question is now a scope of its own, and the panel opens on it.

- **Review scope.** `Review vs <base>` sits above the commit log in the picker, and is the default when the branch has commits on it. The working tree remains the fallback for a repository with no base branch or no history.
- **One page, not one file.** Every changed file is stacked with its own status, stats and sticky header. The sidebar lists them with counts and dims the ones marked viewed. Diffs are fetched as each card nears the viewport, so a forty-file branch is not forty requests up front.
- **Scope is remembered per session.** Stored under `helios.git.scope.<host>.<session>`: two sessions on two branches are two separate reviews, and one's scope means nothing in the other.
- **Comments are prompts.** Click a line, ⇧-click to extend, write what is wrong, and it goes to that session's agent as `Review comment on <path> (diff lines a–b)` with the diff excerpt attached. This is what a hosted review cannot do — the author is still at the keyboard.

**A bug found while building it.** `git diff base HEAD` is two-dot, so commits landed on the base branch after this one was cut show up as changes the branch *deleted* — somebody else's work, rendered backwards, in the middle of your review. `/api/git/changes` and `/api/git/diff` now accept `merge_base=true`, which resolves `from` through `git merge-base` first; existing callers are untouched.

## Test plan

- [x] `go test ./...` — three new tests around the comparison: the two-dot diff includes the base branch's own `elsewhere.txt`, `merge_base=true` reduces it to the branch's single file, and a file the branch never touched returns an empty diff
- [x] `tsc --noEmit`, `node build.mjs`
- [x] Layout rendered against the built stylesheet in Chrome at 1500px: header totals, sidebar with a dimmed viewed file, stacked cards with sticky headers, selected lines highlighted, comment box under the selection
- [ ] Live: open git mid-session and land on the review, mark files viewed, send a comment and watch it arrive as a prompt

Two unrelated tests were posting `cwd:"/tmp/proj"` to `/internal/sessions`. Since #29 the daemon resolves a working directory before launching anything, so a path that does not exist is a 400 — they now use `t.TempDir()`.