### PR TITLE
fix: answer AskUserQuestion with "ask", not "allow"

### DIFF
--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -75,6 +75,13 @@ func allowTool(w http.ResponseWriter) {
 	writePermResponse(w, resp)
 }
 
+// askUser leaves the decision to the CLI's own prompt.
+func askUser(w http.ResponseWriter) {
+	resp := newPermResponse()
+	resp.HookSpecificOutput.Decision.Behavior = "ask"
+	writePermResponse(w, resp)
+}
+
 func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	var input hookInput
 	if err := json.Unmarshal(raw, &input); err != nil {
@@ -84,12 +91,13 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 
 	// AskUserQuestion is not an approval, and it already has a surface: the
 	// PreToolUse hook raises claude.question for it. Raising a second,
-	// blocking notification here put two cards on the phone for one question —
-	// and because this hook blocks the tool, the CLI never rendered the
-	// question UI that answering the other card drives, so neither card could
-	// be answered correctly. Let the tool run; claude.question owns it.
+	// blocking notification here put two cards on the phone for one question.
+	// Stay silent instead — but with "ask", not "allow": for this tool the
+	// permission prompt is the question picker itself, so allowing it skips
+	// the picker and the tool returns an empty answer set. "ask" renders it,
+	// which is also the UI a phone answer drives.
 	if input.ToolName == askUserQuestionTool {
-		allowTool(w)
+		askUser(w)
 		return
 	}
 

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -1101,13 +1101,15 @@ func TestPermission_AskUserQuestionRaisesNoSecondApproval(t *testing.T) {
 			"claude.question is the only surface for a question", len(notifs))
 	}
 
-	// The tool has to be allowed through, or the question is never asked at all.
+	// "ask", not "allow": allow skips the interactive prompt, and for this tool
+	// that prompt is the question picker, so the tool returns no answers at all.
 	var resp permResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response %q: %v", w.Body.String(), err)
 	}
-	if got := resp.HookSpecificOutput.Decision.Behavior; got != "allow" {
-		t.Errorf("decision behavior = %q, want allow", got)
+	if got := resp.HookSpecificOutput.Decision.Behavior; got != "ask" {
+		t.Errorf("decision behavior = %q, want ask — allow would skip the picker "+
+			"and answer the question with nothing", got)
 	}
 	if got := resp.HookSpecificOutput.HookEventName; got != "PermissionRequest" {
 		t.Errorf("hookEventName = %q, want PermissionRequest", got)


### PR DESCRIPTION
## Summary

- The `PermissionRequest` hook replied `behavior: "allow"` for `AskUserQuestion` so it would not raise a second approval card beside the `claude.question` card the `PreToolUse` hook raises. But `"allow"` skips the interactive permission prompt, and for this tool that prompt **is** the question picker — so the picker never rendered and the tool returned `answers: {}`.
- Replying `"ask"` keeps the hook silent without suppressing the UI: the CLI renders its own picker, and no second card appears.
- This also restores answering from the phone: `handleQuestionAction` answers by driving that same picker, which had nothing to drive.

Regression from 08d5d69. Caught live — a real `AskUserQuestion` in this repo returned empty; the transcript shows the permission decision at `.268` and the tool result at `.293`, 25 ms apart, with no human in between.

## Test plan

- [x] `go test ./internal/provider/claude/` — `TestPermission_AskUserQuestionRaisesNoSecondApproval` now asserts `ask`, and still asserts zero `claude.permission` notifications and no blocking
- [x] `go test ./...` — only pre-existing failure is `TestE2EClaudeSnapshotCatchesUpLateViewer` (truecolor snapshot), which fails on clean `main` too
- [ ] Manual: `make install`, restart the daemon, trigger an `AskUserQuestion` — the picker should render and wait
- [ ] Manual: answer that same question from the phone and confirm it resolves the card and the picker together