### PR TITLE
feat(desktop): select markdown lines, copy or send them as a prompt

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -10,7 +10,7 @@ import {
   renderMarkdown,
   resolveFilePath,
 } from '../markdown.ts'
-import { store } from '../store.ts'
+import { store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
   canResume,
@@ -41,7 +41,9 @@ export function ChatPanel({
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
   const scroller = useRef<HTMLDivElement | null>(null)
+  const composer = useRef<HTMLTextAreaElement | null>(null)
   const pinnedToBottom = useRef(true)
+  const promptDraft = useStore((s) => s.promptDraft)
 
   const status = session.status
   const busy = BUSY_STATUSES.has(status)
@@ -73,6 +75,18 @@ export function ChatPanel({
     // Reloads as the agent works: last_event_at moves on every hook, and the
     // transcript is a file the daemon re-reads rather than a stream.
   }, [hostId, session.session_id, session.last_event_at, status, active])
+
+  // Lines picked in the Files panel arrive here rather than being sent: what to
+  // ask about them is still to be typed.
+  useEffect(() => {
+    if (!promptDraft || promptDraft.hostId !== hostId || promptDraft.sessionId !== session.session_id) {
+      return
+    }
+    setDraft((current) => (current ? `${current}\n${promptDraft.text}` : promptDraft.text))
+    store.clearPromptDraft()
+    composer.current?.focus()
+    // seq, not text: sending the same lines twice has to append twice.
+  }, [promptDraft?.seq])
 
   useEffect(() => {
     if (pinnedToBottom.current && scroller.current) {
@@ -172,6 +186,7 @@ export function ChatPanel({
         <div className="composer">
           <div className="composer-input">
             <textarea
+              ref={composer}
               value={draft}
               rows={3}
               placeholder={

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
 import { store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
@@ -224,7 +224,12 @@ export function Detail(): JSX.Element {
                   />
                 )}
                 {name === 'files' && (
-                  <FilesPanel hostId={hostId} cwd={session.cwd} visible={name === panel} />
+                  <FilesPanel
+                    hostId={hostId}
+                    sessionId={session.session_id}
+                    cwd={session.cwd}
+                    visible={name === panel}
+                  />
                 )}
               </PanelBoundary>
             </div>
@@ -301,10 +306,31 @@ function ShellTab({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
 function SessionHeader({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(session.title ?? '')
+  const overflow = useRef<HTMLDetailsElement | null>(null)
   const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
   const terminated = canResume(session)
   const cold = needsRecovery(session)
+
+  // <details> only closes on its own summary, so a menu left open stays open
+  // over whatever the user clicks next.
+  useEffect(() => {
+    const close = (event: Event): void => {
+      const element = overflow.current
+      if (!element?.open) return
+      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
+      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
+      element.open = false
+    }
+    window.addEventListener('mousedown', close)
+    window.addEventListener('keydown', close)
+    window.addEventListener('blur', close)
+    return () => {
+      window.removeEventListener('mousedown', close)
+      window.removeEventListener('keydown', close)
+      window.removeEventListener('blur', close)
+    }
+  }, [])
 
   const run = async (fn: () => Promise<unknown>): Promise<void> => {
     try {
@@ -380,9 +406,14 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}
 
-        <details className="menu">
+        <details className="menu" ref={overflow}>
           <summary>⋯</summary>
-          <div className="menu-body">
+          <div
+            className="menu-body"
+            onClick={() => {
+              if (overflow.current) overflow.current.open = false
+            }}
+          >
             <button onClick={() => void run(() => api(hostId).generateTitle(session.session_id))}>
               Regenerate title
             </button>

--- a/desktop/src/renderer/components/editor.tsx
+++ b/desktop/src/renderer/components/editor.tsx
@@ -21,6 +21,14 @@ export interface Cursor {
   seq: number
 }
 
+/** Where the pointer was, and the lines it was pointing at. */
+export interface ContextTarget {
+  x: number
+  y: number
+  startLine: number
+  endLine: number
+}
+
 interface Props {
   /** The buffer's starting text. Mount one editor per file — key by path. */
   doc: string
@@ -29,6 +37,7 @@ interface Props {
   onChange: (text: string) => void
   onSave: () => void
   cursor?: Cursor | null
+  onContextMenu?: (target: ContextTarget) => void
 }
 
 /**
@@ -39,12 +48,20 @@ interface Props {
  * each character typed. The parent hears about edits through onChange and keeps
  * the draft in a ref.
  */
-export function CodeEditor({ doc, path, readOnly, onChange, onSave, cursor }: Props): JSX.Element {
+export function CodeEditor({
+  doc,
+  path,
+  readOnly,
+  onChange,
+  onSave,
+  cursor,
+  onContextMenu,
+}: Props): JSX.Element {
   const host = useRef<HTMLDivElement | null>(null)
   const view = useRef<EditorView | null>(null)
   // Held in refs so a new callback identity does not tear down the editor.
-  const handlers = useRef({ onChange, onSave })
-  handlers.current = { onChange, onSave }
+  const handlers = useRef({ onChange, onSave, onContextMenu })
+  handlers.current = { onChange, onSave, onContextMenu }
 
   useEffect(() => {
     if (!host.current) return
@@ -70,6 +87,27 @@ export function CodeEditor({ doc, path, readOnly, onChange, onSave, cursor }: Pr
         EditorView.editable.of(!readOnly),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) handlers.current.onChange(update.state.doc.toString())
+        }),
+        EditorView.domEventHandlers({
+          contextmenu: (event, editor) => {
+            const handle = handlers.current.onContextMenu
+            if (!handle) return false
+            const { main } = editor.state.selection
+            // Right-clicking outside the selection asks about the line under
+            // the pointer, which is what the click just pointed at.
+            const at = editor.posAtCoords({ x: event.clientX, y: event.clientY })
+            const inside = at !== null && at >= main.from && at <= main.to
+            const from = inside || at === null ? main.from : at
+            const to = inside || at === null ? main.to : at
+            event.preventDefault()
+            handle({
+              x: event.clientX,
+              y: event.clientY,
+              startLine: editor.state.doc.lineAt(from).number,
+              endLine: editor.state.doc.lineAt(to).number,
+            })
+            return true
+          },
         }),
       ],
     })

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
-import { isMarkdownPath, renderMarkdown } from '../markdown.ts'
+import { isMarkdownPath, languageForPath, renderMarkdownBlocks } from '../markdown.ts'
 import { store, useStore } from '../store.ts'
 import { CodeEditor, type Cursor } from './editor.tsx'
 import { FileTree } from './file-tree.tsx'
@@ -36,10 +36,12 @@ interface OpenFile {
  */
 export function FilesPanel({
   hostId,
+  sessionId,
   cwd,
   visible = true,
 }: {
   hostId: string
+  sessionId: string
   cwd: string
   /** False while another tab is showing. */
   visible?: boolean
@@ -294,6 +296,8 @@ export function FilesPanel({
           <FileView
             file={active}
             root={root}
+            hostId={hostId}
+            sessionId={sessionId}
             text={drafts.current[active.path] ?? active.saved}
             onChange={(text) => edited(active.path, text)}
             onSave={() => void save(active.path)}
@@ -324,6 +328,8 @@ export function FilesPanel({
 function FileView({
   file,
   root,
+  hostId,
+  sessionId,
   text,
   onChange,
   onSave,
@@ -332,6 +338,8 @@ function FileView({
 }: {
   file: OpenFile
   root: string
+  hostId: string
+  sessionId: string
   text: string
   onChange: (text: string) => void
   onSave: () => void
@@ -340,7 +348,25 @@ function FileView({
 }): JSX.Element {
   const markdown = isMarkdownPath(file.path)
   const rendered = markdown && file.mode === 'preview'
-  const html = useMemo(() => (rendered ? renderMarkdown(text) : null), [rendered, text])
+  const blocks = useMemo(() => (rendered ? renderMarkdownBlocks(text) : null), [rendered, text])
+  const [picked, setPicked] = useState<LineRange | null>(null)
+  const [menu, setMenu] = useState<{ x: number; y: number; range: LineRange } | null>(null)
+
+  // A selection is a range of the file that was open when it was made.
+  useEffect(() => {
+    setPicked(null)
+    setMenu(null)
+  }, [file.path, rendered])
+
+  const act = (action: 'copy' | 'prompt', range: LineRange): void => {
+    const lines = text.split('\n').slice(range.start - 1, range.end)
+    if (action === 'copy') {
+      void navigator.clipboard.writeText(lines.join('\n'))
+      store.notify(`Copied ${label(range)}`)
+      return
+    }
+    store.appendPrompt(hostId, sessionId, promptFor(file.path, range, lines))
+  }
 
   return (
     <div className="ws-editor">
@@ -377,8 +403,40 @@ function FileView({
 
       {file.binary ? (
         <p className="empty-note">Binary file — not shown.</p>
-      ) : html !== null ? (
-        <div className="md preview-md" dangerouslySetInnerHTML={{ __html: html }} />
+      ) : blocks !== null ? (
+        <div className="md preview-md">
+          {blocks.map((block) => {
+            const range = { start: block.startLine, end: block.endLine }
+            const on = picked !== null && block.startLine <= picked.end && block.endLine >= picked.start
+            return (
+              <div
+                key={block.startLine}
+                className={on ? 'md-block on' : 'md-block'}
+                title={`${label(range)} — click to select, right-click for actions`}
+                dangerouslySetInnerHTML={{ __html: block.html }}
+                onClick={(event) =>
+                  setPicked((current) =>
+                    // Shift builds a range out of two clicks, the way a line
+                    // gutter does; a plain click starts again from one block.
+                    event.shiftKey && current
+                      ? { start: Math.min(current.start, range.start), end: Math.max(current.end, range.end) }
+                      : current && current.start === range.start && current.end === range.end
+                        ? null
+                        : range,
+                  )
+                }
+                onContextMenu={(event) => {
+                  event.preventDefault()
+                  const covered =
+                    picked !== null && block.startLine >= picked.start && block.endLine <= picked.end
+                  const target = covered ? picked : range
+                  setPicked(target)
+                  setMenu({ x: event.clientX, y: event.clientY, range: target })
+                }}
+              />
+            )
+          })}
+        </div>
       ) : file.readOnly ? (
         <pre className="ws-plain">{text}</pre>
       ) : (
@@ -389,8 +447,80 @@ function FileView({
           onChange={onChange}
           onSave={onSave}
           cursor={file.cursor}
+          onContextMenu={(at) => setMenu({ x: at.x, y: at.y, range: { start: at.startLine, end: at.endLine } })}
         />
       )}
+
+      {menu && (
+        <LineMenu
+          x={menu.x}
+          y={menu.y}
+          range={menu.range}
+          onClose={() => setMenu(null)}
+          onAct={(action) => act(action, menu.range)}
+        />
+      )}
+    </div>
+  )
+}
+
+/** A range of file lines, 1-based and inclusive. */
+interface LineRange {
+  start: number
+  end: number
+}
+
+function label(range: LineRange): string {
+  return range.start === range.end ? `L${range.start}` : `L${range.start}-${range.end}`
+}
+
+/**
+ * Past this the lines go to the agent as a reference instead of a quote: it can
+ * read the file itself, and a prompt is a worse place to put it than the disk.
+ */
+const INLINE_LINE_LIMIT = 40
+
+function promptFor(path: string, range: LineRange, lines: string[]): string {
+  const header = `\`${path}\` ${label(range)}`
+  if (lines.length > INLINE_LINE_LIMIT) return `${header}\n`
+  return `${header}:\n\`\`\`${languageForPath(path) ?? ''}\n${lines.join('\n')}\n\`\`\`\n`
+}
+
+function LineMenu({
+  x,
+  y,
+  range,
+  onClose,
+  onAct,
+}: {
+  x: number
+  y: number
+  range: LineRange
+  onClose: () => void
+  onAct: (action: 'copy' | 'prompt') => void
+}): JSX.Element {
+  useEffect(() => {
+    const dismiss = (event: Event): void => {
+      if (event instanceof KeyboardEvent && event.key !== 'Escape') return
+      onClose()
+    }
+    window.addEventListener('mousedown', dismiss)
+    window.addEventListener('keydown', dismiss)
+    return () => {
+      window.removeEventListener('mousedown', dismiss)
+      window.removeEventListener('keydown', dismiss)
+    }
+  }, [onClose])
+
+  const run = (action: 'copy' | 'prompt'): void => {
+    onAct(action)
+    onClose()
+  }
+
+  return (
+    <div className="line-menu" style={{ left: x, top: y }}>
+      <button onClick={() => run('copy')}>Copy {label(range)}</button>
+      <button onClick={() => run('prompt')}>Send {label(range)} as prompt</button>
     </div>
   )
 }

--- a/desktop/src/renderer/markdown.ts
+++ b/desktop/src/renderer/markdown.ts
@@ -193,6 +193,35 @@ export function renderMarkdown(source: string): string {
   return DOMPurify.sanitize(html, { ADD_ATTR: ['target'] })
 }
 
+/** A rendered top-level block and the source lines it came from. */
+export interface MarkdownBlock {
+  html: string
+  /** 1-based and inclusive, so a block reads as `L12-18` of the file. */
+  startLine: number
+  endLine: number
+}
+
+/**
+ * Markdown to HTML one top-level block at a time, each tagged with its source
+ * line range. Rendering per block is what lets the reader point at a paragraph
+ * and get the lines behind it; `raw` is the only line information marked keeps,
+ * so the ranges are counted from it as the tokens go past.
+ */
+export function renderMarkdownBlocks(source: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = []
+  let line = 1
+  for (const token of marked.lexer(source)) {
+    const startLine = line
+    const newlines = (token.raw.match(/\n/g) ?? []).length
+    line += newlines
+    // Blank lines between blocks belong to neither, and have nothing to render.
+    if (token.type === 'space') continue
+    const html = DOMPurify.sanitize(marked.parser([token], { async: false }), { ADD_ATTR: ['target'] })
+    blocks.push({ html, startLine, endLine: Math.max(startLine, startLine + newlines - 1) })
+  }
+  return blocks
+}
+
 /**
  * Paths mentioned in prose: `~/a/b`, `/a/b`, or a relative path with at least
  * three segments. Same expression as the mobile app, which errs towards missing

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -47,6 +47,18 @@ export interface FileTarget {
   seq: number
 }
 
+/**
+ * Text on its way to a session's composer from a selection elsewhere in the
+ * app. Counted like FileTarget: sending the same lines twice has to arrive
+ * twice.
+ */
+export interface PromptDraft {
+  hostId: string
+  sessionId: string
+  text: string
+  seq: number
+}
+
 export interface State {
   hosts: HostRecord[]
   hostStatus: Record<string, HostStatus>
@@ -63,6 +75,7 @@ export interface State {
    */
   activeTab: string | null
   fileTarget: FileTarget | null
+  promptDraft: PromptDraft | null
   /** Sidebar filter, matched against title, project and cwd. */
   query: string
   showArchived: boolean
@@ -81,6 +94,7 @@ const initial: State = {
   panel: 'chat',
   activeTab: null,
   fileTarget: null,
+  promptDraft: null,
   query: '',
   showArchived: false,
   loading: true,
@@ -265,6 +279,19 @@ class Store {
    */
   clearFileTarget(): void {
     this.set({ fileTarget: null })
+  }
+
+  /** Puts text in the session's composer and shows it, without sending. */
+  appendPrompt(hostId: string, sessionId: string, text: string): void {
+    this.set((s) => ({
+      panel: 'chat',
+      promptDraft: { hostId, sessionId, text, seq: (s.promptDraft?.seq ?? 0) + 1 },
+    }))
+  }
+
+  /** Called by the composer once the text is in the box. */
+  clearPromptDraft(): void {
+    this.set({ promptDraft: null })
   }
 
   setQuery(query: string): void {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1735,6 +1735,51 @@ small {
   max-width: 780px;
 }
 
+/* Rendered prose still has lines underneath it, and a block is what the reader
+   points at to talk about them. */
+.md-block {
+  border-radius: 6px;
+  padding: 2px 6px;
+  margin: 0 -6px;
+  cursor: pointer;
+}
+
+.md-block:hover {
+  background: var(--surface-low);
+}
+
+.md-block.on,
+.md-block.on:hover {
+  background: color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.line-menu {
+  position: fixed;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--surface-high);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+}
+
+.line-menu button {
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: var(--on-surface);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.line-menu button:hover {
+  background: var(--surface-highest);
+}
+
 .git-diff pre,
 .ws-plain {
   flex: 1;


### PR DESCRIPTION
## Summary

- Rendered markdown in the Files panel is now drawn one top-level block at a time, each tagged with the source lines it came from. Click selects a block, shift-click extends the range, right-click opens a menu.
- Menu actions: **Copy L12-18** and **Send L12-18 as prompt**. The prompt lands in the session composer unsent (path + line label, with the lines inlined in a fence up to 40 lines; past that it is a path + range reference the agent can read itself).
- The CodeMirror editor answers the same right-click, taking the range from the current selection — or from the line under the pointer when the click lands outside it.
- Fixes the session `⋯` overflow menu staying open: `<details>` only closes from its own summary, so it now also closes on an outside mousedown, Escape, window blur, and after picking an item.

## Test plan

- [ ] `npm run typecheck` and `npm test` in `desktop/` (both pass locally)
- [ ] Open a `.md` file in the Files panel: click a paragraph, shift-click a later one, confirm the range highlights
- [ ] Right-click the selection → Copy, check the clipboard holds the raw source lines
- [ ] Right-click → Send as prompt, confirm the composer opens with the fenced block and nothing is sent
- [ ] Select >40 lines and send: the prompt should be the path + range only
- [ ] Right-click a selection in a code file, same two actions
- [ ] Open the `⋯` menu and click elsewhere / press Escape / focus another window — it should close each time

> Not exercised in a running app: the installed Helios holds the Electron single-instance lock, so the dev build could not be launched this session.