### PR TITLE
feat: search and re-root worktrees across the git and files panels

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -313,14 +313,31 @@ function FileChip({
   const name = label ?? path.split('/').filter(Boolean).pop() ?? path
   const isDir = !name.includes('.')
   return (
-    <button
-      className="file-chip"
-      title={`Open ${resolved}`}
-      onClick={() => store.openFile(hostId, resolved)}
-    >
-      <span className="file-chip-icon">{isDir ? '▸' : '⌸'}</span>
-      {name}
-    </button>
+    <span className="file-chip">
+      {/* Search, not open: the transcript's path is the checkout the agent ran
+          in, and the Files panel is often rooted somewhere else by then. */}
+      <button
+        className="file-chip-open"
+        title={`Find ${name} in the Files panel`}
+        onClick={() => store.findFile(hostId, resolved)}
+      >
+        <span className="file-chip-icon">{isDir ? '▸' : '⌕'}</span>
+        {name}
+      </button>
+      <button className="file-chip-act" title={`Open ${resolved}`} onClick={() => store.openFile(hostId, resolved)}>
+        ↗
+      </button>
+      <button
+        className="file-chip-act"
+        title="Copy path"
+        onClick={() => {
+          void navigator.clipboard.writeText(resolved)
+          store.notify('Copied path')
+        }}
+      >
+        ⧉
+      </button>
+    </span>
   )
 }
 

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -3,11 +3,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { api, statusOf } from '../bridge.ts'
 import { isMarkdownPath, languageForPath, renderMarkdownBlocks } from '../markdown.ts'
 import { store, useStore } from '../store.ts'
+import { byLastTouched, type Worktree } from '../../shared/models.ts'
 import { CodeEditor, type Cursor } from './editor.tsx'
 import { FileTree } from './file-tree.tsx'
 import { FindInFiles } from './find-in-files.tsx'
 import { PathLabel } from './path-label.tsx'
 import { QuickOpen } from './quick-open.tsx'
+import { RootPicker } from './root-picker.tsx'
 
 /** Past this the editor is read-only: CodeMirror is not a log viewer. */
 const MAX_EDIT_BYTES = 1_000_000
@@ -46,12 +48,17 @@ export function FilesPanel({
   /** False while another tab is showing. */
   visible?: boolean
 }): JSX.Element {
-  const root = useMemo(() => cwd.replace(/\/+$/, '') || '/', [cwd])
+  const [rootOverride, setRootOverride] = useState<string | null>(null)
+  const sessionRoot = useMemo(() => cwd.replace(/\/+$/, '') || '/', [cwd])
+  const root = useMemo(() => (rootOverride ?? sessionRoot).replace(/\/+$/, '') || '/', [sessionRoot, rootOverride])
+  const [worktrees, setWorktrees] = useState<Worktree[]>([])
   const [files, setFiles] = useState<OpenFile[]>([])
   const [activePath, setActivePath] = useState<string | null>(null)
   const [side, setSide] = useState<'tree' | 'find'>('tree')
   const [findSeq, setFindSeq] = useState(0)
   const [quickOpen, setQuickOpen] = useState(false)
+  const [quickOpenQuery, setQuickOpenQuery] = useState('')
+  const [rootPicker, setRootPicker] = useState(false)
   const [reveal, setReveal] = useState<string | null>(null)
   const target = useStore((s) => s.fileTarget)
 
@@ -60,16 +67,31 @@ export function FilesPanel({
   const filesRef = useRef<OpenFile[]>(files)
   filesRef.current = files
 
-  // A different session means a different tree and a different set of buffers.
+  // Another session is another repository until proven otherwise, so the root
+  // it was re-pointed at means nothing here.
   useEffect(() => {
-    setFiles([])
-    setActivePath(null)
-    setReveal(null)
-    drafts.current = {}
-  }, [hostId, root])
+    let cancelled = false
+    api(hostId)
+      .gitWorktrees(cwd)
+      .then((result) => {
+        if (!cancelled) setWorktrees(byLastTouched(result))
+      })
+      .catch(() => {
+        // Not a repository: the session's own directory is the only root.
+        if (!cancelled) setWorktrees([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, cwd])
 
   const openFile = useCallback(
-    async (path: string, at?: { line: number; column: number }): Promise<void> => {
+    async (
+      path: string,
+      at?: { line: number; column: number },
+      /** True when the caller has another path to try if this one is missing. */
+      quiet = false,
+    ): Promise<boolean> => {
       setReveal(path)
       const existing = filesRef.current.find((file) => file.path === path)
       if (existing) {
@@ -81,7 +103,7 @@ export function FilesPanel({
             ),
           )
         }
-        return
+        return true
       }
 
       try {
@@ -103,17 +125,64 @@ export function FilesPanel({
           },
         ])
         setActivePath(path)
+        return true
       } catch (err) {
         // A path from the transcript is as likely to be a directory as a file;
         // the daemon says which with a 400, and the tree has already revealed it.
-        if (statusOf(err) === 400) return
+        if (statusOf(err) === 400) return true
+        if (quiet) return false
         if (statusOf(err) === 413) store.notify('File is too large to open', 'error')
         else if (statusOf(err) === 404) store.notify(`Not found: ${path}`, 'error')
         else store.fail(err)
+        return false
       }
     },
     [hostId],
   )
+
+  // Which files were open, which was in front, and where the tree was pointed.
+  // A session is looked away from and come back to all day; losing the tabs
+  // every time makes the panel a viewer rather than a place to work.
+  const memory = `helios.files.${hostId}.${sessionId}`
+  const restored = useRef<string | null>(null)
+
+  useEffect(() => {
+    restored.current = null
+    setFiles([])
+    setActivePath(null)
+    setReveal(null)
+    drafts.current = {}
+
+    const saved = readWorkspace(memory)
+    setRootOverride(saved?.root ?? null)
+
+    let cancelled = false
+    void (async () => {
+      for (const path of saved?.open ?? []) {
+        if (cancelled) return
+        // Quiet: the agent may have deleted a file since it was last open, and
+        // a toast per missing tab is not news the user asked for.
+        await openFile(path, undefined, true)
+      }
+      if (cancelled) return
+      if (saved?.active) setActivePath(saved.active)
+      restored.current = memory
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [memory, openFile])
+
+  useEffect(() => {
+    // Not before the restore for this session has finished, or the empty state
+    // it starts from would overwrite what is on disk.
+    if (restored.current !== memory) return
+    writeWorkspace(memory, {
+      root: rootOverride,
+      open: files.map((file) => file.path),
+      active: activePath,
+    })
+  }, [memory, rootOverride, files, activePath])
 
   const save = useCallback(
     async (path: string): Promise<void> => {
@@ -198,10 +267,27 @@ export function FilesPanel({
     setFiles((current) => current.map((f) => (f.path === path ? { ...f, dirty } : f)))
   }
 
-  // A chip in the transcript opens the file here.
+  // A chip in the transcript names a path in the session's own checkout, which
+  // is not where the panel is pointed once another root has been picked. Open
+  // the same file under the current root, and fall back to the literal path
+  // when this root does not have it — a file the agent has only just created.
+  const scope = useRef({ root, owners: [] as string[] })
+  scope.current = { root, owners: [sessionRoot, ...worktrees.map((worktree) => worktree.path)] }
+
   useEffect(() => {
     if (!target || target.hostId !== hostId) return
-    void openFile(target.path)
+    const path = target.path
+    if (target.mode === 'find') {
+      setQuickOpenQuery(basename(path))
+      setQuickOpen(true)
+      store.clearFileTarget()
+      return
+    }
+    const mapped = inRoot(path, scope.current.root, scope.current.owners)
+    void (async () => {
+      if (mapped !== path && (await openFile(mapped, undefined, true))) return
+      await openFile(path)
+    })()
     store.clearFileTarget()
     // seq, not path: reopening the same file has to work.
   }, [target?.seq])
@@ -230,6 +316,27 @@ export function FilesPanel({
 
   const active = files.find((file) => file.path === activePath) ?? null
 
+  // The root as a path of its own: every segment above it is a folder the user
+  // can drop the tree onto, which is how you get out of a directory that turned
+  // out to be one level too deep.
+  const crumbs = useMemo(() => {
+    const segments = root.split('/').filter(Boolean)
+    const out = [{ label: '/', path: '/' }]
+    let accumulated = ''
+    for (const segment of segments) {
+      accumulated += `/${segment}`
+      out.push({ label: segment, path: accumulated })
+    }
+    return out
+  }, [root])
+
+  // A deep root overflows the strip, and the segment that matters is the last.
+  const crumbStrip = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const strip = crumbStrip.current
+    if (strip) strip.scrollLeft = strip.scrollWidth
+  }, [root])
+
   return (
     <div className="workspace">
       <aside className="ws-side">
@@ -251,6 +358,33 @@ export function FilesPanel({
           </button>
         </div>
 
+        <div className="ws-root">
+          <div className="ws-crumbs" ref={crumbStrip}>
+            {crumbs.map((crumb, index) => (
+              <button
+                key={crumb.path}
+                className={`ws-crumb${index === crumbs.length - 1 ? ' here' : ''}`}
+                title={crumb.path}
+                onClick={() => setRootOverride(crumb.path)}
+              >
+                {crumb.label}
+              </button>
+            ))}
+          </div>
+          <button
+            className="ws-root-more"
+            title="Choose a worktree or another folder"
+            onClick={() => setRootPicker(true)}
+          >
+            ▾
+          </button>
+          {root !== sessionRoot && (
+            <button className="pill" title="Back to this session's own folder" onClick={() => setRootOverride(null)}>
+              ✕
+            </button>
+          )}
+        </div>
+
         {side === 'tree' ? (
           <FileTree
             hostId={hostId}
@@ -264,7 +398,9 @@ export function FilesPanel({
             hostId={hostId}
             root={root}
             focusSeq={findSeq}
+            worktrees={worktrees}
             onOpen={(path, line, column) => void openFile(path, { line, column })}
+            onPickRoot={setRootOverride}
           />
         )}
       </aside>
@@ -317,8 +453,24 @@ export function FilesPanel({
         <QuickOpen
           hostId={hostId}
           root={root}
+          initialQuery={quickOpenQuery}
+          worktrees={worktrees}
           onOpen={(path) => void openFile(path)}
-          onClose={() => setQuickOpen(false)}
+          onPickRoot={setRootOverride}
+          onClose={() => {
+            setQuickOpen(false)
+            setQuickOpenQuery('')
+          }}
+        />
+      )}
+
+      {rootPicker && (
+        <RootPicker
+          hostId={hostId}
+          root={root}
+          worktrees={worktrees}
+          onPick={(path) => setRootOverride(path)}
+          onClose={() => setRootPicker(false)}
         />
       )}
     </div>
@@ -351,11 +503,31 @@ function FileView({
   const blocks = useMemo(() => (rendered ? renderMarkdownBlocks(text) : null), [rendered, text])
   const [picked, setPicked] = useState<LineRange | null>(null)
   const [menu, setMenu] = useState<{ x: number; y: number; range: LineRange } | null>(null)
+  /** Headings whose section is folded away, by the heading's start line. */
+  const [folds, setFolds] = useState<Set<number>>(new Set())
+
+  // Everything under a folded heading, down to the next heading that is not
+  // deeper than it — folding "## Build" takes its subsections with it.
+  const hidden = useMemo(() => {
+    const out = new Set<number>()
+    if (!blocks || folds.size === 0) return out
+    let under: number | null = null
+    for (const block of blocks) {
+      if (block.depth !== undefined && under !== null && block.depth <= under) under = null
+      if (under !== null) {
+        out.add(block.startLine)
+        continue
+      }
+      if (block.depth !== undefined && folds.has(block.startLine)) under = block.depth
+    }
+    return out
+  }, [blocks, folds])
 
   // A selection is a range of the file that was open when it was made.
   useEffect(() => {
     setPicked(null)
     setMenu(null)
+    setFolds(new Set())
   }, [file.path, rendered])
 
   const act = (action: 'copy' | 'prompt', range: LineRange): void => {
@@ -406,14 +578,15 @@ function FileView({
       ) : blocks !== null ? (
         <div className="md preview-md">
           {blocks.map((block) => {
+            if (hidden.has(block.startLine)) return null
             const range = { start: block.startLine, end: block.endLine }
             const on = picked !== null && block.startLine <= picked.end && block.endLine >= picked.start
+            const folded = folds.has(block.startLine)
             return (
               <div
                 key={block.startLine}
-                className={on ? 'md-block on' : 'md-block'}
+                className={`md-block${on ? ' on' : ''}${block.depth ? ' md-heading' : ''}`}
                 title={`${label(range)} — click to select, right-click for actions`}
-                dangerouslySetInnerHTML={{ __html: block.html }}
                 onClick={(event) =>
                   setPicked((current) =>
                     // Shift builds a range out of two clicks, the way a line
@@ -433,7 +606,25 @@ function FileView({
                   setPicked(target)
                   setMenu({ x: event.clientX, y: event.clientY, range: target })
                 }}
-              />
+              >
+                {block.depth !== undefined && (
+                  <button
+                    className="md-fold"
+                    title={folded ? 'Expand section' : 'Collapse section'}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setFolds((current) => {
+                        const next = new Set(current)
+                        if (!next.delete(block.startLine)) next.add(block.startLine)
+                        return next
+                      })
+                    }}
+                  >
+                    {folded ? '▸' : '▾'}
+                  </button>
+                )}
+                <div className="md-block-body" dangerouslySetInnerHTML={{ __html: block.html }} />
+              </div>
             )
           })}
         </div>
@@ -527,6 +718,43 @@ function LineMenu({
 
 function basename(path: string): string {
   return path.split('/').pop() || path
+}
+
+/** What the panel remembers about a session between visits. */
+interface Workspace {
+  root: string | null
+  open: string[]
+  active: string | null
+}
+
+function readWorkspace(key: string): Workspace | null {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? (JSON.parse(raw) as Workspace) : null
+  } catch {
+    return null
+  }
+}
+
+function writeWorkspace(key: string, workspace: Workspace): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(workspace))
+  } catch {
+    // A full or unavailable store costs the memory, not the panel.
+  }
+}
+
+/**
+ * Rewrites a path from whichever checkout it names into the one on screen. The
+ * longest owner wins: a worktree nested under another repository's directory
+ * would otherwise be read as a path inside it.
+ */
+function inRoot(path: string, root: string, owners: string[]): string {
+  if (path === root || path.startsWith(`${root}/`)) return path
+  const owner = owners
+    .filter((candidate) => candidate && path.startsWith(`${candidate}/`))
+    .sort((a, b) => b.length - a.length)[0]
+  return owner ? `${root}/${path.slice(owner.length + 1)}` : path
 }
 
 /** Paths inside the session's directory read better without its prefix. */

--- a/desktop/src/renderer/components/find-in-files.tsx
+++ b/desktop/src/renderer/components/find-in-files.tsx
@@ -1,18 +1,29 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
-import type { GrepMatch } from '../../shared/models.ts'
+import { RootSuggestions } from './root-picker.tsx'
+import type { GrepMatch, Worktree } from '../../shared/models.ts'
 
 interface Props {
   hostId: string
   root: string
   /** Bumped when ⌘⇧F is pressed again, to put the caret back in the field. */
   focusSeq: number
+  /** Offered when nothing matches: the text is often in another checkout. */
+  worktrees?: Worktree[]
   onOpen: (path: string, line: number, column: number) => void
+  onPickRoot?: (path: string) => void
 }
 
 /** ⌘⇧F: search file contents under the session's directory. */
-export function FindInFiles({ hostId, root, focusSeq, onOpen }: Props): JSX.Element {
+export function FindInFiles({
+  hostId,
+  root,
+  focusSeq,
+  worktrees = [],
+  onOpen,
+  onPickRoot,
+}: Props): JSX.Element {
   const [query, setQuery] = useState('')
   const [caseSensitive, setCaseSensitive] = useState(false)
   const [regex, setRegex] = useState(false)
@@ -29,24 +40,36 @@ export function FindInFiles({ hostId, root, focusSeq, onOpen }: Props): JSX.Elem
 
   // Content search is run on demand rather than per keystroke: it walks the
   // whole tree, and a half-typed word is rarely what was meant.
-  const run = async (): Promise<void> => {
-    if (!query) {
-      setMatches(null)
-      return
-    }
-    setSearching(true)
-    setError(null)
-    try {
-      const result = await api(hostId).grepFiles(root, query, { regex, caseSensitive, limit: 300 })
-      setMatches(result.matches)
-      setTruncated(result.truncated)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-      setMatches([])
-    } finally {
-      setSearching(false)
-    }
-  }
+  const run = useCallback(
+    async (where: string): Promise<void> => {
+      if (!query) {
+        setMatches(null)
+        return
+      }
+      setSearching(true)
+      setError(null)
+      try {
+        const result = await api(hostId).grepFiles(where, query, { regex, caseSensitive, limit: 300 })
+        setMatches(result.matches)
+        setTruncated(result.truncated)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        setMatches([])
+      } finally {
+        setSearching(false)
+      }
+    },
+    [hostId, query, regex, caseSensitive],
+  )
+
+  // Taking a suggestion moves the root under a search that has already been
+  // typed, and the answer the user wanted is the same search run again there.
+  const searched = useRef(root)
+  useEffect(() => {
+    if (searched.current === root) return
+    searched.current = root
+    if (matches !== null) void run(root)
+  }, [root, matches, run])
 
   const groups = groupByFile(matches ?? [])
 
@@ -61,7 +84,7 @@ export function FindInFiles({ hostId, root, focusSeq, onOpen }: Props): JSX.Elem
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           onKeyDown={(event) => {
-            if (event.key === 'Enter') void run()
+            if (event.key === 'Enter') void run(root)
           }}
         />
         <button
@@ -84,7 +107,10 @@ export function FindInFiles({ hostId, root, focusSeq, onOpen }: Props): JSX.Elem
         {searching && <p className="empty-note">Searching…</p>}
         {error && <p className="empty-note">{error}</p>}
         {!searching && !error && matches !== null && matches.length === 0 && (
-          <p className="empty-note">No results.</p>
+          <>
+            <p className="empty-note">No results under {root}.</p>
+            {onPickRoot && <RootSuggestions root={root} worktrees={worktrees} onPick={onPickRoot} />}
+          </>
         )}
         {!searching &&
           groups.map(([rel, hits]) => (

--- a/desktop/src/renderer/components/quick-open.tsx
+++ b/desktop/src/renderer/components/quick-open.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
-import type { FileMatch } from '../../shared/models.ts'
+import { RootSuggestions } from './root-picker.tsx'
+import type { FileMatch, Worktree } from '../../shared/models.ts'
 
 interface Props {
   hostId: string
   root: string
+  /** Seeds the field, for callers that already know part of the name. */
+  initialQuery?: string
+  /** Offered when nothing matches: the file is often in another checkout. */
+  worktrees?: Worktree[]
   onOpen: (path: string) => void
+  onPickRoot?: (path: string) => void
   onClose: () => void
 }
 
@@ -14,8 +20,16 @@ interface Props {
 const DEBOUNCE_MS = 90
 
 /** ⌘P: type part of a file name, press Enter. */
-export function QuickOpen({ hostId, root, onOpen, onClose }: Props): JSX.Element {
-  const [query, setQuery] = useState('')
+export function QuickOpen({
+  hostId,
+  root,
+  initialQuery = '',
+  worktrees = [],
+  onOpen,
+  onPickRoot,
+  onClose,
+}: Props): JSX.Element {
+  const [query, setQuery] = useState(initialQuery)
   const [matches, setMatches] = useState<FileMatch[]>([])
   const [active, setActive] = useState(0)
   const [error, setError] = useState<string | null>(null)
@@ -95,7 +109,21 @@ export function QuickOpen({ hostId, root, onOpen, onClose }: Props): JSX.Element
               <span className="quick-dir">{dirOf(match.rel)}</span>
             </button>
           ))}
-          {!error && matches.length === 0 && <p className="empty-note">No matching file.</p>}
+          {!error && matches.length === 0 && (
+            <>
+              <p className="empty-note">No matching file under {root}.</p>
+              {onPickRoot && (
+                <RootSuggestions
+                  root={root}
+                  worktrees={worktrees}
+                  onPick={(path) => {
+                    onPickRoot(path)
+                    setActive(0)
+                  }}
+                />
+              )}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/renderer/components/root-picker.tsx
+++ b/desktop/src/renderer/components/root-picker.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { api } from '../bridge.ts'
+import { matchesWorktree, timeAgo, type FileEntry, type Worktree } from '../../shared/models.ts'
+
+interface Props {
+  hostId: string
+  /** The folder the tree is rooted at now. */
+  root: string
+  worktrees: Worktree[]
+  onPick: (path: string) => void
+  onClose: () => void
+}
+
+interface Row {
+  path: string
+  label: string
+  note: string
+}
+
+/** Long enough that a fast typist makes one request, short enough to feel live. */
+const DEBOUNCE_MS = 90
+
+/**
+ * Chooses what the Files panel is rooted at: one of the repository's worktrees,
+ * or any directory on the host. Typing a path browses it — an agent's work is
+ * not always inside a worktree, and neither is what the user wants to read.
+ */
+export function RootPicker({ hostId, root, worktrees, onPick, onClose }: Props): JSX.Element {
+  const [query, setQuery] = useState('')
+  const [dirs, setDirs] = useState<FileEntry[]>([])
+  const [active, setActive] = useState(0)
+  const list = useRef<HTMLDivElement | null>(null)
+
+  // An absolute query is a path being typed: list its parent so the folders
+  // under it complete. Anything else filters what is already in view.
+  const typedPath = query.startsWith('/')
+  const browseDir = typedPath ? parentOf(query) : root
+  const needle = (typedPath ? basename(query) : query).toLowerCase()
+
+  useEffect(() => {
+    let cancelled = false
+    const timer = setTimeout(() => {
+      api(hostId)
+        .listFiles(browseDir)
+        .then((result) => {
+          if (!cancelled) setDirs(result.entries.filter((entry) => entry.is_dir))
+        })
+        .catch(() => {
+          if (!cancelled) setDirs([])
+        })
+    }, DEBOUNCE_MS)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [hostId, browseDir])
+
+  const rows = useMemo<Row[]>(() => {
+    const collected: Row[] = []
+    const seen = new Set<string>()
+    const add = (row: Row): void => {
+      if (row.path === root || seen.has(row.path)) return
+      seen.add(row.path)
+      collected.push(row)
+    }
+
+    if (!typedPath) {
+      for (const worktree of worktrees) {
+        if (!matchesWorktree(worktree, query)) continue
+        add({
+          path: worktree.path,
+          label: worktree.branch || '(detached)',
+          note: worktree.date ? `${tail(worktree.path)} · ${timeAgo(worktree.date)}` : tail(worktree.path),
+        })
+      }
+      const parent = parentOf(root)
+      if (parent !== root && basename(parent).toLowerCase().includes(needle)) {
+        add({ path: parent, label: '..', note: parent })
+      }
+    }
+
+    for (const entry of dirs) {
+      if (!entry.name.toLowerCase().includes(needle)) continue
+      add({ path: entry.path, label: entry.name, note: browseDir })
+    }
+
+    // A path that exists but is not listed — a sibling of the browse directory,
+    // or one typed in full — is still a directory the user meant.
+    if (typedPath && !seen.has(query)) {
+      collected.push({ path: query, label: query, note: 'Use this path' })
+    }
+    return collected
+  }, [worktrees, dirs, query, needle, typedPath, browseDir, root])
+
+  useEffect(() => {
+    setActive(0)
+  }, [query])
+
+  useEffect(() => {
+    list.current?.querySelector('.active')?.scrollIntoView({ block: 'nearest' })
+  }, [active])
+
+  const keys = (event: React.KeyboardEvent): void => {
+    if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
+      event.preventDefault()
+      setActive((i) => Math.min(i + 1, rows.length - 1))
+    } else if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
+      event.preventDefault()
+      setActive((i) => Math.max(i - 1, 0))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const row = rows[active]
+      if (row) {
+        onPick(row.path)
+        onClose()
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+    }
+  }
+
+  return (
+    <div className="quick-backdrop" onMouseDown={onClose}>
+      <div className="quick" onMouseDown={(event) => event.stopPropagation()}>
+        <input
+          autoFocus
+          className="quick-input"
+          placeholder="Search worktrees, or type a folder path…"
+          spellCheck={false}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={keys}
+        />
+        <div className="quick-list" ref={list}>
+          {rows.map((row, index) => (
+            <button
+              key={row.path}
+              className={`quick-row ${index === active ? 'active' : ''}`}
+              onMouseEnter={() => setActive(index)}
+              onClick={() => {
+                onPick(row.path)
+                onClose()
+              }}
+            >
+              <span className="quick-name">{row.label}</span>
+              <span className="quick-dir">{row.note}</span>
+            </button>
+          ))}
+          {rows.length === 0 && <p className="empty-note">No folder matches.</p>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Where else the thing being looked for might be. A search that found nothing
+ * is usually pointed one directory too deep, or at the wrong checkout of a
+ * repository several agents are working in at once.
+ */
+export function RootSuggestions({
+  root,
+  worktrees,
+  onPick,
+}: {
+  root: string
+  worktrees: Worktree[]
+  onPick: (path: string) => void
+}): JSX.Element | null {
+  const parent = parentOf(root)
+  const elsewhere = worktrees.filter((worktree) => worktree.path !== root).slice(0, SUGGESTED_WORKTREES)
+  if (parent === root && elsewhere.length === 0) return null
+
+  return (
+    <div className="root-hints">
+      <span className="root-hint-label">Search in</span>
+      {parent !== root && (
+        <button className="pill" title={parent} onClick={() => onPick(parent)}>
+          ↑ {basename(parent)}
+        </button>
+      )}
+      {elsewhere.map((worktree) => (
+        <button key={worktree.path} className="pill" title={worktree.path} onClick={() => onPick(worktree.path)}>
+          {worktree.branch || tail(worktree.path)}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** Enough to cover the agents in flight without becoming a second list. */
+const SUGGESTED_WORKTREES = 4
+
+function parentOf(path: string): string {
+  const cut = path.replace(/\/+$/, '').lastIndexOf('/')
+  return cut <= 0 ? '/' : path.slice(0, cut)
+}
+
+function basename(path: string): string {
+  return path.split('/').filter(Boolean).pop() ?? path
+}
+
+/** The last two segments: the parent directory is what distinguishes them. */
+function tail(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts.length <= 2 ? path : `…/${parts.slice(-2).join('/')}`
+}

--- a/desktop/src/renderer/components/worktrees.tsx
+++ b/desktop/src/renderer/components/worktrees.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { api } from '../bridge.ts'
-import type { Worktree } from '../../shared/models.ts'
+import { byLastTouched, matchesWorktree, timeAgo, type Worktree } from '../../shared/models.ts'
 
 interface Props {
   hostId: string
@@ -19,6 +19,7 @@ interface Props {
 export function WorktreesView({ hostId, cwd, active, onPick }: Props): JSX.Element {
   const [worktrees, setWorktrees] = useState<Worktree[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     let cancelled = false
@@ -26,7 +27,7 @@ export function WorktreesView({ hostId, cwd, active, onPick }: Props): JSX.Eleme
     api(hostId)
       .gitWorktrees(cwd)
       .then((result) => {
-        if (!cancelled) setWorktrees(result)
+        if (!cancelled) setWorktrees(byLastTouched(result))
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err))
@@ -36,13 +37,26 @@ export function WorktreesView({ hostId, cwd, active, onPick }: Props): JSX.Eleme
     }
   }, [hostId, cwd])
 
+  const matches = useMemo(
+    () => (worktrees ?? []).filter((worktree) => matchesWorktree(worktree, query)),
+    [worktrees, query],
+  )
+
   if (error) return <p className="empty-note">{error}</p>
   if (!worktrees) return <p className="empty-note">Loading…</p>
   if (worktrees.length === 0) return <p className="empty-note">No worktrees.</p>
 
   return (
     <div className="worktrees">
-      {worktrees.map((worktree) => (
+      <input
+        className="worktree-search"
+        type="search"
+        placeholder="Search branch, path or subject"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+      />
+      {matches.length === 0 && <p className="empty-note">No worktree matches “{query}”.</p>}
+      {matches.map((worktree) => (
         <button
           key={worktree.path}
           className={`worktree ${worktree.path === active ? 'selected' : ''}`}
@@ -75,6 +89,7 @@ export function WorktreesView({ hostId, cwd, active, onPick }: Props): JSX.Eleme
           <span className="worktree-path">
             <span className="commit-sha">{worktree.head}</span>
             {tail(worktree.path)}
+            {worktree.date && <span>{timeAgo(worktree.date)}</span>}
           </span>
         </button>
       ))}

--- a/desktop/src/renderer/markdown.ts
+++ b/desktop/src/renderer/markdown.ts
@@ -199,6 +199,8 @@ export interface MarkdownBlock {
   /** 1-based and inclusive, so a block reads as `L12-18` of the file. */
   startLine: number
   endLine: number
+  /** Heading level, which is what a document folds along. */
+  depth?: number
 }
 
 /**
@@ -217,7 +219,12 @@ export function renderMarkdownBlocks(source: string): MarkdownBlock[] {
     // Blank lines between blocks belong to neither, and have nothing to render.
     if (token.type === 'space') continue
     const html = DOMPurify.sanitize(marked.parser([token], { async: false }), { ADD_ATTR: ['target'] })
-    blocks.push({ html, startLine, endLine: Math.max(startLine, startLine + newlines - 1) })
+    blocks.push({
+      html,
+      startLine,
+      endLine: Math.max(startLine, startLine + newlines - 1),
+      ...(token.type === 'heading' ? { depth: token.depth } : {}),
+    })
   }
   return blocks
 }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -45,6 +45,8 @@ export interface FileTarget {
   hostId: string
   path: string
   seq: number
+  /** 'find' searches the panel's root for the name instead of opening the path. */
+  mode: 'open' | 'find'
 }
 
 /**
@@ -268,7 +270,19 @@ class Store {
   openFile(hostId: string, path: string): void {
     this.set((s) => ({
       panel: 'files',
-      fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1 },
+      fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open' },
+    }))
+  }
+
+  /**
+   * Looks a file name up in the Files panel. The transcript's path belongs to
+   * the checkout the agent ran in, which is not always the one being browsed —
+   * searching by name finds it wherever the panel is currently rooted.
+   */
+  findFile(hostId: string, path: string): void {
+    this.set((s) => ({
+      panel: 'files',
+      fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'find' },
     }))
   }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1211,8 +1211,7 @@ small {
 .file-chip {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 3px 10px;
+  padding: 2px 4px 2px 8px;
   border-radius: 999px;
   border: 1px solid var(--outline-variant);
   background: transparent;
@@ -1223,9 +1222,41 @@ small {
 }
 
 .file-chip:hover {
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
   border-color: var(--primary);
   color: var(--primary);
+}
+
+.file-chip-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 4px 1px 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.file-chip-act {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.file-chip-open:hover,
+.file-chip-act:hover {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+  color: var(--primary);
+}
+
+.file-chip-open:hover {
+  border-radius: 999px;
+  padding-left: 6px;
+  margin-left: -6px;
 }
 
 .file-chip-icon {
@@ -1753,6 +1784,31 @@ small {
   background: color-mix(in srgb, var(--primary) 16%, transparent);
 }
 
+.md-block.md-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.md-block-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.md-fold {
+  flex: none;
+  width: 16px;
+  padding: 0;
+  background: transparent;
+  color: var(--on-surface-variant);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.md-fold:hover {
+  color: var(--primary);
+}
+
 .line-menu {
   position: fixed;
   z-index: 40;
@@ -1853,6 +1909,85 @@ small {
   margin-left: auto;
 }
 
+.ws-root {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px 0;
+}
+
+.ws-crumbs {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.ws-crumbs::-webkit-scrollbar {
+  display: none;
+}
+
+.ws-crumb {
+  flex: none;
+  padding: 2px 4px;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  font-weight: 400;
+}
+
+.ws-crumb::after {
+  content: '/';
+  margin-left: 4px;
+  color: var(--outline);
+}
+
+.ws-crumb:first-child::after,
+.ws-crumb.here::after {
+  content: '';
+  margin-left: 0;
+}
+
+.ws-crumb.here {
+  color: var(--on-surface);
+  font-weight: 600;
+}
+
+.ws-crumb:hover {
+  background: color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.ws-root-more {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--on-surface-variant);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.ws-root-more:hover {
+  background: color-mix(in srgb, var(--on-surface) 10%, transparent);
+  color: var(--primary);
+}
+
+/* The workspace's glyph buttons are the panel's controls, not decorations on a
+   message, so they carry the size the transcript's cannot afford. */
+.ws-side-head .icon-btn.tiny,
+.ws-file-head .icon-btn.tiny {
+  min-width: 30px;
+  height: 30px;
+  font-size: 18px;
+}
+
 .tree {
   flex: 1;
   overflow: auto;
@@ -1882,9 +2017,9 @@ small {
 }
 
 .tree-twist {
-  width: 10px;
+  width: 12px;
   flex: none;
-  font-size: 9px;
+  font-size: 11px;
   color: var(--on-surface-variant);
 }
 
@@ -1924,11 +2059,11 @@ small {
 }
 
 .find-toggle {
-  width: 26px;
-  height: 26px;
+  width: 30px;
+  height: 30px;
   padding: 0;
   border-radius: var(--r-sm);
-  font-size: 11px;
+  font-size: 13px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: var(--on-surface-variant);
 }
@@ -2114,6 +2249,28 @@ small {
   border-radius: 0;
   background: var(--surface-high);
   font-size: 13px;
+}
+
+.root-hints {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px 10px;
+}
+
+.root-hint-label {
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+.root-hints .pill {
+  cursor: pointer;
+}
+
+.root-hints .pill:hover {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+  color: var(--primary);
 }
 
 .quick-list {
@@ -2635,6 +2792,12 @@ hr {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.worktree-search {
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 12px;
 }
 
 .worktree {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -239,6 +239,8 @@ export interface Worktree {
   is_main: boolean
   head?: string
   subject?: string
+  /** ISO-8601 date of the last commit — what "last touched" orders by. */
+  date?: string
   detached: boolean
   locked: boolean
   ahead: number
@@ -247,6 +249,36 @@ export interface Worktree {
   dirty: number
   /** What ahead and behind were measured against. */
   base?: string
+}
+
+/**
+ * Most recently committed first. Worktrees with no date — pruned, or past the
+ * detail cap the daemon enforces — keep their listing order at the end.
+ */
+export function byLastTouched(worktrees: Worktree[]): Worktree[] {
+  return worktrees
+    .map((worktree, index) => ({ worktree, index }))
+    .sort((a, b) => {
+      const da = Date.parse(a.worktree.date ?? '')
+      const db = Date.parse(b.worktree.date ?? '')
+      if (Number.isNaN(da) || Number.isNaN(db)) {
+        if (Number.isNaN(da) && Number.isNaN(db)) return a.index - b.index
+        return Number.isNaN(da) ? 1 : -1
+      }
+      return db - da || a.index - b.index
+    })
+    .map((entry) => entry.worktree)
+}
+
+/** Matches a worktree on branch, path or last commit subject. */
+export function matchesWorktree(worktree: Worktree, query: string): boolean {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return true
+  return (
+    worktree.branch.toLowerCase().includes(needle) ||
+    worktree.path.toLowerCase().includes(needle) ||
+    (worktree.subject ?? '').toLowerCase().includes(needle)
+  )
 }
 
 /** internal/server/githistory.go:35 */

--- a/internal/server/git.go
+++ b/internal/server/git.go
@@ -201,6 +201,7 @@ type worktreeEntry struct {
 	// to tell several parallel agents apart at a glance.
 	Head     string `json:"head,omitempty"`
 	Subject  string `json:"subject,omitempty"`
+	Date     string `json:"date,omitempty"`
 	Detached bool   `json:"detached"`
 	Locked   bool   `json:"locked"`
 	Ahead    int    `json:"ahead"`
@@ -241,8 +242,10 @@ func (s *PublicServer) handleGitWorktrees(w http.ResponseWriter, r *http.Request
 // describeWorktree fills in branch state. A worktree whose directory has been
 // deleted but not pruned answers nothing, and is left as the porcelain had it.
 func describeWorktree(entry *worktreeEntry) {
-	if out, err := gitCmd(entry.Path, "log", "-1", "--format=%s"); err == nil {
-		entry.Subject = strings.TrimSpace(out)
+	if out, err := gitCmd(entry.Path, "log", "-1", "--format=%cI%n%s"); err == nil {
+		date, subject, _ := strings.Cut(strings.TrimSpace(out), "\n")
+		entry.Date = strings.TrimSpace(date)
+		entry.Subject = strings.TrimSpace(subject)
 	}
 	if out, err := gitCmd(entry.Path, "status", "--porcelain"); err == nil {
 		entry.Dirty = countLines(out)

--- a/mobile/lib/screens/file_browser_screen.dart
+++ b/mobile/lib/screens/file_browser_screen.dart
@@ -31,6 +31,7 @@ class FileBrowserScreen extends StatefulWidget {
 
 class _FileBrowserScreenState extends State<FileBrowserScreen> {
   late String _currentPath;
+  late String _rootPath;
   final List<String> _history = [];
   FileListing? _listing;
   bool _loading = true;
@@ -40,6 +41,7 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
   void initState() {
     super.initState();
     _currentPath = widget.rootPath;
+    _rootPath = widget.rootPath;
     _load(_currentPath);
   }
 
@@ -91,6 +93,75 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
     _load(path);
   }
 
+  /// Re-roots the browser on another worktree of the same repository. History is
+  /// dropped: the paths in it belong to the worktree being left behind.
+  Future<void> _pickRoot() async {
+    final svc = _svc;
+    if (svc == null) return;
+    final worktrees = sortWorktreesByLastTouched(await svc.gitWorktrees(_currentPath));
+    if (!mounted) return;
+    if (worktrees.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('No worktrees here'),
+          duration: Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+    final picked = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return SafeArea(
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  'Root folder',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1.2,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+              ...worktrees.map((wt) {
+                final selected = wt.path == _rootPath;
+                return ListTile(
+                  leading: Icon(
+                    selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                    size: 22,
+                    color: selected ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+                  ),
+                  title: Text(
+                    wt.branch.isEmpty ? '(detached)' : wt.branch,
+                    style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    wt.date.isEmpty ? wt.shortPath : '${wt.shortPath} · ${wt.timeAgo}',
+                    style: const TextStyle(fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onTap: () => Navigator.of(ctx).pop(wt.path),
+                );
+              }),
+            ],
+          ),
+        );
+      },
+    );
+    if (picked == null || !mounted) return;
+    _history.clear();
+    setState(() => _rootPath = picked);
+    _load(picked);
+  }
+
   bool _onBack() {
     if (_history.isNotEmpty) {
       final prev = _history.removeLast();
@@ -136,6 +207,11 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
           title: const Text('Files'),
           actions: [
             IconButton(
+              icon: const Icon(Icons.account_tree_outlined),
+              tooltip: 'Change root folder',
+              onPressed: _pickRoot,
+            ),
+            IconButton(
               icon: const Icon(Icons.chat_bubble_outline),
               tooltip: 'Back to chat',
               onPressed: () => Navigator.of(context).popUntil(
@@ -155,7 +231,7 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 2),
                   child: Icon(
                     Icons.chevron_right,
-                    size: 16,
+                    size: 20,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
@@ -243,6 +319,7 @@ class _EntryTile extends StatelessWidget {
     return ListTile(
       leading: Icon(
         entry.isDir ? Icons.folder : _iconForFile(entry.name),
+        size: 28,
         color: entry.isDir ? Colors.amber.shade700 : theme.colorScheme.onSurfaceVariant,
       ),
       title: Text(
@@ -250,7 +327,7 @@ class _EntryTile extends StatelessWidget {
         style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
       ),
       trailing: entry.isDir
-          ? Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant)
+          ? Icon(Icons.chevron_right, size: 24, color: theme.colorScheme.onSurfaceVariant)
           : Text(
               entry.formattedSize,
               style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
@@ -466,7 +543,7 @@ class _FileViewerScreenState extends State<FileViewerScreen> {
       ),
       child: Row(
         children: [
-          Icon(Icons.code, size: 16, color: accentColor),
+          Icon(Icons.code, size: 20, color: accentColor),
           const SizedBox(width: 6),
           if (_hasSelection) ...[
             Text(
@@ -476,7 +553,7 @@ class _FileViewerScreenState extends State<FileViewerScreen> {
             const SizedBox(width: 8),
             GestureDetector(
               onTap: () => setState(() { _selStart = null; _selEnd = null; }),
-              child: Icon(Icons.close, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              child: Icon(Icons.close, size: 18, color: theme.colorScheme.onSurfaceVariant),
             ),
           ] else
             Text(
@@ -486,7 +563,7 @@ class _FileViewerScreenState extends State<FileViewerScreen> {
           const Spacer(),
           FilledButton.tonalIcon(
             onPressed: () => _showAskAISheet(theme),
-            icon: const Icon(Icons.auto_awesome, size: 16),
+            icon: const Icon(Icons.auto_awesome, size: 18),
             label: const Text('Ask AI', style: TextStyle(fontSize: 12)),
             style: FilledButton.styleFrom(
               visualDensity: VisualDensity.compact,
@@ -518,7 +595,7 @@ class _FileViewerScreenState extends State<FileViewerScreen> {
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.insert_drive_file, size: 16, color: accentColor),
+                      Icon(Icons.insert_drive_file, size: 20, color: accentColor),
                       const SizedBox(width: 6),
                       Flexible(
                         child: Text(

--- a/mobile/lib/screens/git_status_screen.dart
+++ b/mobile/lib/screens/git_status_screen.dart
@@ -1021,6 +1021,8 @@ class _WorktreesTab extends StatefulWidget {
 
 class _WorktreesTabState extends State<_WorktreesTab> {
   List<Worktree>? _worktrees;
+  final _searchController = TextEditingController();
+  String _query = '';
 
   @override
   void initState() {
@@ -1028,11 +1030,17 @@ class _WorktreesTabState extends State<_WorktreesTab> {
     _load();
   }
 
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
   Future<void> _load() async {
     final svc = context.read<HostManager>().serviceFor(widget.hostId);
-    final worktrees = await svc?.gitWorktrees(widget.root);
+    final worktrees = await svc?.gitWorktrees(widget.root) ?? [];
     if (!mounted) return;
-    setState(() => _worktrees = worktrees ?? []);
+    setState(() => _worktrees = sortWorktreesByLastTouched(worktrees));
   }
 
   @override
@@ -1045,18 +1053,69 @@ class _WorktreesTabState extends State<_WorktreesTab> {
         child: Text('No worktrees', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
       );
     }
-    return RefreshIndicator(
-      onRefresh: _load,
-      child: ListView.builder(
-        itemCount: worktrees.length,
-        itemBuilder: (ctx, i) => _WorktreeTile(
-          worktree: worktrees[i],
-          selected: worktrees[i].path == widget.active,
-          onTap: () => widget.onPick(worktrees[i].path),
+    final matches = filterWorktrees(worktrees, _query);
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (v) => setState(() => _query = v),
+            style: const TextStyle(fontSize: 13),
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: 'Search branch, path or subject',
+              hintStyle: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              prefixIcon: const Icon(Icons.search, size: 18),
+              prefixIconConstraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+              suffixIcon: _query.isEmpty
+                  ? null
+                  : IconButton(
+                      icon: const Icon(Icons.close, size: 18),
+                      onPressed: () {
+                        _searchController.clear();
+                        setState(() => _query = '');
+                      },
+                    ),
+              border: const OutlineInputBorder(),
+              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            ),
+          ),
         ),
-      ),
+        Expanded(
+          child: matches.isEmpty
+              ? Center(
+                  child: Text(
+                    'No worktree matches "$_query"',
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  child: ListView.builder(
+                    itemCount: matches.length,
+                    itemBuilder: (ctx, i) => _WorktreeTile(
+                      worktree: matches[i],
+                      selected: matches[i].path == widget.active,
+                      onTap: () => widget.onPick(matches[i].path),
+                    ),
+                  ),
+                ),
+        ),
+      ],
     );
   }
+}
+
+List<Worktree> filterWorktrees(List<Worktree> worktrees, String query) {
+  final needle = query.trim().toLowerCase();
+  if (needle.isEmpty) return worktrees;
+  return worktrees
+      .where((w) =>
+          w.branch.toLowerCase().contains(needle) ||
+          w.path.toLowerCase().contains(needle) ||
+          w.subject.toLowerCase().contains(needle))
+      .toList();
 }
 
 class _WorktreeTile extends StatelessWidget {
@@ -1122,7 +1181,9 @@ class _WorktreeTile extends StatelessWidget {
             ],
             const SizedBox(height: 2),
             Text(
-              '${worktree.head} ${_shortPath(worktree.path)}',
+              worktree.date.isEmpty
+                  ? '${worktree.head} ${_shortPath(worktree.path)}'
+                  : '${worktree.head} ${_shortPath(worktree.path)} · ${worktree.timeAgo}',
               style: TextStyle(
                 fontSize: 11,
                 fontFamily: 'monospace',

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -1413,6 +1413,9 @@ class Worktree {
   final bool isMain;
   final String head;
   final String subject;
+
+  /// ISO-8601 date of the last commit — what "last touched" is ordered by.
+  final String date;
   final bool detached;
   final bool locked;
   final int ahead;
@@ -1430,6 +1433,7 @@ class Worktree {
     required this.isMain,
     this.head = '',
     this.subject = '',
+    this.date = '',
     this.detached = false,
     this.locked = false,
     this.ahead = 0,
@@ -1445,6 +1449,7 @@ class Worktree {
       isMain: json['is_main'] as bool? ?? false,
       head: json['head'] as String? ?? '',
       subject: json['subject'] as String? ?? '',
+      date: json['date'] as String? ?? '',
       detached: json['detached'] as bool? ?? false,
       locked: json['locked'] as bool? ?? false,
       ahead: json['ahead'] as int? ?? 0,
@@ -1459,4 +1464,24 @@ class Worktree {
     if (parts.length <= 3) return path;
     return '.../${parts.sublist(parts.length - 2).join('/')}';
   }
+
+  String get timeAgo => _timeAgo(date);
+}
+
+/// Most recently committed first. Worktrees with no date — pruned, or past the
+/// detail cap the daemon enforces — keep their listing order at the end.
+List<Worktree> sortWorktreesByLastTouched(List<Worktree> worktrees) {
+  final order = {for (var i = 0; i < worktrees.length; i++) worktrees[i].path: i};
+  final sorted = [...worktrees];
+  sorted.sort((a, b) {
+    final da = DateTime.tryParse(a.date)?.toUtc();
+    final db = DateTime.tryParse(b.date)?.toUtc();
+    if (da == null || db == null) {
+      if (da == db) return order[a.path]!.compareTo(order[b.path]!);
+      return da == null ? 1 : -1;
+    }
+    final byDate = db.compareTo(da);
+    return byDate != 0 ? byDate : order[a.path]!.compareTo(order[b.path]!);
+  });
+  return sorted;
 }


### PR DESCRIPTION
## Summary
- Worktrees are ordered by last commit and searchable by branch, path or subject, on both the desktop app and the Flutter client. The daemon now returns each worktree's last commit date.
- The desktop Files panel can be rooted at any worktree or folder: breadcrumb segments re-root, a searchable picker takes a worktree or a typed path, and empty searches suggest the parent folder or a sibling worktree.
- Open tabs, the active tab and the chosen root persist per session in localStorage, so switching sessions no longer loses the workspace.
- Transcript file chips search by name (the path belongs to the agent's checkout), with explicit open and copy actions beside it.
- Markdown previews fold by heading; Files-panel icons sized up on both clients.

## Test plan
- [ ] `make test` and `cd desktop && npm run typecheck && npm test`
- [ ] Reinstall the daemon (`make install`) so `/api/git/worktrees` returns `date`
- [ ] Worktrees tab: search filters, list is newest-first, each row shows a relative time
- [ ] Files panel: breadcrumb re-roots, picker finds worktrees by branch and accepts a typed path, empty search offers parent/worktree
- [ ] Switch sessions and restart the app: tabs, active tab and root come back
- [ ] Chip click searches, ↗ opens, ⧉ copies; markdown heading folds