### PR TITLE
feat(desktop): disconnect a terminal without ending it

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -141,18 +141,32 @@ export function Detail(): JSX.Element {
                 {PANEL_LABELS[name]}
                 {name === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
                 {name === 'terminal' && term && (
-                  <span
-                    className="tab-close"
-                    role="button"
-                    aria-label="Reconnect"
-                    title="Reconnect — the agent keeps running"
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      void store.reconnectTab(term.id)
-                    }}
-                  >
-                    ⟳
-                  </span>
+                  <>
+                    <span
+                      className="tab-close reload"
+                      role="button"
+                      aria-label="Reconnect"
+                      title="Reconnect — the agent keeps running"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        void store.reconnectTab(term.id)
+                      }}
+                    >
+                      ⟳
+                    </span>
+                    <span
+                      className="tab-close"
+                      role="button"
+                      aria-label="Disconnect"
+                      title="Disconnect — the agent keeps running"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        store.disconnectTab(term.id)
+                      }}
+                    >
+                      ⏻
+                    </span>
+                  </>
                 )}
               </button>
             ))}

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -65,14 +65,16 @@ export function TerminalPanes({
   // that does not name one.
   const selected = activeTab ? tabs.find((t) => t.id === activeTab) : undefined
   const current = selected?.sessionId === session?.session_id ? selected : agent
+  const detached = useStore((s) => s.detached)
+  const isDetached = Boolean(hostId && session && detached.includes(terminalId(hostId, session.session_id)))
 
   useEffect(() => {
-    if (!visible || agent || !hostId || !session) return
+    if (!visible || agent || isDetached || !hostId || !session) return
     // Warm sessions attach as soon as the panel is shown: the host is already
     // running, so opening the tab is the whole of the request. A cold one waits
     // for the button below, because attaching would start an agent.
     if (hasTerminal(session)) void store.openTerminal(hostId, session, false)
-  }, [visible, agent, hostId, session])
+  }, [visible, agent, isDetached, hostId, session])
 
   return (
     <div className={visible ? 'panes' : 'panes hidden'}>
@@ -89,7 +91,9 @@ export function TerminalPanes({
           <p>
             {canResume(session)
               ? 'Session terminated — resume to bring the agent back.'
-              : 'No terminal attached to this session.'}
+              : isDetached
+                ? 'Disconnected — the agent kept running.'
+                : 'No terminal attached to this session.'}
           </p>
           {canResume(session) ? (
             <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
@@ -208,6 +212,16 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     if (term.cols === hostCols && term.rows === hostRows) return
     term.resize(hostCols, hostRows)
   }, [hostCols, hostRows])
+
+  // The snapshot a host replays on attach can leave the viewport wherever the
+  // scrollback happened to land. What the reader wants after reconnecting is
+  // the live end of the session, so go there once the connection is up.
+  const live = tab.status.state === 'live'
+  useEffect(() => {
+    if (!live) return
+    const timer = setTimeout(() => termRef.current?.scrollToBottom(), 0)
+    return () => clearTimeout(timer)
+  }, [live])
 
   return (
     <div className={`pane ${active ? 'active' : ''}`}>

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -76,6 +76,12 @@ export interface State {
    * one is in front.
    */
   activeTab: string | null
+  /**
+   * Terminals the user disconnected on purpose, by tab id. Without this the
+   * panel would attach again the moment it is shown, and a disconnect would
+   * last exactly as long as the user stayed on another tab.
+   */
+  detached: string[]
   fileTarget: FileTarget | null
   promptDraft: PromptDraft | null
   /** Sidebar filter, matched against title, project and cwd. */
@@ -95,6 +101,7 @@ const initial: State = {
   selection: null,
   panel: 'chat',
   activeTab: null,
+  detached: [],
   fileTarget: null,
   promptDraft: null,
   query: '',
@@ -331,7 +338,12 @@ class Store {
     // The panel belongs to whichever session is selected, so showing one
     // session's terminal means selecting it.
     const id = terminalId(hostId, session.session_id)
-    this.set({ selection: { hostId, sessionId: session.session_id }, panel: 'terminal', activeTab: id })
+    this.set((s) => ({
+      selection: { hostId, sessionId: session.session_id },
+      panel: 'terminal',
+      activeTab: id,
+      detached: s.detached.filter((tabId) => tabId !== id),
+    }))
 
     if (this.state.tabs.some((t) => t.id === id)) return
 
@@ -413,7 +425,10 @@ class Store {
     if (this.state.tabs.some((t) => t.id === id)) return
 
     const tab: Tab = { id, hostId, sessionId, termId, kind: 'shell', title, status: { state: 'connecting' } }
-    this.set((s) => ({ tabs: [...s.tabs, tab] }))
+    this.set((s) => ({
+      tabs: [...s.tabs, tab],
+      detached: s.detached.filter((tabId) => tabId !== id),
+    }))
     try {
       // Abstain until the pane has measured itself; see openTerminal above.
       await bridge.term.open({ tabId: id, hostId, sessionId, cols: 0, rows: 0, terminalId: termId })
@@ -433,6 +448,17 @@ class Store {
     } catch (err) {
       this.fail(err)
     }
+  }
+
+  /**
+   * Lets go of the terminal without touching what is running in it. The host
+   * keeps the PTY and its scrollback, so attaching again picks the session up
+   * where it was — this frees the viewer, not the agent.
+   */
+  disconnectTab(tabId: string): void {
+    if (!this.state.tabs.some((t) => t.id === tabId)) return
+    this.closeTab(tabId)
+    this.set((s) => ({ detached: s.detached.includes(tabId) ? s.detached : [...s.detached, tabId] }))
   }
 
   /**
@@ -485,8 +511,12 @@ class Store {
    * not start an agent process — and the panel offers the wake instead.
    */
   showTerminal(hostId: string, session: Session): void {
-    this.set({ panel: 'terminal', activeTab: terminalId(hostId, session.session_id) })
-    if (this.state.tabs.some((t) => t.id === terminalId(hostId, session.session_id))) return
+    const id = terminalId(hostId, session.session_id)
+    this.set({ panel: 'terminal', activeTab: id })
+    if (this.state.tabs.some((t) => t.id === id)) return
+    // Looking at a terminal that was disconnected on purpose is not a request
+    // to attach again: the panel offers the button for that.
+    if (this.state.detached.includes(id)) return
     if (hasTerminal(session)) void this.openTerminal(hostId, session, false)
   }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2354,6 +2354,13 @@ small {
   background: color-mix(in srgb, var(--on-surface) 12%, transparent);
 }
 
+/* ⟳ draws smaller than the power glyph beside it at the same point size. */
+.tab-close.reload {
+  width: 26px;
+  height: 26px;
+  font-size: 22px;
+}
+
 .panes {
   flex: 1;
   position: relative;


### PR DESCRIPTION
## Summary
- New `⏻` control beside `⟳` on the Terminal tab: drops the viewer connection while the host PTY and the agent keep running.
- A deliberate disconnect is remembered (`store.detached`), so the panel no longer reattaches the moment the tab is shown again; the pane reads "Disconnected — the agent kept running." and offers Attach.
- Reconnecting scrolls to the bottom once the connection is live, instead of leaving the viewport wherever the replayed snapshot landed.
- Sized the reload glyph so it is not dwarfed by the power glyph beside it.

## Test plan
- [ ] `cd desktop && npm run typecheck && npm test`
- [ ] Disconnect the agent terminal, switch panels and come back: it stays disconnected, Attach brings it up
- [ ] Reconnect a busy terminal: the view lands at the newest output
- [ ] Shell tabs still kill on ✕, and a killed shell disappears from the strip