### PR TITLE
fix(mobile): scope the offline banner and reconnect on wake

### DIFF
--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -532,7 +532,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           _subscribeToHost(host.id);
         }
 
-        final offlineHosts = hm.offlineHosts;
+        final offlineHosts = hm.visibleOfflineHosts;
 
         final allNotifications = hm.allNotifications;
         final allSessions = hm.allSessions;

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -208,63 +208,66 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   Widget _buildOfflineHostBanner(HostConnection host) {
     final theme = Theme.of(context);
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    final fg = theme.colorScheme.onErrorContainer;
+    return Material(
       color: theme.colorScheme.errorContainer,
-      child: Row(
-        children: [
-          Icon(Icons.cloud_off, size: 16, color: theme.colorScheme.onErrorContainer),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '"${host.label}" is offline',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onErrorContainer),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              _hm.serviceFor(host.id)?.reconnect();
-            },
-            style: TextButton.styleFrom(
-              visualDensity: VisualDensity.compact,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-            ),
-            child: Text('Retry', style: TextStyle(fontSize: 12, color: theme.colorScheme.onErrorContainer)),
-          ),
-          TextButton(
-            onPressed: () async {
-              final confirmed = await showDialog<bool>(
-                context: context,
-                builder: (ctx) => AlertDialog(
-                  title: const Text('Remove host?'),
-                  content: Text('Remove "${host.label}"? You can re-pair later.'),
-                  actions: [
-                    TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
-                    FilledButton(
-                      onPressed: () => Navigator.pop(ctx, true),
-                      style: FilledButton.styleFrom(backgroundColor: theme.colorScheme.error),
-                      child: const Text('Remove'),
-                    ),
-                  ],
+      child: InkWell(
+        onTap: () => _hm.serviceFor(host.id)?.reconnect(),
+        onLongPress: () => _confirmRemoveHost(host),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
+          child: Row(
+            children: [
+              Icon(Icons.cloud_off, size: 13, color: fg),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '${host.label} offline',
+                  style: TextStyle(fontSize: 11, color: fg),
+                  overflow: TextOverflow.ellipsis,
                 ),
-              );
-              if (confirmed == true && mounted) {
-                await _hm.removeHost(host.id);
-              }
-            },
-            style: TextButton.styleFrom(
-              visualDensity: VisualDensity.compact,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              padding: const EdgeInsets.symmetric(horizontal: 8),
+              ),
+              Text(
+                'Retry',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: fg,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmRemoveHost(HostConnection host) async {
+    final theme = Theme.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove host?'),
+        content: Text('Remove "${host.label}"? You can re-pair later.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: theme.colorScheme.error,
             ),
-            child: Text('Remove', style: TextStyle(fontSize: 12, color: theme.colorScheme.error)),
+            child: const Text('Remove'),
           ),
         ],
       ),
     );
+    if (confirmed == true && mounted) {
+      await _hm.removeHost(host.id);
+    }
   }
 
   void _toggleGlobalVoice() async {

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -14,6 +14,21 @@ import 'notification_service.dart';
 /// Callback fired when an SSE event arrives on this host.
 typedef SSEEventCallback = void Function(String hostId, SSEEvent event);
 
+/// How long a connected stream may stay silent before it is presumed dead.
+/// The daemon heartbeats every 30s, so this is two missed beats plus slack.
+const streamSilenceThreshold = Duration(seconds: 75);
+
+/// Whether a stream that still reports itself connected has gone silent for
+/// long enough to be presumed dead.
+///
+/// A phone that sleeps through a network change is left holding a half-open
+/// socket: the read never errors, so nothing else notices the stream is gone.
+/// Silence measured against the daemon's heartbeat is the only signal there is.
+bool isStreamStale(DateTime? lastBytesAt, DateTime now) {
+  if (lastBytesAt == null) return false;
+  return now.difference(lastBytesAt) > streamSilenceThreshold;
+}
+
 class DaemonAPIService extends ChangeNotifier {
   final String hostId;
   final String serverUrl;
@@ -24,11 +39,19 @@ class DaemonAPIService extends ChangeNotifier {
   Timer? _pollTimer;
   Timer? _sessionDebounce;
   Timer? _notificationDebounce;
+  Timer? _watchdogTimer;
   bool _running = false;
   bool _connected = false;
   bool _isActiveHost = false;
   int _consecutiveFailures = 0;
   static const _offlineThreshold = 2;
+  static const _watchdogInterval = Duration(seconds: 30);
+
+  /// When the stream last delivered bytes, heartbeats included.
+  DateTime? _lastBytesAt;
+
+  /// Bumped per connect attempt so a superseded one cannot clobber the live one.
+  int _connectGeneration = 0;
 
   List<HeliosNotification> _notifications = [];
   List<HeliosNotification> get notifications => _notifications;
@@ -36,6 +59,10 @@ class DaemonAPIService extends ChangeNotifier {
   List<Session> get sessions => _sessions;
   bool get connected => _connected;
   bool get isOffline => _consecutiveFailures >= _offlineThreshold;
+
+  /// Connected in name only: the socket is open but the daemon has gone quiet
+  /// past the heartbeat window.
+  bool get stale => _connected && isStreamStale(_lastBytesAt, DateTime.now());
 
   bool _notificationsLoaded = false;
   bool get notificationsLoaded => _notificationsLoaded;
@@ -84,6 +111,7 @@ class DaemonAPIService extends ChangeNotifier {
     if (_running) return;
     _running = true;
     _isActiveHost = true;
+    _startWatchdog();
     await _loadSessionCache();
     _connect(); // fire-and-forget — SSE runs in background
   }
@@ -93,7 +121,45 @@ class DaemonAPIService extends ChangeNotifier {
     if (_running) return;
     _running = true;
     _isActiveHost = false;
+    _startWatchdog();
     _connect(); // fire-and-forget — SSE runs in background
+  }
+
+  /// Re-establish the event stream after the app was suspended.
+  ///
+  /// [startActive] and [startBackground] cannot do this: both return early
+  /// while `_running` is set, and it stays set across a pause because the
+  /// stream is deliberately kept alive for background notifications. So resume
+  /// used to be a no-op on the connection — exactly when the socket is most
+  /// likely to have died unnoticed.
+  Future<void> resume({required bool asActiveHost}) async {
+    if (!_running) {
+      await (asActiveHost ? startActive() : startBackground());
+      return;
+    }
+
+    _isActiveHost = asActiveHost;
+    if (asActiveHost) await _loadSessionCache();
+
+    // Timers do not fire while the process is suspended, so the watchdog and
+    // any pending backoff came back late or not at all.
+    _startWatchdog();
+
+    // A brief screen-off leaves a healthy stream; rebuilding it would cost a
+    // reconnect and a refetch for nothing.
+    if (_connected && !stale) return;
+
+    reconnect();
+  }
+
+  /// Catches a stream that died without ever erroring.
+  void _startWatchdog() {
+    _watchdogTimer?.cancel();
+    _watchdogTimer = Timer.periodic(_watchdogInterval, (_) {
+      if (!_running || !stale) return;
+      debugPrint('[$hostId] stream silent past the heartbeat window');
+      reconnect();
+    });
   }
 
   /// Promote from background to active (fetch data, start polling if SSE is down).
@@ -128,12 +194,15 @@ class DaemonAPIService extends ChangeNotifier {
     _connected = false;
     _isActiveHost = false;
     _consecutiveFailures = 0;
+    _lastBytesAt = null;
     _client?.close();
     _client = null;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _pollTimer?.cancel();
     _pollTimer = null;
+    _watchdogTimer?.cancel();
+    _watchdogTimer = null;
     _sessionDebounce?.cancel();
     _sessionDebounce = null;
     _notificationDebounce?.cancel();
@@ -182,8 +251,15 @@ class DaemonAPIService extends ChangeNotifier {
   Future<void> _connect() async {
     if (!_running) return;
 
+    // Every attempt supersedes the one before it. A superseded attempt unwinds
+    // once its client is closed, and without this guard its tail would mark the
+    // live connection dead and queue a second, racing reconnect.
+    final generation = ++_connectGeneration;
+    bool superseded() => !_running || generation != _connectGeneration;
+
     _client?.close();
-    _client = http.Client();
+    final client = http.Client();
+    _client = client;
 
     try {
       final request = http.Request('GET', Uri.parse('$serverUrl/api/events'));
@@ -193,7 +269,8 @@ class DaemonAPIService extends ChangeNotifier {
         'Cache-Control': 'no-cache',
       });
 
-      final response = await _client!.send(request);
+      final response = await client.send(request);
+      if (superseded()) return;
 
       if (response.statusCode == 401) {
         debugPrint('[$hostId] SSE auth failed — refreshing token');
@@ -211,6 +288,7 @@ class DaemonAPIService extends ChangeNotifier {
 
       _consecutiveFailures = 0;
       _connected = true;
+      _lastBytesAt = DateTime.now();
       // SSE is healthy — stop fallback polling
       _pollTimer?.cancel();
       _pollTimer = null;
@@ -224,7 +302,10 @@ class DaemonAPIService extends ChangeNotifier {
       String currentEvent = '';
 
       await for (final chunk in response.stream.transform(utf8.decoder)) {
-        if (!_running) break;
+        if (superseded()) return;
+        // Heartbeats count. The daemon sends ": heartbeat" every 30s, and on a
+        // stream carrying no events it is the only proof the socket is alive.
+        _lastBytesAt = DateTime.now();
 
         buffer += chunk;
         final lines = buffer.split('\n');
@@ -243,11 +324,12 @@ class DaemonAPIService extends ChangeNotifier {
         }
       }
     } catch (e) {
-      if (!_running) return;
+      if (superseded()) return;
       debugPrint('[$hostId] SSE error: $e');
       _consecutiveFailures++;
     }
 
+    if (superseded()) return;
     _connected = false;
     // SSE dropped — start fallback polling if this is the active host
     if (_isActiveHost && _pollTimer == null) _startPolling();

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -11,6 +11,21 @@ import '../models/session.dart';
 import 'api_client.dart';
 import 'daemon_api_service.dart';
 
+/// Narrows the offline hosts to the ones the current filter is showing.
+///
+/// Checked out to a single host, the sessions and notifications on screen are
+/// already filtered to it, so a banner about a different host is a red bar —
+/// with a Remove button — about content that is not there. The dimmed dot in
+/// the app bar carries that host's state instead. Pure so the rule can be
+/// tested without standing up services.
+List<HostConnection> offlineHostsForFilter(
+  List<HostConnection> offline,
+  String? activeHostId,
+) {
+  if (activeHostId == null) return offline;
+  return offline.where((h) => h.id == activeHostId).toList();
+}
+
 class HostManager extends ChangeNotifier {
   static const _hostsKey = 'helios_hosts';
   static const _activeHostKey = 'helios_active_host_id';
@@ -65,6 +80,10 @@ class HostManager extends ChangeNotifier {
       return service != null && service.isOffline;
     }).toList();
   }
+
+  /// The offline hosts worth a banner under the current filter.
+  List<HostConnection> get visibleOfflineHosts =>
+      offlineHostsForFilter(offlineHosts, _activeHostId);
 
   /// All sessions from all hosts, merged.
   List<Session> get allSessions =>
@@ -448,12 +467,9 @@ class HostManager extends ChangeNotifier {
       // the ones most likely to have been answered elsewhere while the app was
       // suspended, and the reconcile sweep only runs on fetch.
       service.fetchNotifications();
-      if (host.id == _activeHostId) {
-        service.fetchSessions();
-        await service.startActive();
-      } else {
-        await service.startBackground();
-      }
+      final isActive = host.id == _activeHostId;
+      if (isActive) service.fetchSessions();
+      await service.resume(asActiveHost: isActive);
     }
   }
 

--- a/mobile/test/connection_resilience_test.dart
+++ b/mobile/test/connection_resilience_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:helios/models/host_connection.dart';
+import 'package:helios/services/daemon_api_service.dart';
+import 'package:helios/services/host_manager.dart';
+
+HostConnection host(String id) => HostConnection(
+      id: id,
+      label: id,
+      serverUrl: 'http://$id.local:7655',
+      deviceId: 'device-$id',
+      colorIndex: 0,
+      addedAt: DateTime.utc(2026, 1, 1),
+    );
+
+void main() {
+  group('offlineHostsForFilter', () {
+    final laptop = host('laptop');
+    final desktop = host('desktop');
+
+    test('shows every offline host under the "All Hosts" filter', () {
+      final visible = offlineHostsForFilter([laptop, desktop], null);
+      expect(visible.map((h) => h.id), ['laptop', 'desktop']);
+    });
+
+    // The lists on screen are already filtered to the active host, so a banner
+    // about another host is noise about content that is not there.
+    test('hides other hosts when checked out to one', () {
+      final visible = offlineHostsForFilter([laptop, desktop], 'laptop');
+      expect(visible.map((h) => h.id), ['laptop']);
+    });
+
+    test('shows nothing when the active host is the one that is up', () {
+      expect(offlineHostsForFilter([desktop], 'laptop'), isEmpty);
+    });
+
+    test('shows nothing when no host is offline', () {
+      expect(offlineHostsForFilter([], 'laptop'), isEmpty);
+      expect(offlineHostsForFilter([], null), isEmpty);
+    });
+  });
+
+  group('isStreamStale', () {
+    final now = DateTime.utc(2026, 8, 13, 18, 55);
+
+    bool staleAfter(Duration silence) =>
+        isStreamStale(now.subtract(silence), now);
+
+    test('a stream inside the heartbeat window is alive', () {
+      expect(staleAfter(const Duration(seconds: 29)), isFalse);
+      // One missed heartbeat is not proof of death — the beat is every 30s.
+      expect(staleAfter(const Duration(seconds: 74)), isFalse);
+    });
+
+    test('two missed heartbeats plus slack means dead', () {
+      expect(staleAfter(const Duration(seconds: 76)), isTrue);
+      // A phone that slept for an hour is the case this exists for.
+      expect(staleAfter(const Duration(hours: 1)), isTrue);
+    });
+
+    test('a stream that never delivered bytes is not judged stale', () {
+      expect(isStreamStale(null, now), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Two connection problems, both visible from the home screen.

## The banner ignored the host filter

`HostManager.offlineHosts` returned every offline host regardless of `activeHostId`. Checked out to one host, the sessions and notifications on screen are already filtered to it via `filteredSessions` / `filteredNotifications` — but an offline host B still stacked a red bar, complete with a **Remove** button, above content that had nothing to do with it. Three hosts, three bars pushing the list down.

Banners are now scoped to the active host. The dimmed per-host dot in the app bar (`_buildConnectionDots`) already carries the state of the others, so nothing is lost. Single-host users see no change.

## Resume did nothing to the connection

`resumeAll()` called `startActive()` / `startBackground()`, and both open with `if (_running) return;`. `_running` is always set, because SSE is deliberately kept alive across a pause for background notifications. So resume only ever ran the notification fetch.

That mattered because a sleeping phone usually wakes holding a half-open socket: `await for` on the response stream never errors, so `_connected` stayed `true` and `_consecutiveFailures` stayed `0`. No banner, no fallback polling, no reconnect — a green dot over a stream that was never going to deliver another event. Timers don't fire while suspended either, so the backoff couldn't recover it.

- Track when the stream last delivered bytes, heartbeats included. The daemon beats every 30s (`internal/server/sse.go:76`) and the client was discarding those lines; on a quiet stream they are the only proof the socket is alive.
- `resume()` reconnects when the stream is down or silent past two missed beats, and leaves a healthy one alone — a brief screen-off shouldn't cost a reconnect and a refetch.
- A 30s watchdog applies the same check in the foreground, so a wifi→cellular handoff self-heals instead of waiting for a background/foreground cycle or a manual Retry.

## Race this exposed

`_connect()` closes the old client, and the superseded stream then unwinds through its own tail — clearing `_connected` and queueing a second reconnect on top of the live one. The Retry button had this already. Connect attempts are now numbered, and a superseded one returns without touching shared state.

## Testing

`mobile/test/connection_resilience_test.dart` covers the banner-scoping rule and the staleness threshold, both extracted as pure functions.

⚠️ Flutter isn't installed in the environment I worked in, so I could not run `flutter test` or `flutter analyze` — the Dart changes are unverified by a compiler. `go build ./...` passes (no Go changes). Worth a local `flutter test` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)