### PR TITLE
fix(mobile): move the offline host banner below the session list

### DIFF
--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -582,7 +582,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           body: Column(
             children: [
               if (_notifPermissionDenied) _buildNotifPermissionBanner(),
-              ...offlineHosts.map((h) => _buildOfflineHostBanner(h)),
               Expanded(
                 child: IndexedStack(
                   index: _currentIndex,
@@ -592,6 +591,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   ],
                 ),
               ),
+              ...offlineHosts.map((h) => _buildOfflineHostBanner(h)),
             ],
           ),
           floatingActionButton: _currentIndex == 0


### PR DESCRIPTION
The offline banner sat above the session list, so a host dropping shoved
every row down and the list jumped back when it recovered. It now renders
after the `IndexedStack`, directly above the nav bar: same strip, same
tap-to-retry and long-press-to-remove, no reflow of the content above it.

## Testing

`flutter analyze` clean, `flutter test` 46/46. Layout change only — one line
moved in the `body: Column`.