### PR TITLE
feat(desktop): keep each session's tab, and select rendered markdown

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { api, statusOf } from '../bridge.ts'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
+import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
 import {
   extractFilePaths,
   highlightCode,
@@ -44,6 +45,7 @@ export function ChatPanel({
   const composer = useRef<HTMLTextAreaElement | null>(null)
   const pinnedToBottom = useRef(true)
   const promptDraft = useStore((s) => s.promptDraft)
+  const [selection, clearSelection] = useTextSelection(scroller)
 
   const status = session.status
   const busy = BUSY_STATUSES.has(status)
@@ -170,6 +172,30 @@ export function ChatPanel({
         )}
       </div>
 
+      {/* The transcript has no file behind it to point at, so a selection
+          travels as the text itself. */}
+      {selection && (
+        <SelectionMenu
+          anchor="above"
+          x={selection.x}
+          y={selection.y}
+          actions={[
+            {
+              label: 'Copy',
+              run: () => {
+                void navigator.clipboard.writeText(selection.text)
+                store.notify('Copied selection')
+              },
+            },
+            {
+              label: 'Send as prompt',
+              run: () => store.appendPrompt(hostId, session.session_id, quote(selection.text)),
+            },
+          ]}
+          onClose={clearSelection}
+        />
+      )}
+
       {/* No composer for a terminated session: the daemon refuses its prompts,
           so offering the box only trades a typed prompt for a 409. */}
       {terminated ? (
@@ -226,6 +252,15 @@ export function ChatPanel({
       )}
     </div>
   )
+}
+
+/** Quoted, so the composer keeps the lines apart from what is typed about them. */
+function quote(text: string): string {
+  return `${text
+    .trim()
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n')}\n`
 }
 
 interface MessageProps {

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
-import { store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
+import { currentPanel, currentTab, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { ChatPanel } from './chat.tsx'
 import { PanelBoundary } from './error-boundary.tsx'
@@ -56,7 +56,7 @@ export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const sessions = useStore((s) => s.sessions)
   const notifications = useStore((s) => s.notifications)
-  const panel = useStore((s) => s.panel)
+  const panel = useStore(currentPanel)
   const tabs = useStore((s) => s.tabs)
 
   const hostId = selection?.hostId ?? null
@@ -68,7 +68,7 @@ export function Detail(): JSX.Element {
     ? (notifications[hostId ?? ''] ?? []).filter((n) => n.source_session === session.session_id).length
     : 0
   const term = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
-  const activeTab = useStore((s) => s.activeTab)
+  const activeTab = useStore(currentTab)
   const shells = tabs.filter(
     (t) => t.kind === 'shell' && t.hostId === hostId && t.sessionId === session?.session_id,
   )
@@ -420,6 +420,22 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}
 
+        {/* Out of the overflow menu: ending a session is a thing done often
+            enough to be one click, and the confirm is what guards it. */}
+        {!terminated && (
+          <button
+            className="ghost danger"
+            title="End the agent — only Resume brings it back"
+            onClick={() => {
+              if (confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
+                void run(() => api(hostId).terminate(session.session_id))
+              }
+            }}
+          >
+            Terminate
+          </button>
+        )}
+
         <details className="menu" ref={overflow}>
           <summary>⋯</summary>
           <div
@@ -446,9 +462,6 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
               }
             >
               {session.archived ? 'Unarchive' : 'Archive'}
-            </button>
-            <button onClick={() => void run(() => api(hostId).terminate(session.session_id))}>
-              Terminate
             </button>
             <button
               className="danger"

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -10,6 +10,7 @@ import { FindInFiles } from './find-in-files.tsx'
 import { PathLabel } from './path-label.tsx'
 import { QuickOpen } from './quick-open.tsx'
 import { RootPicker } from './root-picker.tsx'
+import { SelectionMenu, useTextSelection, type MenuAction } from './selection-menu.tsx'
 
 /** Past this the editor is read-only: CodeMirror is not a log viewer. */
 const MAX_EDIT_BYTES = 1_000_000
@@ -501,10 +502,16 @@ function FileView({
   const markdown = isMarkdownPath(file.path)
   const rendered = markdown && file.mode === 'preview'
   const blocks = useMemo(() => (rendered ? renderMarkdownBlocks(text) : null), [rendered, text])
-  const [picked, setPicked] = useState<LineRange | null>(null)
   const [menu, setMenu] = useState<{ x: number; y: number; range: LineRange } | null>(null)
   /** Headings whose section is folded away, by the heading's start line. */
   const [folds, setFolds] = useState<Set<number>>(new Set())
+  const preview = useRef<HTMLDivElement | null>(null)
+  const [selection, clearSelection] = useTextSelection(preview)
+  const [width, setWidth] = useState(readReadingWidth)
+
+  // The rendered prose still has lines underneath it, and what the reader
+  // highlighted names them: the blocks its two ends fall in.
+  const picked = useMemo(() => (selection ? linesOf(selection.range) : null), [selection])
 
   // Everything under a folded heading, down to the next heading that is not
   // deeper than it — folding "## Build" takes its subsections with it.
@@ -523,9 +530,9 @@ function FileView({
     return out
   }, [blocks, folds])
 
-  // A selection is a range of the file that was open when it was made.
+  // A menu names lines, and a fold names a heading, of the file that was open
+  // when they were made.
   useEffect(() => {
-    setPicked(null)
     setMenu(null)
     setFolds(new Set())
   }, [file.path, rendered])
@@ -538,6 +545,36 @@ function FileView({
       return
     }
     store.appendPrompt(hostId, sessionId, promptFor(file.path, range, lines))
+  }
+
+  // Whole lines either way, as the editor's own menu does: the source is what
+  // the agent will be asked about, not the prose it renders as.
+  const actions = (range: LineRange): MenuAction[] => [
+    { label: `Copy ${label(range)}`, run: () => act('copy', range) },
+    { label: `Send ${label(range)} as prompt`, run: () => act('prompt', range) },
+  ]
+
+  // Dragging the right edge moves both: the column stays centred, so it grows
+  // by twice what the pointer travelled. The drag starts from the width on
+  // screen, not the one in state — a column asked to be wider than the panel
+  // is drawn at the panel's width, and dragging back from anywhere else would
+  // move nothing until it had caught up.
+  const resize = (event: React.PointerEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    const fromX = event.clientX
+    const fromWidth = event.currentTarget.parentElement?.getBoundingClientRect().width ?? width
+    let latest = fromWidth
+    const move = (moved: PointerEvent): void => {
+      latest = clampWidth(fromWidth + (moved.clientX - fromX) * 2)
+      setWidth(latest)
+    }
+    const done = (): void => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', done)
+      writeReadingWidth(latest)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', done)
   }
 
   return (
@@ -576,57 +613,57 @@ function FileView({
       {file.binary ? (
         <p className="empty-note">Binary file — not shown.</p>
       ) : blocks !== null ? (
-        <div className="md preview-md">
-          {blocks.map((block) => {
-            if (hidden.has(block.startLine)) return null
-            const range = { start: block.startLine, end: block.endLine }
-            const on = picked !== null && block.startLine <= picked.end && block.endLine >= picked.start
-            const folded = folds.has(block.startLine)
-            return (
-              <div
-                key={block.startLine}
-                className={`md-block${on ? ' on' : ''}${block.depth ? ' md-heading' : ''}`}
-                title={`${label(range)} — click to select, right-click for actions`}
-                onClick={(event) =>
-                  setPicked((current) =>
-                    // Shift builds a range out of two clicks, the way a line
-                    // gutter does; a plain click starts again from one block.
-                    event.shiftKey && current
-                      ? { start: Math.min(current.start, range.start), end: Math.max(current.end, range.end) }
-                      : current && current.start === range.start && current.end === range.end
-                        ? null
-                        : range,
-                  )
-                }
-                onContextMenu={(event) => {
-                  event.preventDefault()
-                  const covered =
-                    picked !== null && block.startLine >= picked.start && block.endLine <= picked.end
-                  const target = covered ? picked : range
-                  setPicked(target)
-                  setMenu({ x: event.clientX, y: event.clientY, range: target })
-                }}
-              >
-                {block.depth !== undefined && (
-                  <button
-                    className="md-fold"
-                    title={folded ? 'Expand section' : 'Collapse section'}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      setFolds((current) => {
-                        const next = new Set(current)
-                        if (!next.delete(block.startLine)) next.add(block.startLine)
-                        return next
-                      })
-                    }}
-                  >
-                    {folded ? '▸' : '▾'}
-                  </button>
-                )}
-                <div className="md-block-body" dangerouslySetInnerHTML={{ __html: block.html }} />
-              </div>
-            )
-          })}
+        <div className="md preview-md" ref={preview}>
+          <div className="md-doc" style={{ width }}>
+            {blocks.map((block) => {
+              if (hidden.has(block.startLine)) return null
+              const range = { start: block.startLine, end: block.endLine }
+              const folded = folds.has(block.startLine)
+              return (
+                <div
+                  key={block.startLine}
+                  className={`md-block${block.depth ? ' md-heading' : ''}`}
+                  data-line-start={block.startLine}
+                  data-line-end={block.endLine}
+                  title={label(range)}
+                  onContextMenu={(event) => {
+                    event.preventDefault()
+                    // Right-clicking outside the selection asks about the block
+                    // under the pointer, which is what the click pointed at.
+                    const covered =
+                      picked !== null && block.startLine >= picked.start && block.endLine <= picked.end
+                    setMenu({ x: event.clientX, y: event.clientY, range: covered ? picked : range })
+                  }}
+                >
+                  {block.depth !== undefined && (
+                    <button
+                      className="md-fold"
+                      title={folded ? 'Expand section' : 'Collapse section'}
+                      onClick={() =>
+                        setFolds((current) => {
+                          const next = new Set(current)
+                          if (!next.delete(block.startLine)) next.add(block.startLine)
+                          return next
+                        })
+                      }
+                    >
+                      {folded ? '▸' : '▾'}
+                    </button>
+                  )}
+                  <div className="md-block-body" dangerouslySetInnerHTML={{ __html: block.html }} />
+                </div>
+              )
+            })}
+            <div
+              className="md-grip"
+              title="Drag to set the reading width — double-click to reset"
+              onPointerDown={resize}
+              onDoubleClick={() => {
+                setWidth(DEFAULT_WIDTH)
+                writeReadingWidth(DEFAULT_WIDTH)
+              }}
+            />
+          </div>
         </div>
       ) : file.readOnly ? (
         <pre className="ws-plain">{text}</pre>
@@ -642,14 +679,19 @@ function FileView({
         />
       )}
 
-      {menu && (
-        <LineMenu
-          x={menu.x}
-          y={menu.y}
-          range={menu.range}
-          onClose={() => setMenu(null)}
-          onAct={(action) => act(action, menu.range)}
-        />
+      {menu ? (
+        <SelectionMenu x={menu.x} y={menu.y} actions={actions(menu.range)} onClose={() => setMenu(null)} />
+      ) : (
+        selection &&
+        picked && (
+          <SelectionMenu
+            anchor="above"
+            x={selection.x}
+            y={selection.y}
+            actions={actions(picked)}
+            onClose={clearSelection}
+          />
+        )
       )}
     </div>
   )
@@ -677,43 +719,47 @@ function promptFor(path: string, range: LineRange, lines: string[]): string {
   return `${header}:\n\`\`\`${languageForPath(path) ?? ''}\n${lines.join('\n')}\n\`\`\`\n`
 }
 
-function LineMenu({
-  x,
-  y,
-  range,
-  onClose,
-  onAct,
-}: {
-  x: number
-  y: number
-  range: LineRange
-  onClose: () => void
-  onAct: (action: 'copy' | 'prompt') => void
-}): JSX.Element {
-  useEffect(() => {
-    const dismiss = (event: Event): void => {
-      if (event instanceof KeyboardEvent && event.key !== 'Escape') return
-      onClose()
-    }
-    window.addEventListener('mousedown', dismiss)
-    window.addEventListener('keydown', dismiss)
-    return () => {
-      window.removeEventListener('mousedown', dismiss)
-      window.removeEventListener('keydown', dismiss)
-    }
-  }, [onClose])
+/** The file lines a selection covers, from the blocks its two ends fall in. */
+function linesOf(range: Range): LineRange | null {
+  const from = blockLines(range.startContainer)
+  const to = blockLines(range.endContainer)
+  if (!from || !to) return null
+  return { start: Math.min(from.start, to.start), end: Math.max(from.end, to.end) }
+}
 
-  const run = (action: 'copy' | 'prompt'): void => {
-    onAct(action)
-    onClose()
+function blockLines(node: Node): LineRange | null {
+  const element = node instanceof Element ? node : node.parentElement
+  const block = element?.closest<HTMLElement>('[data-line-start]')
+  if (!block) return null
+  return { start: Number(block.dataset.lineStart), end: Number(block.dataset.lineEnd) }
+}
+
+/** How wide the rendered column is, in pixels — a reading preference, not a
+ *  property of any one file, so every preview shares it. */
+const DEFAULT_WIDTH = 780
+const MIN_WIDTH = 420
+const MAX_WIDTH = 1400
+const WIDTH_KEY = 'helios.md-width'
+
+function clampWidth(width: number): number {
+  return Math.round(Math.min(Math.max(width, MIN_WIDTH), MAX_WIDTH))
+}
+
+function readReadingWidth(): number {
+  try {
+    const saved = Number(localStorage.getItem(WIDTH_KEY))
+    return saved > 0 ? clampWidth(saved) : DEFAULT_WIDTH
+  } catch {
+    return DEFAULT_WIDTH
   }
+}
 
-  return (
-    <div className="line-menu" style={{ left: x, top: y }}>
-      <button onClick={() => run('copy')}>Copy {label(range)}</button>
-      <button onClick={() => run('prompt')}>Send {label(range)} as prompt</button>
-    </div>
-  )
+function writeReadingWidth(width: number): void {
+  try {
+    localStorage.setItem(WIDTH_KEY, String(width))
+  } catch {
+    // A full or unavailable store costs the preference, not the panel.
+  }
 }
 
 function basename(path: string): string {

--- a/desktop/src/renderer/components/selection-menu.tsx
+++ b/desktop/src/renderer/components/selection-menu.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+
+/** One entry of a popover: what it says, and what it does. */
+export interface MenuAction {
+  label: string
+  run: () => void
+}
+
+/**
+ * A small popover at a point on screen.
+ *
+ * Mousedown inside it is swallowed: the browser would otherwise collapse the
+ * selection the menu is about, and unmounting on that mousedown would take the
+ * button out of the document before its own click could land.
+ */
+export function SelectionMenu({
+  x,
+  y,
+  anchor = 'point',
+  actions,
+  onClose,
+}: {
+  x: number
+  y: number
+  /** 'point' sits below-right of the pointer; 'above' floats over a selection. */
+  anchor?: 'point' | 'above'
+  actions: MenuAction[]
+  onClose: () => void
+}): JSX.Element {
+  const box = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const dismiss = (event: Event): void => {
+      if (event instanceof KeyboardEvent && event.key !== 'Escape') return
+      if (event.type === 'mousedown' && event.target instanceof Node && box.current?.contains(event.target)) return
+      onClose()
+    }
+    window.addEventListener('mousedown', dismiss)
+    window.addEventListener('keydown', dismiss)
+    return () => {
+      window.removeEventListener('mousedown', dismiss)
+      window.removeEventListener('keydown', dismiss)
+    }
+  }, [onClose])
+
+  // Centred on the selection, so a menu near either edge would hang off it.
+  const left = anchor === 'above' ? Math.min(Math.max(x, 110), window.innerWidth - 110) : x
+
+  return (
+    <div
+      className={`line-menu${anchor === 'above' ? ' floating' : ''}`}
+      ref={box}
+      style={{ left, top: y }}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          onClick={() => {
+            action.run()
+            onClose()
+          }}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** A live text selection, and where a menu about it belongs. */
+export interface TextSelection {
+  /** The middle of the selection, and its top edge, in viewport coordinates. */
+  x: number
+  y: number
+  text: string
+  range: Range
+}
+
+/**
+ * The text selected inside an element, tracked for as long as it stands.
+ *
+ * Read on mouseup rather than on selectionchange: a menu that follows the
+ * pointer through a drag lands under it as often as beside it.
+ */
+export function useTextSelection(
+  container: RefObject<HTMLElement | null>,
+): [TextSelection | null, () => void] {
+  const [selected, setSelected] = useState<TextSelection | null>(null)
+
+  useEffect(() => {
+    const read = (): void => {
+      const host = container.current
+      const selection = window.getSelection()
+      if (!host || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+        setSelected(null)
+        return
+      }
+      const range = selection.getRangeAt(0)
+      if (!host.contains(range.commonAncestorContainer)) {
+        setSelected(null)
+        return
+      }
+      const rect = range.getBoundingClientRect()
+      setSelected({
+        x: rect.left + rect.width / 2,
+        y: rect.top,
+        text: range.toString(),
+        range: range.cloneRange(),
+      })
+    }
+
+    // Scrolling moves the selection out from under a menu pinned to the
+    // viewport, so the rectangle is measured again rather than dropped.
+    window.addEventListener('mouseup', read)
+    window.addEventListener('keyup', read)
+    window.addEventListener('scroll', read, true)
+    return () => {
+      window.removeEventListener('mouseup', read)
+      window.removeEventListener('keyup', read)
+      window.removeEventListener('scroll', read, true)
+    }
+  }, [container])
+
+  // Dismissing takes the selection with it. Leaving it standing would bring the
+  // menu straight back, since the next mouseup or keyup reads it again.
+  const clear = useCallback((): void => {
+    window.getSelection()?.removeAllRanges()
+    setSelected(null)
+  }, [])
+
+  return [selected, clear]
+}

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -5,7 +5,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 
 import { bridge } from '../bridge.ts'
-import { store, terminalId, useStore, type Tab } from '../store.ts'
+import { currentTab, store, terminalId, useStore, type Tab } from '../store.ts'
 import { canResume, hasTerminal, type Session } from '../../shared/models.ts'
 
 /**
@@ -58,13 +58,12 @@ export function TerminalPanes({
   visible: boolean
 }): JSX.Element {
   const tabs = useStore((s) => s.tabs)
-  const activeTab = useStore((s) => s.activeTab)
+  const activeTab = useStore(currentTab)
   const agent = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
   // The strip decides which of the session's terminals is in front; the
   // agent's is the one a session starts with and the fallback for everything
   // that does not name one.
-  const selected = activeTab ? tabs.find((t) => t.id === activeTab) : undefined
-  const current = selected?.sessionId === session?.session_id ? selected : agent
+  const current = (activeTab ? tabs.find((t) => t.id === activeTab) : undefined) ?? agent
   const detached = useStore((s) => s.detached)
   const isDetached = Boolean(hostId && session && detached.includes(terminalId(hostId, session.session_id)))
 

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -34,6 +34,15 @@ export interface Selection {
   sessionId: string
 }
 
+/**
+ * What a session's own state is keyed by. Which panel is in front, and which of
+ * its terminals, belong to the session being looked at rather than to the
+ * window: coming back to a session should find it as it was left.
+ */
+export function sessionKey(hostId: string, sessionId: string): string {
+  return `${hostId}:${sessionId}`
+}
+
 export type RightPanel = 'chat' | 'terminal' | 'approvals' | 'git' | 'files'
 
 /**
@@ -69,13 +78,14 @@ export interface State {
   /** Open terminal connections, one per session, keyed by `terminalId`. */
   tabs: Tab[]
   selection: Selection | null
-  panel: RightPanel
+  /** The panel each session was last reading, by `sessionKey`. */
+  panels: Record<string, RightPanel>
   /**
-   * Which terminal the panel shows, as a tab id. A session has several once
-   * the user opens shells beside its agent, and the strip needs to know which
-   * one is in front.
+   * Which terminal a session's panel shows, as a tab id, by `sessionKey`. A
+   * session has several once the user opens shells beside its agent, and the
+   * strip needs to know which one is in front.
    */
-  activeTab: string | null
+  activeTabs: Record<string, string>
   /**
    * Terminals the user disconnected on purpose, by tab id. Without this the
    * panel would attach again the moment it is shown, and a disconnect would
@@ -99,8 +109,8 @@ const initial: State = {
   notifications: {},
   tabs: [],
   selection: null,
-  panel: 'chat',
-  activeTab: null,
+  panels: {},
+  activeTabs: {},
   detached: [],
   fileTarget: null,
   promptDraft: null,
@@ -165,7 +175,7 @@ class Store {
     bridge.app.onActivateNotification((target) => {
       if (!target.sessionId) return
       this.select(target.hostId, target.sessionId)
-      this.set({ panel: 'approvals' })
+      this.setPanel('approvals')
     })
 
     const hosts = await bridge.hosts.list()
@@ -201,7 +211,13 @@ class Store {
   async refreshSessions(hostId: string): Promise<void> {
     try {
       const sessions = await api(hostId).listSessions()
+      const before = this.state.sessions[hostId]
       this.set((s) => ({ sessions: { ...s.sessions, [hostId]: sessions } }))
+      for (const session of sessions) {
+        if (session.status !== 'terminated') continue
+        const was = before?.find((s) => s.session_id === session.session_id)
+        if (was && was.status !== 'terminated') this.onTerminated(hostId, session.session_id)
+      }
     } catch (err) {
       this.fail(err)
     }
@@ -249,6 +265,7 @@ class Store {
   }
 
   private patchSession(hostId: string, sessionId: string, patch: Partial<Session>): void {
+    const was = this.state.sessions[hostId]?.find((s) => s.session_id === sessionId)
     this.set((s) => {
       const list = s.sessions[hostId]
       if (!list) return {}
@@ -261,6 +278,26 @@ class Store {
         },
       }
     })
+    if (patch.status === 'terminated' && was && was.status !== 'terminated') {
+      this.onTerminated(hostId, sessionId)
+    }
+  }
+
+  /**
+   * A session that has just ended has nothing left to watch: its terminals go,
+   * and it lets go of the detail pane if it was the one on screen. Driven by
+   * the status rather than by the click, so a terminate from the TUI, from
+   * mobile, or from the agent exiting on its own lands the same way.
+   *
+   * Only on the transition. Selecting a session that ended long ago is a
+   * request to read its transcript, not something to undo.
+   */
+  private onTerminated(hostId: string, sessionId: string): void {
+    for (const tab of this.state.tabs.filter((t) => t.hostId === hostId && t.sessionId === sessionId)) {
+      this.closeTab(tab.id)
+    }
+    const { selection } = this.state
+    if (selection?.hostId === hostId && selection.sessionId === sessionId) this.set({ selection: null })
   }
 
   // ─── Selection and panels ──────────────────────────────────────────────
@@ -270,13 +307,13 @@ class Store {
   }
 
   setPanel(panel: RightPanel): void {
-    this.set({ panel })
+    this.set((s) => ({ panels: showPanel(s, s.selection, panel) }))
   }
 
   /** Shows a file in the Files panel, switching to it. */
   openFile(hostId: string, path: string): void {
     this.set((s) => ({
-      panel: 'files',
+      panels: showPanel(s, s.selection, 'files'),
       fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open' },
     }))
   }
@@ -288,7 +325,7 @@ class Store {
    */
   findFile(hostId: string, path: string): void {
     this.set((s) => ({
-      panel: 'files',
+      panels: showPanel(s, s.selection, 'files'),
       fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'find' },
     }))
   }
@@ -305,7 +342,7 @@ class Store {
   /** Puts text in the session's composer and shows it, without sending. */
   appendPrompt(hostId: string, sessionId: string, text: string): void {
     this.set((s) => ({
-      panel: 'chat',
+      panels: showPanel(s, { hostId, sessionId }, 'chat'),
       promptDraft: { hostId, sessionId, text, seq: (s.promptDraft?.seq ?? 0) + 1 },
     }))
   }
@@ -338,10 +375,11 @@ class Store {
     // The panel belongs to whichever session is selected, so showing one
     // session's terminal means selecting it.
     const id = terminalId(hostId, session.session_id)
+    const target = { hostId, sessionId: session.session_id }
     this.set((s) => ({
-      selection: { hostId, sessionId: session.session_id },
-      panel: 'terminal',
-      activeTab: id,
+      selection: target,
+      panels: showPanel(s, target, 'terminal'),
+      activeTabs: showTab(s, target, id),
       detached: s.detached.filter((tabId) => tabId !== id),
     }))
 
@@ -384,11 +422,12 @@ class Store {
    * it runs no agent and appears nowhere but this session's terminal strip.
    */
   async openShell(hostId: string, sessionId: string): Promise<void> {
-    this.set({ selection: { hostId, sessionId }, panel: 'terminal' })
+    const target = { hostId, sessionId }
+    this.set((s) => ({ selection: target, panels: showPanel(s, target, 'terminal') }))
     try {
       const info = await api(hostId).openShell(sessionId)
       await this.attachTerminal(hostId, sessionId, info.id, shellLabel(info.id))
-      this.set({ activeTab: terminalId(hostId, info.id) })
+      this.set((s) => ({ activeTabs: showTab(s, target, terminalId(hostId, info.id)) }))
     } catch (err) {
       this.fail(err)
     }
@@ -512,7 +551,8 @@ class Store {
    */
   showTerminal(hostId: string, session: Session): void {
     const id = terminalId(hostId, session.session_id)
-    this.set({ panel: 'terminal', activeTab: id })
+    const target = { hostId, sessionId: session.session_id }
+    this.set((s) => ({ panels: showPanel(s, target, 'terminal'), activeTabs: showTab(s, target, id) }))
     if (this.state.tabs.some((t) => t.id === id)) return
     // Looking at a terminal that was disconnected on purpose is not a request
     // to attach again: the panel offers the button for that.
@@ -524,13 +564,16 @@ class Store {
     void bridge.term.close(tabId)
     this.set((s) => ({
       tabs: s.tabs.filter((t) => t.id !== tabId),
-      activeTab: s.activeTab === tabId ? null : s.activeTab,
+      activeTabs: Object.fromEntries(Object.entries(s.activeTabs).filter(([, id]) => id !== tabId)),
     }))
   }
 
   /** Brings one of a session's terminals to the front. */
   selectTab(tabId: string): void {
-    this.set({ panel: 'terminal', activeTab: tabId })
+    const tab = this.state.tabs.find((t) => t.id === tabId)
+    if (!tab) return
+    const target = { hostId: tab.hostId, sessionId: tab.sessionId }
+    this.set((s) => ({ panels: showPanel(s, target, 'terminal'), activeTabs: showTab(s, target, tabId) }))
   }
 
   // ─── Feedback ──────────────────────────────────────────────────────────
@@ -550,6 +593,27 @@ export const store = new Store()
 
 export function useStore<T>(select: (state: State) => T): T {
   return useSyncExternalStore(store.subscribe, () => select(store.getSnapshot()))
+}
+
+/** The panel the selected session is reading. */
+export function currentPanel(state: State): RightPanel {
+  if (!state.selection) return 'chat'
+  return state.panels[sessionKey(state.selection.hostId, state.selection.sessionId)] ?? 'chat'
+}
+
+/** The terminal the selected session has in front, if it has named one. */
+export function currentTab(state: State): string | null {
+  if (!state.selection) return null
+  return state.activeTabs[sessionKey(state.selection.hostId, state.selection.sessionId)] ?? null
+}
+
+function showPanel(state: State, target: Selection | null, panel: RightPanel): Record<string, RightPanel> {
+  if (!target) return state.panels
+  return { ...state.panels, [sessionKey(target.hostId, target.sessionId)]: panel }
+}
+
+function showTab(state: State, target: Selection, tabId: string): Record<string, string> {
+  return { ...state.activeTabs, [sessionKey(target.hostId, target.sessionId)]: tabId }
 }
 
 function str(value: unknown): string {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1757,31 +1757,54 @@ small {
 }
 
 /* Rendered markdown gets the reading width and padding a document wants,
-   rather than the edge-to-edge layout of a code listing. */
+   rather than the edge-to-edge layout of a code listing. The scroller fills the
+   panel and the column sits centred in it, so the width is the reader's to set
+   without stranding the rest of the panel behind a hard cap. */
 .preview-md {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  display: flex;
+  justify-content: center;
   padding: 16px 20px;
-  max-width: 780px;
+  cursor: text;
 }
 
-/* Rendered prose still has lines underneath it, and a block is what the reader
-   points at to talk about them. */
+.md-doc {
+  position: relative;
+  flex: none;
+  max-width: 100%;
+}
+
+/* Sits just outside the column's right edge; the drag moves both edges, since
+   the column is centred. */
+.md-grip {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -14px;
+  width: 10px;
+  cursor: col-resize;
+}
+
+.md-grip::after {
+  content: '';
+  position: absolute;
+  inset: 0 4px;
+  border-radius: 2px;
+  background: transparent;
+}
+
+.md-grip:hover::after {
+  background: var(--outline-variant);
+}
+
+/* Rendered prose still has lines underneath it, and what the reader highlights
+   is what names them. */
 .md-block {
   border-radius: 6px;
   padding: 2px 6px;
   margin: 0 -6px;
-  cursor: pointer;
-}
-
-.md-block:hover {
-  background: var(--surface-low);
-}
-
-.md-block.on,
-.md-block.on:hover {
-  background: color-mix(in srgb, var(--primary) 16%, transparent);
 }
 
 .md-block.md-heading {
@@ -1819,6 +1842,14 @@ small {
   border-radius: 10px;
   background: var(--surface-high);
   box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+}
+
+/* Anchored to a selection rather than to a pointer: centred over it, and clear
+   of the text it is about. */
+.line-menu.floating {
+  flex-direction: row;
+  min-width: 0;
+  transform: translate(-50%, calc(-100% - 8px));
 }
 
 .line-menu button {


### PR DESCRIPTION
## Summary

- **Panel and terminal are per session.** `panel`/`activeTab` were single globals, so opening Files on one session and clicking another put that one in Files too. Both are now keyed `hostId:sessionId`, with `currentPanel`/`currentTab` selectors; a session comes back to what it was left reading.
- **The markdown preview has a reading column you can drag.** The 780px cap sat on the scroller, pinning the column to one edge and stranding the rest of the panel. The scroller now fills the panel and centres a `.md-doc` column with a grip on its right edge — 420–1400px, double-click to reset, persisted in `localStorage['helios.md-width']`. The drag starts from the width on screen, so a column wider than the panel still answers the first pixel.
- **Text selects as text.** Click-to-select-a-block is gone and the preview shows a text cursor. Highlighting prose offers `Copy L12-18` / `Send L12-18 as prompt`, acting on the source lines the selection's two ends fall in; right-click still gives the point-anchored menu. The transcript gets the same popover with `Copy` / `Send as prompt`, quoting the selected text with `>`.
- **Terminate is on the header**, behind a confirm, and out of the overflow menu.
- **A session that ends closes.** Its terminals are closed and it releases the detail pane. Driven off the status transition, so a terminate from the TUI, from mobile, or an agent exiting on its own lands the same way. Only on the transition — a session that ended an hour ago still opens for reading.

Also fixes a live bug from #38: the old `LineMenu` closed on any mousedown, including the one landing on its own buttons, so the button was out of the document before its click could fire.

## Test plan

- [x] `npm run typecheck`, `npm run build`, `npm test` (29 pass)
- [x] Alpha on Files → select Beta → opens on Agent → back to Alpha → Files
- [x] Drag the preview grip: resizes, clamps, persists; double-click resets; no horizontal overflow past the panel
- [x] Select across two preview blocks → `Copy L1-4` / `Send L1-4 as prompt`; the send lands fenced source in the composer and switches to Agent
- [x] Select transcript prose → `Send as prompt` appends it quoted
- [x] Escape dismisses the popover and it stays dismissed
- [x] Right-click a preview block → point-anchored menu with that block's lines; heading fold still works
- [x] Terminate from the header closes the terminal pane and returns to "Select a session."
- [x] A pushed `session_status: terminated` for the selected session does the same
- [x] Reopening a terminated session from the sidebar keeps it open with Resume

Exercised in a browser against a stubbed preload bridge rather than a live daemon, to avoid touching a running agent's PTY.