### PR TITLE
fix(desktop): let rendered markdown fill the panel, and show its handle

### DIFF
--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -556,16 +556,18 @@ function FileView({
 
   // Dragging the right edge moves both: the column stays centred, so it grows
   // by twice what the pointer travelled. The drag starts from the width on
-  // screen, not the one in state — a column asked to be wider than the panel
-  // is drawn at the panel's width, and dragging back from anywhere else would
-  // move nothing until it had caught up.
+  // screen rather than from state, so the first pixel of a drag always moves
+  // the edge, and stops at the room the panel has — a column wider than that
+  // is a number the reader cannot see the effect of.
   const resize = (event: React.PointerEvent<HTMLDivElement>): void => {
     event.preventDefault()
     const fromX = event.clientX
-    const fromWidth = event.currentTarget.parentElement?.getBoundingClientRect().width ?? width
+    const doc = event.currentTarget.parentElement
+    const fromWidth = doc?.getBoundingClientRect().width ?? MIN_WIDTH
+    const room = roomFor(doc)
     let latest = fromWidth
     const move = (moved: PointerEvent): void => {
-      latest = clampWidth(fromWidth + (moved.clientX - fromX) * 2)
+      latest = clampWidth(fromWidth + (moved.clientX - fromX) * 2, room)
       setWidth(latest)
     }
     const done = (): void => {
@@ -614,7 +616,7 @@ function FileView({
         <p className="empty-note">Binary file — not shown.</p>
       ) : blocks !== null ? (
         <div className="md preview-md" ref={preview}>
-          <div className="md-doc" style={{ width }}>
+          <div className="md-doc" style={{ width: width ?? '100%' }}>
             {blocks.map((block) => {
               if (hidden.has(block.startLine)) return null
               const range = { start: block.startLine, end: block.endLine }
@@ -656,11 +658,11 @@ function FileView({
             })}
             <div
               className="md-grip"
-              title="Drag to set the reading width — double-click to reset"
+              title="Drag to narrow the text — double-click to fill the panel"
               onPointerDown={resize}
               onDoubleClick={() => {
-                setWidth(DEFAULT_WIDTH)
-                writeReadingWidth(DEFAULT_WIDTH)
+                setWidth(null)
+                writeReadingWidth(null)
               }}
             />
           </div>
@@ -734,29 +736,40 @@ function blockLines(node: Node): LineRange | null {
   return { start: Number(block.dataset.lineStart), end: Number(block.dataset.lineEnd) }
 }
 
-/** How wide the rendered column is, in pixels — a reading preference, not a
- *  property of any one file, so every preview shares it. */
-const DEFAULT_WIDTH = 780
+/**
+ * How wide the rendered column is, in pixels. A reading preference rather than
+ * a property of any one file, so every preview shares it — and null until the
+ * reader says otherwise, which means the whole panel. A document that arrives
+ * pre-narrowed just looks like a panel that will not fill.
+ */
 const MIN_WIDTH = 420
-const MAX_WIDTH = 1400
 const WIDTH_KEY = 'helios.md-width'
 
-function clampWidth(width: number): number {
-  return Math.round(Math.min(Math.max(width, MIN_WIDTH), MAX_WIDTH))
+function clampWidth(width: number, room: number): number {
+  return Math.round(Math.min(Math.max(width, MIN_WIDTH), Math.max(room, MIN_WIDTH)))
 }
 
-function readReadingWidth(): number {
+/** What the scroller has to give, inside its padding. */
+function roomFor(doc: Element | null): number {
+  const scroller = doc?.closest('.preview-md')
+  if (!scroller) return Number.POSITIVE_INFINITY
+  const style = getComputedStyle(scroller)
+  return scroller.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight)
+}
+
+function readReadingWidth(): number | null {
   try {
     const saved = Number(localStorage.getItem(WIDTH_KEY))
-    return saved > 0 ? clampWidth(saved) : DEFAULT_WIDTH
+    return saved > 0 ? Math.max(saved, MIN_WIDTH) : null
   } catch {
-    return DEFAULT_WIDTH
+    return null
   }
 }
 
-function writeReadingWidth(width: number): void {
+function writeReadingWidth(width: number | null): void {
   try {
-    localStorage.setItem(WIDTH_KEY, String(width))
+    if (width === null) localStorage.removeItem(WIDTH_KEY)
+    else localStorage.setItem(WIDTH_KEY, String(width))
   } catch {
     // A full or unavailable store costs the preference, not the panel.
   }

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1776,27 +1776,31 @@ small {
   max-width: 100%;
 }
 
-/* Sits just outside the column's right edge; the drag moves both edges, since
-   the column is centred. */
+/* Sits on the column's right edge; the drag moves both, since the column is
+   centred. Drawn faintly at rest rather than on hover alone — a handle nobody
+   can see is a column that does not resize. */
 .md-grip {
   position: absolute;
   top: 0;
   bottom: 0;
-  right: -14px;
-  width: 10px;
+  right: -16px;
+  width: 16px;
   cursor: col-resize;
 }
 
 .md-grip::after {
   content: '';
   position: absolute;
-  inset: 0 4px;
+  inset: 0 7px;
   border-radius: 2px;
-  background: transparent;
+  background: var(--outline-variant);
+  opacity: 0.5;
 }
 
 .md-grip:hover::after {
-  background: var(--outline-variant);
+  inset: 0 6px;
+  background: var(--primary);
+  opacity: 1;
 }
 
 /* Rendered prose still has lines underneath it, and what the reader highlights


### PR DESCRIPTION
## Summary

Follow-up to #43, which shipped the reading column too timid to be useful.

- **Opens filling the panel.** The width was 780px by default whatever the panel measured, so a wide window put the document in a narrow strip with dead space either side. Width is now unset until the reader narrows it, and unset means the whole panel.
- **The handle is visible.** It was transparent until hovered, over a 10px target in the gutter — so the column looked both small and fixed. Now drawn faintly at rest, 16px wide, and picked out in the accent colour on hover.
- **The drag stops at the panel, not at 1400px.** Past the panel's width the column cannot grow, so the extra was stored as a number with no visible effect and the next drag spent itself catching up.

Double-click on the handle now restores "fill the panel" rather than 780px.

## Test plan

- [x] `npm run typecheck`, `npm run build`, `npm test` (29 pass)
- [x] Opens at the full panel width with no horizontal overflow
- [x] Handle is hit-tested at its centre (`elementFromPoint`) and shows `col-resize`
- [x] Drag left 150px narrows by 300px; drag right past the edge clamps to the panel and stores that, not 1400
- [x] Double-click restores fill and clears the stored width