### PR TITLE
fix(desktop): let the markdown preview be selected

### DIFF
--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1768,6 +1768,9 @@ small {
   justify-content: center;
   padding: 16px 20px;
   cursor: text;
+  /* The window is chrome, and chrome does not select — but a document is not
+     chrome. Prose here opts back in, as the transcript's messages do. */
+  user-select: text;
 }
 
 .md-doc {


### PR DESCRIPTION
## Summary

Follow-up to #43: the selection popover could not fire in the preview, because the prose could not be selected in the first place.

`body` sets `user-select: none` — a desktop window's chrome does not select — and every place that holds real text opts back in: inputs, `code`/`pre`, and `.msg-body` in the transcript. The preview never did. Dragging over rendered markdown selected nothing, so the menu had nothing to appear over. Only the code inside a fence, which opts in through the `code` rule, could be picked up at all.

`.preview-md` now opts in the same way.

## Test plan

- [x] `npm run build`
- [x] Computed `user-select` on preview prose is `text` (was `none`)
- [x] Real double-click on a paragraph selects a word and raises `Copy L3` / `Send L3 as prompt`
- [x] Real double-click in the transcript still raises `Copy` / `Send as prompt`

Verified with hit-tested browser input this time. My original testing built a `Range` in script and called `addRange`, which selects regardless of `user-select` — so it passed against code that no user could have used.