### PR TITLE
fix(desktop): reach Settings from the tray, not only the menu bar

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -59,7 +59,7 @@ async function start(): Promise<void> {
   prefs = new PrefsStore()
   prefs.load()
   hud = new Hud(rendererDir, path.join(distDir, 'preload', 'preload.js'), activateNotification)
-  notifier = new Notifier(hosts, hud, prefs, activateNotification, () => {
+  notifier = new Notifier(hosts, hud, prefs, activateNotification, openSettings, () => {
     quitting = true
     app.quit()
   })
@@ -172,6 +172,11 @@ function focusWindow(): void {
   window.focus()
 }
 
+function openSettings(): void {
+  focusWindow()
+  window?.webContents.send('app:open-settings')
+}
+
 function activateNotification(target: NotifyTarget): void {
   focusWindow()
   if (target.sessionId) window?.webContents.send('app:activate-notification', target)
@@ -190,10 +195,7 @@ function buildMenu(): Menu {
               {
                 label: 'Settings…',
                 accelerator: 'CmdOrCtrl+,',
-                click: () => {
-                  focusWindow()
-                  window?.webContents.send('app:open-settings')
-                },
+                click: openSettings,
               },
               { type: 'separator' as const },
               { role: 'services' as const },
@@ -218,14 +220,7 @@ function buildMenu(): Menu {
         ...(isMac
           ? []
           : [
-              {
-                label: 'Settings…',
-                accelerator: 'CmdOrCtrl+,',
-                click: () => {
-                  focusWindow()
-                  window?.webContents.send('app:open-settings')
-                },
-              },
+              { label: 'Settings…', accelerator: 'CmdOrCtrl+,', click: openSettings },
             ]),
         { type: 'separator' as const },
         isMac ? { role: 'close' as const } : { role: 'quit' as const },

--- a/desktop/src/main/notify.ts
+++ b/desktop/src/main/notify.ts
@@ -34,6 +34,7 @@ export class Notifier {
     private readonly hud: Hud,
     private readonly prefs: PrefsStore,
     private readonly onActivate: (target: NotifyTarget) => void,
+    private readonly onSettings: () => void,
     private readonly onQuit: () => void,
   ) {}
 
@@ -184,6 +185,10 @@ export class Notifier {
         ...(items.length ? [{ type: 'separator' as const }, ...items] : []),
         { type: 'separator' },
         { label: 'Open Helios', click: () => this.onActivate({ hostId: '', notificationId: '', sessionId: '' }) },
+        // Also in the app menu, but the menu bar belongs to whichever app is
+        // frontmost — and an app with its window closed may not have one at
+        // all. The tray is the surface that is always there.
+        { label: 'Settings…', click: () => this.onSettings() },
         { label: 'Quit', click: () => this.onQuit() },
       ]),
     )


### PR DESCRIPTION
The Settings dialog added in #46 was reachable from one place: the app menu.
That menu belongs to whichever app is frontmost, and this app is built to stay
resident with its window closed — at which point there is no Helios menu bar and
the setting cannot be opened at all.

It is now in the tray menu too, beside Open Helios and Quit. The tray is the one
surface that is always there, which is the whole reason the app stays resident.

Found while investigating a report of Helios having no dock icon and no menu bar.
That turned out to be separate and pre-existing — `lsappinfo` reports the
installed build as `type="UIElement"` where Code, kitty and Finder are
`Foreground` — and I could not reproduce it from a cold start: a bare Electron
app, a Tray, a `skipTaskbar` window, a replay of the whole startup sequence, and
fresh builds of this app all come up `Foreground`. Unresolved, tracked
separately. This PR only removes the dependence on a menu bar that may not exist.

## Testing

`tsc --noEmit`, `node build.mjs`, 36 desktop tests, `go build ./...`.
The tray item itself is not covered by a test and has not been clicked in a
running app.