### PR TITLE
feat: attach files to a prompt from the desktop and the phone

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -26,6 +26,22 @@ import type {
 const TOKEN_LIFETIME = 3600
 const TOKEN_REFRESH_MARGIN = 300
 const REQUEST_TIMEOUT = 15_000
+/** An upload carries megabytes over a tunnel; the shared timeout is for JSON. */
+const UPLOAD_TIMEOUT = 120_000
+
+/** One file on its way up: the bytes, and what to call them at the far end. */
+export interface UploadPart {
+  name: string
+  type: string
+  bytes: Uint8Array<ArrayBuffer>
+}
+
+/** Where the daemon put it. The path is what goes on to the agent. */
+export interface UploadedFile {
+  name: string
+  path: string
+  size: number
+}
 
 export class ApiError extends Error {
   constructor(
@@ -152,6 +168,51 @@ export class ApiClient {
    */
   sendPrompt(id: string, message: string): Promise<{ success: boolean; queued?: boolean }> {
     return this.request('POST', `/api/sessions/${encodeURIComponent(id)}/send`, { message })
+  }
+
+  /**
+   * Stores files beside the session and answers with the path of each.
+   *
+   * The bytes stop here. What reaches the agent is a path, which it opens with
+   * its own tools — so an attachment costs the model nothing until it looks.
+   */
+  async uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
+    const path = `/api/sessions/${encodeURIComponent(id)}/files`
+    let response = await this.sendForm(path, files)
+    if (response.status === 401) {
+      this.invalidate()
+      response = await this.sendForm(path, files)
+    }
+
+    const text = await response.text()
+    const parsed = (text ? safeParse(text) : undefined) as
+      | { files?: UploadedFile[]; error?: string; message?: string }
+      | undefined
+
+    if (!response.ok) {
+      throw new ApiError(
+        response.status,
+        parsed?.message ?? parsed?.error ?? `upload failed with ${response.status}`,
+        parsed?.error,
+      )
+    }
+    return parsed?.files ?? []
+  }
+
+  /** A form is rebuilt per attempt: a consumed body cannot be sent twice. */
+  private sendForm(path: string, files: UploadPart[]): Promise<Response> {
+    const form = new FormData()
+    for (const file of files) {
+      const blob = new Blob([file.bytes], { type: file.type || 'application/octet-stream' })
+      form.append('file', blob, file.name)
+    }
+    // No Content-Type of ours: fetch writes it with the multipart boundary.
+    return fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { Authorization: this.authHeader() },
+      body: form,
+      signal: AbortSignal.timeout(UPLOAD_TIMEOUT),
+    })
   }
 
   stop(id: string): Promise<unknown> {

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -41,6 +41,10 @@ export function ChatPanel({
   const [total, setTotal] = useState(0)
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
+  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const [dropping, setDropping] = useState(false)
+  const picker = useRef<HTMLInputElement | null>(null)
+  const nextAttachment = useRef(0)
   const scroller = useRef<HTMLDivElement | null>(null)
   const composer = useRef<HTMLTextAreaElement | null>(null)
   const pinnedToBottom = useRef(true)
@@ -106,13 +110,52 @@ export function ChatPanel({
     }
   }
 
+  /** Reads the files into memory now: a dropped File is not valid for long. */
+  const attach = async (files: FileList | File[] | null): Promise<void> => {
+    const chosen = [...(files ?? [])]
+    if (chosen.length === 0) return
+    const read = await Promise.all(
+      chosen.map(async (file) => ({
+        id: ++nextAttachment.current,
+        // A pasted screenshot arrives unnamed, and the name becomes the
+        // filename on disk and the path in the prompt.
+        name: file.name || pastedName(file.type),
+        type: file.type,
+        size: file.size,
+        bytes: new Uint8Array(await file.arrayBuffer()),
+        preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+      })),
+    )
+    setAttachments((current) => [...current, ...read])
+  }
+
+  const drop = (attachment: Attachment): void => {
+    if (attachment.preview) URL.revokeObjectURL(attachment.preview)
+    setAttachments((current) => current.filter((a) => a.id !== attachment.id))
+  }
+
   const send = async (): Promise<void> => {
     const text = draft.trim()
-    if (!text || sending) return
+    if ((!text && attachments.length === 0) || sending) return
     setSending(true)
     try {
-      const result = await api(hostId).sendPrompt(session.session_id, text)
+      // Upload first: a prompt naming a path the daemon never stored is worse
+      // than no prompt, and the agent would go looking for it.
+      let message = text
+      if (attachments.length > 0) {
+        const stored = await api(hostId).uploadFiles(
+          session.session_id,
+          attachments.map(({ name, type, bytes }) => ({ name, type, bytes })),
+        )
+        message = [...stored.map((file) => `Attached: ${file.path}`), '', text].join('\n').trim()
+      }
+
+      const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')
+      for (const attachment of attachments) {
+        if (attachment.preview) URL.revokeObjectURL(attachment.preview)
+      }
+      setAttachments([])
       if (result.queued) store.notify('Queued — the agent is mid-turn')
       void store.refreshSessions(hostId)
     } catch (err) {
@@ -209,8 +252,71 @@ export function ChatPanel({
           </button>
         </div>
       ) : (
-        <div className="composer">
+        <div
+          className={dropping ? 'composer dropping' : 'composer'}
+          onDragOver={(event) => {
+            if (!event.dataTransfer.types.includes('Files')) return
+            event.preventDefault()
+            setDropping(true)
+          }}
+          onDragLeave={(event) => {
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
+            setDropping(false)
+          }}
+          onDrop={(event) => {
+            if (!event.dataTransfer.types.includes('Files')) return
+            event.preventDefault()
+            setDropping(false)
+            void attach(event.dataTransfer.files)
+          }}
+        >
+          {attachments.length > 0 && (
+            <div className="attachments">
+              {attachments.map((attachment) => (
+                <span key={attachment.id} className="attachment">
+                  {attachment.preview ? (
+                    <img className="attachment-thumb" src={attachment.preview} alt="" />
+                  ) : (
+                    <span className="attachment-icon">◫</span>
+                  )}
+                  <span className="attachment-name" title={attachment.name}>
+                    {attachment.name}
+                  </span>
+                  <span className="attachment-size">{fileSize(attachment.size)}</span>
+                  <button
+                    className="attachment-drop"
+                    aria-label={`Remove ${attachment.name}`}
+                    title="Remove"
+                    onClick={() => drop(attachment)}
+                  >
+                    ✕
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
           <div className="composer-input">
+            <input
+              ref={picker}
+              type="file"
+              multiple
+              hidden
+              onChange={(event) => {
+                void attach(event.target.files)
+                // Cleared so picking the same file twice fires onChange twice.
+                event.target.value = ''
+              }}
+            />
+            <button
+              className="icon-btn attach-btn"
+              title="Attach files — or paste and drop them here"
+              aria-label="Attach files"
+              disabled={sending}
+              onClick={() => picker.current?.click()}
+            >
+              ⊕
+            </button>
             <textarea
               ref={composer}
               value={draft}
@@ -221,6 +327,13 @@ export function ChatPanel({
                   : 'Send a prompt (↵ to send, ⇧↵ for a new line)'
               }
               onChange={(event) => setDraft(event.target.value)}
+              onPaste={(event) => {
+                // A screenshot on the clipboard comes through as a file. Let
+                // the default run when there is none, or pasted text is lost.
+                if (event.clipboardData.files.length === 0) return
+                event.preventDefault()
+                void attach(event.clipboardData.files)
+              }}
               onKeyDown={(event) => {
                 if (event.key !== 'Enter') return
                 // An IME uses Enter to accept a candidate; sending there would
@@ -233,7 +346,7 @@ export function ChatPanel({
             />
             <button
               className="filled send-btn"
-              disabled={!draft.trim() || sending}
+              disabled={(!draft.trim() && attachments.length === 0) || sending}
               title={cold ? 'Wake and send' : 'Send (↵)'}
               aria-label={cold ? 'Wake and send' : 'Send'}
               onClick={() => void send()}
@@ -252,6 +365,30 @@ export function ChatPanel({
       )}
     </div>
   )
+}
+
+/** A file held in the composer, read into memory and not yet uploaded. */
+interface Attachment {
+  id: number
+  name: string
+  type: string
+  size: number
+  bytes: Uint8Array
+  /** Object URL for images, so the chip shows what was pasted. */
+  preview: string | null
+}
+
+/** A pasted image has no name of its own, and the name becomes the path. */
+function pastedName(type: string): string {
+  const ext = type.split('/')[1]?.split('+')[0] ?? 'bin'
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, '')
+  return `pasted-${stamp}.${ext}`
+}
+
+function fileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 /** Quoted, so the composer keeps the lines apart from what is typed about them. */

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,8 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 			s.handleSessionTranscript(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/send"):
 			s.handleSessionSend(w, r)
+		case r.Method == "POST" && strings.HasSuffix(path, "/files"):
+			s.handleSessionUpload(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/stop"):
 			s.handleSessionStop(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/terminate"):

--- a/internal/server/uploads.go
+++ b/internal/server/uploads.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// Larger than the 10 MB read limit: a phone photo clears that on its own,
+	// and the agent reads what lands here with its own tools rather than
+	// through the file API.
+	maxUploadSize = 25 * 1024 * 1024
+	// Parts above this spill to a temp file instead of being held in memory.
+	uploadMemoryLimit = 8 * 1024 * 1024
+)
+
+type uploadedFile struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// uploadDir is where a session's attachments live: beside the database and the
+// logs, not in the workspace. A repository is the user's, and dropping files
+// into it to hand the agent a screenshot would show up in their next diff.
+func uploadDir(sessionID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".helios", "uploads", sessionID), nil
+}
+
+// handleSessionUpload takes multipart form files and writes them to the
+// session's upload directory, answering with the absolute path of each.
+//
+// The path is the point: the client puts it in the prompt and the agent opens
+// it with Read, so nothing about the bytes has to cross the model's context to
+// get there.
+func (s *PublicServer) handleSessionUpload(w http.ResponseWriter, r *http.Request) {
+	id := extractSessionID(r.URL.Path, "/files")
+	if id == "" {
+		jsonError(w, "missing session id", http.StatusBadRequest)
+		return
+	}
+
+	session, err := s.shared.DB.GetSession(id)
+	if err != nil || session == nil {
+		jsonError(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
+	if err := r.ParseMultipartForm(uploadMemoryLimit); err != nil {
+		// MaxBytesReader is the usual cause, and a size is more use than a parse
+		// error the caller can do nothing with.
+		jsonResponse(w, http.StatusRequestEntityTooLarge, map[string]interface{}{
+			"error":    "upload_too_large",
+			"message":  fmt.Sprintf("upload exceeds the %d MB limit", maxUploadSize/(1024*1024)),
+			"max_size": maxUploadSize,
+		})
+		return
+	}
+	defer func() {
+		if r.MultipartForm != nil {
+			_ = r.MultipartForm.RemoveAll()
+		}
+	}()
+
+	headers := r.MultipartForm.File["file"]
+	if len(headers) == 0 {
+		jsonError(w, "no files in request", http.StatusBadRequest)
+		return
+	}
+
+	dir, err := uploadDir(id)
+	if err != nil {
+		jsonError(w, "no home directory to store uploads in", http.StatusInternalServerError)
+		return
+	}
+	// 0700: an attachment is as private as the session it belongs to.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		jsonError(w, "failed to create upload directory", http.StatusInternalServerError)
+		return
+	}
+
+	saved := make([]uploadedFile, 0, len(headers))
+	for _, header := range headers {
+		file, err := storeUpload(dir, header)
+		if err != nil {
+			log.Printf("session-upload: session=%s file=%q: %v", id, header.Filename, err)
+			jsonError(w, fmt.Sprintf("failed to store %s", safeName(header.Filename)), http.StatusInternalServerError)
+			return
+		}
+		saved = append(saved, file)
+	}
+
+	log.Printf("session-upload: session=%s stored %d file(s) in %s", id, len(saved), dir)
+	jsonResponse(w, http.StatusOK, map[string]interface{}{"files": saved})
+}
+
+func storeUpload(dir string, header *multipart.FileHeader) (uploadedFile, error) {
+	src, err := header.Open()
+	if err != nil {
+		return uploadedFile{}, err
+	}
+	defer src.Close()
+
+	path := uniquePath(dir, safeName(header.Filename))
+	dst, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return uploadedFile{}, err
+	}
+	defer dst.Close()
+
+	size, err := io.Copy(dst, src)
+	if err != nil {
+		// A half-written attachment is worse than none: the agent would read it
+		// and report on a truncated file.
+		os.Remove(path)
+		return uploadedFile{}, err
+	}
+
+	return uploadedFile{Name: filepath.Base(path), Path: path, Size: size}, nil
+}
+
+// safeName reduces whatever the client sent to a single filename. The name
+// comes from a remote client, so a path in it is either a browser quirk or an
+// attempt to write outside the directory; neither is worth honouring.
+func safeName(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	base := filepath.Base(strings.TrimSpace(name))
+	base = strings.TrimLeft(base, ".")
+	if base == "" || base == "/" {
+		return "upload"
+	}
+	// Control characters and separators have no business in a filename, and the
+	// path goes on to be pasted into a prompt.
+	base = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || r == '/' {
+			return '-'
+		}
+		return r
+	}, base)
+	if len(base) > 120 {
+		ext := filepath.Ext(base)
+		base = base[:120-len(ext)] + ext
+	}
+	return base
+}
+
+// uniquePath keeps the name the user knows the file by, and only numbers it
+// when that name is taken — screenshot.png, screenshot-1.png.
+func uniquePath(dir, name string) string {
+	candidate := filepath.Join(dir, name)
+	if _, err := os.Stat(candidate); os.IsNotExist(err) {
+		return candidate
+	}
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	for n := 1; ; n++ {
+		candidate = filepath.Join(dir, fmt.Sprintf("%s-%d%s", stem, n, ext))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}

--- a/internal/server/uploads_test.go
+++ b/internal/server/uploads_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+func newUploadTest(t *testing.T) (*PublicServer, *Shared, string) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	shared := NewShared(db, notifications.NewManager(db), newStubBackend())
+	return &PublicServer{shared: shared}, shared, home
+}
+
+type part struct {
+	name    string
+	content string
+}
+
+func upload(t *testing.T, s *PublicServer, sessionID string, parts ...part) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	for _, p := range parts {
+		w, err := form.CreateFormFile("file", p.name)
+		if err != nil {
+			t.Fatalf("create form file: %v", err)
+		}
+		if _, err := w.Write([]byte(p.content)); err != nil {
+			t.Fatalf("write part: %v", err)
+		}
+	}
+	form.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sessionID+"/files", &body)
+	req.Header.Set("Content-Type", form.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	s.handleSessionUpload(rec, req)
+
+	var payload map[string]interface{}
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("decode response %q: %v", rec.Body.String(), err)
+		}
+	}
+	return rec, payload
+}
+
+func uploadedPaths(t *testing.T, payload map[string]interface{}) []string {
+	t.Helper()
+	files, ok := payload["files"].([]interface{})
+	if !ok {
+		t.Fatalf("no files in response: %v", payload)
+	}
+	paths := make([]string, 0, len(files))
+	for _, entry := range files {
+		file, ok := entry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("bad file entry: %v", entry)
+		}
+		paths = append(paths, file["path"].(string))
+	}
+	return paths
+}
+
+// The path in the response is the whole feature: the client pastes it into a
+// prompt, so it has to be absolute and it has to hold the bytes that were sent.
+func TestUpload_StoresTheFileAndReturnsItsPath(t *testing.T) {
+	s, shared, home := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	rec, payload := upload(t, s, "sess-1", part{name: "diagram.png", content: "not really a png"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+
+	paths := uploadedPaths(t, payload)
+	if len(paths) != 1 {
+		t.Fatalf("files: got %d, want 1", len(paths))
+	}
+
+	want := filepath.Join(home, ".helios", "uploads", "sess-1", "diagram.png")
+	if paths[0] != want {
+		t.Errorf("path: got %q, want %q", paths[0], want)
+	}
+	content, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatalf("read stored file: %v", err)
+	}
+	if string(content) != "not really a png" {
+		t.Errorf("content: got %q", content)
+	}
+}
+
+// The filename arrives from a remote client, so a path inside it is either a
+// browser quirk or an attempt to write somewhere it should not.
+func TestUpload_FilenameCannotEscapeTheUploadDirectory(t *testing.T) {
+	s, shared, home := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	_, payload := upload(t, s, "sess-1", part{name: "../../../etc/passwd", content: "x"})
+	paths := uploadedPaths(t, payload)
+
+	dir := filepath.Join(home, ".helios", "uploads", "sess-1")
+	if filepath.Dir(paths[0]) != dir {
+		t.Errorf("escaped the upload directory: %q", paths[0])
+	}
+	if strings.Contains(paths[0], "..") {
+		t.Errorf("path still traverses: %q", paths[0])
+	}
+}
+
+// Two screenshots are both called Screenshot.png. Neither may overwrite the
+// other: the first one's path is already in a prompt by then.
+func TestUpload_SameNameTwiceKeepsBothFiles(t *testing.T) {
+	s, shared, _ := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	_, first := upload(t, s, "sess-1", part{name: "shot.png", content: "one"})
+	_, second := upload(t, s, "sess-1", part{name: "shot.png", content: "two"})
+
+	firstPath, secondPath := uploadedPaths(t, first)[0], uploadedPaths(t, second)[0]
+	if firstPath == secondPath {
+		t.Fatalf("second upload reused the path %q", firstPath)
+	}
+	if got := filepath.Base(secondPath); got != "shot-1.png" {
+		t.Errorf("second name: got %q, want shot-1.png", got)
+	}
+
+	content, err := os.ReadFile(firstPath)
+	if err != nil || string(content) != "one" {
+		t.Errorf("first file was overwritten: %q, %v", content, err)
+	}
+}
+
+func TestUpload_SeveralFilesInOneRequest(t *testing.T) {
+	s, shared, _ := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	_, payload := upload(t, s, "sess-1",
+		part{name: "a.txt", content: "a"},
+		part{name: "b.txt", content: "b"},
+	)
+	if paths := uploadedPaths(t, payload); len(paths) != 2 {
+		t.Fatalf("files: got %d, want 2", len(paths))
+	}
+}
+
+func TestUpload_UnknownSessionIsRejected(t *testing.T) {
+	s, _, home := newUploadTest(t)
+
+	rec, _ := upload(t, s, "nope", part{name: "a.txt", content: "a"})
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", rec.Code)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".helios", "uploads", "nope")); !os.IsNotExist(err) {
+		t.Errorf("created a directory for a session that does not exist")
+	}
+}
+
+func TestUpload_RequestWithoutFilesIsRejected(t *testing.T) {
+	s, shared, _ := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	rec, _ := upload(t, s, "sess-1")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+}

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import '../models/session.dart';
 import '../models/message.dart';
@@ -8,6 +10,7 @@ import '../models/provider.dart';
 import '../providers/card_registry.dart' as registry;
 import '../providers/claude/notification_ext.dart';
 import '../providers/claude/verbs.dart';
+import '../services/api_client.dart';
 import '../services/host_manager.dart';
 import '../services/daemon_api_service.dart';
 import '../widgets/message_card.dart';
@@ -35,6 +38,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       <String, _SubRoute>{}; // sessionId → last sub-screen
 
   final _promptController = TextEditingController();
+  final List<UploadFile> _attachments = [];
   final _scrollController = ScrollController();
   List<Message> _messages = [];
   bool _loading = true;
@@ -208,17 +212,117 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     }
   }
 
+  /// Picks attachments, from the gallery, the camera, or the file browser.
+  Future<void> _attach(_AttachSource source) async {
+    try {
+      final picked = <UploadFile>[];
+      if (source == _AttachSource.files) {
+        final result = await FilePicker.pickFiles(
+          allowMultiple: true,
+          withData: true,
+        );
+        for (final file in result?.files ?? <PlatformFile>[]) {
+          if (file.bytes != null) {
+            picked.add(UploadFile(name: file.name, bytes: file.bytes!));
+          }
+        }
+      } else {
+        final image = await ImagePicker().pickImage(
+          source: source == _AttachSource.camera
+              ? ImageSource.camera
+              : ImageSource.gallery,
+        );
+        if (image != null) {
+          picked.add(
+            UploadFile(name: image.name, bytes: await image.readAsBytes()),
+          );
+        }
+      }
+      if (picked.isNotEmpty && mounted) {
+        setState(() => _attachments.addAll(picked));
+      }
+    } catch (e) {
+      debugPrint('[attach] $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not read that file')),
+        );
+      }
+    }
+  }
+
+  void _showAttachSheet() {
+    showModalBottomSheet(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: const Text('Photo library'),
+              onTap: () {
+                Navigator.pop(ctx);
+                _attach(_AttachSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_camera_outlined),
+              title: const Text('Camera'),
+              onTap: () {
+                Navigator.pop(ctx);
+                _attach(_AttachSource.camera);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.attach_file),
+              title: const Text('File'),
+              onTap: () {
+                Navigator.pop(ctx);
+                _attach(_AttachSource.files);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _sendPrompt() async {
     final text = _promptController.text.trim();
-    if (text.isEmpty) return;
+    if (text.isEmpty && _attachments.isEmpty) return;
 
     setState(() => _sending = true);
     final sse = _sse;
+
+    // Upload first. A prompt naming a path the daemon never stored sends the
+    // agent looking for a file that is not there.
+    var message = text;
+    if (_attachments.isNotEmpty) {
+      final paths = sse == null
+          ? null
+          : await sse.uploadSessionFiles(
+              widget.session.sessionId,
+              _attachments,
+            );
+      if (paths == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Could not upload the attachments')),
+          );
+          setState(() => _sending = false);
+        }
+        return;
+      }
+      message = [...paths.map((p) => 'Attached: $p'), '', text].join('\n').trim();
+    }
+
     final error = sse == null
         ? 'Not connected'
-        : await sse.sendSessionPrompt(widget.session.sessionId, text);
+        : await sse.sendSessionPrompt(widget.session.sessionId, message);
     if (error == null && mounted) {
       _promptController.clear();
+      setState(() => _attachments.clear());
       await Future.delayed(const Duration(milliseconds: 500));
       await _loadTranscript();
     } else if (mounted) {
@@ -1306,6 +1410,24 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
                 );
               },
             ),
+          if (_attachments.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: _attachments
+                    .map(
+                      (file) => _AttachmentChip(
+                        file: file,
+                        onRemove: _sending
+                            ? null
+                            : () => setState(() => _attachments.remove(file)),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
           Row(
             children: [
               if (hasCommands)
@@ -1317,6 +1439,11 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
                   ),
                   tooltip: 'Commands',
                 ),
+              IconButton(
+                onPressed: canSend && !_sending ? _showAttachSheet : null,
+                icon: const Icon(Icons.add_photo_alternate_outlined, size: 22),
+                tooltip: 'Attach a photo or file',
+              ),
               Expanded(
                 child: AnimatedBuilder(
                   animation: _breathController,
@@ -1700,4 +1827,80 @@ enum _SubRouteType { gitStatus, fileBrowser }
 class _SubRoute {
   final _SubRouteType type;
   _SubRoute(this.type);
+}
+
+enum _AttachSource { gallery, camera, files }
+
+/// One pending attachment. A thumbnail for images, because the point of
+/// sending a screenshot is knowing which screenshot went.
+class _AttachmentChip extends StatelessWidget {
+  final UploadFile file;
+  final VoidCallback? onRemove;
+
+  const _AttachmentChip({required this.file, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.only(left: 6, right: 2, top: 3, bottom: 3),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (file.isImage)
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: Image.memory(
+                file.bytes,
+                width: 20,
+                height: 20,
+                fit: BoxFit.cover,
+                gaplessPlayback: true,
+              ),
+            )
+          else
+            Icon(
+              Icons.insert_drive_file_outlined,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          const SizedBox(width: 6),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 140),
+            child: Text(
+              file.name,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 12),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            _size(file.size),
+            style: TextStyle(
+              fontSize: 11,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          IconButton(
+            onPressed: onRemove,
+            icon: const Icon(Icons.close, size: 14),
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+            padding: EdgeInsets.zero,
+            tooltip: 'Remove',
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _size(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).round()} KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
 }

--- a/mobile/lib/services/api_client.dart
+++ b/mobile/lib/services/api_client.dart
@@ -135,6 +135,31 @@ class ApiClient {
     return resp;
   }
 
+  /// Posts files as multipart/form-data, each under the field `file`.
+  ///
+  /// A [http.MultipartRequest] is spent once sent, so the retry after a 401
+  /// builds a second one rather than replaying the first.
+  Future<http.Response> postFiles(String path, List<UploadFile> files) async {
+    Future<http.Response> attempt() async {
+      final request = http.MultipartRequest('POST', Uri.parse('$serverUrl$path'));
+      request.headers.addAll(await _authHeaders());
+      for (final file in files) {
+        request.files.add(
+          http.MultipartFile.fromBytes('file', file.bytes, filename: file.name),
+        );
+      }
+      return http.Response.fromStream(await request.send());
+    }
+
+    final resp = await attempt();
+    if (resp.statusCode == 401) {
+      debugPrint('[ApiClient] 401 on POST $path — refreshing token');
+      invalidateToken();
+      return attempt();
+    }
+    return resp;
+  }
+
   Future<http.Response> delete(String path) async {
     final resp = await http.delete(
       Uri.parse('$serverUrl$path'),
@@ -149,5 +174,26 @@ class ApiClient {
       );
     }
     return resp;
+  }
+}
+
+/// A file picked on the device, held in memory until it is uploaded.
+class UploadFile {
+  final String name;
+  final Uint8List bytes;
+
+  const UploadFile({required this.name, required this.bytes});
+
+  int get size => bytes.length;
+
+  /// True for the kinds the composer shows a thumbnail for.
+  bool get isImage {
+    final lower = name.toLowerCase();
+    return lower.endsWith('.png') ||
+        lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.gif') ||
+        lower.endsWith('.webp') ||
+        lower.endsWith('.heic');
   }
 }

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -607,6 +607,32 @@ class DaemonAPIService extends ChangeNotifier {
     return [];
   }
 
+  /// Uploads attachments and returns the path the daemon stored each under.
+  ///
+  /// The bytes stop at the daemon: the prompt carries the paths, and the agent
+  /// opens them with its own tools. Returns null when the upload failed, which
+  /// the caller reports rather than sending a prompt naming files that are not
+  /// there.
+  Future<List<String>?> uploadSessionFiles(
+    String sessionId,
+    List<UploadFile> files,
+  ) async {
+    if (files.isEmpty) return const [];
+    try {
+      final resp = await _api.postFiles('/api/sessions/$sessionId/files', files);
+      if (resp.statusCode != 200) {
+        debugPrint('[$hostId] uploadSessionFiles: ${resp.statusCode} ${resp.body}');
+        return null;
+      }
+      final data = jsonDecode(resp.body);
+      final list = (data['files'] as List?) ?? [];
+      return list.map((f) => f['path'] as String).toList();
+    } catch (e) {
+      debugPrint('[$hostId] Failed to upload files: $e');
+      return null;
+    }
+  }
+
   /// Sends a prompt and waits for the agent to accept it.
   ///
   /// Returns null when it did. Anything else is the reason it did not, worth

--- a/mobile/linux/flutter/generated_plugin_registrant.cc
+++ b/mobile/linux/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,16 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <open_file_linux/open_file_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/mobile/linux/flutter/generated_plugins.cmake
+++ b/mobile/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   flutter_secure_storage_linux
   gtk
   open_file_linux

--- a/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,8 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import file_picker
+import file_selector_macos
 import flutter_local_notifications
 import flutter_secure_storage_macos
 import flutter_tts
@@ -18,6 +20,8 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -137,6 +145,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.3"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -214,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7+1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -328,6 +384,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+17"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   jni:
     dependency: transitive
     description:
@@ -428,10 +548,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   mobile_scanner:
     dependency: "direct main"
     description:
@@ -833,10 +961,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   open_file: ^3.5.10
   # Temp/cache directory for APK download
   path_provider: ^2.1.5
+  file_picker: ^11.0.3
+  image_picker: ^1.2.3
 
 dev_dependencies:
   flutter_test:

--- a/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -16,6 +17,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTtsPluginRegisterWithRegistrar(

--- a/mobile/windows/flutter/generated_plugins.cmake
+++ b/mobile/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  file_selector_windows
   flutter_secure_storage_windows
   flutter_tts
   permission_handler_windows


### PR DESCRIPTION
## Summary

A screenshot of a broken layout, a log with the stack trace in it, a PDF of the spec — all of it had to reach the agent by being described, or saved somewhere and named by hand.

**Daemon.** `POST /api/sessions/{id}/files` takes multipart uploads (field `file`, several per request) and stores them under `~/.helios/uploads/<session>/`, answering with the absolute path of each. The path is the whole mechanism: the client puts it in the prompt as an `Attached:` line and the agent opens it with Read, so the bytes never cross the model's context — a 20 MB video costs the same prompt as a one-line note.

**Desktop.** Attach by button, by drop, or by paste. Paste is the one that matters: a screenshot goes from clipboard to agent without being a file the user has to think about. Bytes cross IPC to the main process, which does the multipart POST with its own 120s timeout and 401 retry.

**Mobile.** Photo library, camera, or file browser (`image_picker` + `file_picker`). Same chips, same `Attached:` lines.

Uploads happen *before* the prompt is sent — a prompt naming a path the daemon never stored is worse than no prompt, because the agent goes looking and finds nothing.

### Handling hostile input

Filenames come from a remote client, so they are reduced to a basename before touching the filesystem: `../../etc/passwd` is stored as `passwd` inside the session directory. A name already taken is numbered (`shot-1.png`) rather than overwritten, since the first file's path is already in a prompt by then. 25 MB cap, `0700` directory, `0600` files, and a half-written file is removed rather than left for the agent to read and report on.

## Test plan

- [x] `go build ./...`, `go test ./internal/server/` — 6 new upload tests: stores and returns the path, filename cannot escape the directory, same name twice keeps both, several files per request, unknown session 404s, no-files 400s
- [x] `npm run typecheck`, `npm run build`, `npm test` (36 pass)
- [x] `flutter analyze` clean; debug APK builds with both pickers
- [x] Desktop exercised in a browser harness with real events: a pasted unnamed screenshot became `pasted-<timestamp>.png` with a thumbnail; a dropped `server.log` produced a file chip and the "Drop to attach" overlay; sending emitted `Attached: <path>` per file followed by the typed text, then cleared the chips and the draft

Desktop was verified against a stubbed preload bridge rather than a live daemon, to avoid touching a running agent's PTY.

## Note on the branch

Built in a worktree because the main checkout has in-flight theming work touching `bridge.ts`, `ipc.ts` and `styles.css`. My edits to those three were reapplied by hand against a clean checkout; the diff contains no theme changes.