### PR TITLE
feat(desktop): theme the app with VS Code colour themes

### DIFF
--- a/desktop/build.mjs
+++ b/desktop/build.mjs
@@ -77,6 +77,9 @@ await cp(resolve(root, 'src/renderer/index.html'), resolve(out, 'renderer/index.
 await cp(resolve(root, 'src/renderer/hud.html'), resolve(out, 'renderer/hud.html'))
 await cp(resolve(root, 'node_modules/@xterm/xterm/css/xterm.css'), resolve(out, 'renderer/xterm.css'))
 await cp(resolve(root, 'assets'), resolve(out, 'assets'), { recursive: true })
+// Bundled colour themes live at the repo root so the Flutter app can pick them
+// up as an asset directory later without the files having to move.
+await cp(resolve(root, '../themes'), resolve(out, 'themes'), { recursive: true })
 
 if (watch) {
   const contexts = await Promise.all(configs.map((c) => esbuild.context(c)))

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -24,7 +24,6 @@
         "@codemirror/language": "^6.12.4",
         "@codemirror/search": "^6.7.1",
         "@codemirror/state": "^6.7.1",
-        "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.43.8",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
@@ -249,19 +248,6 @@
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/theme-one-dark": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
-      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
@@ -1598,6 +1584,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1705,7 +1692,8 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -1764,6 +1752,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1930,7 +1919,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1950,7 +1938,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1973,7 +1960,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1989,8 +1975,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1998,7 +1983,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -2643,7 +2627,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -2768,7 +2751,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -2782,7 +2764,6 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -3011,6 +2992,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -3216,7 +3198,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -3230,7 +3211,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3246,7 +3226,6 @@
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -3260,7 +3239,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3689,8 +3667,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -4294,8 +4271,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -4449,7 +4425,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -4463,7 +4438,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4479,8 +4453,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -4488,7 +4461,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -4505,40 +4477,35 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -5037,7 +5004,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5285,8 +5251,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -5359,6 +5324,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5414,7 +5380,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -5424,8 +5389,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.1.4",
@@ -5433,7 +5397,6 @@
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5444,7 +5407,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5964,7 +5926,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -6370,7 +6331,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -6386,7 +6346,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,6 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.7.1",
-    "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.8",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",

--- a/desktop/scripts/fetch-themes.mjs
+++ b/desktop/scripts/fetch-themes.mjs
@@ -1,0 +1,121 @@
+// Refreshes the bundled colour themes in the repo-root `themes/` directory.
+//
+// Themes are vendored rather than fetched at runtime, and flattened rather than
+// stored as their authors publish them: an upstream theme is often a two- or
+// three-file `include` chain rooted at a VS Code built-in, which is fine inside
+// VS Code and unresolvable anywhere else. Each file written here is a complete,
+// standalone VS Code colour theme, so the same file works whether it ships with
+// the app or a user drops it into ~/.helios/themes.
+//
+// Usage: node scripts/fetch-themes.mjs
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parseJsonc } from '../src/shared/theme/vscode.ts'
+import { mergeThemes, modeFromUiTheme } from '../src/shared/theme/resolve.ts'
+
+const out = resolve(dirname(fileURLToPath(import.meta.url)), '../../themes')
+
+const VSCODE = 'https://raw.githubusercontent.com/microsoft/vscode/main/extensions'
+
+/** Themes published as a plain JSON file in a git repo. */
+const RAW = [
+  { id: 'dark-modern', url: `${VSCODE}/theme-defaults/themes/dark_modern.json`, type: 'dark' },
+  { id: 'light-modern', url: `${VSCODE}/theme-defaults/themes/light_modern.json`, type: 'light' },
+  { id: 'monokai', url: `${VSCODE}/theme-monokai/themes/monokai-color-theme.json`, type: 'dark' },
+  { id: 'solarized-dark', url: `${VSCODE}/theme-solarized-dark/themes/solarized-dark-color-theme.json`, type: 'dark' },
+  { id: 'solarized-light', url: `${VSCODE}/theme-solarized-light/themes/solarized-light-color-theme.json`, type: 'light' },
+  {
+    id: 'tokyo-night',
+    url: 'https://raw.githubusercontent.com/enkia/tokyo-night-vscode-theme/master/themes/tokyo-night-color-theme.json',
+    type: 'dark',
+  },
+  {
+    id: 'nord',
+    url: 'https://raw.githubusercontent.com/nordtheme/visual-studio-code/develop/themes/nord-color-theme.json',
+    type: 'dark',
+  },
+  {
+    id: 'one-dark-pro',
+    url: 'https://raw.githubusercontent.com/Binaryify/OneDark-Pro/master/themes/OneDark-Pro.json',
+    type: 'dark',
+  },
+]
+
+/**
+ * Themes whose repos generate their JSON at package time, so the published
+ * extension is the only place the finished file exists.
+ */
+const EXTENSIONS = [
+  { publisher: 'Catppuccin', name: 'catppuccin-vsc', pick: { 'catppuccin-mocha': /mocha/i, 'catppuccin-latte': /latte/i } },
+  { publisher: 'dracula-theme', name: 'theme-dracula', pick: { dracula: /^Dracula Theme$/ } },
+  { publisher: 'GitHub', name: 'github-vscode-theme', pick: { 'github-dark': /^GitHub Dark$/, 'github-light': /^GitHub Light$/ } },
+  { publisher: 'jdinhlife', name: 'gruvbox', pick: { 'gruvbox-dark': /Dark Medium/i, 'gruvbox-light': /Light Medium/i } },
+]
+
+async function fetchText(url) {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${response.status} ${url}`)
+  return response.text()
+}
+
+/** Follows an `include` up its chain, merging each parent under its child. */
+async function flattenRemote(url) {
+  const theme = parseJsonc(await fetchText(url))
+  if (!theme.include) return theme
+  const parentUrl = new URL(theme.include, url).toString()
+  return mergeThemes(await flattenRemote(parentUrl), theme)
+}
+
+function flattenLocal(dir, file) {
+  const theme = parseJsonc(readFileSync(resolve(dir, file), 'utf8'))
+  if (!theme.include) return theme
+  return mergeThemes(flattenLocal(resolve(dir, dirname(file)), theme.include), theme)
+}
+
+function write(id, theme, type) {
+  const body = {
+    name: theme.name ?? id,
+    type: theme.type ?? type,
+    colors: theme.colors ?? {},
+    tokenColors: theme.tokenColors ?? [],
+  }
+  writeFileSync(resolve(out, `${id}.json`), JSON.stringify(body, null, 2) + '\n')
+  const keys = Object.keys(body.colors).length
+  console.log(`  ${id.padEnd(18)} ${body.type.padEnd(5)} ${String(keys).padStart(4)} colours  ${body.tokenColors.length} token rules`)
+}
+
+async function fromExtension(spec) {
+  const meta = await (await fetch(`https://open-vsx.org/api/${spec.publisher}/${spec.name}/latest`)).json()
+  const url = meta.files?.download
+  if (!url) throw new Error(`no download for ${spec.publisher}.${spec.name}`)
+  const dir = mkdtempSync(resolve(tmpdir(), 'helios-theme-'))
+  try {
+    const vsix = resolve(dir, 'ext.vsix')
+    writeFileSync(vsix, Buffer.from(await (await fetch(url)).arrayBuffer()))
+    execFileSync('unzip', ['-qo', vsix, '-d', dir])
+    const pkg = JSON.parse(readFileSync(resolve(dir, 'extension/package.json'), 'utf8'))
+    const contributed = pkg.contributes?.themes ?? []
+    for (const [id, match] of Object.entries(spec.pick)) {
+      const entry = contributed.find((t) => match.test(t.label ?? '') || match.test(t.path ?? ''))
+      if (!entry) {
+        console.log(`  ${id.padEnd(18)} SKIPPED — no match in ${spec.publisher}.${spec.name}`)
+        continue
+      }
+      const theme = flattenLocal(resolve(dir, 'extension'), entry.path)
+      write(id, theme, modeFromUiTheme(entry.uiTheme) ?? 'dark')
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+mkdirSync(out, { recursive: true })
+console.log(`writing to ${out}`)
+for (const spec of RAW) write(spec.id, await flattenRemote(spec.url), spec.type)
+for (const spec of EXTENSIONS) await fromExtension(spec)
+console.log(`\n${readdirSync(out).filter((f) => f.endsWith('.json')).length} themes`)

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,10 +1,12 @@
-import { ipcMain, type BrowserWindow, type IpcMainInvokeEvent } from 'electron'
+import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { ApiError, type ApiClient } from './api.ts'
 import type { HostRegistry } from './hosts.ts'
 import type { Notifier } from './notify.ts'
 import type { PrefsStore } from './prefs.ts'
 import type { TerminalManager } from './terminals.ts'
+import type { ThemeRegistry } from './themes.ts'
+import type { AppearancePrefs } from '../shared/models.ts'
 
 /**
  * REST calls the renderer may make. An allow-list rather than a reflective
@@ -19,6 +21,7 @@ const API_METHODS = new Set<keyof ApiClient>([
   'transcript',
   'subagents',
   'sendPrompt',
+  'uploadFiles',
   'stop',
   'terminate',
   'resume',
@@ -58,6 +61,7 @@ export interface IpcDeps {
   terminals: TerminalManager
   notifier: Notifier
   prefs: PrefsStore
+  themes: ThemeRegistry
   window: () => BrowserWindow | null
 }
 
@@ -70,7 +74,7 @@ export interface IpcDeps {
  * string otherwise.
  */
 export function registerIpc(deps: IpcDeps): void {
-  const { hosts, terminals, notifier, prefs } = deps
+  const { hosts, terminals, notifier, prefs, themes } = deps
 
   const send = (channel: string, payload: unknown): void => {
     const window = deps.window()
@@ -132,6 +136,41 @@ export function registerIpc(deps: IpcDeps): void {
   handle('prefs:setSound', async (_e, enabled: boolean) => prefs.setSound(enabled))
   handle('prefs:setAlert', async (_e, type: string, enabled: boolean) => prefs.setAlert(type, enabled))
   handle('prefs:reset', async () => prefs.reset())
+
+  // ─── Appearance ────────────────────────────────────────────────────────
+
+  // Every window, not just the main one: the HUD draws its cards from the same
+  // variables and would otherwise keep the old theme until it next opened.
+  const broadcastTheme = (): { theme: unknown; terminal: unknown } => {
+    const payload = { theme: themes.active(), terminal: themes.activeTerminal() }
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('theme:changed', payload)
+    }
+    return payload
+  }
+
+  themes.onSystemChange(broadcastTheme)
+
+  // Synchronous, and the only channel that is: the preload script reads it
+  // before the page has scripts of its own so it can paint the theme onto
+  // <html> ahead of the first frame. Going through invoke would put a promise
+  // between the document opening and its colours arriving, which is the flash
+  // this avoids.
+  ipcMain.on('theme:boot', (event) => {
+    event.returnValue = { theme: themes.active(), terminal: themes.activeTerminal() }
+  })
+
+  handle('theme:list', async () => themes.list())
+  handle('theme:prefs', async () => themes.getPrefs())
+  handle('theme:set', async (_e, next: Partial<AppearancePrefs>) => {
+    themes.setPrefs(next)
+    return broadcastTheme()
+  })
+  handle('theme:reload', async () => {
+    themes.reload()
+    broadcastTheme()
+    return themes.list()
+  })
 
   // ─── Terminals ─────────────────────────────────────────────────────────
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -6,6 +6,7 @@ import { Hud } from './hud.ts'
 import { Notifier, type NotifyTarget } from './notify.ts'
 import { PrefsStore } from './prefs.ts'
 import { TerminalManager } from './terminals.ts'
+import { ThemeRegistry } from './themes.ts'
 import { registerIpc } from './ipc.ts'
 
 /** dist/main → dist. The main bundle is CommonJS, so __dirname is the real thing. */
@@ -20,6 +21,7 @@ let terminals: TerminalManager | null = null
 let notifier: Notifier | null = null
 let hud: Hud | null = null
 let prefs: PrefsStore | null = null
+let themes: ThemeRegistry | null = null
 let quitting = false
 
 /** Brings the HUD forward and gives it the keyboard, since it opens unfocused. */
@@ -58,13 +60,15 @@ async function start(): Promise<void> {
   terminals = new TerminalManager(hosts)
   prefs = new PrefsStore()
   prefs.load()
+  themes = new ThemeRegistry(path.join(distDir, 'themes'))
+  themes.load()
   hud = new Hud(rendererDir, path.join(distDir, 'preload', 'preload.js'), activateNotification)
   notifier = new Notifier(hosts, hud, prefs, activateNotification, openSettings, () => {
     quitting = true
     app.quit()
   })
 
-  registerIpc({ hosts, terminals, notifier, prefs, window: () => window })
+  registerIpc({ hosts, terminals, notifier, prefs, themes, window: () => window })
 
   // The HUD is shown without focus, so nothing reaches its keyboard handlers
   // until the user asks for it.
@@ -111,7 +115,9 @@ function createWindow(): void {
     minHeight: 560,
     show: false,
     icon: appIcon,
-    backgroundColor: '#101014',
+    // The frame is painted before the renderer runs, so it has to come from the
+    // theme too or the window flashes the old dark grey on every open.
+    backgroundColor: themes?.active().vars['--surface'] ?? '#101014',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       preload: path.join(distDir, 'preload', 'preload.js'),

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -1,0 +1,144 @@
+import { app, nativeTheme } from 'electron'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { resolveTheme, type HeliosTheme, type ThemeMode } from '../shared/theme/resolve.ts'
+import { parseJsonc, type VSCodeTheme } from '../shared/theme/vscode.ts'
+import type { AppearancePrefs, ThemeSummary } from '../shared/models.ts'
+
+export const DEFAULT_APPEARANCE: AppearancePrefs = {
+  mode: 'system',
+  lightTheme: 'light-modern',
+  darkTheme: 'dark-modern',
+  terminalTheme: 'match',
+}
+
+/**
+ * The colour themes available on this machine, and which of them is in force.
+ *
+ * Themes are VS Code colour theme files: the bundled ones vendored into
+ * `themes/`, plus anything the user has dropped into `~/.helios/themes`. A user
+ * file whose name matches a bundled theme replaces it, so a bundled theme can
+ * be overridden without being deleted.
+ */
+export class ThemeRegistry {
+  private readonly bundledDir: string
+  private readonly userDir: string
+  private readonly file: string
+  private themes = new Map<string, HeliosTheme>()
+  private prefs: AppearancePrefs = { ...DEFAULT_APPEARANCE }
+
+  constructor(bundledDir: string, userDataDir = app.getPath('userData'), home = os.homedir()) {
+    this.bundledDir = bundledDir
+    this.userDir = path.join(home, '.helios', 'themes')
+    this.file = path.join(userDataDir, 'appearance.json')
+  }
+
+  load(): void {
+    this.reload()
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.file, 'utf8')) as Partial<AppearancePrefs>
+      this.prefs = {
+        mode: parsed.mode ?? DEFAULT_APPEARANCE.mode,
+        lightTheme: parsed.lightTheme ?? DEFAULT_APPEARANCE.lightTheme,
+        darkTheme: parsed.darkTheme ?? DEFAULT_APPEARANCE.darkTheme,
+        terminalTheme: parsed.terminalTheme ?? DEFAULT_APPEARANCE.terminalTheme,
+      }
+    } catch {
+      this.prefs = { ...DEFAULT_APPEARANCE }
+    }
+  }
+
+  /** Rescans both directories, so an edited theme file does not need a restart. */
+  reload(): void {
+    this.themes = new Map()
+    for (const dir of [this.bundledDir, this.userDir]) this.scan(dir)
+  }
+
+  private scan(dir: string): void {
+    let entries: string[]
+    try {
+      entries = fs.readdirSync(dir)
+    } catch {
+      // A missing ~/.helios/themes is the normal case, not a problem.
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith('.json')) continue
+      const id = entry.slice(0, -'.json'.length)
+      try {
+        const raw = parseJsonc(fs.readFileSync(path.join(dir, entry), 'utf8')) as VSCodeTheme
+        this.themes.set(id, resolveTheme(id, raw))
+      } catch (err) {
+        console.error(`theme ${id} failed to load:`, err)
+      }
+    }
+  }
+
+  list(): ThemeSummary[] {
+    return [...this.themes.values()]
+      .map((theme) => ({
+        id: theme.id,
+        name: theme.name,
+        mode: theme.mode,
+        swatch: [
+          theme.vars['--surface'] as string,
+          theme.vars['--surface-high'] as string,
+          theme.vars['--primary'] as string,
+          theme.vars['--syn-string'] as string,
+          theme.vars['--syn-keyword'] as string,
+        ],
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  getPrefs(): AppearancePrefs {
+    return { ...this.prefs }
+  }
+
+  setPrefs(next: Partial<AppearancePrefs>): AppearancePrefs {
+    this.prefs = { ...this.prefs, ...next }
+    fs.mkdirSync(path.dirname(this.file), { recursive: true })
+    fs.writeFileSync(this.file, JSON.stringify(this.prefs, null, 2))
+    return this.getPrefs()
+  }
+
+  /**
+   * Calls back when the OS appearance changes, but only while the user is
+   * following it — a pinned light or dark theme should not move because someone
+   * flipped a system switch.
+   */
+  onSystemChange(listener: () => void): void {
+    nativeTheme.on('updated', () => {
+      if (this.prefs.mode === 'system') listener()
+    })
+  }
+
+  /** Which of the two slots applies right now. */
+  activeMode(): ThemeMode {
+    if (this.prefs.mode !== 'system') return this.prefs.mode
+    return nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
+  }
+
+  active(): HeliosTheme {
+    const mode = this.activeMode()
+    const wanted = mode === 'dark' ? this.prefs.darkTheme : this.prefs.lightTheme
+    return (
+      this.themes.get(wanted) ??
+      this.themes.get(mode === 'dark' ? DEFAULT_APPEARANCE.darkTheme : DEFAULT_APPEARANCE.lightTheme) ??
+      // A user who has emptied the themes directory still gets an app.
+      resolveTheme('fallback', { type: mode })
+    )
+  }
+
+  /**
+   * The terminal palette, which is a separate choice: 'match' takes it from the
+   * UI theme, anything else pins it so a preferred terminal look survives a
+   * change of app theme.
+   */
+  activeTerminal(): HeliosTheme['ansi'] {
+    if (this.prefs.terminalTheme === 'match') return this.active().ansi
+    return (this.themes.get(this.prefs.terminalTheme) ?? this.active()).ansi
+  }
+}

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -1,5 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+import { applyTheme } from '../shared/theme/apply.ts'
+import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
+
+interface ThemeBoot {
+  theme: HeliosTheme
+  terminal: XtermTheme
+}
+
 /**
  * The only surface the renderer gets.
  *
@@ -35,6 +43,31 @@ function on(channel: string, listener: (payload: unknown) => void): () => void {
   return () => ipcRenderer.removeListener(channel, wrapped)
 }
 
+/**
+ * Painted here, in the preload, rather than by the app.
+ *
+ * This script runs before any of the page's own scripts, so the variables are
+ * on <html> before the first frame is composited — React then mounts into an
+ * already-themed document. Doing it after mount means one frame of whatever the
+ * stylesheet's defaults happen to be, which is a visible flash on every launch.
+ */
+const boot = ipcRenderer.sendSync('theme:boot') as ThemeBoot
+
+if (document.documentElement) {
+  applyTheme(document.documentElement, boot.theme)
+} else {
+  // Usually this branch: a preload runs before the parser has built <html>, so
+  // there is nothing to write to yet. Waiting for DOMContentLoaded would be too
+  // late — the stylesheet is parsed by then and its defaults get a frame. The
+  // observer fires the moment <html> appears, which is still before <head>.
+  const observer = new MutationObserver(() => {
+    if (!document.documentElement) return
+    applyTheme(document.documentElement, boot.theme)
+    observer.disconnect()
+  })
+  observer.observe(document, { childList: true })
+}
+
 const helios = {
   hosts: {
     list: () => call('hosts:list'),
@@ -67,6 +100,19 @@ const helios = {
     setSound: (enabled: boolean) => call('prefs:setSound', enabled),
     setAlert: (type: string, enabled: boolean) => call('prefs:setAlert', type, enabled),
     reset: () => call('prefs:reset'),
+  },
+  theme: {
+    /**
+     * The theme already painted onto <html> by the time the page runs. Returned
+     * rather than re-fetched so the renderer starts from exactly what is on
+     * screen instead of asking again and risking a second, different answer.
+     */
+    boot: () => boot,
+    list: () => call('theme:list'),
+    prefs: () => call('theme:prefs'),
+    set: (next: unknown) => call('theme:set', next),
+    reload: () => call('theme:reload'),
+    onChanged: (fn: (payload: unknown) => void) => on('theme:changed', fn),
   },
   hud: {
     resize: (height: number) => ipcRenderer.send('hud:resize', height),

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -1,4 +1,6 @@
+import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
 import type {
+  AppearancePrefs,
   CommandInfo,
   DeviceInfo,
   DirectoryInfo,
@@ -17,6 +19,7 @@ import type {
   NotificationPrefs,
   ProviderInfo,
   Session,
+  ThemeSummary,
   SSEEvent,
   Subagent,
   TabStatus,
@@ -35,6 +38,20 @@ import type {
  */
 
 type Unsubscribe = () => void
+
+/** One file on its way up: the bytes, and what to call them at the far end. */
+export interface UploadPart {
+  name: string
+  type: string
+  bytes: Uint8Array
+}
+
+/** Where the daemon put it. The path is what goes on to the agent. */
+export interface UploadedFile {
+  name: string
+  path: string
+  size: number
+}
 
 interface RawBridge {
   hosts: {
@@ -76,6 +93,15 @@ interface RawBridge {
     setSound(enabled: boolean): Promise<NotificationPrefs>
     setAlert(type: string, enabled: boolean): Promise<NotificationPrefs>
     reset(): Promise<NotificationPrefs>
+  }
+  theme: {
+    /** The theme the preload already painted, before this code ran. */
+    boot(): { theme: HeliosTheme; terminal: XtermTheme }
+    list(): Promise<ThemeSummary[]>
+    prefs(): Promise<AppearancePrefs>
+    set(next: Partial<AppearancePrefs>): Promise<{ theme: HeliosTheme; terminal: XtermTheme }>
+    reload(): Promise<ThemeSummary[]>
+    onChanged(fn: (payload: { theme: HeliosTheme; terminal: XtermTheme }) => void): Unsubscribe
   }
   hud: {
     resize(height: number): void
@@ -137,6 +163,10 @@ export class HostApi {
   }
   sendPrompt(id: string, message: string): Promise<{ success: boolean; queued?: boolean }> {
     return this.call('sendPrompt', id, message)
+  }
+  /** The bytes cross to the main process, which does the multipart POST. */
+  uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
+    return this.call('uploadFiles', id, files)
   }
   stop(id: string): Promise<unknown> {
     return this.call('stop', id)

--- a/desktop/src/renderer/codemirror-theme.ts
+++ b/desktop/src/renderer/codemirror-theme.ts
@@ -1,0 +1,74 @@
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import { EditorView } from '@codemirror/view'
+import { tags } from '@lezer/highlight'
+import type { Extension } from '@codemirror/state'
+
+/**
+ * The editor, in terms of the same variables the rest of the app uses.
+ *
+ * Every colour is a `var()` rather than a resolved value, so this extension is
+ * built once and still follows the theme: CodeMirror injects it as a stylesheet
+ * and the browser resolves the variables against `<html>` at paint. Rebuilding
+ * the editor on a theme change would be the alternative, and it would discard
+ * the undo history to recolour a buffer.
+ */
+const highlight = HighlightStyle.define([
+  { tag: [tags.comment, tags.lineComment, tags.blockComment], color: 'var(--syn-comment)', fontStyle: 'italic' },
+  { tag: [tags.keyword, tags.modifier, tags.controlKeyword, tags.moduleKeyword], color: 'var(--syn-keyword)' },
+  { tag: [tags.string, tags.special(tags.string), tags.inserted], color: 'var(--syn-string)' },
+  { tag: tags.regexp, color: 'var(--syn-regexp)' },
+  { tag: [tags.number, tags.integer, tags.float], color: 'var(--syn-number)' },
+  { tag: [tags.bool, tags.null, tags.atom], color: 'var(--syn-literal)' },
+  { tag: [tags.constant(tags.variableName), tags.standard(tags.name)], color: 'var(--syn-constant)' },
+  { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: 'var(--syn-function)' },
+  { tag: [tags.typeName, tags.className, tags.namespace, tags.self], color: 'var(--syn-type)' },
+  { tag: [tags.variableName, tags.definition(tags.variableName)], color: 'var(--syn-variable)' },
+  { tag: [tags.propertyName, tags.definition(tags.propertyName)], color: 'var(--syn-property)' },
+  { tag: [tags.attributeName, tags.attributeValue], color: 'var(--syn-attribute)' },
+  { tag: [tags.tagName, tags.angleBracket, tags.deleted], color: 'var(--syn-tag)' },
+  { tag: [tags.meta, tags.processingInstruction, tags.heading], color: 'var(--syn-meta)' },
+  { tag: [tags.operator, tags.operatorKeyword, tags.derefOperator], color: 'var(--syn-operator)' },
+  { tag: [tags.punctuation, tags.separator, tags.bracket], color: 'var(--syn-punctuation)' },
+  { tag: tags.invalid, color: 'var(--error)' },
+  { tag: tags.link, color: 'var(--primary)', textDecoration: 'underline' },
+  { tag: tags.emphasis, fontStyle: 'italic' },
+  { tag: tags.strong, fontWeight: 'bold' },
+])
+
+const chrome = EditorView.theme({
+  '&': { color: 'var(--syn-fg)', backgroundColor: 'var(--surface)' },
+  '.cm-content': { caretColor: 'var(--primary)' },
+  '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--primary)' },
+  '&.cm-focused .cm-selectionBackgroundValue, .cm-selectionBackground, .cm-content ::selection': {
+    backgroundColor: 'var(--primary-container)',
+  },
+  '.cm-gutters': {
+    backgroundColor: 'var(--surface)',
+    color: 'var(--on-surface-variant)',
+    border: 'none',
+    borderRight: '1px solid var(--outline-variant)',
+  },
+  '.cm-activeLine': { backgroundColor: 'var(--surface-low)' },
+  '.cm-activeLineGutter': { backgroundColor: 'var(--surface-low)', color: 'var(--on-surface)' },
+  '.cm-foldPlaceholder': {
+    backgroundColor: 'var(--surface-high)',
+    color: 'var(--on-surface-variant)',
+    border: 'none',
+  },
+  '.cm-searchMatch': { backgroundColor: 'var(--primary-container)', outline: '1px solid var(--outline)' },
+  '.cm-searchMatch.cm-searchMatch-selected': { backgroundColor: 'var(--primary)', color: 'var(--on-primary)' },
+  '.cm-selectionMatch': { backgroundColor: 'var(--surface-highest)' },
+  '.cm-matchingBracket, .cm-nonmatchingBracket': {
+    backgroundColor: 'var(--surface-highest)',
+    outline: '1px solid var(--outline)',
+  },
+  '.cm-tooltip': {
+    backgroundColor: 'var(--surface-high)',
+    color: 'var(--on-surface)',
+    border: '1px solid var(--outline-variant)',
+  },
+  '.cm-tooltip .cm-tooltip-arrow:after': { borderTopColor: 'var(--surface-high)' },
+  '.cm-panels': { backgroundColor: 'var(--surface-container)', color: 'var(--on-surface)' },
+})
+
+export const heliosEditorTheme: Extension = [chrome, syntaxHighlighting(highlight)]

--- a/desktop/src/renderer/components/editor.tsx
+++ b/desktop/src/renderer/components/editor.tsx
@@ -9,10 +9,11 @@ import { rust } from '@codemirror/lang-rust'
 import { yaml } from '@codemirror/lang-yaml'
 import { indentUnit } from '@codemirror/language'
 import { EditorState, type Extension } from '@codemirror/state'
-import { oneDark } from '@codemirror/theme-one-dark'
 import { EditorView, keymap } from '@codemirror/view'
 import { basicSetup } from 'codemirror'
 import { useEffect, useRef } from 'react'
+
+import { heliosEditorTheme } from '../codemirror-theme.ts'
 
 /** A place to put the cursor, re-sent with a new seq to jump there again. */
 export interface Cursor {
@@ -70,7 +71,7 @@ export function CodeEditor({
       doc,
       extensions: [
         basicSetup,
-        oneDark,
+        heliosEditorTheme,
         indentUnit.of('  '),
         ...(language ? [language] : []),
         keymap.of([

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -4,7 +4,7 @@ import { bridge } from '../bridge.ts'
 import { store } from '../store.ts'
 import { Modal } from './newsession.tsx'
 import { ALERT_TYPES } from '../../shared/notifications.ts'
-import type { NotificationPrefs } from '../../shared/models.ts'
+import type { AppearancePrefs, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
 
 /**
  * Which types can be silenced, in the order the phone lists them. Keeping the
@@ -49,12 +49,44 @@ const GROUPS: { heading: string; note: string; types: { type: string; label: str
 const LISTED = GROUPS.flatMap((group) => group.types.map((t) => t.type))
 const MISSING = ALERT_TYPES.filter((type) => !LISTED.includes(type))
 
+const MODES: { value: AppearancePrefs['mode']; label: string; detail: string }[] = [
+  { value: 'system', label: 'System', detail: 'Follow the OS, switching as it does.' },
+  { value: 'light', label: 'Light', detail: 'Always the light theme below.' },
+  { value: 'dark', label: 'Dark', detail: 'Always the dark theme below.' },
+]
+
 export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Element {
   const [prefs, setPrefs] = useState<NotificationPrefs | null>(null)
+  const [appearance, setAppearance] = useState<AppearancePrefs | null>(null)
+  const [themes, setThemes] = useState<ThemeSummary[]>([])
 
   useEffect(() => {
     void bridge.prefs.get().then(setPrefs)
+    void bridge.theme.prefs().then(setAppearance)
+    void bridge.theme.list().then(setThemes)
   }, [])
+
+  const setTheme = async (next: Partial<AppearancePrefs>): Promise<void> => {
+    if (!appearance) return
+    // Set locally first: the main process is the source of truth but it
+    // answers with the resolved theme, not the preference, and a picker that
+    // waits for a round trip feels like it ignored the click.
+    setAppearance({ ...appearance, ...next })
+    try {
+      await bridge.theme.set(next)
+    } catch (err) {
+      store.fail(err)
+      setAppearance(await bridge.theme.prefs())
+    }
+  }
+
+  const reloadThemes = async (): Promise<void> => {
+    try {
+      setThemes(await bridge.theme.reload())
+    } catch (err) {
+      store.fail(err)
+    }
+  }
 
   const apply = async (change: Promise<NotificationPrefs>): Promise<void> => {
     try {
@@ -66,6 +98,57 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
 
   return (
     <Modal title="Settings" onClose={onClose}>
+      <section className="settings-group">
+        <h3>Appearance</h3>
+        <p className="modal-note">
+          Themes are VS Code colour themes. Drop any theme JSON into <code>~/.helios/themes</code> to add your
+          own.
+        </p>
+
+        <div className="mode-row">
+          {MODES.map((mode) => (
+            <label key={mode.value} className="check" title={mode.detail}>
+              <input
+                type="radio"
+                name="theme-mode"
+                checked={appearance?.mode === mode.value}
+                disabled={!appearance}
+                onChange={() => void setTheme({ mode: mode.value })}
+              />
+              {mode.label}
+            </label>
+          ))}
+        </div>
+
+        {/* Both slots stay visible on a pinned mode: they are what 'System'
+            will switch between, and hiding the other one makes it look as
+            though the choice was lost. */}
+        <ThemePicker
+          label="Dark theme"
+          themes={themes.filter((theme) => theme.mode === 'dark')}
+          value={appearance?.darkTheme}
+          onPick={(id) => void setTheme({ darkTheme: id })}
+        />
+        <ThemePicker
+          label="Light theme"
+          themes={themes.filter((theme) => theme.mode === 'light')}
+          value={appearance?.lightTheme}
+          onPick={(id) => void setTheme({ lightTheme: id })}
+        />
+        <ThemePicker
+          label="Terminal"
+          themes={themes}
+          value={appearance?.terminalTheme}
+          match="Match UI theme"
+          onPick={(id) => void setTheme({ terminalTheme: id })}
+        />
+
+        <button className="ghost" onClick={() => void reloadThemes()}>
+          Reload themes
+        </button>
+      </section>
+
+      <h3>Notifications</h3>
       <p className="modal-note">
         Requests always appear — on screen and on the tray. These toggles decide whether they also make a sound.
       </p>
@@ -109,5 +192,57 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         </button>
       </div>
     </Modal>
+  )
+}
+
+/**
+ * A theme list with a swatch each, because a name is not much to choose from —
+ * "Gruvbox Dark Medium" and "Gruvbox Dark Hard" are the same words and quite
+ * different rooms to sit in.
+ */
+function ThemePicker({
+  label,
+  themes,
+  value,
+  match,
+  onPick,
+}: {
+  label: string
+  themes: ThemeSummary[]
+  value: string | undefined
+  /** Present on the terminal picker, whose first option is to follow the UI. */
+  match?: string
+  onPick: (id: string) => void
+}): JSX.Element {
+  return (
+    <div className="theme-picker">
+      <span className="theme-picker-label">{label}</span>
+      <div className="theme-grid">
+        {match && (
+          <button
+            className={value === 'match' ? 'theme-chip selected' : 'theme-chip'}
+            onClick={() => onPick('match')}
+          >
+            <span className="theme-swatch inherit" />
+            {match}
+          </button>
+        )}
+        {themes.map((theme) => (
+          <button
+            key={theme.id}
+            className={value === theme.id ? 'theme-chip selected' : 'theme-chip'}
+            onClick={() => onPick(theme.id)}
+            title={theme.id}
+          >
+            <span className="theme-swatch">
+              {theme.swatch.map((colour, index) => (
+                <i key={index} style={{ background: colour }} />
+              ))}
+            </span>
+            {theme.name}
+          </button>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -18,28 +18,6 @@ bridge.term.onOutput(({ tabId, data }) => sinks.get(tabId)?.(data))
 
 const encoder = new TextEncoder()
 
-const THEME = {
-  background: '#101014',
-  foreground: '#d8d8e0',
-  cursor: '#ffb03a',
-  selectionBackground: '#33334a',
-  black: '#1c1c24',
-  red: '#ff6b6b',
-  green: '#7ddc8a',
-  yellow: '#ffb03a',
-  blue: '#6aa9ff',
-  magenta: '#c58cff',
-  cyan: '#5fd7d7',
-  white: '#d8d8e0',
-  brightBlack: '#5a5a68',
-  brightRed: '#ff8f8f',
-  brightGreen: '#a4eaad',
-  brightYellow: '#ffca70',
-  brightBlue: '#9cc5ff',
-  brightMagenta: '#dcb4ff',
-  brightWhite: '#ffffff',
-}
-
 /**
  * The terminal panel: the selected session's terminal, and every other open one
  * kept mounted behind it.
@@ -116,6 +94,15 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
+  const theme = useStore((s) => s.terminalTheme)
+
+  // Assigned rather than passed on construction: rebuilding the terminal to
+  // recolour it would throw away the scrollback, which the host cannot replay
+  // a second time.
+  useEffect(() => {
+    const term = termRef.current
+    if (term) term.options.theme = theme
+  }, [theme])
 
   useEffect(() => {
     const container = hostRef.current
@@ -129,7 +116,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
       // The host replays its own scrollback on attach, so a deep local buffer
       // only duplicates what a snapshot already delivered.
       scrollback: 5000,
-      theme: THEME,
+      theme,
       macOptionIsMeta: true,
     })
     const fit = new FitAddon()

--- a/desktop/src/renderer/hljs-vars.css
+++ b/desktop/src/renderer/hljs-vars.css
@@ -1,0 +1,105 @@
+/* highlight.js token colours, in terms of the syntax roles a theme defines.
+   This replaces the packaged stylesheets, which hardcode one palette and so
+   cannot follow the theme. Only colour is set here — every highlighted block is
+   a `pre.code-block`, which owns its own background, padding and font. */
+
+.hljs {
+  color: var(--syn-fg);
+  background: var(--code-bg);
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: var(--syn-comment);
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-doctag,
+.hljs-formula {
+  color: var(--syn-keyword);
+}
+
+/* Deletions ride with tags because a removed line reads as the same warning
+   colour in every theme this maps from. */
+.hljs-name,
+.hljs-section,
+.hljs-selector-tag,
+.hljs-subst,
+.hljs-deletion {
+  color: var(--syn-tag);
+}
+
+.hljs-literal {
+  color: var(--syn-literal);
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: var(--syn-constant);
+}
+
+.hljs-string,
+.hljs-addition,
+.hljs-meta .hljs-string {
+  color: var(--syn-string);
+}
+
+.hljs-regexp {
+  color: var(--syn-regexp);
+}
+
+.hljs-attribute {
+  color: var(--syn-attribute);
+}
+
+.hljs-number {
+  color: var(--syn-number);
+}
+
+.hljs-variable,
+.hljs-template-variable {
+  color: var(--syn-variable);
+}
+
+.hljs-attr,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+  color: var(--syn-property);
+}
+
+.hljs-title,
+.hljs-title.function_ {
+  color: var(--syn-function);
+}
+
+.hljs-type,
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: var(--syn-type);
+}
+
+.hljs-meta,
+.hljs-selector-id,
+.hljs-link {
+  color: var(--syn-meta);
+}
+
+.hljs-operator,
+.hljs-punctuation {
+  color: var(--syn-operator);
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}

--- a/desktop/src/renderer/hud.css
+++ b/desktop/src/renderer/hud.css
@@ -27,7 +27,7 @@ body {
   border-radius: 12px;
   border: 1px solid var(--outline-variant);
   background: var(--surface);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 45%);
+  box-shadow: 0 12px 32px var(--shadow-soft);
   overflow: hidden;
 }
 

--- a/desktop/src/renderer/hud.tsx
+++ b/desktop/src/renderer/hud.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 
 import { NotificationCard } from './components/notification-card.tsx'
+import { applyTheme } from '../shared/theme/apply.ts'
 import type { Notification } from '../shared/models.ts'
 
 import './styles.css'
@@ -34,9 +35,13 @@ function Hud(): JSX.Element {
     const offRetract = bridge.hud.onRetract((key) => {
       setCards((current) => current.filter((c) => keyOf(c.hostId, c.notification.id) !== key))
     })
+    // The preload painted the boot theme; this window outlives most theme
+    // changes, so it has to follow them like the main one does.
+    const offTheme = bridge.theme.onChanged(({ theme }) => applyTheme(document.documentElement, theme))
     return () => {
       offPresent()
       offRetract()
+      offTheme()
     }
   }, [])
 

--- a/desktop/src/renderer/index.tsx
+++ b/desktop/src/renderer/index.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client'
 
 import { App } from './app.tsx'
 // The code theme first: the app's own sheet overrides pieces of it.
-import 'highlight.js/styles/atom-one-dark.css'
+import './hljs-vars.css'
 import './styles.css'
 
 const container = document.getElementById('root')

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,8 +1,10 @@
 import { useSyncExternalStore } from 'react'
 
 import { api, bridge, statusOf } from './bridge.ts'
+import { applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
+import type { XtermTheme } from '../shared/theme/resolve.ts'
 
 export interface Tab {
   id: string
@@ -100,6 +102,8 @@ export interface State {
   loading: boolean
   toast: { text: string; kind: 'info' | 'error' } | null
   pairingLink: string | null
+  /** The palette xterm draws with; the CSS side is set on <html>, not here. */
+  terminalTheme: XtermTheme
 }
 
 const initial: State = {
@@ -117,6 +121,7 @@ const initial: State = {
   query: '',
   showArchived: false,
   loading: true,
+  terminalTheme: bridge.theme.boot().terminal,
   toast: null,
   pairingLink: null,
 }
@@ -155,6 +160,14 @@ class Store {
   // ─── Lifecycle ─────────────────────────────────────────────────────────
 
   async init(): Promise<void> {
+    // The preload painted the boot theme already; this keeps up with changes
+    // made afterwards, whether from the settings dialog or the OS switching
+    // between light and dark underneath us.
+    bridge.theme.onChanged(({ theme, terminal }) => {
+      applyTheme(document.documentElement, theme)
+      this.set({ terminalTheme: terminal })
+    })
+
     bridge.hosts.onChanged((hosts) => {
       this.set({ hosts })
       for (const host of hosts) void this.refreshHost(host.id)

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -21,11 +21,43 @@
 
   --error: #ffb4ab;
   --error-container: #93000a;
+  --on-error-container: #ffdad6;
   /* atom-one-dark's own background, so highlighted code sits on the colour the
      theme was drawn for — the same theme the mobile transcript uses. */
   --code-bg: #282c34;
   --inverse-surface: #e2e2e6;
   --inverse-on-surface: #2e3036;
+
+  /* Lifted overlays and the sheets they dim. Carried as whole colours rather
+     than an alpha a rule multiplies, because a light theme wants a different
+     black here and the rule using it should not have to know which theme it is
+     under. */
+  --shadow-soft: rgb(0 0 0 / 45%);
+  --shadow-strong: rgb(0 0 0 / 65%);
+  --scrim: rgb(0 0 0 / 40%);
+  --scrim-strong: rgb(0 0 0 / 60%);
+
+  /* Syntax roles. Named for what a token means rather than what colour it is,
+     so one set feeds highlight.js in the transcript and CodeMirror in the
+     editor. The defaults below are atom-one-dark's, which is what both used
+     before themes existed. */
+  --syn-fg: #abb2bf;
+  --syn-comment: #5c6370;
+  --syn-keyword: #c678dd;
+  --syn-tag: #e06c75;
+  --syn-literal: #56b6c2;
+  --syn-constant: #56b6c2;
+  --syn-string: #98c379;
+  --syn-regexp: #98c379;
+  --syn-attribute: #98c379;
+  --syn-number: #d19a66;
+  --syn-variable: #d19a66;
+  --syn-property: #d19a66;
+  --syn-function: #61aeee;
+  --syn-meta: #61aeee;
+  --syn-type: #e6c07b;
+  --syn-operator: #abb2bf;
+  --syn-punctuation: #abb2bf;
 
   /* Session status, matching _statusColor in the mobile sessions screen. */
   --s-starting: #4db6ac;
@@ -48,7 +80,10 @@
   --chat-column: 1100px;
 
   font-synthesis: none;
-  color-scheme: dark;
+  /* Indirected through a variable so a theme sets one value and the form
+     controls, scrollbars and caret follow it along with everything else. */
+  --color-scheme: dark;
+  color-scheme: var(--color-scheme);
 }
 
 * {
@@ -360,7 +395,7 @@ small {
   place-items: center;
   border-radius: 999px;
   background: var(--error-container);
-  color: #ffdad6;
+  color: var(--on-error-container);
   font-size: 11px;
   font-weight: 700;
 }
@@ -846,7 +881,7 @@ small {
   background: var(--surface-high);
   border-radius: var(--r-md);
   padding: 8px;
-  box-shadow: 0 8px 24px #0009;
+  box-shadow: 0 8px 24px var(--shadow-soft);
 }
 
 .menu-body button {
@@ -1462,12 +1497,103 @@ small {
   /* Inline-block by default, and auto margins do not centre one. */
   display: block;
   width: 100%;
-  /* Room for the send button, so a long line does not run under it. */
+  /* Room for the buttons on either side, so a long line runs under neither. */
   padding-right: 48px;
+  padding-left: 42px;
   resize: vertical;
   min-height: 60px;
   border-radius: var(--r-md);
   line-height: 1.5;
+}
+
+/* Attachments: the bytes go to the daemon, and the prompt carries the path. */
+
+.attach-btn {
+  position: absolute;
+  left: 8px;
+  bottom: 12px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  font-size: 15px;
+  color: var(--on-surface-variant);
+}
+
+.attach-btn:hover:not(:disabled) {
+  color: var(--primary);
+}
+
+/* A file dropped anywhere over the composer counts, so the whole of it lights
+   up rather than some target the pointer has to find. */
+.composer.dropping .composer-input::after {
+  content: 'Drop to attach';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--primary);
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--primary) 12%, var(--surface));
+  font-size: 12px;
+  color: var(--primary);
+  pointer-events: none;
+}
+
+.attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.attachment {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 240px;
+  padding: 3px 4px 3px 6px;
+  border-radius: 999px;
+  background: var(--surface-highest);
+  font-size: 12px;
+}
+
+.attachment-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.attachment-icon {
+  color: var(--on-surface-variant);
+}
+
+.attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-size {
+  flex: none;
+  color: var(--on-surface-variant);
+}
+
+.attachment-drop {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--on-surface-variant);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.attachment-drop:hover {
+  background: var(--surface-low);
+  color: var(--error);
 }
 
 .composer-actions {
@@ -1848,7 +1974,7 @@ small {
   padding: 4px;
   border-radius: 10px;
   background: var(--surface-high);
-  box-shadow: 0 8px 24px rgb(0 0 0 / 45%);
+  box-shadow: 0 8px 24px var(--shadow-soft);
 }
 
 /* Anchored to a selection rather than to a pointer: centred over it, and clear
@@ -2269,7 +2395,7 @@ small {
   display: flex;
   justify-content: center;
   padding-top: 72px;
-  background: color-mix(in srgb, #000 40%, transparent);
+  background: var(--scrim);
 }
 
 .quick {
@@ -2279,7 +2405,7 @@ small {
   flex-direction: column;
   background: var(--surface-container);
   border-radius: var(--r-md);
-  box-shadow: 0 18px 48px rgb(0 0 0 / 45%);
+  box-shadow: 0 18px 48px var(--shadow-soft);
   overflow: hidden;
 }
 
@@ -2461,7 +2587,7 @@ small {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: #0009;
+  background: var(--scrim-strong);
   display: grid;
   place-items: center;
   z-index: 100;
@@ -2475,7 +2601,7 @@ small {
   flex-direction: column;
   background: var(--surface-high);
   border-radius: var(--r-xl);
-  box-shadow: 0 24px 64px #000b;
+  box-shadow: 0 24px 64px var(--shadow-strong);
 }
 
 .modal-head {
@@ -2585,13 +2711,13 @@ hr {
   padding: 12px 18px;
   font-size: 13px;
   z-index: 200;
-  box-shadow: 0 6px 20px #0009;
+  box-shadow: 0 6px 20px var(--shadow-soft);
   animation: rise 160ms ease;
 }
 
 .toast.error {
   background: var(--error-container);
-  color: #ffdad6;
+  color: var(--on-error-container);
 }
 
 @keyframes rise {
@@ -2660,7 +2786,7 @@ hr {
   padding: 6px;
   border-radius: var(--r-md);
   background: var(--surface-high);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 45%);
+  box-shadow: 0 12px 32px var(--shadow-soft);
 }
 
 .scope-row {
@@ -3145,6 +3271,91 @@ hr {
 
 .settings-group .check small {
   color: var(--on-surface-variant);
+}
+
+/* ─── Theme picker ──────────────────────────────────────────────────────── */
+
+.mode-row {
+  display: flex;
+  gap: 18px;
+  margin-top: 10px;
+}
+
+.mode-row .check {
+  margin-top: 0;
+  align-items: center;
+}
+
+.theme-picker {
+  margin-top: 14px;
+}
+
+.theme-picker-label {
+  display: block;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+  margin-bottom: 6px;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 6px;
+}
+
+.theme-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-sm);
+  background: var(--surface-container);
+  color: var(--on-surface);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.theme-chip:hover {
+  background: var(--surface-high);
+}
+
+.theme-chip.selected {
+  border-color: var(--primary);
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+}
+
+/* A slice of the theme itself — a name alone does not distinguish two
+   variants of the same palette. */
+.theme-swatch {
+  display: flex;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 16px;
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid var(--outline-variant);
+}
+
+.theme-swatch i {
+  flex: 1;
+}
+
+.theme-picker + .ghost {
+  margin-top: 14px;
+}
+
+.theme-swatch.inherit {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--surface-high) 0 4px,
+    var(--surface-highest) 4px 8px
+  );
 }
 
 .modal-note {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -459,3 +459,24 @@ export interface NotificationPrefs {
   sound: boolean
   alerts: Record<string, boolean>
 }
+
+/**
+ * Per-machine appearance. Two theme slots rather than one so that following the
+ * OS has both a light and a dark answer to give; `mode` decides which slot is
+ * read, and 'system' hands that decision to the OS.
+ */
+export interface AppearancePrefs {
+  mode: 'system' | 'light' | 'dark'
+  lightTheme: string
+  darkTheme: string
+  /** A theme id, or 'match' to follow whichever UI theme is active. */
+  terminalTheme: string
+}
+
+/** A theme as the picker lists it; `swatch` is a handful of representative colours. */
+export interface ThemeSummary {
+  id: string
+  name: string
+  mode: 'dark' | 'light'
+  swatch: string[]
+}

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -1,0 +1,16 @@
+import type { HeliosTheme } from './resolve.ts'
+
+/**
+ * Writes a theme onto the document root as inline custom properties.
+ *
+ * Inline rather than a generated stylesheet because inline declarations outrank
+ * the `:root` block in styles.css without needing `!important`, and because the
+ * preload script can do it before the page has a stylesheet at all.
+ *
+ * Every value has already been normalised to `#rrggbb` or a fixed `rgb(... / n%)`
+ * by the resolver, so a hand-written theme file cannot smuggle anything else
+ * into a property here.
+ */
+export function applyTheme(root: HTMLElement, theme: Pick<HeliosTheme, 'vars'>): void {
+  for (const [name, value] of Object.entries(theme.vars)) root.style.setProperty(name, value)
+}

--- a/desktop/src/shared/theme/mapping.ts
+++ b/desktop/src/shared/theme/mapping.ts
@@ -1,0 +1,309 @@
+/**
+ * Which VS Code colour keys and TextMate scopes feed which part of Helios.
+ *
+ * Every entry is a priority list plus a derivation, because a theme that sets
+ * the key is the lucky case. The derivation is what makes a theme with nothing
+ * but a background and a foreground still produce a usable app.
+ */
+
+import { ensureContrast, mix, pickReadable, toHex, toRgba, type Rgb } from './vscode.ts'
+
+export const ANSI_NAMES = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+] as const
+
+export type AnsiName = (typeof ANSI_NAMES)[number]
+
+/** `terminal.ansiBrightBlack` and friends; the key is the name capitalised. */
+export function ansiKey(name: AnsiName): string {
+  return `terminal.ansi${name[0]?.toUpperCase()}${name.slice(1)}`
+}
+
+/**
+ * Used when a theme sets no `terminal.ansi*` keys at all. The dark palette is
+ * the one the app shipped with before themes existed, so a theme that says
+ * nothing about the terminal leaves it looking as it always did.
+ */
+export const DEFAULT_ANSI: Record<'dark' | 'light', Record<AnsiName, string>> = {
+  dark: {
+    black: '#1c1c24',
+    red: '#ff6b6b',
+    green: '#7ddc8a',
+    yellow: '#ffb03a',
+    blue: '#6aa9ff',
+    magenta: '#c58cff',
+    cyan: '#5fd7d7',
+    white: '#d8d8e0',
+    brightBlack: '#5a5a68',
+    brightRed: '#ff8f8f',
+    brightGreen: '#a4eaad',
+    brightYellow: '#ffca70',
+    brightBlue: '#9cc5ff',
+    brightMagenta: '#dcb4ff',
+    brightCyan: '#8ee8e8',
+    brightWhite: '#ffffff',
+  },
+  light: {
+    black: '#24292e',
+    red: '#d1383d',
+    green: '#2d8a4e',
+    yellow: '#a06b00',
+    blue: '#1f6feb',
+    magenta: '#8250df',
+    cyan: '#0f7c8a',
+    white: '#6e7781',
+    brightBlack: '#57606a',
+    brightRed: '#cf222e',
+    brightGreen: '#1a7f37',
+    brightYellow: '#7d4e00',
+    brightBlue: '#0969da',
+    brightMagenta: '#6639ba',
+    brightCyan: '#106b75',
+    brightWhite: '#24292f',
+  },
+}
+
+/**
+ * Syntax roles, and the TextMate scopes that stand for them, most specific
+ * first. Roles are named for what a token means so that one resolution feeds
+ * both highlight.js in the transcript and CodeMirror in the editor.
+ */
+export const SYNTAX_SCOPES: Record<string, string[]> = {
+  keyword: ['keyword.control', 'keyword', 'storage.type', 'storage.modifier'],
+  comment: ['comment', 'punctuation.definition.comment'],
+  string: ['string.quoted', 'string'],
+  regexp: ['string.regexp', 'string'],
+  number: ['constant.numeric', 'constant'],
+  literal: ['constant.language.boolean', 'constant.language', 'constant'],
+  constant: ['constant.language', 'constant.character', 'constant.other', 'constant'],
+  function: ['entity.name.function', 'support.function', 'meta.function-call'],
+  type: ['entity.name.type', 'entity.name.class', 'support.type', 'support.class'],
+  variable: ['variable.other.readwrite', 'variable.other', 'variable'],
+  property: ['variable.other.property', 'support.variable.property', 'meta.object-literal.key'],
+  attribute: ['entity.other.attribute-name'],
+  tag: ['entity.name.tag', 'meta.tag'],
+  meta: ['meta.preprocessor', 'keyword.other.preprocessor', 'markup.heading', 'entity.name.section'],
+  operator: ['keyword.operator'],
+  punctuation: ['punctuation.separator', 'punctuation'],
+}
+
+/**
+ * What a syntax role falls back to when the theme's `tokenColors` say nothing
+ * about it — which includes themes that ship none at all. The terminal palette
+ * is the right source: it is the one place every theme states what it thinks
+ * "red" and "green" look like.
+ */
+export const SYNTAX_FALLBACK: Record<string, (ansi: Record<AnsiName, Rgb>, fg: Rgb, bg: Rgb) => Rgb> = {
+  keyword: (a) => a.magenta,
+  comment: (_a, fg, bg) => mix(fg, bg, 0.55),
+  string: (a) => a.green,
+  regexp: (a) => a.green,
+  number: (a) => a.yellow,
+  literal: (a) => a.cyan,
+  constant: (a) => a.cyan,
+  function: (a) => a.blue,
+  type: (a) => a.brightYellow,
+  variable: (_a, fg) => fg,
+  property: (a) => a.cyan,
+  attribute: (a) => a.green,
+  tag: (a) => a.red,
+  meta: (a) => a.blue,
+  operator: (_a, fg) => fg,
+  punctuation: (_a, fg) => fg,
+}
+
+export interface DeriveContext {
+  /** `editor.background`, the colour everything else is measured against. */
+  bg: Rgb
+  /** `editor.foreground`. */
+  fg: Rgb
+  isDark: boolean
+  /** A step up the tonal surface ladder: `bg` mixed `t` of the way to `fg`. */
+  ladder(t: number): Rgb
+  ansi: Record<AnsiName, Rgb>
+  /** A UI role resolved earlier in the list. */
+  role(name: string): Rgb
+}
+
+export interface RoleSpec {
+  /** VS Code colour keys to try, in priority order. */
+  keys: string[]
+  derive(ctx: DeriveContext): Rgb
+  /**
+   * Reject a key whose colour does not stand off the background by at least
+   * this ratio, and carry on down the list. Border keys in particular are
+   * routinely set to something like `#ffffff1a`, which flattens to almost the
+   * background — faithful to the theme, and invisible in a UI that leans on
+   * borders more than VS Code does.
+   */
+  minContrast?: number
+  /**
+   * What `minContrast` is measured against. Defaults to the editor background;
+   * an `on-` role names the container it is written on instead, which is the
+   * only surface its legibility depends on.
+   */
+  against?(ctx: DeriveContext): Rgb
+}
+
+/**
+ * The UI roles, in resolution order — later entries may read earlier ones
+ * through `ctx.role`.
+ *
+ * The surface ladder is derived rather than read from `sideBar.background` and
+ * friends on purpose. Those keys are not ordered by elevation: plenty of dark
+ * themes make the sidebar darker than the editor, which would invert the ladder
+ * and put the app's raised surfaces below its base one. Mixing towards the
+ * foreground always climbs, in a light theme as well as a dark one.
+ */
+export const UI_ROLES: [string, RoleSpec][] = [
+  ['surface', { keys: ['editor.background'], derive: (c) => c.bg }],
+  ['surface-low', { keys: [], derive: (c) => c.ladder(0.04) }],
+  ['surface-container', { keys: [], derive: (c) => c.ladder(0.08) }],
+  ['surface-high', { keys: [], derive: (c) => c.ladder(0.13) }],
+  ['surface-highest', { keys: [], derive: (c) => c.ladder(0.19) }],
+
+  ['on-surface', { keys: ['editor.foreground', 'foreground'], derive: (c) => c.fg }],
+  [
+    'on-surface-variant',
+    {
+      keys: ['descriptionForeground'],
+      minContrast: 3,
+      derive: (c) => mix(c.fg, c.bg, 0.28),
+    },
+  ],
+  [
+    'outline-variant',
+    {
+      keys: ['panel.border', 'editorGroup.border', 'widget.border'],
+      minContrast: 1.15,
+      derive: (c) => mix(c.fg, c.bg, 0.78),
+    },
+  ],
+  // Grown out of the subtle border rather than read from a key of its own.
+  // Border keys point both ways — Nord's is a hair off the background, Dracula
+  // uses its accent purple — so taking the same source for both and pushing one
+  // further is the only way the emphatic border is reliably the louder of the
+  // two, whichever the theme handed us.
+  ['outline', { keys: [], derive: (c) => ensureContrast(mix(c.role('outline-variant'), c.fg, 0.35), c.bg, 2.2) }],
+
+  // `textLink.foreground` before `button.background`: the accent is read as
+  // text on a surface far more often than it is filled behind one, and a
+  // button colour chosen to sit under white lettering is frequently too dark
+  // to read against the editor background.
+  [
+    'primary',
+    {
+      keys: ['textLink.foreground', 'focusBorder', 'button.background', 'progressBar.background'],
+      minContrast: 3,
+      derive: (c) => c.ansi.blue,
+    },
+  ],
+  [
+    'on-primary',
+    {
+      keys: ['button.foreground'],
+      minContrast: 4,
+      against: (c) => c.role('primary'),
+      derive: (c) => pickReadable(c.role('primary'), [c.bg, c.fg]),
+    },
+  ],
+  [
+    'primary-container',
+    {
+      keys: ['list.activeSelectionBackground', 'editor.selectionBackground'],
+      derive: (c) => mix(c.bg, c.role('primary'), c.isDark ? 0.32 : 0.22),
+    },
+  ],
+  [
+    'on-primary-container',
+    {
+      keys: ['list.activeSelectionForeground'],
+      minContrast: 4,
+      against: (c) => c.role('primary-container'),
+      derive: (c) => pickReadable(c.role('primary-container'), [c.fg, c.bg, mix(c.role('primary'), c.fg, 0.6)]),
+    },
+  ],
+
+  [
+    'error',
+    {
+      keys: ['errorForeground', 'editorError.foreground', 'list.errorForeground'],
+      minContrast: 2.2,
+      derive: (c) => c.ansi.red,
+    },
+  ],
+  [
+    'error-container',
+    {
+      keys: ['inputValidation.errorBackground'],
+      derive: (c) => mix(c.bg, c.role('error'), c.isDark ? 0.34 : 0.24),
+    },
+  ],
+  [
+    'on-error-container',
+    {
+      keys: ['inputValidation.errorForeground'],
+      minContrast: 4,
+      against: (c) => c.role('error-container'),
+      derive: (c) => pickReadable(c.role('error-container'), [c.fg, c.bg, mix(c.role('error'), c.fg, 0.6)]),
+    },
+  ],
+
+  // Not `editor.background`, which is already `--surface`: a code block that
+  // matches the panel behind it has no edges.
+  ['code-bg', { keys: ['textCodeBlock.background'], derive: (c) => c.ladder(0.05) }],
+  ['inverse-surface', { keys: [], derive: (c) => c.role('on-surface') }],
+  ['inverse-on-surface', { keys: [], derive: (c) => c.bg }],
+
+  // Status vocabulary, taken from the terminal palette rather than from
+  // `charts.*`: every theme states an opinion about the sixteen terminal
+  // colours, few state one about charts, and the terminal set is guaranteed
+  // to be mutually distinct.
+  //
+  // The floor matters here more than anywhere else. These are drawn as small
+  // dots and short labels on a panel, and a terminal yellow picked to sit on a
+  // light theme's white background is legible as output and invisible as a
+  // six-pixel dot.
+  ['s-starting', { keys: [], minContrast: 3, derive: (c) => c.ansi.cyan }],
+  ['s-active', { keys: [], minContrast: 3, derive: (c) => c.ansi.green }],
+  ['s-compacting', { keys: [], minContrast: 3, derive: (c) => c.ansi.magenta }],
+  ['s-waiting', { keys: [], minContrast: 3, derive: (c) => c.ansi.yellow }],
+  ['s-idle', { keys: [], minContrast: 3, derive: (c) => c.ansi.blue }],
+  ['s-error', { keys: [], minContrast: 3, derive: (c) => c.role('error') }],
+  ['s-off', { keys: ['disabledForeground'], minContrast: 2, derive: (c) => c.role('outline') }],
+]
+
+/**
+ * Lifted overlays. A light theme still casts a black shadow, just a fainter
+ * one — the same alpha that reads as depth on a dark surface reads as dirt on
+ * a white one.
+ */
+export function overlayVars(isDark: boolean): Record<string, string> {
+  const black = { r: 0, g: 0, b: 0, a: 1 }
+  const alphas = isDark
+    ? { soft: 0.45, strong: 0.65, scrim: 0.4, scrimStrong: 0.6 }
+    : { soft: 0.16, strong: 0.26, scrim: 0.28, scrimStrong: 0.42 }
+  return {
+    '--shadow-soft': toRgba(black, alphas.soft),
+    '--shadow-strong': toRgba(black, alphas.strong),
+    '--scrim': toRgba(black, alphas.scrim),
+    '--scrim-strong': toRgba(black, alphas.scrimStrong),
+  }
+}
+
+export { toHex }

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -1,0 +1,207 @@
+/**
+ * Turns a VS Code colour theme into the CSS variables and terminal palette the
+ * app draws with.
+ *
+ * Pure: no filesystem, no Electron. Reading and merging theme files is the
+ * registry's job in the main process; everything here is a function of the
+ * parsed object, which is what makes the awkward cases testable.
+ */
+
+import {
+  ANSI_NAMES,
+  DEFAULT_ANSI,
+  SYNTAX_FALLBACK,
+  SYNTAX_SCOPES,
+  UI_ROLES,
+  ansiKey,
+  overlayVars,
+  type AnsiName,
+  type DeriveContext,
+} from './mapping.ts'
+import {
+  composite,
+  contrast,
+  ensureContrast,
+  luminance,
+  mix,
+  parseColor,
+  rgb,
+  toHex,
+  type Rgb,
+  type VSCodeTheme,
+} from './vscode.ts'
+
+export type ThemeMode = 'dark' | 'light'
+
+export interface XtermTheme extends Record<AnsiName, string> {
+  background: string
+  foreground: string
+  cursor: string
+  selectionBackground: string
+}
+
+export interface HeliosTheme {
+  id: string
+  name: string
+  mode: ThemeMode
+  /** CSS custom properties, including the leading `--`. */
+  vars: Record<string, string>
+  ansi: XtermTheme
+}
+
+const FALLBACK_BG: Record<ThemeMode, Rgb> = { dark: rgb(0x11, 0x13, 0x18), light: rgb(0xff, 0xff, 0xff) }
+const FALLBACK_FG: Record<ThemeMode, Rgb> = { dark: rgb(0xe2, 0xe2, 0xe6), light: rgb(0x1f, 0x1f, 0x1f) }
+
+/**
+ * `uiTheme` from the extension's `package.json`, for the many themes that omit
+ * the top-level `type` field.
+ */
+export function modeFromUiTheme(uiTheme: string | undefined): ThemeMode | null {
+  if (uiTheme === 'vs-dark' || uiTheme === 'hc-black') return 'dark'
+  if (uiTheme === 'vs' || uiTheme === 'hc-light') return 'light'
+  return null
+}
+
+function declaredMode(theme: VSCodeTheme, hint: string | undefined): ThemeMode | null {
+  const type = theme.type?.toLowerCase()
+  if (type === 'dark' || type === 'hc' || type === 'hc-black') return 'dark'
+  if (type === 'light' || type === 'hclight' || type === 'hc-light') return 'light'
+  return modeFromUiTheme(hint)
+}
+
+/** A theme rule's scope may be a list, a comma-separated string, or both. */
+function scopesOf(scope: string | string[] | undefined): string[] {
+  if (!scope) return []
+  const parts = Array.isArray(scope) ? scope : [scope]
+  return parts
+    .flatMap((part) => part.split(','))
+    .map((part) => part.trim())
+    // A descendant selector such as `meta.function entity.name` keys off its
+    // last segment, which is the scope actually being coloured.
+    .map((part) => part.split(/\s+/).pop() ?? '')
+    .filter(Boolean)
+}
+
+/**
+ * Scope to colour, last rule winning — the same precedence VS Code applies when
+ * two rules name the same scope.
+ */
+function indexTokenColors(theme: VSCodeTheme, bg: Rgb): Map<string, Rgb> {
+  const index = new Map<string, Rgb>()
+  for (const rule of theme.tokenColors ?? []) {
+    const colour = parseColor(rule.settings?.foreground)
+    if (!colour) continue
+    for (const scope of scopesOf(rule.scope)) index.set(scope, composite(colour, bg))
+  }
+  return index
+}
+
+/** Longest matching prefix: `keyword.control.flow` falls back to `keyword`. */
+function lookupScope(index: Map<string, Rgb>, scope: string): Rgb | null {
+  let probe = scope
+  for (;;) {
+    const hit = index.get(probe)
+    if (hit) return hit
+    const cut = probe.lastIndexOf('.')
+    if (cut < 0) return null
+    probe = probe.slice(0, cut)
+  }
+}
+
+export function resolveTheme(
+  id: string,
+  theme: VSCodeTheme,
+  options: { name?: string; uiTheme?: string } = {},
+): HeliosTheme {
+  const colors = theme.colors ?? {}
+  const rawBg = parseColor(colors['editor.background'])
+
+  // Order matters: a theme that states its type is believed, and one that does
+  // not is judged by how dark its editor is. Only a theme with neither gets the
+  // arbitrary answer.
+  const mode: ThemeMode =
+    declaredMode(theme, options.uiTheme) ?? (rawBg ? (luminance(rawBg) < 0.4 ? 'dark' : 'light') : 'dark')
+
+  const bg = rawBg ? composite(rawBg, FALLBACK_BG[mode]) : FALLBACK_BG[mode]
+  const rawFg = parseColor(colors['editor.foreground']) ?? parseColor(colors['foreground'])
+  const fg = rawFg ? composite(rawFg, bg) : FALLBACK_FG[mode]
+
+  const colour = (key: string): Rgb | null => {
+    const parsed = parseColor(colors[key])
+    return parsed ? composite(parsed, bg) : null
+  }
+
+  const ansi = {} as Record<AnsiName, Rgb>
+  for (const name of ANSI_NAMES) {
+    ansi[name] = colour(ansiKey(name)) ?? (parseColor(DEFAULT_ANSI[mode][name]) as Rgb)
+  }
+
+  const resolved = new Map<string, Rgb>()
+  const ctx: DeriveContext = {
+    bg,
+    fg,
+    isDark: mode === 'dark',
+    ladder: (t) => mix(bg, fg, t),
+    ansi,
+    role: (name) => resolved.get(name) ?? bg,
+  }
+
+  const vars: Record<string, string> = {}
+  for (const [name, spec] of UI_ROLES) {
+    const against = spec.against ? spec.against(ctx) : bg
+    let value: Rgb | null = null
+    for (const key of spec.keys) {
+      const candidate = colour(key)
+      if (!candidate) continue
+      // Prefer a key that already works over nudging one that does not.
+      if (spec.minContrast && contrast(candidate, against) < spec.minContrast) continue
+      value = candidate
+      break
+    }
+    const chosen = value ?? spec.derive(ctx)
+    const final = spec.minContrast ? ensureContrast(chosen, against, spec.minContrast) : chosen
+    resolved.set(name, final)
+    vars[`--${name}`] = toHex(final)
+  }
+
+  const tokens = indexTokenColors(theme, bg)
+  vars['--syn-fg'] = toHex(fg)
+  for (const [role, candidates] of Object.entries(SYNTAX_SCOPES)) {
+    let value: Rgb | null = null
+    for (const scope of candidates) {
+      value = lookupScope(tokens, scope)
+      if (value) break
+    }
+    const fallback = SYNTAX_FALLBACK[role]
+    vars[`--syn-${role}`] = toHex(value ?? (fallback ? fallback(ansi, fg, bg) : fg))
+  }
+
+  Object.assign(vars, overlayVars(mode === 'dark'))
+  vars['--color-scheme'] = mode
+
+  const terminalBg = colour('terminal.background') ?? bg
+  const ansiTheme = {
+    background: toHex(terminalBg),
+    foreground: toHex(colour('terminal.foreground') ?? fg),
+    cursor: toHex(colour('terminalCursor.foreground') ?? colour('editorCursor.foreground') ?? fg),
+    selectionBackground: toHex(
+      colour('terminal.selectionBackground') ?? colour('editor.selectionBackground') ?? mix(terminalBg, fg, 0.25),
+    ),
+  } as XtermTheme
+  for (const name of ANSI_NAMES) ansiTheme[name] = toHex(ansi[name])
+
+  return { id, name: options.name ?? theme.name ?? id, mode, vars, ansi: ansiTheme }
+}
+
+/**
+ * Layers a theme over the one its `include` names. Child keys win; the parent
+ * supplies everything the child left out.
+ */
+export function mergeThemes(parent: VSCodeTheme, child: VSCodeTheme): VSCodeTheme {
+  return {
+    name: child.name ?? parent.name,
+    type: child.type ?? parent.type,
+    colors: { ...(parent.colors ?? {}), ...(child.colors ?? {}) },
+    tokenColors: [...(parent.tokenColors ?? []), ...(child.tokenColors ?? [])],
+  }
+}

--- a/desktop/src/shared/theme/vscode.ts
+++ b/desktop/src/shared/theme/vscode.ts
@@ -1,0 +1,187 @@
+/**
+ * The VS Code colour theme format, and the colour arithmetic needed to make one
+ * usable.
+ *
+ * Themes in the wild are partial: the format has several hundred colour keys
+ * and a theme sets whichever ones its author cared about. Everything here
+ * exists so a missing key is a question the resolver can answer rather than a
+ * hole in the UI.
+ */
+
+export interface TokenColor {
+  /** A scope selector, a list of them, or a comma-separated string of them. */
+  scope?: string | string[]
+  settings?: { foreground?: string; fontStyle?: string }
+}
+
+export interface VSCodeTheme {
+  name?: string
+  /** Absent more often than not; the resolver falls back to luminance. */
+  type?: string
+  /** A sibling theme file this one layers on top of. */
+  include?: string
+  colors?: Record<string, string>
+  tokenColors?: TokenColor[]
+}
+
+export interface Rgb {
+  r: number
+  g: number
+  b: number
+  /** 0–1. Themes use 8-digit hex freely, including for whole backgrounds. */
+  a: number
+}
+
+/**
+ * JSON with comments and trailing commas, which is what VS Code accepts and
+ * therefore what theme authors write. Strings are tracked so a `//` inside one
+ * is not mistaken for a comment.
+ */
+export function parseJsonc(text: string): unknown {
+  let out = ''
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]
+    if (ch === '"') {
+      const start = i
+      i++
+      while (i < text.length) {
+        if (text[i] === '\\') i += 2
+        else if (text[i] === '"') {
+          i++
+          break
+        } else i++
+      }
+      out += text.slice(start, i)
+      continue
+    }
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++
+      continue
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      i += 2
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++
+      i += 2
+      continue
+    }
+    out += ch
+    i++
+  }
+  return JSON.parse(out.replace(/,(\s*[}\]])/g, '$1'))
+}
+
+const HEX = /^#([0-9a-f]{3,8})$/i
+
+/** Parses the hex forms VS Code allows. Anything else is not a colour. */
+export function parseColor(value: string | undefined): Rgb | null {
+  if (!value) return null
+  const match = HEX.exec(value.trim())
+  if (!match) return null
+  const hex = match[1] as string
+  const expand = (s: string): number => parseInt(s.length === 1 ? s + s : s, 16)
+  if (hex.length === 3 || hex.length === 4) {
+    return {
+      r: expand(hex[0] as string),
+      g: expand(hex[1] as string),
+      b: expand(hex[2] as string),
+      a: hex.length === 4 ? expand(hex[3] as string) / 255 : 1,
+    }
+  }
+  if (hex.length === 6 || hex.length === 8) {
+    return {
+      r: parseInt(hex.slice(0, 2), 16),
+      g: parseInt(hex.slice(2, 4), 16),
+      b: parseInt(hex.slice(4, 6), 16),
+      a: hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1,
+    }
+  }
+  return null
+}
+
+export function rgb(r: number, g: number, b: number, a = 1): Rgb {
+  return { r, g, b, a }
+}
+
+const clamp = (n: number): number => Math.max(0, Math.min(255, Math.round(n)))
+
+/** Flattens a translucent colour onto an opaque one. */
+export function composite(front: Rgb, back: Rgb): Rgb {
+  if (front.a >= 1) return { ...front, a: 1 }
+  const t = front.a
+  return {
+    r: clamp(front.r * t + back.r * (1 - t)),
+    g: clamp(front.g * t + back.g * (1 - t)),
+    b: clamp(front.b * t + back.b * (1 - t)),
+    a: 1,
+  }
+}
+
+/** `t` is how far to travel from `a` towards `b`. */
+export function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  return {
+    r: clamp(a.r + (b.r - a.r) * t),
+    g: clamp(a.g + (b.g - a.g) * t),
+    b: clamp(a.b + (b.b - a.b) * t),
+    a: 1,
+  }
+}
+
+/** WCAG relative luminance, 0–1. */
+export function luminance(c: Rgb): number {
+  const channel = (v: number): number => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b)
+}
+
+export function contrast(a: Rgb, b: Rgb): number {
+  const la = luminance(a)
+  const lb = luminance(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+/** Whichever candidate reads best against `background`. */
+export function pickReadable(background: Rgb, candidates: Rgb[]): Rgb {
+  let best = candidates[0] as Rgb
+  let bestRatio = -1
+  for (const candidate of candidates) {
+    const ratio = contrast(background, candidate)
+    if (ratio > bestRatio) {
+      best = candidate
+      bestRatio = ratio
+    }
+  }
+  return best
+}
+
+/**
+ * Nudges a colour towards white or black — whichever the background is not —
+ * until it stands off that background by `target`.
+ *
+ * Needed because a theme's palette is chosen against the one background VS Code
+ * puts it on, and Helios puts the same colours on others: a terminal yellow
+ * that reads fine as terminal output is close to invisible as a status dot on a
+ * light theme's panel. Travelling towards the extreme rather than recolouring
+ * keeps the hue, so the result still looks like the theme.
+ */
+export function ensureContrast(colour: Rgb, background: Rgb, target: number): Rgb {
+  if (contrast(colour, background) >= target) return colour
+  const toward = luminance(background) > 0.4 ? rgb(0, 0, 0) : rgb(255, 255, 255)
+  let result = colour
+  for (let t = 0.05; t <= 1.0001; t += 0.05) {
+    result = mix(colour, toward, t)
+    if (contrast(result, background) >= target) break
+  }
+  return result
+}
+
+export function toHex(c: Rgb): string {
+  const pair = (n: number): string => clamp(n).toString(16).padStart(2, '0')
+  return `#${pair(c.r)}${pair(c.g)}${pair(c.b)}`
+}
+
+export function toRgba(c: Rgb, alpha: number): string {
+  return `rgb(${clamp(c.r)} ${clamp(c.g)} ${clamp(c.b)} / ${Math.round(alpha * 100)}%)`
+}

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -1,0 +1,261 @@
+// The resolver's job is to survive incomplete themes, which is what almost
+// every real theme is. These cover the cases that actually turn up in the wild:
+// a theme with nothing but a background, one that states no type, one whose
+// colours carry alpha, and one with no syntax rules at all.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { resolveTheme, mergeThemes, modeFromUiTheme } from '../src/shared/theme/resolve.ts'
+import {
+  composite,
+  contrast,
+  ensureContrast,
+  luminance,
+  mix,
+  parseColor,
+  parseJsonc,
+  pickReadable,
+  toHex,
+} from '../src/shared/theme/vscode.ts'
+
+test('parseJsonc tolerates comments and trailing commas', () => {
+  const parsed = parseJsonc(`{
+    // a line comment
+    "name": "T", /* and a block one */
+    "colors": { "editor.background": "#000000", },
+  }`) as { name: string; colors: Record<string, string> }
+  assert.equal(parsed.name, 'T')
+  assert.equal(parsed.colors['editor.background'], '#000000')
+})
+
+test('parseJsonc does not treat // inside a string as a comment', () => {
+  const parsed = parseJsonc('{"url": "https://example.com/x"}') as { url: string }
+  assert.equal(parsed.url, 'https://example.com/x')
+})
+
+test('parseColor handles every hex width', () => {
+  assert.deepEqual(parseColor('#abc'), { r: 0xaa, g: 0xbb, b: 0xcc, a: 1 })
+  assert.equal(parseColor('#ff0000ff')?.a, 1)
+  assert.equal(parseColor('#00000000')?.a, 0)
+  assert.equal(parseColor('rebeccapurple'), null)
+  assert.equal(parseColor(undefined), null)
+})
+
+test('composite flattens alpha onto the background', () => {
+  const half = { r: 255, g: 255, b: 255, a: 0.5 }
+  assert.equal(toHex(composite(half, { r: 0, g: 0, b: 0, a: 1 })), '#808080')
+})
+
+test('pickReadable prefers the higher contrast candidate', () => {
+  const white = { r: 255, g: 255, b: 255, a: 1 }
+  const black = { r: 0, g: 0, b: 0, a: 1 }
+  assert.equal(toHex(pickReadable(black, [black, white])), '#ffffff')
+  assert.equal(toHex(pickReadable(white, [black, white])), '#000000')
+})
+
+test('a theme with only a background and foreground yields a climbing surface ladder', () => {
+  const theme = resolveTheme('bare', {
+    colors: { 'editor.background': '#101014', 'editor.foreground': '#d8d8e0' },
+  })
+  const steps = ['--surface', '--surface-low', '--surface-container', '--surface-high', '--surface-highest']
+  const lums = steps.map((name) => luminance(parseColor(theme.vars[name]) as never))
+  for (let i = 1; i < lums.length; i++) {
+    assert.ok((lums[i] as number) > (lums[i - 1] as number), `${steps[i]} must sit above ${steps[i - 1]}`)
+  }
+})
+
+test('the ladder still climbs on a light theme', () => {
+  const theme = resolveTheme('bare-light', {
+    type: 'light',
+    colors: { 'editor.background': '#ffffff', 'editor.foreground': '#1f1f1f' },
+  })
+  const low = luminance(parseColor(theme.vars['--surface-low']) as never)
+  const high = luminance(parseColor(theme.vars['--surface-highest']) as never)
+  assert.ok(low > high, 'a light ladder climbs by getting darker')
+  assert.equal(theme.mode, 'light')
+  assert.equal(theme.vars['--color-scheme'], 'light')
+})
+
+test('mode is inferred from background luminance when the theme declares none', () => {
+  assert.equal(resolveTheme('a', { colors: { 'editor.background': '#080d14' } }).mode, 'dark')
+  assert.equal(resolveTheme('b', { colors: { 'editor.background': '#fafafa' } }).mode, 'light')
+})
+
+test('a declared type beats luminance', () => {
+  const theme = resolveTheme('odd', { type: 'dark', colors: { 'editor.background': '#fafafa' } })
+  assert.equal(theme.mode, 'dark')
+})
+
+test('uiTheme from package.json supplies the mode when type is absent', () => {
+  assert.equal(modeFromUiTheme('vs-dark'), 'dark')
+  assert.equal(modeFromUiTheme('vs'), 'light')
+  assert.equal(modeFromUiTheme(undefined), null)
+  const theme = resolveTheme('x', { colors: { 'editor.background': '#fafafa' } }, { uiTheme: 'vs-dark' })
+  assert.equal(theme.mode, 'dark')
+})
+
+test('translucent theme colours are flattened, never emitted with alpha', () => {
+  const theme = resolveTheme('alpha', {
+    colors: {
+      'editor.background': '#000000',
+      'editor.foreground': '#ffffff',
+      'list.activeSelectionBackground': '#ffffff80',
+    },
+  })
+  for (const [name, value] of Object.entries(theme.vars)) {
+    if (!name.startsWith('--s') && !name.startsWith('--o') && !name.startsWith('--c')) continue
+    if (name.startsWith('--shadow') || name.startsWith('--scrim') || name === '--color-scheme') continue
+    assert.match(value, /^#[0-9a-f]{6}$/, `${name} must be opaque hex, got ${value}`)
+  }
+  assert.equal(theme.vars['--primary-container'], '#808080')
+})
+
+test('a theme with no tokenColors still gets syntax roles, from its terminal palette', () => {
+  const theme = resolveTheme('no-tokens', {
+    colors: {
+      'editor.background': '#080d14',
+      'editor.foreground': '#efefef',
+      'terminal.ansiGreen': '#00ff00',
+      'terminal.ansiMagenta': '#ff00ff',
+    },
+  })
+  assert.equal(theme.vars['--syn-string'], '#00ff00')
+  assert.equal(theme.vars['--syn-keyword'], '#ff00ff')
+  assert.equal(theme.vars['--syn-fg'], '#efefef')
+})
+
+test('syntax roles match a token scope by its longest prefix', () => {
+  const theme = resolveTheme('tokens', {
+    colors: { 'editor.background': '#000000', 'editor.foreground': '#ffffff' },
+    tokenColors: [
+      { scope: 'keyword', settings: { foreground: '#111111' } },
+      { scope: ['comment', 'punctuation.definition.comment'], settings: { foreground: '#222222' } },
+      { scope: 'string.quoted, string.template', settings: { foreground: '#333333' } },
+      // A descendant selector keys off its final segment.
+      { scope: 'meta.function entity.name.function', settings: { foreground: '#444444' } },
+    ],
+  })
+  // `keyword.control` is tried first and is absent, so it falls back to `keyword`.
+  assert.equal(theme.vars['--syn-keyword'], '#111111')
+  assert.equal(theme.vars['--syn-comment'], '#222222')
+  assert.equal(theme.vars['--syn-string'], '#333333')
+  assert.equal(theme.vars['--syn-function'], '#444444')
+})
+
+test('the last rule naming a scope wins', () => {
+  const theme = resolveTheme('dupes', {
+    colors: { 'editor.background': '#000000' },
+    tokenColors: [
+      { scope: 'keyword', settings: { foreground: '#111111' } },
+      { scope: 'keyword', settings: { foreground: '#999999' } },
+    ],
+  })
+  assert.equal(theme.vars['--syn-keyword'], '#999999')
+})
+
+test('the terminal palette falls back per colour, not all or nothing', () => {
+  const theme = resolveTheme('partial-ansi', {
+    colors: { 'editor.background': '#101014', 'terminal.ansiRed': '#abcdef' },
+  })
+  assert.equal(theme.ansi.red, '#abcdef')
+  assert.equal(theme.ansi.green, '#7ddc8a')
+  // No terminal.background, so the editor's stands in.
+  assert.equal(theme.ansi.background, '#101014')
+})
+
+test('status colours come from the terminal palette and stay distinct', () => {
+  const theme = resolveTheme('status', {
+    colors: { 'editor.background': '#101014', 'editor.foreground': '#d8d8e0' },
+  })
+  const status = ['--s-starting', '--s-active', '--s-compacting', '--s-waiting', '--s-idle', '--s-error']
+  const values = status.map((name) => theme.vars[name])
+  assert.equal(new Set(values).size, values.length, 'each session state needs its own colour')
+})
+
+// Border keys point in both directions in the wild: Nord sets one a hair off
+// its background, Dracula uses its accent purple. The emphatic border has to
+// come out louder than the subtle one either way.
+for (const [label, border] of [
+  ['a near-invisible border key', '#ffffff1a'],
+  ['a border key set to a loud accent', '#bd93f9'],
+] as const) {
+  test(`outline stays louder than outline-variant given ${label}`, () => {
+    const theme = resolveTheme('borders', {
+      colors: { 'editor.background': '#282a36', 'editor.foreground': '#f8f8f2', 'panel.border': border },
+    })
+    const bg = parseColor('#282a36') as never
+    const outline = contrast(parseColor(theme.vars['--outline']) as never, bg)
+    const variant = contrast(parseColor(theme.vars['--outline-variant']) as never, bg)
+    assert.ok(outline > variant, `outline ${outline.toFixed(2)} must beat variant ${variant.toFixed(2)}`)
+  })
+}
+
+test('status colours are pushed off a light background rather than left invisible', () => {
+  const theme = resolveTheme('pale', {
+    type: 'light',
+    colors: {
+      'editor.background': '#ffffff',
+      'editor.foreground': '#1f1f1f',
+      // Legible as terminal output on this background, hopeless as a 6px dot.
+      'terminal.ansiYellow': '#f0e68c',
+    },
+  })
+  const white = parseColor('#ffffff') as never
+  assert.ok(contrast(parseColor(theme.vars['--s-waiting']) as never, white) >= 3)
+})
+
+test('an on- role is measured against its container, not the surface', () => {
+  const theme = resolveTheme('containers', {
+    colors: {
+      'editor.background': '#2e3440',
+      'editor.foreground': '#d8dee9',
+      // Container and error are the same colour here, which is what leaves the
+      // naive derivation writing red on red.
+      'inputValidation.errorBackground': '#bf616a',
+      'errorForeground': '#bf616a',
+    },
+  })
+  const container = parseColor(theme.vars['--error-container']) as never
+  assert.ok(contrast(parseColor(theme.vars['--on-error-container']) as never, container) >= 4)
+})
+
+test('ensureContrast keeps a colour that already passes', () => {
+  const black = { r: 0, g: 0, b: 0, a: 1 }
+  const white = { r: 255, g: 255, b: 255, a: 1 }
+  assert.equal(toHex(ensureContrast(white, black, 4.5)), '#ffffff')
+  // Mid grey on white has to darken to get there.
+  const grey = { r: 160, g: 160, b: 160, a: 1 }
+  assert.ok(contrast(ensureContrast(grey, white, 4.5), white) >= 4.5)
+})
+
+test('code background differs from the surface it sits on', () => {
+  const theme = resolveTheme('code', { colors: { 'editor.background': '#101014', 'editor.foreground': '#ffffff' } })
+  assert.notEqual(theme.vars['--code-bg'], theme.vars['--surface'])
+})
+
+test('an empty theme resolves rather than throwing', () => {
+  const theme = resolveTheme('empty', {})
+  assert.equal(theme.mode, 'dark')
+  assert.equal(theme.name, 'empty')
+  assert.match(theme.vars['--surface'] as string, /^#[0-9a-f]{6}$/)
+  assert.match(theme.ansi.brightWhite, /^#[0-9a-f]{6}$/)
+})
+
+test('mergeThemes layers a child over what its include supplied', () => {
+  const merged = mergeThemes(
+    { colors: { 'editor.background': '#000000', 'editor.foreground': '#ffffff' }, tokenColors: [{ scope: 'keyword', settings: { foreground: '#111111' } }] },
+    { name: 'Child', colors: { 'editor.background': '#123456' } },
+  )
+  assert.equal(merged.name, 'Child')
+  assert.equal(merged.colors?.['editor.background'], '#123456')
+  assert.equal(merged.colors?.['editor.foreground'], '#ffffff')
+  assert.equal(merged.tokenColors?.length, 1)
+})
+
+test('mix travels the requested fraction', () => {
+  const black = { r: 0, g: 0, b: 0, a: 1 }
+  const white = { r: 255, g: 255, b: 255, a: 1 }
+  assert.equal(toHex(mix(black, white, 0)), '#000000')
+  assert.equal(toHex(mix(black, white, 1)), '#ffffff')
+  assert.equal(toHex(mix(black, white, 0.5)), '#808080')
+})

--- a/themes/LICENSES.md
+++ b/themes/LICENSES.md
@@ -1,0 +1,35 @@
+# Bundled colour themes
+
+Every file in this directory is a VS Code colour theme, vendored from the
+project named below and flattened into a single self-contained file (upstream
+themes are often an `include` chain rooted at a VS Code built-in, which only
+resolves inside VS Code). Colour values and token rules are unmodified.
+
+Regenerate with `node --experimental-strip-types desktop/scripts/fetch-themes.mjs`.
+
+All of the below are MIT licensed.
+
+| File | Theme | Upstream |
+| --- | --- | --- |
+| `dark-modern.json` | Dark Modern | [microsoft/vscode](https://github.com/microsoft/vscode) — `extensions/theme-defaults` |
+| `light-modern.json` | Light Modern | [microsoft/vscode](https://github.com/microsoft/vscode) — `extensions/theme-defaults` |
+| `monokai.json` | Monokai | [microsoft/vscode](https://github.com/microsoft/vscode) — `extensions/theme-monokai`, after the Monokai theme by Wimer Hazenberg |
+| `solarized-dark.json` | Solarized Dark | [microsoft/vscode](https://github.com/microsoft/vscode) — `extensions/theme-solarized-dark`, after Solarized by Ethan Schoonover |
+| `solarized-light.json` | Solarized Light | [microsoft/vscode](https://github.com/microsoft/vscode) — `extensions/theme-solarized-light`, after Solarized by Ethan Schoonover |
+| `tokyo-night.json` | Tokyo Night | [enkia/tokyo-night-vscode-theme](https://github.com/enkia/tokyo-night-vscode-theme) |
+| `nord.json` | Nord | [nordtheme/visual-studio-code](https://github.com/nordtheme/visual-studio-code) |
+| `one-dark-pro.json` | One Dark Pro | [Binaryify/OneDark-Pro](https://github.com/Binaryify/OneDark-Pro) |
+| `catppuccin-mocha.json` | Catppuccin Mocha | [catppuccin/vscode](https://github.com/catppuccin/vscode) |
+| `catppuccin-latte.json` | Catppuccin Latte | [catppuccin/vscode](https://github.com/catppuccin/vscode) |
+| `dracula.json` | Dracula | [dracula/visual-studio-code](https://github.com/dracula/visual-studio-code) |
+| `github-dark.json` | GitHub Dark | [primer/github-vscode-theme](https://github.com/primer/github-vscode-theme) |
+| `github-light.json` | GitHub Light | [primer/github-vscode-theme](https://github.com/primer/github-vscode-theme) |
+| `gruvbox-dark.json` | Gruvbox Dark Medium | [jdinhlife/gruvbox](https://github.com/jdinhlife/gruvbox) |
+| `gruvbox-light.json` | Gruvbox Light Medium | [jdinhlife/gruvbox](https://github.com/jdinhlife/gruvbox) |
+
+## Adding your own
+
+Drop any VS Code colour theme JSON into `~/.helios/themes/` and it appears in
+the picker; the filename becomes its id, and a file whose id matches a bundled
+theme replaces it. Themes with an unresolved `include` still load — the missing
+parent is skipped and anything it would have supplied is derived instead.

--- a/themes/catppuccin-latte.json
+++ b/themes/catppuccin-latte.json
@@ -1,0 +1,2406 @@
+{
+  "name": "Catppuccin Latte",
+  "type": "light",
+  "colors": {
+    "focusBorder": "#8839ef",
+    "foreground": "#4c4f69",
+    "disabledForeground": "#6c6f85",
+    "widget.shadow": "#e6e9ef80",
+    "selection.background": "#8839ef66",
+    "descriptionForeground": "#4c4f69",
+    "errorForeground": "#d20f39",
+    "icon.foreground": "#8839ef",
+    "sash.hoverBorder": "#8839ef",
+    "textBlockQuote.background": "#e6e9ef",
+    "textBlockQuote.border": "#dce0e8",
+    "textCodeBlock.background": "#e6e9ef",
+    "textLink.activeForeground": "#04a5e5",
+    "textLink.foreground": "#1e66f5",
+    "textPreformat.foreground": "#4c4f69",
+    "textSeparator.foreground": "#8839ef",
+    "activityBar.background": "#dce0e8",
+    "activityBar.foreground": "#8839ef",
+    "activityBar.dropBorder": "#8839ef33",
+    "activityBar.inactiveForeground": "#9ca0b0",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#8839ef",
+    "activityBarBadge.foreground": "#dce0e8",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "activityBarTop.foreground": "#8839ef",
+    "activityBarTop.activeBorder": "#00000000",
+    "activityBarTop.inactiveForeground": "#9ca0b0",
+    "activityBarTop.dropBorder": "#8839ef33",
+    "badge.background": "#bcc0cc",
+    "badge.foreground": "#4c4f69",
+    "breadcrumb.activeSelectionForeground": "#8839ef",
+    "breadcrumb.background": "#eff1f5",
+    "breadcrumb.focusForeground": "#8839ef",
+    "breadcrumb.foreground": "#4c4f69cc",
+    "breadcrumbPicker.background": "#e6e9ef",
+    "button.background": "#8839ef",
+    "button.foreground": "#dce0e8",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#9c5af2",
+    "button.secondaryForeground": "#4c4f69",
+    "button.secondaryBackground": "#acb0be",
+    "button.secondaryHoverBackground": "#c0c3ce",
+    "checkbox.background": "#bcc0cc",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#8839ef",
+    "dropdown.background": "#e6e9ef",
+    "dropdown.listBackground": "#acb0be",
+    "dropdown.border": "#8839ef",
+    "dropdown.foreground": "#4c4f69",
+    "debugToolBar.background": "#dce0e8",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#dce0e8",
+    "debugExceptionWidget.border": "#8839ef",
+    "debugTokenExpression.number": "#fe640b",
+    "debugTokenExpression.boolean": "#8839ef",
+    "debugTokenExpression.string": "#40a02b",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
+    "debugIcon.breakpointUnverifiedForeground": "#bf607c",
+    "debugIcon.breakpointCurrentStackframeForeground": "#acb0be",
+    "debugIcon.breakpointStackframeForeground": "#acb0be",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#1e66f5",
+    "debugIcon.stopForeground": "#d20f39",
+    "debugIcon.disconnectForeground": "#acb0be",
+    "debugIcon.restartForeground": "#179299",
+    "debugIcon.stepOverForeground": "#8839ef",
+    "debugIcon.stepIntoForeground": "#4c4f69",
+    "debugIcon.stepOutForeground": "#4c4f69",
+    "debugIcon.continueForeground": "#40a02b",
+    "debugIcon.stepBackForeground": "#acb0be",
+    "debugConsole.infoForeground": "#1e66f5",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#dc8a78",
+    "debugConsoleInputIcon.foreground": "#4c4f69",
+    "testing.runAction": "#8839ef",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#1e66f5",
+    "testing.iconUnset": "#4c4f69",
+    "testing.iconSkipped": "#6c6f85",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#1e66f5",
+    "testing.iconUnset.retired": "#4c4f69",
+    "testing.iconSkipped.retired": "#6c6f85",
+    "testing.peekBorder": "#8839ef",
+    "testing.peekHeaderBackground": "#acb0be",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
+    "testing.messagePeekBorder": "#8839ef",
+    "testing.messagePeekHeaderBackground": "#acb0be",
+    "testing.coveredBackground": "#40a02b4d",
+    "testing.coveredBorder": "#00000000",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
+    "testing.uncoveredBorder": "#00000000",
+    "testing.uncoveredGutterBackground": "#d20f3940",
+    "testing.coverCountBadgeBackground": "#00000000",
+    "testing.coverCountBadgeForeground": "#8839ef",
+    "diffEditor.border": "#acb0be",
+    "diffEditor.insertedTextBackground": "#40a02b33",
+    "diffEditor.removedTextBackground": "#d20f3933",
+    "diffEditor.insertedLineBackground": "#40a02b26",
+    "diffEditor.removedLineBackground": "#d20f3926",
+    "diffEditor.diagonalFill": "#acb0be99",
+    "diffEditorOverview.insertedForeground": "#40a02bcc",
+    "diffEditorOverview.removedForeground": "#d20f39cc",
+    "editor.background": "#eff1f5",
+    "editor.findMatchBackground": "#e6adbd",
+    "editor.findMatchBorder": "#d20f3933",
+    "editor.findMatchHighlightBackground": "#a9daf0",
+    "editor.findMatchHighlightBorder": "#04a5e533",
+    "editor.findRangeHighlightBackground": "#a9daf0",
+    "editor.findRangeHighlightBorder": "#04a5e533",
+    "editor.foldBackground": "#04a5e540",
+    "editor.foreground": "#4c4f69",
+    "editor.hoverHighlightBackground": "#04a5e540",
+    "editor.lineHighlightBackground": "#4c4f6912",
+    "editor.lineHighlightBorder": "#00000000",
+    "editor.rangeHighlightBackground": "#04a5e540",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#7c7f934d",
+    "editor.selectionHighlightBackground": "#7c7f9333",
+    "editor.selectionHighlightBorder": "#7c7f9333",
+    "editor.wordHighlightBackground": "#7c7f9333",
+    "editor.wordHighlightStrongBackground": "#1e66f526",
+    "editorBracketMatch.background": "#7c7f931a",
+    "editorBracketMatch.border": "#7c7f93",
+    "editorCodeLens.foreground": "#8c8fa1",
+    "editorCursor.background": "#eff1f5",
+    "editorCursor.foreground": "#dc8a78",
+    "editorGroup.border": "#acb0be",
+    "editorGroup.dropBackground": "#8839ef33",
+    "editorGroup.emptyBackground": "#eff1f5",
+    "editorGroupHeader.tabsBackground": "#dce0e8",
+    "editorGutter.addedBackground": "#40a02b",
+    "editorGutter.background": "#eff1f5",
+    "editorGutter.commentRangeForeground": "#ccd0da",
+    "editorGutter.commentGlyphForeground": "#8839ef",
+    "editorGutter.deletedBackground": "#d20f39",
+    "editorGutter.foldingControlForeground": "#7c7f93",
+    "editorGutter.modifiedBackground": "#df8e1d",
+    "editorHoverWidget.background": "#e6e9ef",
+    "editorHoverWidget.border": "#acb0be",
+    "editorHoverWidget.foreground": "#4c4f69",
+    "editorIndentGuide.activeBackground": "#acb0be",
+    "editorIndentGuide.background": "#bcc0cc",
+    "editorInlayHint.foreground": "#acb0be",
+    "editorInlayHint.background": "#e6e9efbf",
+    "editorInlayHint.typeForeground": "#5c5f77",
+    "editorInlayHint.typeBackground": "#e6e9efbf",
+    "editorInlayHint.parameterForeground": "#6c6f85",
+    "editorInlayHint.parameterBackground": "#e6e9efbf",
+    "editorLineNumber.activeForeground": "#8839ef",
+    "editorLineNumber.foreground": "#8c8fa1",
+    "editorLink.activeForeground": "#8839ef",
+    "editorMarkerNavigation.background": "#e6e9ef",
+    "editorMarkerNavigationError.background": "#d20f39",
+    "editorMarkerNavigationInfo.background": "#1e66f5",
+    "editorMarkerNavigationWarning.background": "#fe640b",
+    "editorOverviewRuler.background": "#e6e9ef",
+    "editorOverviewRuler.border": "#4c4f6912",
+    "editorOverviewRuler.modifiedForeground": "#df8e1d",
+    "editorRuler.foreground": "#acb0be",
+    "editor.stackFrameHighlightBackground": "#df8e1d26",
+    "editor.focusedStackFrameHighlightBackground": "#40a02b26",
+    "editorStickyScrollHover.background": "#ccd0da",
+    "editorSuggestWidget.background": "#e6e9ef",
+    "editorSuggestWidget.border": "#acb0be",
+    "editorSuggestWidget.foreground": "#4c4f69",
+    "editorSuggestWidget.highlightForeground": "#8839ef",
+    "editorSuggestWidget.selectedBackground": "#ccd0da",
+    "editorWhitespace.foreground": "#7c7f9366",
+    "editorWidget.background": "#e6e9ef",
+    "editorWidget.foreground": "#4c4f69",
+    "editorWidget.resizeBorder": "#acb0be",
+    "editorLightBulb.foreground": "#df8e1d",
+    "editorError.foreground": "#d20f39",
+    "editorError.border": "#00000000",
+    "editorError.background": "#00000000",
+    "editorWarning.foreground": "#fe640b",
+    "editorWarning.border": "#00000000",
+    "editorWarning.background": "#00000000",
+    "editorInfo.foreground": "#1e66f5",
+    "editorInfo.border": "#00000000",
+    "editorInfo.background": "#00000000",
+    "problemsErrorIcon.foreground": "#d20f39",
+    "problemsInfoIcon.foreground": "#1e66f5",
+    "problemsWarningIcon.foreground": "#fe640b",
+    "extensionButton.prominentForeground": "#dce0e8",
+    "extensionButton.prominentBackground": "#8839ef",
+    "extensionButton.separator": "#eff1f5",
+    "extensionButton.prominentHoverBackground": "#9c5af2",
+    "extensionBadge.remoteBackground": "#1e66f5",
+    "extensionBadge.remoteForeground": "#dce0e8",
+    "extensionIcon.starForeground": "#df8e1d",
+    "extensionIcon.verifiedForeground": "#40a02b",
+    "extensionIcon.preReleaseForeground": "#acb0be",
+    "extensionIcon.sponsorForeground": "#ea76cb",
+    "gitDecoration.addedResourceForeground": "#40a02b",
+    "gitDecoration.conflictingResourceForeground": "#8839ef",
+    "gitDecoration.deletedResourceForeground": "#d20f39",
+    "gitDecoration.ignoredResourceForeground": "#9ca0b0",
+    "gitDecoration.modifiedResourceForeground": "#df8e1d",
+    "gitDecoration.stageDeletedResourceForeground": "#d20f39",
+    "gitDecoration.stageModifiedResourceForeground": "#df8e1d",
+    "gitDecoration.submoduleResourceForeground": "#1e66f5",
+    "gitDecoration.untrackedResourceForeground": "#40a02b",
+    "scmGraph.historyItemRefColor": "#1e66f5",
+    "scmGraph.historyItemBaseRefColor": "#fe640b",
+    "scmGraph.historyItemRemoteRefColor": "#8839ef",
+    "scmGraph.foreground1": "#df8e1d",
+    "scmGraph.foreground2": "#d20f39",
+    "scmGraph.foreground3": "#40a02b",
+    "scmGraph.foreground4": "#8839ef",
+    "scmGraph.foreground5": "#179299",
+    "input.background": "#ccd0da",
+    "input.border": "#00000000",
+    "input.foreground": "#4c4f69",
+    "input.placeholderForeground": "#4c4f6973",
+    "inputOption.activeBackground": "#acb0be",
+    "inputOption.activeBorder": "#8839ef",
+    "inputOption.activeForeground": "#4c4f69",
+    "inputValidation.errorBackground": "#d20f39",
+    "inputValidation.errorBorder": "#dce0e833",
+    "inputValidation.errorForeground": "#dce0e8",
+    "inputValidation.infoBackground": "#1e66f5",
+    "inputValidation.infoBorder": "#dce0e833",
+    "inputValidation.infoForeground": "#dce0e8",
+    "inputValidation.warningBackground": "#fe640b",
+    "inputValidation.warningBorder": "#dce0e833",
+    "inputValidation.warningForeground": "#dce0e8",
+    "list.activeSelectionBackground": "#ccd0da",
+    "list.activeSelectionForeground": "#4c4f69",
+    "list.dropBackground": "#8839ef33",
+    "list.focusBackground": "#ccd0da",
+    "list.focusForeground": "#4c4f69",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#8839ef",
+    "list.hoverBackground": "#ccd0da80",
+    "list.hoverForeground": "#4c4f69",
+    "list.inactiveSelectionBackground": "#ccd0da",
+    "list.inactiveSelectionForeground": "#4c4f69",
+    "list.warningForeground": "#fe640b",
+    "listFilterWidget.background": "#bcc0cc",
+    "listFilterWidget.noMatchesOutline": "#d20f39",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#7c7f93",
+    "tree.inactiveIndentGuidesStroke": "#bcc0cc",
+    "menu.background": "#eff1f5",
+    "menu.border": "#eff1f580",
+    "menu.foreground": "#4c4f69",
+    "menu.selectionBackground": "#acb0be",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#4c4f69",
+    "menu.separatorBackground": "#acb0be",
+    "menubar.selectionBackground": "#bcc0cc",
+    "menubar.selectionForeground": "#4c4f69",
+    "merge.commonContentBackground": "#bcc0cc",
+    "merge.commonHeaderBackground": "#acb0be",
+    "merge.currentContentBackground": "#40a02b33",
+    "merge.currentHeaderBackground": "#40a02b66",
+    "merge.incomingContentBackground": "#1e66f533",
+    "merge.incomingHeaderBackground": "#1e66f566",
+    "minimap.background": "#e6e9ef80",
+    "minimap.findMatchHighlight": "#04a5e54d",
+    "minimap.selectionHighlight": "#acb0bebf",
+    "minimap.selectionOccurrenceHighlight": "#acb0bebf",
+    "minimap.warningHighlight": "#fe640bbf",
+    "minimap.errorHighlight": "#d20f39bf",
+    "minimapSlider.background": "#8839ef33",
+    "minimapSlider.hoverBackground": "#8839ef66",
+    "minimapSlider.activeBackground": "#8839ef99",
+    "minimapGutter.addedBackground": "#40a02bbf",
+    "minimapGutter.deletedBackground": "#d20f39bf",
+    "minimapGutter.modifiedBackground": "#df8e1dbf",
+    "notificationCenter.border": "#8839ef",
+    "notificationCenterHeader.foreground": "#4c4f69",
+    "notificationCenterHeader.background": "#e6e9ef",
+    "notificationToast.border": "#8839ef",
+    "notifications.foreground": "#4c4f69",
+    "notifications.background": "#e6e9ef",
+    "notifications.border": "#8839ef",
+    "notificationLink.foreground": "#1e66f5",
+    "notificationsErrorIcon.foreground": "#d20f39",
+    "notificationsWarningIcon.foreground": "#fe640b",
+    "notificationsInfoIcon.foreground": "#1e66f5",
+    "panel.background": "#eff1f5",
+    "panel.border": "#acb0be",
+    "panelSection.border": "#acb0be",
+    "panelSection.dropBackground": "#8839ef33",
+    "panelTitle.activeBorder": "#8839ef",
+    "panelTitle.activeForeground": "#4c4f69",
+    "panelTitle.inactiveForeground": "#6c6f85",
+    "peekView.border": "#8839ef",
+    "peekViewEditor.background": "#e6e9ef",
+    "peekViewEditorGutter.background": "#e6e9ef",
+    "peekViewEditor.matchHighlightBackground": "#04a5e54d",
+    "peekViewEditor.matchHighlightBorder": "#00000000",
+    "peekViewResult.background": "#e6e9ef",
+    "peekViewResult.fileForeground": "#4c4f69",
+    "peekViewResult.lineForeground": "#4c4f69",
+    "peekViewResult.matchHighlightBackground": "#04a5e54d",
+    "peekViewResult.selectionBackground": "#ccd0da",
+    "peekViewResult.selectionForeground": "#4c4f69",
+    "peekViewTitle.background": "#eff1f5",
+    "peekViewTitleDescription.foreground": "#5c5f77b3",
+    "peekViewTitleLabel.foreground": "#4c4f69",
+    "pickerGroup.border": "#8839ef",
+    "pickerGroup.foreground": "#8839ef",
+    "progressBar.background": "#8839ef",
+    "scrollbar.shadow": "#dce0e8",
+    "scrollbarSlider.activeBackground": "#ccd0da66",
+    "scrollbarSlider.background": "#acb0be80",
+    "scrollbarSlider.hoverBackground": "#9ca0b0",
+    "settings.focusedRowBackground": "#acb0be33",
+    "settings.headerForeground": "#4c4f69",
+    "settings.modifiedItemIndicator": "#8839ef",
+    "settings.dropdownBackground": "#bcc0cc",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#bcc0cc",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#bcc0cc",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#e6e9ef",
+    "sideBar.dropBackground": "#8839ef33",
+    "sideBar.foreground": "#4c4f69",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#e6e9ef",
+    "sideBarSectionHeader.foreground": "#4c4f69",
+    "sideBarTitle.foreground": "#8839ef",
+    "banner.background": "#bcc0cc",
+    "banner.foreground": "#4c4f69",
+    "banner.iconForeground": "#4c4f69",
+    "statusBar.background": "#dce0e8",
+    "statusBar.foreground": "#4c4f69",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#dce0e8",
+    "statusBar.noFolderForeground": "#4c4f69",
+    "statusBar.noFolderBorder": "#00000000",
+    "statusBar.debuggingBackground": "#fe640b",
+    "statusBar.debuggingForeground": "#dce0e8",
+    "statusBar.debuggingBorder": "#00000000",
+    "statusBarItem.remoteBackground": "#1e66f5",
+    "statusBarItem.remoteForeground": "#dce0e8",
+    "statusBarItem.activeBackground": "#acb0be66",
+    "statusBarItem.hoverBackground": "#acb0be33",
+    "statusBarItem.prominentForeground": "#8839ef",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#acb0be33",
+    "statusBarItem.errorForeground": "#d20f39",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#fe640b",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#5c5f77",
+    "commandCenter.inactiveForeground": "#5c5f77",
+    "commandCenter.activeForeground": "#8839ef",
+    "commandCenter.background": "#e6e9ef",
+    "commandCenter.activeBackground": "#acb0be33",
+    "commandCenter.border": "#00000000",
+    "commandCenter.inactiveBorder": "#00000000",
+    "commandCenter.activeBorder": "#8839ef",
+    "tab.activeBackground": "#eff1f5",
+    "tab.activeBorder": "#00000000",
+    "tab.activeBorderTop": "#8839ef",
+    "tab.activeForeground": "#8839ef",
+    "tab.activeModifiedBorder": "#df8e1d",
+    "tab.border": "#e6e9ef",
+    "tab.hoverBackground": "#ffffff",
+    "tab.hoverBorder": "#00000000",
+    "tab.hoverForeground": "#8839ef",
+    "tab.inactiveBackground": "#e6e9ef",
+    "tab.inactiveForeground": "#9ca0b0",
+    "tab.inactiveModifiedBorder": "#df8e1d4d",
+    "tab.lastPinnedBorder": "#8839ef",
+    "tab.unfocusedActiveBackground": "#e6e9ef",
+    "tab.unfocusedActiveBorder": "#00000000",
+    "tab.unfocusedActiveBorderTop": "#8839ef4d",
+    "tab.unfocusedInactiveBackground": "#d6dbe5",
+    "terminal.foreground": "#4c4f69",
+    "terminal.ansiBlack": "#5c5f77",
+    "terminal.ansiRed": "#d20f39",
+    "terminal.ansiGreen": "#40a02b",
+    "terminal.ansiYellow": "#df8e1d",
+    "terminal.ansiBlue": "#1e66f5",
+    "terminal.ansiMagenta": "#ea76cb",
+    "terminal.ansiCyan": "#179299",
+    "terminal.ansiWhite": "#acb0be",
+    "terminal.ansiBrightBlack": "#6c6f85",
+    "terminal.ansiBrightRed": "#de293e",
+    "terminal.ansiBrightGreen": "#49af3d",
+    "terminal.ansiBrightYellow": "#eea02d",
+    "terminal.ansiBrightBlue": "#456eff",
+    "terminal.ansiBrightMagenta": "#fe85d8",
+    "terminal.ansiBrightCyan": "#2d9fa8",
+    "terminal.ansiBrightWhite": "#bcc0cc",
+    "terminal.selectionBackground": "#acb0be",
+    "terminal.inactiveSelectionBackground": "#acb0be80",
+    "terminalCursor.background": "#eff1f5",
+    "terminalCursor.foreground": "#dc8a78",
+    "terminal.border": "#acb0be",
+    "terminal.dropBackground": "#8839ef33",
+    "terminal.tab.activeBorder": "#8839ef",
+    "terminalCommandDecoration.defaultBackground": "#acb0be",
+    "terminalCommandDecoration.successBackground": "#40a02b",
+    "terminalCommandDecoration.errorBackground": "#d20f39",
+    "titleBar.activeBackground": "#dce0e8",
+    "titleBar.activeForeground": "#4c4f69",
+    "titleBar.inactiveBackground": "#dce0e8",
+    "titleBar.inactiveForeground": "#4c4f6980",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#e6e9ef",
+    "welcomePage.progress.background": "#dce0e8",
+    "welcomePage.progress.foreground": "#8839ef",
+    "walkThrough.embeddedEditorBackground": "#eff1f54d",
+    "symbolIcon.textForeground": "#4c4f69",
+    "symbolIcon.arrayForeground": "#fe640b",
+    "symbolIcon.booleanForeground": "#8839ef",
+    "symbolIcon.classForeground": "#df8e1d",
+    "symbolIcon.colorForeground": "#ea76cb",
+    "symbolIcon.constantForeground": "#fe640b",
+    "symbolIcon.constructorForeground": "#7287fd",
+    "symbolIcon.enumeratorForeground": "#df8e1d",
+    "symbolIcon.enumeratorMemberForeground": "#df8e1d",
+    "symbolIcon.eventForeground": "#ea76cb",
+    "symbolIcon.fieldForeground": "#4c4f69",
+    "symbolIcon.fileForeground": "#8839ef",
+    "symbolIcon.folderForeground": "#8839ef",
+    "symbolIcon.functionForeground": "#1e66f5",
+    "symbolIcon.interfaceForeground": "#df8e1d",
+    "symbolIcon.keyForeground": "#179299",
+    "symbolIcon.keywordForeground": "#8839ef",
+    "symbolIcon.methodForeground": "#1e66f5",
+    "symbolIcon.moduleForeground": "#4c4f69",
+    "symbolIcon.namespaceForeground": "#df8e1d",
+    "symbolIcon.nullForeground": "#e64553",
+    "symbolIcon.numberForeground": "#fe640b",
+    "symbolIcon.objectForeground": "#df8e1d",
+    "symbolIcon.operatorForeground": "#179299",
+    "symbolIcon.packageForeground": "#dd7878",
+    "symbolIcon.propertyForeground": "#e64553",
+    "symbolIcon.referenceForeground": "#df8e1d",
+    "symbolIcon.snippetForeground": "#dd7878",
+    "symbolIcon.stringForeground": "#40a02b",
+    "symbolIcon.structForeground": "#179299",
+    "symbolIcon.typeParameterForeground": "#e64553",
+    "symbolIcon.unitForeground": "#4c4f69",
+    "symbolIcon.variableForeground": "#4c4f69",
+    "charts.foreground": "#4c4f69",
+    "charts.lines": "#5c5f77",
+    "charts.red": "#d20f39",
+    "charts.blue": "#1e66f5",
+    "charts.yellow": "#df8e1d",
+    "charts.orange": "#fe640b",
+    "charts.green": "#40a02b",
+    "charts.purple": "#8839ef",
+    "errorLens.errorBackground": "#d20f3926",
+    "errorLens.errorBackgroundLight": "#d20f3926",
+    "errorLens.errorForeground": "#d20f39",
+    "errorLens.errorForegroundLight": "#d20f39",
+    "errorLens.errorMessageBackground": "#d20f3926",
+    "errorLens.hintBackground": "#40a02b26",
+    "errorLens.hintBackgroundLight": "#40a02b26",
+    "errorLens.hintForeground": "#40a02b",
+    "errorLens.hintForegroundLight": "#40a02b",
+    "errorLens.hintMessageBackground": "#40a02b26",
+    "errorLens.infoBackground": "#1e66f526",
+    "errorLens.infoBackgroundLight": "#1e66f526",
+    "errorLens.infoForeground": "#1e66f5",
+    "errorLens.infoForegroundLight": "#1e66f5",
+    "errorLens.infoMessageBackground": "#1e66f526",
+    "errorLens.statusBarErrorForeground": "#d20f39",
+    "errorLens.statusBarHintForeground": "#40a02b",
+    "errorLens.statusBarIconErrorForeground": "#d20f39",
+    "errorLens.statusBarIconWarningForeground": "#fe640b",
+    "errorLens.statusBarInfoForeground": "#1e66f5",
+    "errorLens.statusBarWarningForeground": "#fe640b",
+    "errorLens.warningBackground": "#fe640b26",
+    "errorLens.warningBackgroundLight": "#fe640b26",
+    "errorLens.warningForeground": "#fe640b",
+    "errorLens.warningForegroundLight": "#fe640b",
+    "errorLens.warningMessageBackground": "#fe640b26",
+    "issues.closed": "#8839ef",
+    "issues.newIssueDecoration": "#dc8a78",
+    "issues.open": "#40a02b",
+    "pullRequests.closed": "#d20f39",
+    "pullRequests.draft": "#7c7f93",
+    "pullRequests.merged": "#8839ef",
+    "pullRequests.notification": "#4c4f69",
+    "pullRequests.open": "#40a02b",
+    "gitlens.gutterBackgroundColor": "#ccd0da4d",
+    "gitlens.gutterForegroundColor": "#4c4f69",
+    "gitlens.gutterUncommittedForegroundColor": "#8839ef",
+    "gitlens.trailingLineBackgroundColor": "#00000000",
+    "gitlens.trailingLineForegroundColor": "#4c4f694d",
+    "gitlens.lineHighlightBackgroundColor": "#8839ef26",
+    "gitlens.lineHighlightOverviewRulerColor": "#8839efcc",
+    "gitlens.openAutolinkedIssueIconColor": "#40a02b",
+    "gitlens.closedAutolinkedIssueIconColor": "#8839ef",
+    "gitlens.closedPullRequestIconColor": "#d20f39",
+    "gitlens.openPullRequestIconColor": "#40a02b",
+    "gitlens.mergedPullRequestIconColor": "#8839ef",
+    "gitlens.unpublishedChangesIconColor": "#40a02b",
+    "gitlens.unpublishedCommitIconColor": "#40a02b",
+    "gitlens.unpulledChangesIconColor": "#fe640b",
+    "gitlens.decorations.branchAheadForegroundColor": "#40a02b",
+    "gitlens.decorations.branchBehindForegroundColor": "#fe640b",
+    "gitlens.decorations.branchDivergedForegroundColor": "#df8e1d",
+    "gitlens.decorations.branchUnpublishedForegroundColor": "#40a02b",
+    "gitlens.decorations.branchMissingUpstreamForegroundColor": "#fe640b",
+    "gitlens.decorations.statusMergingOrRebasingConflictForegroundColor": "#e64553",
+    "gitlens.decorations.statusMergingOrRebasingForegroundColor": "#df8e1d",
+    "gitlens.decorations.workspaceRepoMissingForegroundColor": "#6c6f85",
+    "gitlens.decorations.workspaceCurrentForegroundColor": "#8839ef",
+    "gitlens.decorations.workspaceRepoOpenForegroundColor": "#8839ef",
+    "gitlens.decorations.worktreeHasUncommittedChangesForegroundColor": "#fe640b",
+    "gitlens.decorations.worktreeMissingForegroundColor": "#e64553",
+    "gitlens.graphLane1Color": "#8839ef",
+    "gitlens.graphLane2Color": "#df8e1d",
+    "gitlens.graphLane3Color": "#1e66f5",
+    "gitlens.graphLane4Color": "#dd7878",
+    "gitlens.graphLane5Color": "#40a02b",
+    "gitlens.graphLane6Color": "#7287fd",
+    "gitlens.graphLane7Color": "#dc8a78",
+    "gitlens.graphLane8Color": "#d20f39",
+    "gitlens.graphLane9Color": "#179299",
+    "gitlens.graphLane10Color": "#ea76cb",
+    "gitlens.graphChangesColumnAddedColor": "#40a02b",
+    "gitlens.graphChangesColumnDeletedColor": "#d20f39",
+    "gitlens.graphMinimapMarkerHeadColor": "#40a02b",
+    "gitlens.graphScrollMarkerHeadColor": "#40a02b",
+    "gitlens.graphMinimapMarkerUpstreamColor": "#388c26",
+    "gitlens.graphScrollMarkerUpstreamColor": "#388c26",
+    "gitlens.graphMinimapMarkerHighlightsColor": "#df8e1d",
+    "gitlens.graphScrollMarkerHighlightsColor": "#df8e1d",
+    "gitlens.graphMinimapMarkerLocalBranchesColor": "#1e66f5",
+    "gitlens.graphScrollMarkerLocalBranchesColor": "#1e66f5",
+    "gitlens.graphMinimapMarkerRemoteBranchesColor": "#0b57ef",
+    "gitlens.graphScrollMarkerRemoteBranchesColor": "#0b57ef",
+    "gitlens.graphMinimapMarkerStashesColor": "#8839ef",
+    "gitlens.graphScrollMarkerStashesColor": "#8839ef",
+    "gitlens.graphMinimapMarkerTagsColor": "#dd7878",
+    "gitlens.graphScrollMarkerTagsColor": "#dd7878",
+    "editorBracketHighlight.foreground1": "#d20f39",
+    "editorBracketHighlight.foreground2": "#fe640b",
+    "editorBracketHighlight.foreground3": "#df8e1d",
+    "editorBracketHighlight.foreground4": "#40a02b",
+    "editorBracketHighlight.foreground5": "#209fb5",
+    "editorBracketHighlight.foreground6": "#8839ef",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#e64553",
+    "button.secondaryBorder": "#8839ef",
+    "table.headerBackground": "#ccd0da",
+    "table.headerForeground": "#4c4f69",
+    "list.focusAndSelectionBackground": "#bcc0cc"
+  },
+  "tokenColors": [
+    {
+      "name": "Basic text & variable names (incl. leading punctuation)",
+      "scope": [
+        "text",
+        "source",
+        "variable.other.readwrite",
+        "punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Parentheses, Brackets, Braces",
+      "scope": "punctuation",
+      "settings": {
+        "foreground": "#7c7f93",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#7c7f93",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Booleans, constants, numbers",
+      "scope": [
+        "constant.numeric",
+        "variable.other.constant",
+        "entity.name.constant",
+        "constant.language.boolean",
+        "constant.language.false",
+        "constant.language.true",
+        "keyword.other.unit.user-defined",
+        "keyword.other.unit.suffix.floating-point"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.operator.word",
+        "keyword.operator.new",
+        "variable.language.super",
+        "support.type.primitive",
+        "storage.type",
+        "storage.modifier",
+        "punctuation.definition.keyword"
+      ],
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": "entity.name.tag.documentation",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": [
+        "keyword.operator",
+        "punctuation.accessor",
+        "punctuation.definition.generic",
+        "meta.function.closure punctuation.section.parameters",
+        "punctuation.definition.tag",
+        "punctuation.separator.key-value"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.function-call.method",
+        "support.function",
+        "support.function.misc",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": [
+        "entity.name.class",
+        "entity.other.inherited-class",
+        "support.class",
+        "meta.function-call.constructor",
+        "entity.name.struct"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Enum",
+      "scope": "entity.name.enum",
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Enum member",
+      "scope": [
+        "meta.enum variable.other.readwrite",
+        "variable.other.enummember"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Object properties",
+      "scope": "meta.property.object",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Types",
+      "scope": [
+        "meta.type",
+        "meta.type-alias",
+        "support.type",
+        "entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Decorators",
+      "scope": [
+        "meta.annotation variable.function",
+        "meta.annotation variable.annotation.function",
+        "meta.annotation punctuation.definition.annotation",
+        "meta.decorator",
+        "punctuation.decorator"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter",
+        "meta.function.parameters"
+      ],
+      "settings": {
+        "foreground": "#e64553",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Built-ins",
+      "scope": [
+        "constant.language",
+        "support.function.builtin"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.documentation",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Preprocessor directives",
+      "scope": [
+        "keyword.control.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Type parameters",
+      "scope": "punctuation.definition.typeparameters",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Property names (left hand assignments in json/yaml/css/less)",
+      "scope": [
+        "support.type.property-name.css",
+        "support.type.property-name.less"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "This/Self keyword",
+      "scope": [
+        "variable.language.this",
+        "variable.language.this punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Object properties",
+      "scope": "variable.object.property",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "String template interpolation",
+      "scope": [
+        "string.template variable",
+        "string variable"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "`new` as bold",
+      "scope": "keyword.operator.new",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ extern keyword",
+      "scope": "storage.modifier.specifier.extern.cpp",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "C++ scope resolution",
+      "scope": [
+        "entity.name.scope-resolution.template.call.cpp",
+        "entity.name.scope-resolution.parameter.cpp",
+        "entity.name.scope-resolution.cpp",
+        "entity.name.scope-resolution.function.definition.cpp"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "C++ doc keywords",
+      "scope": "storage.type.class.doxygen",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "C++ operators",
+      "scope": [
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "C# Interpolated Strings",
+      "scope": "meta.interpolation.cs",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "C# xml-style docs",
+      "scope": "comment.block.documentation.cs",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Classes, reflecting the className color in JSX",
+      "scope": [
+        "source.css entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "punctuation.separator.operator.css",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Pseudo classes",
+      "scope": "source.css entity.other.attribute-name.pseudo-class",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "scope": "source.css constant.other.unicode-range",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "scope": "source.css variable.parameter.url",
+      "settings": {
+        "foreground": "#40a02b",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "CSS vendored property names",
+      "scope": [
+        "support.type.vendored.property-name"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Less/SCSS right-hand variables (@/$-prefixed)",
+      "scope": [
+        "source.css meta.property-value variable",
+        "source.css meta.property-value variable.other.less",
+        "source.css meta.property-value variable.other.less punctuation.definition.variable.less",
+        "meta.definition.variable.scss"
+      ],
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "CSS variables (--prefixed)",
+      "scope": [
+        "source.css meta.property-list variable",
+        "meta.property-list variable.other.less",
+        "meta.property-list variable.other.less punctuation.definition.variable.less"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "CSS Percentage values, styled the same as numbers",
+      "scope": "keyword.other.unit.percentage.css",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "CSS Attribute selectors, styled the same as strings",
+      "scope": "source.css meta.attribute-selector",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "JSON/YAML keys, other left-hand assignments",
+      "scope": [
+        "keyword.other.definition.ini",
+        "punctuation.support.type.property-name.json",
+        "support.type.property-name.json",
+        "punctuation.support.type.property-name.toml",
+        "support.type.property-name.toml",
+        "entity.name.tag.yaml",
+        "punctuation.support.type.property-name.yaml",
+        "support.type.property-name.yaml"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "JSON/YAML constants",
+      "scope": [
+        "constant.language.json",
+        "constant.language.yaml"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "YAML anchors",
+      "scope": [
+        "entity.name.type.anchor.yaml",
+        "variable.other.alias.yaml"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "TOML tables / ini groups",
+      "scope": [
+        "support.type.property-name.table",
+        "entity.name.section.group-title.ini"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "TOML dates",
+      "scope": "constant.other.time.datetime.offset.toml",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "YAML anchor puctuation",
+      "scope": [
+        "punctuation.definition.anchor.yaml",
+        "punctuation.definition.alias.yaml"
+      ],
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "YAML triple dashes",
+      "scope": "entity.other.document.begin.yaml",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Markup Diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Diff Inserted",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Diff Deleted",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "dotenv left-hand side assignments",
+      "scope": [
+        "variable.other.env"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "dotenv reference to existing env variable",
+      "scope": [
+        "string.quoted variable.other.env"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "GDScript functions",
+      "scope": "support.function.builtin.gdscript",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "GDScript constants",
+      "scope": "constant.language.gdscript",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Comment keywords",
+      "scope": "comment meta.annotation.go",
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "go:embed, go:build, etc.",
+      "scope": "comment meta.annotation.parameters.go",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Go constants (nil, true, false)",
+      "scope": "constant.language.go",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "GraphQL variables",
+      "scope": "variable.graphql",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "GraphQL aliases",
+      "scope": "string.unquoted.alias.graphql",
+      "settings": {
+        "foreground": "#dd7878"
+      }
+    },
+    {
+      "name": "GraphQL enum members",
+      "scope": "constant.character.enum.graphql",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "GraphQL field in types",
+      "scope": "meta.objectvalues.graphql constant.object.key.graphql string.unquoted.graphql",
+      "settings": {
+        "foreground": "#dd7878"
+      }
+    },
+    {
+      "name": "data constructors",
+      "scope": [
+        "meta.declaration.data constant.other.haskell",
+        "constant.other.haskell",
+        "meta.declaration.pattern constant.other.haskell",
+        "constant.language.unit.haskell punctuation",
+        "constant.language.unit.unboxed.haskell punctuation"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "types",
+      "scope": [
+        "storage.type.haskell"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "`()` unit type (not italicized)",
+      "scope": [
+        "support.constant.unit.haskell punctuation",
+        "support.constant.unit.haskell keyword.operator.hash",
+        "support.constant.unit.unboxed.haskell punctuation",
+        "support.constant.unit.unboxed.haskell keyword.operator.hash"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "type parameters",
+      "scope": [
+        "variable.other.generic-type.haskell"
+      ],
+      "settings": {
+        "foreground": "#e64553",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "special words (builtin constants-like)",
+      "scope": [
+        "keyword.other.default.haskell",
+        "keyword.other.role.nominal.haskell",
+        "keyword.other.role.representational.haskell",
+        "keyword.other.role.phantom.haskell"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "pragma specifiers",
+      "scope": [
+        "keyword.other.preprocessor.haskell",
+        "keyword.other.preprocessor.pragma.haskell"
+      ],
+      "settings": {
+        "foreground": "#dc8a78"
+      }
+    },
+    {
+      "name": "pragma arguments",
+      "scope": [
+        "keyword.other.preprocessor.extension.haskell"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "C preprocessor directives",
+      "scope": [
+        "source.haskell meta.preprocessor.c",
+        "source.haskell meta.preprocessor.c punctuation.definition.preprocessor.c"
+      ],
+      "settings": {
+        "foreground": "#dc8a78"
+      }
+    },
+    {
+      "name": "Haskell preprocessor directives",
+      "scope": [
+        "meta.preprocessor.haskell"
+      ],
+      "settings": {
+        "foreground": "#7c7f93"
+      }
+    },
+    {
+      "name": "getters in data constructors/records",
+      "scope": [
+        "variable.other.member.haskell",
+        "variable.other.member.definition.haskell"
+      ],
+      "settings": {
+        "foreground": "#7287fd",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "fix else keyword",
+      "scope": [
+        "keyword.control.else.haskell"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "char literals (are enum variants)",
+      "scope": [
+        "string.quoted.single.haskell",
+        "string.quoted.single.haskell punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "operators",
+      "scope": [
+        "storage.type.operator.haskell",
+        "storage.type.operator.infix.haskell",
+        "entity.name.function.infix.haskell",
+        "punctuation.backtick.haskell"
+      ],
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "the , in `(,)`",
+      "scope": [
+        "support.constant.tuple.haskell",
+        "support.constant.tuple.unboxed.haskell"
+      ],
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "a few special symbols",
+      "scope": [
+        "keyword.operator.lambda.haskell",
+        "keyword.operator.pipe.haskell",
+        "keyword.operator.double-dot.haskell",
+        "variable.other.member.wildcard.haskell"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "delimiter-like",
+      "scope": [
+        "meta.type-application keyword.operator.prefix.at.haskell",
+        "keyword.operator.infix.tight.at.haskell",
+        "keyword.operator.prefix.tilde.haskell",
+        "keyword.operator.prefix.bang.haskell",
+        "keyword.operator.double-colon.haskell",
+        "keyword.operator.big-arrow.haskell",
+        "meta.function.type-declaration keyword.operator.period.haskell",
+        "meta.type-declaration keyword.operator.period.haskell",
+        "meta.declaration.type keyword.operator.period.haskell"
+      ],
+      "settings": {
+        "foreground": "#7c7f93",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "TemplateHaskell and QuasiQuoter (macros)",
+      "scope": [
+        "keyword.operator.prefix.dollar.haskell",
+        "keyword.operator.quasi-quotation.begin.haskell",
+        "keyword.operator.quasi-quotation.end.haskell"
+      ],
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "minus sign in negative num literals",
+      "scope": [
+        "keyword.operator.prefix.minus.haskell"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "HTML/XML DOCTYPE as keyword",
+      "scope": [
+        "keyword.other.doctype",
+        "meta.tag.sgml.doctype punctuation.definition.tag",
+        "meta.tag.metadata.doctype entity.name.tag",
+        "meta.tag.metadata.doctype punctuation.definition.tag"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "HTML/XML-like <tags/>",
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Special characters like &amp;",
+      "scope": [
+        "text.html constant.character.entity",
+        "text.html constant.character.entity punctuation",
+        "constant.character.entity.xml",
+        "constant.character.entity.xml punctuation",
+        "constant.character.entity.js.jsx",
+        "constant.charactger.entity.js.jsx punctuation",
+        "constant.character.entity.tsx",
+        "constant.character.entity.tsx punctuation"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "HTML/XML tag attribute values",
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Components",
+      "scope": [
+        "support.class.component",
+        "support.class.component.jsx",
+        "support.class.component.tsx",
+        "support.class.component.vue"
+      ],
+      "settings": {
+        "foreground": "#ea76cb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Annotations",
+      "scope": [
+        "punctuation.definition.annotation",
+        "storage.type.annotation"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Java enums",
+      "scope": "constant.other.enum.java",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Java imports",
+      "scope": "storage.modifier.import.java",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Javadoc",
+      "scope": "comment.block.javadoc.java keyword.other.documentation.javadoc.java",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Exported Variable",
+      "scope": "meta.export variable.other.readwrite.js",
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "JS/TS constants & properties",
+      "scope": [
+        "variable.other.constant.js",
+        "variable.other.constant.ts",
+        "variable.other.property.js",
+        "variable.other.property.ts"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "JSDoc; these are mainly params, so styled as such",
+      "scope": [
+        "variable.other.jsdoc",
+        "comment.block.documentation variable.other"
+      ],
+      "settings": {
+        "foreground": "#e64553",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "JSDoc keywords",
+      "scope": "storage.type.class.jsdoc",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": "support.type.object.console.js",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Node constants as keywords (module, etc.)",
+      "scope": [
+        "support.constant.node",
+        "support.type.object.module.js"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "implements as keyword",
+      "scope": "storage.modifier.implements",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Builtin types",
+      "scope": [
+        "constant.language.null.js",
+        "constant.language.null.ts",
+        "constant.language.undefined.js",
+        "constant.language.undefined.ts",
+        "support.type.builtin.ts"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "scope": "variable.parameter.generic",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Arrow functions",
+      "scope": [
+        "keyword.declaration.function.arrow.js",
+        "storage.type.function.arrow.ts"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Decorator punctuations (decorators inherit from blue functions, instead of styleguide peach)",
+      "scope": "punctuation.decorator.ts",
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Extra JS/TS keywords",
+      "scope": [
+        "keyword.operator.expression.in.js",
+        "keyword.operator.expression.in.ts",
+        "keyword.operator.expression.infer.ts",
+        "keyword.operator.expression.instanceof.js",
+        "keyword.operator.expression.instanceof.ts",
+        "keyword.operator.expression.is",
+        "keyword.operator.expression.keyof.ts",
+        "keyword.operator.expression.of.js",
+        "keyword.operator.expression.of.ts",
+        "keyword.operator.expression.typeof.ts"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Julia macros",
+      "scope": "support.function.macro.julia",
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Julia language constants (true, false)",
+      "scope": "constant.language.julia",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Julia other constants (these seem to be arguments inside arrays)",
+      "scope": "constant.other.symbol.julia",
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "LaTeX preamble",
+      "scope": "text.tex keyword.control.preamble",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "LaTeX be functions",
+      "scope": "text.tex support.function.be",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "LaTeX math",
+      "scope": "constant.other.general.math.tex",
+      "settings": {
+        "foreground": "#dd7878"
+      }
+    },
+    {
+      "name": "Liquid Builtin Objects & User Defined Variables",
+      "scope": "variable.language.liquid",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Lua docstring keywords",
+      "scope": "comment.line.double-dash.documentation.lua storage.type.annotation.lua",
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Lua docstring variables",
+      "scope": [
+        "comment.line.double-dash.documentation.lua entity.name.variable.lua",
+        "comment.line.double-dash.documentation.lua variable.lua"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "scope": [
+        "heading.1.markdown punctuation.definition.heading.markdown",
+        "heading.1.markdown",
+        "heading.1.quarto punctuation.definition.heading.quarto",
+        "heading.1.quarto",
+        "markup.heading.atx.1.mdx",
+        "markup.heading.atx.1.mdx punctuation.definition.heading.mdx",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.heading-0.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "scope": [
+        "heading.2.markdown punctuation.definition.heading.markdown",
+        "heading.2.markdown",
+        "heading.2.quarto punctuation.definition.heading.quarto",
+        "heading.2.quarto",
+        "markup.heading.atx.2.mdx",
+        "markup.heading.atx.2.mdx punctuation.definition.heading.mdx",
+        "markup.heading.setext.2.markdown",
+        "markup.heading.heading-1.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "scope": [
+        "heading.3.markdown punctuation.definition.heading.markdown",
+        "heading.3.markdown",
+        "heading.3.quarto punctuation.definition.heading.quarto",
+        "heading.3.quarto",
+        "markup.heading.atx.3.mdx",
+        "markup.heading.atx.3.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-2.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "scope": [
+        "heading.4.markdown punctuation.definition.heading.markdown",
+        "heading.4.markdown",
+        "heading.4.quarto punctuation.definition.heading.quarto",
+        "heading.4.quarto",
+        "markup.heading.atx.4.mdx",
+        "markup.heading.atx.4.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-3.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "scope": [
+        "heading.5.markdown punctuation.definition.heading.markdown",
+        "heading.5.markdown",
+        "heading.5.quarto punctuation.definition.heading.quarto",
+        "heading.5.quarto",
+        "markup.heading.atx.5.mdx",
+        "markup.heading.atx.5.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-4.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#209fb5"
+      }
+    },
+    {
+      "scope": [
+        "heading.6.markdown punctuation.definition.heading.markdown",
+        "heading.6.markdown",
+        "heading.6.quarto punctuation.definition.heading.quarto",
+        "heading.6.quarto",
+        "markup.heading.atx.6.mdx",
+        "markup.heading.atx.6.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-5.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#7287fd"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "foreground": "#6c6f85",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "Markdown auto links",
+      "scope": [
+        "punctuation.definition.link",
+        "markup.underline.link"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Markdown links",
+      "scope": [
+        "text.html.markdown punctuation.definition.link.title",
+        "text.html.quarto punctuation.definition.link.title",
+        "string.other.link.title.markdown",
+        "string.other.link.title.quarto",
+        "markup.link",
+        "punctuation.definition.constant.markdown",
+        "punctuation.definition.constant.quarto",
+        "constant.other.reference.link.markdown",
+        "constant.other.reference.link.quarto",
+        "markup.substitution.attribute-reference"
+      ],
+      "settings": {
+        "foreground": "#7287fd"
+      }
+    },
+    {
+      "name": "Markdown code spans",
+      "scope": [
+        "punctuation.definition.raw.markdown",
+        "punctuation.definition.raw.quarto",
+        "markup.inline.raw.string.markdown",
+        "markup.inline.raw.string.quarto",
+        "markup.raw.block.markdown",
+        "markup.raw.block.quarto"
+      ],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Markdown triple backtick language identifier",
+      "scope": "fenced_code.block.language",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Markdown triple backticks",
+      "scope": [
+        "markup.fenced_code.block punctuation.definition",
+        "markup.raw support.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#7c7f93"
+      }
+    },
+    {
+      "name": "Markdown quotes",
+      "scope": [
+        "markup.quote",
+        "punctuation.definition.quote.begin"
+      ],
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Markdown separators",
+      "scope": "meta.separator.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Markdown list bullets",
+      "scope": [
+        "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.list.begin.quarto",
+        "markup.list.bullet"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Quarto headings",
+      "scope": "markup.heading.quarto",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Nix attribute names",
+      "scope": [
+        "entity.other.attribute-name.multipart.nix",
+        "entity.other.attribute-name.single.nix"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Nix parameter names",
+      "scope": "variable.parameter.name.nix",
+      "settings": {
+        "foreground": "#4c4f69",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Nix interpolated parameter names",
+      "scope": "meta.embedded variable.parameter.name.nix",
+      "settings": {
+        "foreground": "#7287fd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Nix paths",
+      "scope": "string.unquoted.path.nix",
+      "settings": {
+        "foreground": "#ea76cb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "PHP Attributes",
+      "scope": [
+        "support.attribute.builtin",
+        "meta.attribute.php"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "PHP Parameters (needed for the leading dollar sign)",
+      "scope": "meta.function.parameters.php punctuation.definition.variable.php",
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "PHP Constants (null, __FILE__, etc.)",
+      "scope": "constant.language.php",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "PHP functions",
+      "scope": "text.html.php support.function",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "PHPdoc keywords",
+      "scope": "keyword.other.phpdoc.php",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Python argument functions reset to text, otherwise they inherit blue from function-call",
+      "scope": [
+        "support.variable.magic.python",
+        "meta.function-call.arguments.python"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Python double underscore functions",
+      "scope": [
+        "support.function.magic.python"
+      ],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python `self` keyword",
+      "scope": [
+        "variable.parameter.function.language.special.self.python",
+        "variable.language.special.self.python"
+      ],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow/logical (for ... in)",
+      "scope": [
+        "keyword.control.flow.python",
+        "keyword.operator.logical.python"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "python function calls",
+      "scope": [
+        "meta.function-call.python"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "python function decorators",
+      "scope": [
+        "entity.name.function.decorator.python",
+        "punctuation.definition.decorator.python"
+      ],
+      "settings": {
+        "foreground": "#fe640b",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Python exception & builtins such as exit()",
+      "scope": [
+        "support.type.exception.python",
+        "support.function.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "entity.name.type",
+      "scope": [
+        "support.type.python"
+      ],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "python constants (True/False)",
+      "scope": "constant.language.python",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Arguments accessed later in the function body",
+      "scope": [
+        "meta.indexed-name.python",
+        "meta.item-access.python"
+      ],
+      "settings": {
+        "foreground": "#e64553",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python f-strings/binary/unicode storage types",
+      "scope": "storage.type.string.python",
+      "settings": {
+        "foreground": "#40a02b",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python type hints",
+      "scope": "meta.function.parameters.python",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "R function calls",
+      "scope": "meta.function-call.r",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "R function call arguments",
+      "scope": "meta.function-call.arguments.r",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Regex string begin/end in JS/TS",
+      "scope": [
+        "string.regexp punctuation.definition.string.begin",
+        "string.regexp punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Regex anchors (^, $)",
+      "scope": "keyword.control.anchor.regexp",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Regex regular string match",
+      "scope": "string.regexp.ts",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Regex group parenthesis & backreference (\\1, \\2, \\3, ...)",
+      "scope": [
+        "punctuation.definition.group.regexp",
+        "keyword.other.back-reference.regexp"
+      ],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Regex character class []",
+      "scope": "punctuation.definition.character-class.regexp",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Regex character classes (\\d, \\w, \\s)",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Regex range",
+      "scope": "constant.other.character-class.range.regexp",
+      "settings": {
+        "foreground": "#dc8a78"
+      }
+    },
+    {
+      "name": "Regex quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Regex constant/numeric",
+      "scope": "constant.character.numeric.regexp",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Regex lookaheads, negative lookaheads, lookbehinds, negative lookbehinds",
+      "scope": [
+        "punctuation.definition.group.no-capture.regexp",
+        "meta.assertion.look-ahead.regexp",
+        "meta.assertion.negative-look-ahead.regexp"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Rust attribute",
+      "scope": [
+        "meta.annotation.rust",
+        "meta.annotation.rust punctuation",
+        "meta.attribute.rust",
+        "punctuation.definition.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust attribute strings",
+      "scope": [
+        "meta.attribute.rust string.quoted.double.rust",
+        "meta.attribute.rust string.quoted.single.char.rust"
+      ],
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust keyword",
+      "scope": [
+        "entity.name.function.macro.rules.rust",
+        "storage.type.module.rust",
+        "storage.modifier.rust",
+        "storage.type.struct.rust",
+        "storage.type.enum.rust",
+        "storage.type.trait.rust",
+        "storage.type.union.rust",
+        "storage.type.impl.rust",
+        "storage.type.rust",
+        "storage.type.function.rust",
+        "storage.type.type.rust"
+      ],
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust u/i32, u/i64, etc.",
+      "scope": "entity.name.type.numeric.rust",
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust generic",
+      "scope": "meta.generic.rust",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust impl",
+      "scope": "entity.name.impl.rust",
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust module",
+      "scope": "entity.name.module.rust",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust trait",
+      "scope": "entity.name.trait.rust",
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust struct",
+      "scope": "storage.type.source.rust",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Rust union",
+      "scope": "entity.name.union.rust",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Rust enum member",
+      "scope": "meta.enum.rust storage.type.source.rust",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Rust macro",
+      "scope": [
+        "support.macro.rust",
+        "meta.macro.rust support.function.rust",
+        "entity.name.function.macro.rust"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust lifetime",
+      "scope": [
+        "storage.modifier.lifetime.rust",
+        "entity.name.type.lifetime"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust string formatting",
+      "scope": "string.quoted.double.rust constant.other.placeholder.rust",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Rust return type generic",
+      "scope": "meta.function.return-type.rust meta.generic.rust storage.type.rust",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "meta.function.call.rust",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Rust angle brackets",
+      "scope": "punctuation.brackets.angle.rust",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "constant.other.caps.rust",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust function parameters",
+      "scope": [
+        "meta.function.definition.rust variable.other.rust"
+      ],
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "Rust closure variables",
+      "scope": "meta.function.call.rust variable.other.rust",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Rust self",
+      "scope": "variable.language.self.rust",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Rust metavariable names",
+      "scope": [
+        "variable.other.metavariable.name.rust",
+        "meta.macro.metavariable.rust keyword.operator.macro.dollar.rust"
+      ],
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "Shell shebang",
+      "scope": [
+        "comment.line.shebang",
+        "comment.line.shebang punctuation.definition.comment",
+        "comment.line.shebang",
+        "punctuation.definition.comment.shebang.shell",
+        "meta.shebang.shell"
+      ],
+      "settings": {
+        "foreground": "#ea76cb",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Shell shebang command",
+      "scope": "comment.line.shebang constant.language",
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Shell interpolated command",
+      "scope": [
+        "meta.function-call.arguments.shell punctuation.definition.variable.shell",
+        "meta.function-call.arguments.shell punctuation.section.interpolation",
+        "meta.function-call.arguments.shell punctuation.definition.variable.shell",
+        "meta.function-call.arguments.shell punctuation.section.interpolation"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Shell interpolated command variable",
+      "scope": "meta.string meta.interpolation.parameter.shell variable.other.readwrite",
+      "settings": {
+        "foreground": "#fe640b",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "source.shell punctuation.section.interpolation",
+        "punctuation.definition.evaluation.backticks.shell"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Shell EOF",
+      "scope": "entity.name.tag.heredoc.shell",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Shell quoted variable",
+      "scope": "string.quoted.double.shell variable.other.normal.shell",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "scope": [
+        "markup.heading.typst"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    }
+  ]
+}

--- a/themes/catppuccin-mocha.json
+++ b/themes/catppuccin-mocha.json
@@ -1,0 +1,2406 @@
+{
+  "name": "Catppuccin Mocha",
+  "type": "dark",
+  "colors": {
+    "focusBorder": "#cba6f7",
+    "foreground": "#cdd6f4",
+    "disabledForeground": "#a6adc8",
+    "widget.shadow": "#18182580",
+    "selection.background": "#cba6f766",
+    "descriptionForeground": "#cdd6f4",
+    "errorForeground": "#f38ba8",
+    "icon.foreground": "#cba6f7",
+    "sash.hoverBorder": "#cba6f7",
+    "textBlockQuote.background": "#181825",
+    "textBlockQuote.border": "#11111b",
+    "textCodeBlock.background": "#181825",
+    "textLink.activeForeground": "#89dceb",
+    "textLink.foreground": "#89b4fa",
+    "textPreformat.foreground": "#cdd6f4",
+    "textSeparator.foreground": "#cba6f7",
+    "activityBar.background": "#11111b",
+    "activityBar.foreground": "#cba6f7",
+    "activityBar.dropBorder": "#cba6f733",
+    "activityBar.inactiveForeground": "#6c7086",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#cba6f7",
+    "activityBarBadge.foreground": "#11111b",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "activityBarTop.foreground": "#cba6f7",
+    "activityBarTop.activeBorder": "#00000000",
+    "activityBarTop.inactiveForeground": "#6c7086",
+    "activityBarTop.dropBorder": "#cba6f733",
+    "badge.background": "#45475a",
+    "badge.foreground": "#cdd6f4",
+    "breadcrumb.activeSelectionForeground": "#cba6f7",
+    "breadcrumb.background": "#1e1e2e",
+    "breadcrumb.focusForeground": "#cba6f7",
+    "breadcrumb.foreground": "#cdd6f4cc",
+    "breadcrumbPicker.background": "#181825",
+    "button.background": "#cba6f7",
+    "button.foreground": "#11111b",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#dec7fa",
+    "button.secondaryForeground": "#cdd6f4",
+    "button.secondaryBackground": "#585b70",
+    "button.secondaryHoverBackground": "#686b84",
+    "checkbox.background": "#45475a",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#cba6f7",
+    "dropdown.background": "#181825",
+    "dropdown.listBackground": "#585b70",
+    "dropdown.border": "#cba6f7",
+    "dropdown.foreground": "#cdd6f4",
+    "debugToolBar.background": "#11111b",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#11111b",
+    "debugExceptionWidget.border": "#cba6f7",
+    "debugTokenExpression.number": "#fab387",
+    "debugTokenExpression.boolean": "#cba6f7",
+    "debugTokenExpression.string": "#a6e3a1",
+    "debugTokenExpression.error": "#f38ba8",
+    "debugIcon.breakpointForeground": "#f38ba8",
+    "debugIcon.breakpointDisabledForeground": "#f38ba899",
+    "debugIcon.breakpointUnverifiedForeground": "#a6738c",
+    "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
+    "debugIcon.breakpointStackframeForeground": "#585b70",
+    "debugIcon.startForeground": "#a6e3a1",
+    "debugIcon.pauseForeground": "#89b4fa",
+    "debugIcon.stopForeground": "#f38ba8",
+    "debugIcon.disconnectForeground": "#585b70",
+    "debugIcon.restartForeground": "#94e2d5",
+    "debugIcon.stepOverForeground": "#cba6f7",
+    "debugIcon.stepIntoForeground": "#cdd6f4",
+    "debugIcon.stepOutForeground": "#cdd6f4",
+    "debugIcon.continueForeground": "#a6e3a1",
+    "debugIcon.stepBackForeground": "#585b70",
+    "debugConsole.infoForeground": "#89b4fa",
+    "debugConsole.warningForeground": "#fab387",
+    "debugConsole.errorForeground": "#f38ba8",
+    "debugConsole.sourceForeground": "#f5e0dc",
+    "debugConsoleInputIcon.foreground": "#cdd6f4",
+    "testing.runAction": "#cba6f7",
+    "testing.iconErrored": "#f38ba8",
+    "testing.iconFailed": "#f38ba8",
+    "testing.iconPassed": "#a6e3a1",
+    "testing.iconQueued": "#89b4fa",
+    "testing.iconUnset": "#cdd6f4",
+    "testing.iconSkipped": "#a6adc8",
+    "testing.iconErrored.retired": "#f38ba8",
+    "testing.iconFailed.retired": "#f38ba8",
+    "testing.iconPassed.retired": "#a6e3a1",
+    "testing.iconQueued.retired": "#89b4fa",
+    "testing.iconUnset.retired": "#cdd6f4",
+    "testing.iconSkipped.retired": "#a6adc8",
+    "testing.peekBorder": "#cba6f7",
+    "testing.peekHeaderBackground": "#585b70",
+    "testing.message.error.lineBackground": "#f38ba826",
+    "testing.message.info.decorationForeground": "#a6e3a1cc",
+    "testing.message.info.lineBackground": "#a6e3a126",
+    "testing.messagePeekBorder": "#cba6f7",
+    "testing.messagePeekHeaderBackground": "#585b70",
+    "testing.coveredBackground": "#a6e3a14d",
+    "testing.coveredBorder": "#00000000",
+    "testing.coveredGutterBackground": "#a6e3a14d",
+    "testing.uncoveredBranchBackground": "#f38ba833",
+    "testing.uncoveredBackground": "#f38ba833",
+    "testing.uncoveredBorder": "#00000000",
+    "testing.uncoveredGutterBackground": "#f38ba840",
+    "testing.coverCountBadgeBackground": "#00000000",
+    "testing.coverCountBadgeForeground": "#cba6f7",
+    "diffEditor.border": "#585b70",
+    "diffEditor.insertedTextBackground": "#a6e3a133",
+    "diffEditor.removedTextBackground": "#f38ba833",
+    "diffEditor.insertedLineBackground": "#a6e3a126",
+    "diffEditor.removedLineBackground": "#f38ba826",
+    "diffEditor.diagonalFill": "#585b7099",
+    "diffEditorOverview.insertedForeground": "#a6e3a1cc",
+    "diffEditorOverview.removedForeground": "#f38ba8cc",
+    "editor.background": "#1e1e2e",
+    "editor.findMatchBackground": "#5e3f53",
+    "editor.findMatchBorder": "#f38ba833",
+    "editor.findMatchHighlightBackground": "#3e5767",
+    "editor.findMatchHighlightBorder": "#89dceb33",
+    "editor.findRangeHighlightBackground": "#3e5767",
+    "editor.findRangeHighlightBorder": "#89dceb33",
+    "editor.foldBackground": "#89dceb40",
+    "editor.foreground": "#cdd6f4",
+    "editor.hoverHighlightBackground": "#89dceb40",
+    "editor.lineHighlightBackground": "#cdd6f412",
+    "editor.lineHighlightBorder": "#00000000",
+    "editor.rangeHighlightBackground": "#89dceb40",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#9399b240",
+    "editor.selectionHighlightBackground": "#9399b233",
+    "editor.selectionHighlightBorder": "#9399b233",
+    "editor.wordHighlightBackground": "#9399b233",
+    "editor.wordHighlightStrongBackground": "#89b4fa33",
+    "editorBracketMatch.background": "#9399b21a",
+    "editorBracketMatch.border": "#9399b2",
+    "editorCodeLens.foreground": "#7f849c",
+    "editorCursor.background": "#1e1e2e",
+    "editorCursor.foreground": "#f5e0dc",
+    "editorGroup.border": "#585b70",
+    "editorGroup.dropBackground": "#cba6f733",
+    "editorGroup.emptyBackground": "#1e1e2e",
+    "editorGroupHeader.tabsBackground": "#11111b",
+    "editorGutter.addedBackground": "#a6e3a1",
+    "editorGutter.background": "#1e1e2e",
+    "editorGutter.commentRangeForeground": "#313244",
+    "editorGutter.commentGlyphForeground": "#cba6f7",
+    "editorGutter.deletedBackground": "#f38ba8",
+    "editorGutter.foldingControlForeground": "#9399b2",
+    "editorGutter.modifiedBackground": "#f9e2af",
+    "editorHoverWidget.background": "#181825",
+    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.foreground": "#cdd6f4",
+    "editorIndentGuide.activeBackground": "#585b70",
+    "editorIndentGuide.background": "#45475a",
+    "editorInlayHint.foreground": "#585b70",
+    "editorInlayHint.background": "#181825bf",
+    "editorInlayHint.typeForeground": "#bac2de",
+    "editorInlayHint.typeBackground": "#181825bf",
+    "editorInlayHint.parameterForeground": "#a6adc8",
+    "editorInlayHint.parameterBackground": "#181825bf",
+    "editorLineNumber.activeForeground": "#cba6f7",
+    "editorLineNumber.foreground": "#7f849c",
+    "editorLink.activeForeground": "#cba6f7",
+    "editorMarkerNavigation.background": "#181825",
+    "editorMarkerNavigationError.background": "#f38ba8",
+    "editorMarkerNavigationInfo.background": "#89b4fa",
+    "editorMarkerNavigationWarning.background": "#fab387",
+    "editorOverviewRuler.background": "#181825",
+    "editorOverviewRuler.border": "#cdd6f412",
+    "editorOverviewRuler.modifiedForeground": "#f9e2af",
+    "editorRuler.foreground": "#585b70",
+    "editor.stackFrameHighlightBackground": "#f9e2af26",
+    "editor.focusedStackFrameHighlightBackground": "#a6e3a126",
+    "editorStickyScrollHover.background": "#313244",
+    "editorSuggestWidget.background": "#181825",
+    "editorSuggestWidget.border": "#585b70",
+    "editorSuggestWidget.foreground": "#cdd6f4",
+    "editorSuggestWidget.highlightForeground": "#cba6f7",
+    "editorSuggestWidget.selectedBackground": "#313244",
+    "editorWhitespace.foreground": "#9399b266",
+    "editorWidget.background": "#181825",
+    "editorWidget.foreground": "#cdd6f4",
+    "editorWidget.resizeBorder": "#585b70",
+    "editorLightBulb.foreground": "#f9e2af",
+    "editorError.foreground": "#f38ba8",
+    "editorError.border": "#00000000",
+    "editorError.background": "#00000000",
+    "editorWarning.foreground": "#fab387",
+    "editorWarning.border": "#00000000",
+    "editorWarning.background": "#00000000",
+    "editorInfo.foreground": "#89b4fa",
+    "editorInfo.border": "#00000000",
+    "editorInfo.background": "#00000000",
+    "problemsErrorIcon.foreground": "#f38ba8",
+    "problemsInfoIcon.foreground": "#89b4fa",
+    "problemsWarningIcon.foreground": "#fab387",
+    "extensionButton.prominentForeground": "#11111b",
+    "extensionButton.prominentBackground": "#cba6f7",
+    "extensionButton.separator": "#1e1e2e",
+    "extensionButton.prominentHoverBackground": "#dec7fa",
+    "extensionBadge.remoteBackground": "#89b4fa",
+    "extensionBadge.remoteForeground": "#11111b",
+    "extensionIcon.starForeground": "#f9e2af",
+    "extensionIcon.verifiedForeground": "#a6e3a1",
+    "extensionIcon.preReleaseForeground": "#585b70",
+    "extensionIcon.sponsorForeground": "#f5c2e7",
+    "gitDecoration.addedResourceForeground": "#a6e3a1",
+    "gitDecoration.conflictingResourceForeground": "#cba6f7",
+    "gitDecoration.deletedResourceForeground": "#f38ba8",
+    "gitDecoration.ignoredResourceForeground": "#6c7086",
+    "gitDecoration.modifiedResourceForeground": "#f9e2af",
+    "gitDecoration.stageDeletedResourceForeground": "#f38ba8",
+    "gitDecoration.stageModifiedResourceForeground": "#f9e2af",
+    "gitDecoration.submoduleResourceForeground": "#89b4fa",
+    "gitDecoration.untrackedResourceForeground": "#a6e3a1",
+    "scmGraph.historyItemRefColor": "#89b4fa",
+    "scmGraph.historyItemBaseRefColor": "#fab387",
+    "scmGraph.historyItemRemoteRefColor": "#cba6f7",
+    "scmGraph.foreground1": "#f9e2af",
+    "scmGraph.foreground2": "#f38ba8",
+    "scmGraph.foreground3": "#a6e3a1",
+    "scmGraph.foreground4": "#cba6f7",
+    "scmGraph.foreground5": "#94e2d5",
+    "input.background": "#313244",
+    "input.border": "#00000000",
+    "input.foreground": "#cdd6f4",
+    "input.placeholderForeground": "#cdd6f473",
+    "inputOption.activeBackground": "#585b70",
+    "inputOption.activeBorder": "#cba6f7",
+    "inputOption.activeForeground": "#cdd6f4",
+    "inputValidation.errorBackground": "#f38ba8",
+    "inputValidation.errorBorder": "#11111b33",
+    "inputValidation.errorForeground": "#11111b",
+    "inputValidation.infoBackground": "#89b4fa",
+    "inputValidation.infoBorder": "#11111b33",
+    "inputValidation.infoForeground": "#11111b",
+    "inputValidation.warningBackground": "#fab387",
+    "inputValidation.warningBorder": "#11111b33",
+    "inputValidation.warningForeground": "#11111b",
+    "list.activeSelectionBackground": "#313244",
+    "list.activeSelectionForeground": "#cdd6f4",
+    "list.dropBackground": "#cba6f733",
+    "list.focusBackground": "#313244",
+    "list.focusForeground": "#cdd6f4",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#cba6f7",
+    "list.hoverBackground": "#31324480",
+    "list.hoverForeground": "#cdd6f4",
+    "list.inactiveSelectionBackground": "#313244",
+    "list.inactiveSelectionForeground": "#cdd6f4",
+    "list.warningForeground": "#fab387",
+    "listFilterWidget.background": "#45475a",
+    "listFilterWidget.noMatchesOutline": "#f38ba8",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#9399b2",
+    "tree.inactiveIndentGuidesStroke": "#45475a",
+    "menu.background": "#1e1e2e",
+    "menu.border": "#1e1e2e80",
+    "menu.foreground": "#cdd6f4",
+    "menu.selectionBackground": "#585b70",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#cdd6f4",
+    "menu.separatorBackground": "#585b70",
+    "menubar.selectionBackground": "#45475a",
+    "menubar.selectionForeground": "#cdd6f4",
+    "merge.commonContentBackground": "#45475a",
+    "merge.commonHeaderBackground": "#585b70",
+    "merge.currentContentBackground": "#a6e3a133",
+    "merge.currentHeaderBackground": "#a6e3a166",
+    "merge.incomingContentBackground": "#89b4fa33",
+    "merge.incomingHeaderBackground": "#89b4fa66",
+    "minimap.background": "#18182580",
+    "minimap.findMatchHighlight": "#89dceb4d",
+    "minimap.selectionHighlight": "#585b70bf",
+    "minimap.selectionOccurrenceHighlight": "#585b70bf",
+    "minimap.warningHighlight": "#fab387bf",
+    "minimap.errorHighlight": "#f38ba8bf",
+    "minimapSlider.background": "#cba6f733",
+    "minimapSlider.hoverBackground": "#cba6f766",
+    "minimapSlider.activeBackground": "#cba6f799",
+    "minimapGutter.addedBackground": "#a6e3a1bf",
+    "minimapGutter.deletedBackground": "#f38ba8bf",
+    "minimapGutter.modifiedBackground": "#f9e2afbf",
+    "notificationCenter.border": "#cba6f7",
+    "notificationCenterHeader.foreground": "#cdd6f4",
+    "notificationCenterHeader.background": "#181825",
+    "notificationToast.border": "#cba6f7",
+    "notifications.foreground": "#cdd6f4",
+    "notifications.background": "#181825",
+    "notifications.border": "#cba6f7",
+    "notificationLink.foreground": "#89b4fa",
+    "notificationsErrorIcon.foreground": "#f38ba8",
+    "notificationsWarningIcon.foreground": "#fab387",
+    "notificationsInfoIcon.foreground": "#89b4fa",
+    "panel.background": "#1e1e2e",
+    "panel.border": "#585b70",
+    "panelSection.border": "#585b70",
+    "panelSection.dropBackground": "#cba6f733",
+    "panelTitle.activeBorder": "#cba6f7",
+    "panelTitle.activeForeground": "#cdd6f4",
+    "panelTitle.inactiveForeground": "#a6adc8",
+    "peekView.border": "#cba6f7",
+    "peekViewEditor.background": "#181825",
+    "peekViewEditorGutter.background": "#181825",
+    "peekViewEditor.matchHighlightBackground": "#89dceb4d",
+    "peekViewEditor.matchHighlightBorder": "#00000000",
+    "peekViewResult.background": "#181825",
+    "peekViewResult.fileForeground": "#cdd6f4",
+    "peekViewResult.lineForeground": "#cdd6f4",
+    "peekViewResult.matchHighlightBackground": "#89dceb4d",
+    "peekViewResult.selectionBackground": "#313244",
+    "peekViewResult.selectionForeground": "#cdd6f4",
+    "peekViewTitle.background": "#1e1e2e",
+    "peekViewTitleDescription.foreground": "#bac2deb3",
+    "peekViewTitleLabel.foreground": "#cdd6f4",
+    "pickerGroup.border": "#cba6f7",
+    "pickerGroup.foreground": "#cba6f7",
+    "progressBar.background": "#cba6f7",
+    "scrollbar.shadow": "#11111b",
+    "scrollbarSlider.activeBackground": "#31324466",
+    "scrollbarSlider.background": "#585b7080",
+    "scrollbarSlider.hoverBackground": "#6c7086",
+    "settings.focusedRowBackground": "#585b7033",
+    "settings.headerForeground": "#cdd6f4",
+    "settings.modifiedItemIndicator": "#cba6f7",
+    "settings.dropdownBackground": "#45475a",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#45475a",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#45475a",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#181825",
+    "sideBar.dropBackground": "#cba6f733",
+    "sideBar.foreground": "#cdd6f4",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#181825",
+    "sideBarSectionHeader.foreground": "#cdd6f4",
+    "sideBarTitle.foreground": "#cba6f7",
+    "banner.background": "#45475a",
+    "banner.foreground": "#cdd6f4",
+    "banner.iconForeground": "#cdd6f4",
+    "statusBar.background": "#11111b",
+    "statusBar.foreground": "#cdd6f4",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#11111b",
+    "statusBar.noFolderForeground": "#cdd6f4",
+    "statusBar.noFolderBorder": "#00000000",
+    "statusBar.debuggingBackground": "#fab387",
+    "statusBar.debuggingForeground": "#11111b",
+    "statusBar.debuggingBorder": "#00000000",
+    "statusBarItem.remoteBackground": "#89b4fa",
+    "statusBarItem.remoteForeground": "#11111b",
+    "statusBarItem.activeBackground": "#585b7066",
+    "statusBarItem.hoverBackground": "#585b7033",
+    "statusBarItem.prominentForeground": "#cba6f7",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#585b7033",
+    "statusBarItem.errorForeground": "#f38ba8",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#fab387",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#bac2de",
+    "commandCenter.inactiveForeground": "#bac2de",
+    "commandCenter.activeForeground": "#cba6f7",
+    "commandCenter.background": "#181825",
+    "commandCenter.activeBackground": "#585b7033",
+    "commandCenter.border": "#00000000",
+    "commandCenter.inactiveBorder": "#00000000",
+    "commandCenter.activeBorder": "#cba6f7",
+    "tab.activeBackground": "#1e1e2e",
+    "tab.activeBorder": "#00000000",
+    "tab.activeBorderTop": "#cba6f7",
+    "tab.activeForeground": "#cba6f7",
+    "tab.activeModifiedBorder": "#f9e2af",
+    "tab.border": "#181825",
+    "tab.hoverBackground": "#28283d",
+    "tab.hoverBorder": "#00000000",
+    "tab.hoverForeground": "#cba6f7",
+    "tab.inactiveBackground": "#181825",
+    "tab.inactiveForeground": "#6c7086",
+    "tab.inactiveModifiedBorder": "#f9e2af4d",
+    "tab.lastPinnedBorder": "#cba6f7",
+    "tab.unfocusedActiveBackground": "#181825",
+    "tab.unfocusedActiveBorder": "#00000000",
+    "tab.unfocusedActiveBorderTop": "#cba6f74d",
+    "tab.unfocusedInactiveBackground": "#0e0e16",
+    "terminal.foreground": "#cdd6f4",
+    "terminal.ansiBlack": "#45475a",
+    "terminal.ansiRed": "#f38ba8",
+    "terminal.ansiGreen": "#a6e3a1",
+    "terminal.ansiYellow": "#f9e2af",
+    "terminal.ansiBlue": "#89b4fa",
+    "terminal.ansiMagenta": "#f5c2e7",
+    "terminal.ansiCyan": "#94e2d5",
+    "terminal.ansiWhite": "#a6adc8",
+    "terminal.ansiBrightBlack": "#585b70",
+    "terminal.ansiBrightRed": "#f37799",
+    "terminal.ansiBrightGreen": "#89d88b",
+    "terminal.ansiBrightYellow": "#ebd391",
+    "terminal.ansiBrightBlue": "#74a8fc",
+    "terminal.ansiBrightMagenta": "#f2aede",
+    "terminal.ansiBrightCyan": "#6bd7ca",
+    "terminal.ansiBrightWhite": "#bac2de",
+    "terminal.selectionBackground": "#585b70",
+    "terminal.inactiveSelectionBackground": "#585b7080",
+    "terminalCursor.background": "#1e1e2e",
+    "terminalCursor.foreground": "#f5e0dc",
+    "terminal.border": "#585b70",
+    "terminal.dropBackground": "#cba6f733",
+    "terminal.tab.activeBorder": "#cba6f7",
+    "terminalCommandDecoration.defaultBackground": "#585b70",
+    "terminalCommandDecoration.successBackground": "#a6e3a1",
+    "terminalCommandDecoration.errorBackground": "#f38ba8",
+    "titleBar.activeBackground": "#11111b",
+    "titleBar.activeForeground": "#cdd6f4",
+    "titleBar.inactiveBackground": "#11111b",
+    "titleBar.inactiveForeground": "#cdd6f480",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#181825",
+    "welcomePage.progress.background": "#11111b",
+    "welcomePage.progress.foreground": "#cba6f7",
+    "walkThrough.embeddedEditorBackground": "#1e1e2e4d",
+    "symbolIcon.textForeground": "#cdd6f4",
+    "symbolIcon.arrayForeground": "#fab387",
+    "symbolIcon.booleanForeground": "#cba6f7",
+    "symbolIcon.classForeground": "#f9e2af",
+    "symbolIcon.colorForeground": "#f5c2e7",
+    "symbolIcon.constantForeground": "#fab387",
+    "symbolIcon.constructorForeground": "#b4befe",
+    "symbolIcon.enumeratorForeground": "#f9e2af",
+    "symbolIcon.enumeratorMemberForeground": "#f9e2af",
+    "symbolIcon.eventForeground": "#f5c2e7",
+    "symbolIcon.fieldForeground": "#cdd6f4",
+    "symbolIcon.fileForeground": "#cba6f7",
+    "symbolIcon.folderForeground": "#cba6f7",
+    "symbolIcon.functionForeground": "#89b4fa",
+    "symbolIcon.interfaceForeground": "#f9e2af",
+    "symbolIcon.keyForeground": "#94e2d5",
+    "symbolIcon.keywordForeground": "#cba6f7",
+    "symbolIcon.methodForeground": "#89b4fa",
+    "symbolIcon.moduleForeground": "#cdd6f4",
+    "symbolIcon.namespaceForeground": "#f9e2af",
+    "symbolIcon.nullForeground": "#eba0ac",
+    "symbolIcon.numberForeground": "#fab387",
+    "symbolIcon.objectForeground": "#f9e2af",
+    "symbolIcon.operatorForeground": "#94e2d5",
+    "symbolIcon.packageForeground": "#f2cdcd",
+    "symbolIcon.propertyForeground": "#eba0ac",
+    "symbolIcon.referenceForeground": "#f9e2af",
+    "symbolIcon.snippetForeground": "#f2cdcd",
+    "symbolIcon.stringForeground": "#a6e3a1",
+    "symbolIcon.structForeground": "#94e2d5",
+    "symbolIcon.typeParameterForeground": "#eba0ac",
+    "symbolIcon.unitForeground": "#cdd6f4",
+    "symbolIcon.variableForeground": "#cdd6f4",
+    "charts.foreground": "#cdd6f4",
+    "charts.lines": "#bac2de",
+    "charts.red": "#f38ba8",
+    "charts.blue": "#89b4fa",
+    "charts.yellow": "#f9e2af",
+    "charts.orange": "#fab387",
+    "charts.green": "#a6e3a1",
+    "charts.purple": "#cba6f7",
+    "errorLens.errorBackground": "#f38ba826",
+    "errorLens.errorBackgroundLight": "#f38ba826",
+    "errorLens.errorForeground": "#f38ba8",
+    "errorLens.errorForegroundLight": "#f38ba8",
+    "errorLens.errorMessageBackground": "#f38ba826",
+    "errorLens.hintBackground": "#a6e3a126",
+    "errorLens.hintBackgroundLight": "#a6e3a126",
+    "errorLens.hintForeground": "#a6e3a1",
+    "errorLens.hintForegroundLight": "#a6e3a1",
+    "errorLens.hintMessageBackground": "#a6e3a126",
+    "errorLens.infoBackground": "#89b4fa26",
+    "errorLens.infoBackgroundLight": "#89b4fa26",
+    "errorLens.infoForeground": "#89b4fa",
+    "errorLens.infoForegroundLight": "#89b4fa",
+    "errorLens.infoMessageBackground": "#89b4fa26",
+    "errorLens.statusBarErrorForeground": "#f38ba8",
+    "errorLens.statusBarHintForeground": "#a6e3a1",
+    "errorLens.statusBarIconErrorForeground": "#f38ba8",
+    "errorLens.statusBarIconWarningForeground": "#fab387",
+    "errorLens.statusBarInfoForeground": "#89b4fa",
+    "errorLens.statusBarWarningForeground": "#fab387",
+    "errorLens.warningBackground": "#fab38726",
+    "errorLens.warningBackgroundLight": "#fab38726",
+    "errorLens.warningForeground": "#fab387",
+    "errorLens.warningForegroundLight": "#fab387",
+    "errorLens.warningMessageBackground": "#fab38726",
+    "issues.closed": "#cba6f7",
+    "issues.newIssueDecoration": "#f5e0dc",
+    "issues.open": "#a6e3a1",
+    "pullRequests.closed": "#f38ba8",
+    "pullRequests.draft": "#9399b2",
+    "pullRequests.merged": "#cba6f7",
+    "pullRequests.notification": "#cdd6f4",
+    "pullRequests.open": "#a6e3a1",
+    "gitlens.gutterBackgroundColor": "#3132444d",
+    "gitlens.gutterForegroundColor": "#cdd6f4",
+    "gitlens.gutterUncommittedForegroundColor": "#cba6f7",
+    "gitlens.trailingLineBackgroundColor": "#00000000",
+    "gitlens.trailingLineForegroundColor": "#cdd6f44d",
+    "gitlens.lineHighlightBackgroundColor": "#cba6f726",
+    "gitlens.lineHighlightOverviewRulerColor": "#cba6f7cc",
+    "gitlens.openAutolinkedIssueIconColor": "#a6e3a1",
+    "gitlens.closedAutolinkedIssueIconColor": "#cba6f7",
+    "gitlens.closedPullRequestIconColor": "#f38ba8",
+    "gitlens.openPullRequestIconColor": "#a6e3a1",
+    "gitlens.mergedPullRequestIconColor": "#cba6f7",
+    "gitlens.unpublishedChangesIconColor": "#a6e3a1",
+    "gitlens.unpublishedCommitIconColor": "#a6e3a1",
+    "gitlens.unpulledChangesIconColor": "#fab387",
+    "gitlens.decorations.branchAheadForegroundColor": "#a6e3a1",
+    "gitlens.decorations.branchBehindForegroundColor": "#fab387",
+    "gitlens.decorations.branchDivergedForegroundColor": "#f9e2af",
+    "gitlens.decorations.branchUnpublishedForegroundColor": "#a6e3a1",
+    "gitlens.decorations.branchMissingUpstreamForegroundColor": "#fab387",
+    "gitlens.decorations.statusMergingOrRebasingConflictForegroundColor": "#eba0ac",
+    "gitlens.decorations.statusMergingOrRebasingForegroundColor": "#f9e2af",
+    "gitlens.decorations.workspaceRepoMissingForegroundColor": "#a6adc8",
+    "gitlens.decorations.workspaceCurrentForegroundColor": "#cba6f7",
+    "gitlens.decorations.workspaceRepoOpenForegroundColor": "#cba6f7",
+    "gitlens.decorations.worktreeHasUncommittedChangesForegroundColor": "#fab387",
+    "gitlens.decorations.worktreeMissingForegroundColor": "#eba0ac",
+    "gitlens.graphLane1Color": "#cba6f7",
+    "gitlens.graphLane2Color": "#f9e2af",
+    "gitlens.graphLane3Color": "#89b4fa",
+    "gitlens.graphLane4Color": "#f2cdcd",
+    "gitlens.graphLane5Color": "#a6e3a1",
+    "gitlens.graphLane6Color": "#b4befe",
+    "gitlens.graphLane7Color": "#f5e0dc",
+    "gitlens.graphLane8Color": "#f38ba8",
+    "gitlens.graphLane9Color": "#94e2d5",
+    "gitlens.graphLane10Color": "#f5c2e7",
+    "gitlens.graphChangesColumnAddedColor": "#a6e3a1",
+    "gitlens.graphChangesColumnDeletedColor": "#f38ba8",
+    "gitlens.graphMinimapMarkerHeadColor": "#a6e3a1",
+    "gitlens.graphScrollMarkerHeadColor": "#a6e3a1",
+    "gitlens.graphMinimapMarkerUpstreamColor": "#93dd8d",
+    "gitlens.graphScrollMarkerUpstreamColor": "#93dd8d",
+    "gitlens.graphMinimapMarkerHighlightsColor": "#f9e2af",
+    "gitlens.graphScrollMarkerHighlightsColor": "#f9e2af",
+    "gitlens.graphMinimapMarkerLocalBranchesColor": "#89b4fa",
+    "gitlens.graphScrollMarkerLocalBranchesColor": "#89b4fa",
+    "gitlens.graphMinimapMarkerRemoteBranchesColor": "#71a4f9",
+    "gitlens.graphScrollMarkerRemoteBranchesColor": "#71a4f9",
+    "gitlens.graphMinimapMarkerStashesColor": "#cba6f7",
+    "gitlens.graphScrollMarkerStashesColor": "#cba6f7",
+    "gitlens.graphMinimapMarkerTagsColor": "#f2cdcd",
+    "gitlens.graphScrollMarkerTagsColor": "#f2cdcd",
+    "editorBracketHighlight.foreground1": "#f38ba8",
+    "editorBracketHighlight.foreground2": "#fab387",
+    "editorBracketHighlight.foreground3": "#f9e2af",
+    "editorBracketHighlight.foreground4": "#a6e3a1",
+    "editorBracketHighlight.foreground5": "#74c7ec",
+    "editorBracketHighlight.foreground6": "#cba6f7",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#eba0ac",
+    "button.secondaryBorder": "#cba6f7",
+    "table.headerBackground": "#313244",
+    "table.headerForeground": "#cdd6f4",
+    "list.focusAndSelectionBackground": "#45475a"
+  },
+  "tokenColors": [
+    {
+      "name": "Basic text & variable names (incl. leading punctuation)",
+      "scope": [
+        "text",
+        "source",
+        "variable.other.readwrite",
+        "punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Parentheses, Brackets, Braces",
+      "scope": "punctuation",
+      "settings": {
+        "foreground": "#9399b2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#9399b2",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Booleans, constants, numbers",
+      "scope": [
+        "constant.numeric",
+        "variable.other.constant",
+        "entity.name.constant",
+        "constant.language.boolean",
+        "constant.language.false",
+        "constant.language.true",
+        "keyword.other.unit.user-defined",
+        "keyword.other.unit.suffix.floating-point"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "scope": [
+        "keyword",
+        "keyword.operator.word",
+        "keyword.operator.new",
+        "variable.language.super",
+        "support.type.primitive",
+        "storage.type",
+        "storage.modifier",
+        "punctuation.definition.keyword"
+      ],
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": "entity.name.tag.documentation",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": [
+        "keyword.operator",
+        "punctuation.accessor",
+        "punctuation.definition.generic",
+        "meta.function.closure punctuation.section.parameters",
+        "punctuation.definition.tag",
+        "punctuation.separator.key-value"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "meta.function-call.method",
+        "support.function",
+        "support.function.misc",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": [
+        "entity.name.class",
+        "entity.other.inherited-class",
+        "support.class",
+        "meta.function-call.constructor",
+        "entity.name.struct"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Enum",
+      "scope": "entity.name.enum",
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Enum member",
+      "scope": [
+        "meta.enum variable.other.readwrite",
+        "variable.other.enummember"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Object properties",
+      "scope": "meta.property.object",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Types",
+      "scope": [
+        "meta.type",
+        "meta.type-alias",
+        "support.type",
+        "entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Decorators",
+      "scope": [
+        "meta.annotation variable.function",
+        "meta.annotation variable.annotation.function",
+        "meta.annotation punctuation.definition.annotation",
+        "meta.decorator",
+        "punctuation.decorator"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "scope": [
+        "variable.parameter",
+        "meta.function.parameters"
+      ],
+      "settings": {
+        "foreground": "#eba0ac",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Built-ins",
+      "scope": [
+        "constant.language",
+        "support.function.builtin"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.documentation",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Preprocessor directives",
+      "scope": [
+        "keyword.control.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Type parameters",
+      "scope": "punctuation.definition.typeparameters",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Property names (left hand assignments in json/yaml/css/less)",
+      "scope": [
+        "support.type.property-name.css",
+        "support.type.property-name.less"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "This/Self keyword",
+      "scope": [
+        "variable.language.this",
+        "variable.language.this punctuation.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Object properties",
+      "scope": "variable.object.property",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "String template interpolation",
+      "scope": [
+        "string.template variable",
+        "string variable"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "`new` as bold",
+      "scope": "keyword.operator.new",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ extern keyword",
+      "scope": "storage.modifier.specifier.extern.cpp",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "C++ scope resolution",
+      "scope": [
+        "entity.name.scope-resolution.template.call.cpp",
+        "entity.name.scope-resolution.parameter.cpp",
+        "entity.name.scope-resolution.cpp",
+        "entity.name.scope-resolution.function.definition.cpp"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "C++ doc keywords",
+      "scope": "storage.type.class.doxygen",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "C++ operators",
+      "scope": [
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "C# Interpolated Strings",
+      "scope": "meta.interpolation.cs",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "C# xml-style docs",
+      "scope": "comment.block.documentation.cs",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Classes, reflecting the className color in JSX",
+      "scope": [
+        "source.css entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "punctuation.separator.operator.css",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Pseudo classes",
+      "scope": "source.css entity.other.attribute-name.pseudo-class",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "scope": "source.css constant.other.unicode-range",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "scope": "source.css variable.parameter.url",
+      "settings": {
+        "foreground": "#a6e3a1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "CSS vendored property names",
+      "scope": [
+        "support.type.vendored.property-name"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Less/SCSS right-hand variables (@/$-prefixed)",
+      "scope": [
+        "source.css meta.property-value variable",
+        "source.css meta.property-value variable.other.less",
+        "source.css meta.property-value variable.other.less punctuation.definition.variable.less",
+        "meta.definition.variable.scss"
+      ],
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "CSS variables (--prefixed)",
+      "scope": [
+        "source.css meta.property-list variable",
+        "meta.property-list variable.other.less",
+        "meta.property-list variable.other.less punctuation.definition.variable.less"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "CSS Percentage values, styled the same as numbers",
+      "scope": "keyword.other.unit.percentage.css",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "CSS Attribute selectors, styled the same as strings",
+      "scope": "source.css meta.attribute-selector",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "JSON/YAML keys, other left-hand assignments",
+      "scope": [
+        "keyword.other.definition.ini",
+        "punctuation.support.type.property-name.json",
+        "support.type.property-name.json",
+        "punctuation.support.type.property-name.toml",
+        "support.type.property-name.toml",
+        "entity.name.tag.yaml",
+        "punctuation.support.type.property-name.yaml",
+        "support.type.property-name.yaml"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "JSON/YAML constants",
+      "scope": [
+        "constant.language.json",
+        "constant.language.yaml"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "YAML anchors",
+      "scope": [
+        "entity.name.type.anchor.yaml",
+        "variable.other.alias.yaml"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "TOML tables / ini groups",
+      "scope": [
+        "support.type.property-name.table",
+        "entity.name.section.group-title.ini"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "TOML dates",
+      "scope": "constant.other.time.datetime.offset.toml",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "YAML anchor puctuation",
+      "scope": [
+        "punctuation.definition.anchor.yaml",
+        "punctuation.definition.alias.yaml"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "YAML triple dashes",
+      "scope": "entity.other.document.begin.yaml",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Markup Diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Diff Inserted",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Diff Deleted",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "dotenv left-hand side assignments",
+      "scope": [
+        "variable.other.env"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "dotenv reference to existing env variable",
+      "scope": [
+        "string.quoted variable.other.env"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "GDScript functions",
+      "scope": "support.function.builtin.gdscript",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "GDScript constants",
+      "scope": "constant.language.gdscript",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Comment keywords",
+      "scope": "comment meta.annotation.go",
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "go:embed, go:build, etc.",
+      "scope": "comment meta.annotation.parameters.go",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Go constants (nil, true, false)",
+      "scope": "constant.language.go",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "GraphQL variables",
+      "scope": "variable.graphql",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "GraphQL aliases",
+      "scope": "string.unquoted.alias.graphql",
+      "settings": {
+        "foreground": "#f2cdcd"
+      }
+    },
+    {
+      "name": "GraphQL enum members",
+      "scope": "constant.character.enum.graphql",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "GraphQL field in types",
+      "scope": "meta.objectvalues.graphql constant.object.key.graphql string.unquoted.graphql",
+      "settings": {
+        "foreground": "#f2cdcd"
+      }
+    },
+    {
+      "name": "data constructors",
+      "scope": [
+        "meta.declaration.data constant.other.haskell",
+        "constant.other.haskell",
+        "meta.declaration.pattern constant.other.haskell",
+        "constant.language.unit.haskell punctuation",
+        "constant.language.unit.unboxed.haskell punctuation"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "types",
+      "scope": [
+        "storage.type.haskell"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "`()` unit type (not italicized)",
+      "scope": [
+        "support.constant.unit.haskell punctuation",
+        "support.constant.unit.haskell keyword.operator.hash",
+        "support.constant.unit.unboxed.haskell punctuation",
+        "support.constant.unit.unboxed.haskell keyword.operator.hash"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "type parameters",
+      "scope": [
+        "variable.other.generic-type.haskell"
+      ],
+      "settings": {
+        "foreground": "#eba0ac",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "special words (builtin constants-like)",
+      "scope": [
+        "keyword.other.default.haskell",
+        "keyword.other.role.nominal.haskell",
+        "keyword.other.role.representational.haskell",
+        "keyword.other.role.phantom.haskell"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "pragma specifiers",
+      "scope": [
+        "keyword.other.preprocessor.haskell",
+        "keyword.other.preprocessor.pragma.haskell"
+      ],
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "pragma arguments",
+      "scope": [
+        "keyword.other.preprocessor.extension.haskell"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "C preprocessor directives",
+      "scope": [
+        "source.haskell meta.preprocessor.c",
+        "source.haskell meta.preprocessor.c punctuation.definition.preprocessor.c"
+      ],
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "Haskell preprocessor directives",
+      "scope": [
+        "meta.preprocessor.haskell"
+      ],
+      "settings": {
+        "foreground": "#9399b2"
+      }
+    },
+    {
+      "name": "getters in data constructors/records",
+      "scope": [
+        "variable.other.member.haskell",
+        "variable.other.member.definition.haskell"
+      ],
+      "settings": {
+        "foreground": "#b4befe",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "fix else keyword",
+      "scope": [
+        "keyword.control.else.haskell"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "char literals (are enum variants)",
+      "scope": [
+        "string.quoted.single.haskell",
+        "string.quoted.single.haskell punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "operators",
+      "scope": [
+        "storage.type.operator.haskell",
+        "storage.type.operator.infix.haskell",
+        "entity.name.function.infix.haskell",
+        "punctuation.backtick.haskell"
+      ],
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "the , in `(,)`",
+      "scope": [
+        "support.constant.tuple.haskell",
+        "support.constant.tuple.unboxed.haskell"
+      ],
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "a few special symbols",
+      "scope": [
+        "keyword.operator.lambda.haskell",
+        "keyword.operator.pipe.haskell",
+        "keyword.operator.double-dot.haskell",
+        "variable.other.member.wildcard.haskell"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "delimiter-like",
+      "scope": [
+        "meta.type-application keyword.operator.prefix.at.haskell",
+        "keyword.operator.infix.tight.at.haskell",
+        "keyword.operator.prefix.tilde.haskell",
+        "keyword.operator.prefix.bang.haskell",
+        "keyword.operator.double-colon.haskell",
+        "keyword.operator.big-arrow.haskell",
+        "meta.function.type-declaration keyword.operator.period.haskell",
+        "meta.type-declaration keyword.operator.period.haskell",
+        "meta.declaration.type keyword.operator.period.haskell"
+      ],
+      "settings": {
+        "foreground": "#9399b2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "TemplateHaskell and QuasiQuoter (macros)",
+      "scope": [
+        "keyword.operator.prefix.dollar.haskell",
+        "keyword.operator.quasi-quotation.begin.haskell",
+        "keyword.operator.quasi-quotation.end.haskell"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "minus sign in negative num literals",
+      "scope": [
+        "keyword.operator.prefix.minus.haskell"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "HTML/XML DOCTYPE as keyword",
+      "scope": [
+        "keyword.other.doctype",
+        "meta.tag.sgml.doctype punctuation.definition.tag",
+        "meta.tag.metadata.doctype entity.name.tag",
+        "meta.tag.metadata.doctype punctuation.definition.tag"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "HTML/XML-like <tags/>",
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Special characters like &amp;",
+      "scope": [
+        "text.html constant.character.entity",
+        "text.html constant.character.entity punctuation",
+        "constant.character.entity.xml",
+        "constant.character.entity.xml punctuation",
+        "constant.character.entity.js.jsx",
+        "constant.charactger.entity.js.jsx punctuation",
+        "constant.character.entity.tsx",
+        "constant.character.entity.tsx punctuation"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "HTML/XML tag attribute values",
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Components",
+      "scope": [
+        "support.class.component",
+        "support.class.component.jsx",
+        "support.class.component.tsx",
+        "support.class.component.vue"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Annotations",
+      "scope": [
+        "punctuation.definition.annotation",
+        "storage.type.annotation"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Java enums",
+      "scope": "constant.other.enum.java",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Java imports",
+      "scope": "storage.modifier.import.java",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Javadoc",
+      "scope": "comment.block.javadoc.java keyword.other.documentation.javadoc.java",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Exported Variable",
+      "scope": "meta.export variable.other.readwrite.js",
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "JS/TS constants & properties",
+      "scope": [
+        "variable.other.constant.js",
+        "variable.other.constant.ts",
+        "variable.other.property.js",
+        "variable.other.property.ts"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "JSDoc; these are mainly params, so styled as such",
+      "scope": [
+        "variable.other.jsdoc",
+        "comment.block.documentation variable.other"
+      ],
+      "settings": {
+        "foreground": "#eba0ac",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "JSDoc keywords",
+      "scope": "storage.type.class.jsdoc",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": "support.type.object.console.js",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Node constants as keywords (module, etc.)",
+      "scope": [
+        "support.constant.node",
+        "support.type.object.module.js"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "implements as keyword",
+      "scope": "storage.modifier.implements",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Builtin types",
+      "scope": [
+        "constant.language.null.js",
+        "constant.language.null.ts",
+        "constant.language.undefined.js",
+        "constant.language.undefined.ts",
+        "support.type.builtin.ts"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "scope": "variable.parameter.generic",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Arrow functions",
+      "scope": [
+        "keyword.declaration.function.arrow.js",
+        "storage.type.function.arrow.ts"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Decorator punctuations (decorators inherit from blue functions, instead of styleguide peach)",
+      "scope": "punctuation.decorator.ts",
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Extra JS/TS keywords",
+      "scope": [
+        "keyword.operator.expression.in.js",
+        "keyword.operator.expression.in.ts",
+        "keyword.operator.expression.infer.ts",
+        "keyword.operator.expression.instanceof.js",
+        "keyword.operator.expression.instanceof.ts",
+        "keyword.operator.expression.is",
+        "keyword.operator.expression.keyof.ts",
+        "keyword.operator.expression.of.js",
+        "keyword.operator.expression.of.ts",
+        "keyword.operator.expression.typeof.ts"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Julia macros",
+      "scope": "support.function.macro.julia",
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Julia language constants (true, false)",
+      "scope": "constant.language.julia",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Julia other constants (these seem to be arguments inside arrays)",
+      "scope": "constant.other.symbol.julia",
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "LaTeX preamble",
+      "scope": "text.tex keyword.control.preamble",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "LaTeX be functions",
+      "scope": "text.tex support.function.be",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "LaTeX math",
+      "scope": "constant.other.general.math.tex",
+      "settings": {
+        "foreground": "#f2cdcd"
+      }
+    },
+    {
+      "name": "Liquid Builtin Objects & User Defined Variables",
+      "scope": "variable.language.liquid",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Lua docstring keywords",
+      "scope": "comment.line.double-dash.documentation.lua storage.type.annotation.lua",
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Lua docstring variables",
+      "scope": [
+        "comment.line.double-dash.documentation.lua entity.name.variable.lua",
+        "comment.line.double-dash.documentation.lua variable.lua"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "scope": [
+        "heading.1.markdown punctuation.definition.heading.markdown",
+        "heading.1.markdown",
+        "heading.1.quarto punctuation.definition.heading.quarto",
+        "heading.1.quarto",
+        "markup.heading.atx.1.mdx",
+        "markup.heading.atx.1.mdx punctuation.definition.heading.mdx",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.heading-0.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "scope": [
+        "heading.2.markdown punctuation.definition.heading.markdown",
+        "heading.2.markdown",
+        "heading.2.quarto punctuation.definition.heading.quarto",
+        "heading.2.quarto",
+        "markup.heading.atx.2.mdx",
+        "markup.heading.atx.2.mdx punctuation.definition.heading.mdx",
+        "markup.heading.setext.2.markdown",
+        "markup.heading.heading-1.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "scope": [
+        "heading.3.markdown punctuation.definition.heading.markdown",
+        "heading.3.markdown",
+        "heading.3.quarto punctuation.definition.heading.quarto",
+        "heading.3.quarto",
+        "markup.heading.atx.3.mdx",
+        "markup.heading.atx.3.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-2.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "scope": [
+        "heading.4.markdown punctuation.definition.heading.markdown",
+        "heading.4.markdown",
+        "heading.4.quarto punctuation.definition.heading.quarto",
+        "heading.4.quarto",
+        "markup.heading.atx.4.mdx",
+        "markup.heading.atx.4.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-3.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "scope": [
+        "heading.5.markdown punctuation.definition.heading.markdown",
+        "heading.5.markdown",
+        "heading.5.quarto punctuation.definition.heading.quarto",
+        "heading.5.quarto",
+        "markup.heading.atx.5.mdx",
+        "markup.heading.atx.5.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-4.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#74c7ec"
+      }
+    },
+    {
+      "scope": [
+        "heading.6.markdown punctuation.definition.heading.markdown",
+        "heading.6.markdown",
+        "heading.6.quarto punctuation.definition.heading.quarto",
+        "heading.6.quarto",
+        "markup.heading.atx.6.mdx",
+        "markup.heading.atx.6.mdx punctuation.definition.heading.mdx",
+        "markup.heading.heading-5.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "foreground": "#a6adc8",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "Markdown auto links",
+      "scope": [
+        "punctuation.definition.link",
+        "markup.underline.link"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Markdown links",
+      "scope": [
+        "text.html.markdown punctuation.definition.link.title",
+        "text.html.quarto punctuation.definition.link.title",
+        "string.other.link.title.markdown",
+        "string.other.link.title.quarto",
+        "markup.link",
+        "punctuation.definition.constant.markdown",
+        "punctuation.definition.constant.quarto",
+        "constant.other.reference.link.markdown",
+        "constant.other.reference.link.quarto",
+        "markup.substitution.attribute-reference"
+      ],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "name": "Markdown code spans",
+      "scope": [
+        "punctuation.definition.raw.markdown",
+        "punctuation.definition.raw.quarto",
+        "markup.inline.raw.string.markdown",
+        "markup.inline.raw.string.quarto",
+        "markup.raw.block.markdown",
+        "markup.raw.block.quarto"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Markdown triple backtick language identifier",
+      "scope": "fenced_code.block.language",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Markdown triple backticks",
+      "scope": [
+        "markup.fenced_code.block punctuation.definition",
+        "markup.raw support.asciidoc"
+      ],
+      "settings": {
+        "foreground": "#9399b2"
+      }
+    },
+    {
+      "name": "Markdown quotes",
+      "scope": [
+        "markup.quote",
+        "punctuation.definition.quote.begin"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Markdown separators",
+      "scope": "meta.separator.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Markdown list bullets",
+      "scope": [
+        "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.list.begin.quarto",
+        "markup.list.bullet"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Quarto headings",
+      "scope": "markup.heading.quarto",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Nix attribute names",
+      "scope": [
+        "entity.other.attribute-name.multipart.nix",
+        "entity.other.attribute-name.single.nix"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Nix parameter names",
+      "scope": "variable.parameter.name.nix",
+      "settings": {
+        "foreground": "#cdd6f4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Nix interpolated parameter names",
+      "scope": "meta.embedded variable.parameter.name.nix",
+      "settings": {
+        "foreground": "#b4befe",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Nix paths",
+      "scope": "string.unquoted.path.nix",
+      "settings": {
+        "foreground": "#f5c2e7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "PHP Attributes",
+      "scope": [
+        "support.attribute.builtin",
+        "meta.attribute.php"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "PHP Parameters (needed for the leading dollar sign)",
+      "scope": "meta.function.parameters.php punctuation.definition.variable.php",
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "PHP Constants (null, __FILE__, etc.)",
+      "scope": "constant.language.php",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "PHP functions",
+      "scope": "text.html.php support.function",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "PHPdoc keywords",
+      "scope": "keyword.other.phpdoc.php",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Python argument functions reset to text, otherwise they inherit blue from function-call",
+      "scope": [
+        "support.variable.magic.python",
+        "meta.function-call.arguments.python"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Python double underscore functions",
+      "scope": [
+        "support.function.magic.python"
+      ],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python `self` keyword",
+      "scope": [
+        "variable.parameter.function.language.special.self.python",
+        "variable.language.special.self.python"
+      ],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow/logical (for ... in)",
+      "scope": [
+        "keyword.control.flow.python",
+        "keyword.operator.logical.python"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "python function calls",
+      "scope": [
+        "meta.function-call.python"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "python function decorators",
+      "scope": [
+        "entity.name.function.decorator.python",
+        "punctuation.definition.decorator.python"
+      ],
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Python exception & builtins such as exit()",
+      "scope": [
+        "support.type.exception.python",
+        "support.function.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "entity.name.type",
+      "scope": [
+        "support.type.python"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "python constants (True/False)",
+      "scope": "constant.language.python",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Arguments accessed later in the function body",
+      "scope": [
+        "meta.indexed-name.python",
+        "meta.item-access.python"
+      ],
+      "settings": {
+        "foreground": "#eba0ac",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python f-strings/binary/unicode storage types",
+      "scope": "storage.type.string.python",
+      "settings": {
+        "foreground": "#a6e3a1",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python type hints",
+      "scope": "meta.function.parameters.python",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "R function calls",
+      "scope": "meta.function-call.r",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "R function call arguments",
+      "scope": "meta.function-call.arguments.r",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Regex string begin/end in JS/TS",
+      "scope": [
+        "string.regexp punctuation.definition.string.begin",
+        "string.regexp punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Regex anchors (^, $)",
+      "scope": "keyword.control.anchor.regexp",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Regex regular string match",
+      "scope": "string.regexp.ts",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Regex group parenthesis & backreference (\\1, \\2, \\3, ...)",
+      "scope": [
+        "punctuation.definition.group.regexp",
+        "keyword.other.back-reference.regexp"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Regex character class []",
+      "scope": "punctuation.definition.character-class.regexp",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Regex character classes (\\d, \\w, \\s)",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Regex range",
+      "scope": "constant.other.character-class.range.regexp",
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "Regex quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Regex constant/numeric",
+      "scope": "constant.character.numeric.regexp",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Regex lookaheads, negative lookaheads, lookbehinds, negative lookbehinds",
+      "scope": [
+        "punctuation.definition.group.no-capture.regexp",
+        "meta.assertion.look-ahead.regexp",
+        "meta.assertion.negative-look-ahead.regexp"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Rust attribute",
+      "scope": [
+        "meta.annotation.rust",
+        "meta.annotation.rust punctuation",
+        "meta.attribute.rust",
+        "punctuation.definition.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust attribute strings",
+      "scope": [
+        "meta.attribute.rust string.quoted.double.rust",
+        "meta.attribute.rust string.quoted.single.char.rust"
+      ],
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust keyword",
+      "scope": [
+        "entity.name.function.macro.rules.rust",
+        "storage.type.module.rust",
+        "storage.modifier.rust",
+        "storage.type.struct.rust",
+        "storage.type.enum.rust",
+        "storage.type.trait.rust",
+        "storage.type.union.rust",
+        "storage.type.impl.rust",
+        "storage.type.rust",
+        "storage.type.function.rust",
+        "storage.type.type.rust"
+      ],
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust u/i32, u/i64, etc.",
+      "scope": "entity.name.type.numeric.rust",
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Rust generic",
+      "scope": "meta.generic.rust",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust impl",
+      "scope": "entity.name.impl.rust",
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust module",
+      "scope": "entity.name.module.rust",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust trait",
+      "scope": "entity.name.trait.rust",
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust struct",
+      "scope": "storage.type.source.rust",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Rust union",
+      "scope": "entity.name.union.rust",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Rust enum member",
+      "scope": "meta.enum.rust storage.type.source.rust",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Rust macro",
+      "scope": [
+        "support.macro.rust",
+        "meta.macro.rust support.function.rust",
+        "entity.name.function.macro.rust"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust lifetime",
+      "scope": [
+        "storage.modifier.lifetime.rust",
+        "entity.name.type.lifetime"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust string formatting",
+      "scope": "string.quoted.double.rust constant.other.placeholder.rust",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Rust return type generic",
+      "scope": "meta.function.return-type.rust meta.generic.rust storage.type.rust",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "meta.function.call.rust",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Rust angle brackets",
+      "scope": "punctuation.brackets.angle.rust",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "constant.other.caps.rust",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust function parameters",
+      "scope": [
+        "meta.function.definition.rust variable.other.rust"
+      ],
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "Rust closure variables",
+      "scope": "meta.function.call.rust variable.other.rust",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Rust self",
+      "scope": "variable.language.self.rust",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Rust metavariable names",
+      "scope": [
+        "variable.other.metavariable.name.rust",
+        "meta.macro.metavariable.rust keyword.operator.macro.dollar.rust"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Shell shebang",
+      "scope": [
+        "comment.line.shebang",
+        "comment.line.shebang punctuation.definition.comment",
+        "comment.line.shebang",
+        "punctuation.definition.comment.shebang.shell",
+        "meta.shebang.shell"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Shell shebang command",
+      "scope": "comment.line.shebang constant.language",
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Shell interpolated command",
+      "scope": [
+        "meta.function-call.arguments.shell punctuation.definition.variable.shell",
+        "meta.function-call.arguments.shell punctuation.section.interpolation",
+        "meta.function-call.arguments.shell punctuation.definition.variable.shell",
+        "meta.function-call.arguments.shell punctuation.section.interpolation"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Shell interpolated command variable",
+      "scope": "meta.string meta.interpolation.parameter.shell variable.other.readwrite",
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "source.shell punctuation.section.interpolation",
+        "punctuation.definition.evaluation.backticks.shell"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Shell EOF",
+      "scope": "entity.name.tag.heredoc.shell",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Shell quoted variable",
+      "scope": "string.quoted.double.shell variable.other.normal.shell",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "scope": [
+        "markup.heading.typst"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    }
+  ]
+}

--- a/themes/dark-modern.json
+++ b/themes/dark-modern.json
@@ -1,0 +1,717 @@
+{
+  "name": "Dark Modern",
+  "type": "dark",
+  "colors": {
+    "checkbox.border": "#3C3C3C",
+    "editor.background": "#1F1F1F",
+    "editor.foreground": "#CCCCCC",
+    "editor.inactiveSelectionBackground": "#3A3D41",
+    "editorIndentGuide.background1": "#404040",
+    "editorIndentGuide.activeBackground1": "#707070",
+    "editor.selectionHighlightBackground": "#ADD6FF26",
+    "list.dropBackground": "#383B3D",
+    "activityBarBadge.background": "#0078D4",
+    "sideBarTitle.foreground": "#CCCCCC",
+    "input.placeholderForeground": "#989898",
+    "menu.background": "#1F1F1F",
+    "menu.foreground": "#CCCCCC",
+    "menu.separatorBackground": "#454545",
+    "menu.border": "#454545",
+    "menu.selectionBackground": "#0078d4",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.remoteBackground": "#0078D4",
+    "ports.iconRunningProcessForeground": "#369432",
+    "sideBarSectionHeader.background": "#181818",
+    "sideBarSectionHeader.border": "#2B2B2B",
+    "tab.selectedBackground": "#37373D",
+    "tab.selectedForeground": "#FFFFFF",
+    "tab.lastPinnedBorder": "#ccc3",
+    "list.activeSelectionIconForeground": "#FFF",
+    "terminal.inactiveSelectionBackground": "#3A3D41",
+    "widget.border": "#313131",
+    "actionBar.toggledBackground": "#383a49",
+    "agentsPanel.border": "#303031",
+    "agentsChatInput.border": "#303031",
+    "agentsChatInput.focusBorder": "#007ACC",
+    "agentsNewSessionButton.border": "#303031",
+    "surface.border": "#252526",
+    "modernActivityBar.activeBackground": "#FFFFFF22",
+    "modernActivityBar.hoverBackground": "#FFFFFF11",
+    "activityBar.activeBorder": "#0078D4",
+    "activityBar.background": "#181818",
+    "activityBar.border": "#2B2B2B",
+    "activityBar.foreground": "#D7D7D7",
+    "activityBar.inactiveForeground": "#868686",
+    "activityBarBadge.foreground": "#FFFFFF",
+    "badge.background": "#616161",
+    "badge.foreground": "#F8F8F8",
+    "button.background": "#0078D4",
+    "button.border": "#ffffff1a",
+    "button.foreground": "#FFFFFF",
+    "button.hoverBackground": "#026EC1",
+    "button.secondaryBackground": "#00000000",
+    "button.secondaryForeground": "#CCCCCC",
+    "button.secondaryHoverBackground": "#2B2B2B",
+    "chat.slashCommandBackground": "#26477866",
+    "chat.slashCommandForeground": "#85B6FF",
+    "chat.editedFileForeground": "#E2C08D",
+    "checkbox.background": "#313131",
+    "debugToolBar.background": "#181818",
+    "descriptionForeground": "#9D9D9D",
+    "dropdown.background": "#313131",
+    "dropdown.border": "#3C3C3C",
+    "dropdown.foreground": "#CCCCCC",
+    "dropdown.listBackground": "#1F1F1F",
+    "editor.findMatchBackground": "#9E6A03",
+    "editorGroup.border": "#FFFFFF17",
+    "editorGroupHeader.tabsBackground": "#181818",
+    "editorGroupHeader.tabsBorder": "#2B2B2B",
+    "editorGutter.addedBackground": "#2EA043",
+    "editorGutter.deletedBackground": "#F85149",
+    "editorGutter.modifiedBackground": "#0078D4",
+    "editorLineNumber.activeForeground": "#CCCCCC",
+    "editorLineNumber.foreground": "#6E7681",
+    "editorOverviewRuler.border": "#010409",
+    "editorWidget.background": "#202020",
+    "errorForeground": "#F85149",
+    "focusBorder": "#0078D4",
+    "foreground": "#CCCCCC",
+    "icon.foreground": "#CCCCCC",
+    "input.background": "#313131",
+    "input.border": "#3C3C3C",
+    "input.foreground": "#CCCCCC",
+    "inputOption.activeBackground": "#2489DB82",
+    "inputOption.activeBorder": "#2488DB",
+    "keybindingLabel.foreground": "#CCCCCC",
+    "notificationCenterHeader.background": "#1F1F1F",
+    "notificationCenterHeader.foreground": "#CCCCCC",
+    "notifications.background": "#1F1F1F",
+    "notifications.border": "#2B2B2B",
+    "notifications.foreground": "#CCCCCC",
+    "panel.background": "#181818",
+    "panel.border": "#2B2B2B",
+    "panelInput.border": "#2B2B2B",
+    "panelTitle.activeBorder": "#0078D4",
+    "panelTitle.activeForeground": "#CCCCCC",
+    "panelTitle.inactiveForeground": "#9D9D9D",
+    "peekViewEditor.background": "#1F1F1F",
+    "peekViewEditor.matchHighlightBackground": "#BB800966",
+    "peekViewResult.background": "#1F1F1F",
+    "peekViewResult.matchHighlightBackground": "#BB800966",
+    "pickerGroup.border": "#3C3C3C",
+    "progressBar.background": "#0078D4",
+    "quickInput.background": "#222222",
+    "quickInput.foreground": "#CCCCCC",
+    "settings.dropdownBackground": "#313131",
+    "settings.dropdownBorder": "#3C3C3C",
+    "settings.headerForeground": "#FFFFFF",
+    "settings.modifiedItemIndicator": "#BB800966",
+    "sideBar.background": "#181818",
+    "sideBar.border": "#2B2B2B",
+    "sideBar.foreground": "#CCCCCC",
+    "sideBarSectionHeader.foreground": "#CCCCCC",
+    "statusBar.background": "#181818",
+    "statusBar.border": "#2B2B2B",
+    "statusBarItem.hoverBackground": "#F1F1F133",
+    "statusBarItem.hoverForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#0078D4",
+    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.focusBorder": "#0078D4",
+    "statusBar.foreground": "#CCCCCC",
+    "statusBar.noFolderBackground": "#1F1F1F",
+    "statusBarItem.focusBorder": "#0078D4",
+    "statusBarItem.prominentBackground": "#6E768166",
+    "tab.activeBackground": "#1F1F1F",
+    "tab.activeBorder": "#1F1F1F",
+    "tab.activeBorderTop": "#0078D4",
+    "tab.activeForeground": "#FFFFFF",
+    "tab.selectedBorderTop": "#6caddf",
+    "tab.border": "#2B2B2B",
+    "tab.hoverBackground": "#1F1F1F",
+    "tab.inactiveBackground": "#181818",
+    "tab.inactiveForeground": "#9D9D9D",
+    "tab.unfocusedActiveBorder": "#1F1F1F",
+    "tab.unfocusedActiveBorderTop": "#2B2B2B",
+    "tab.unfocusedHoverBackground": "#1F1F1F",
+    "terminal.foreground": "#CCCCCC",
+    "terminal.tab.activeBorder": "#0078D4",
+    "textBlockQuote.background": "#2B2B2B",
+    "textBlockQuote.border": "#616161",
+    "textCodeBlock.background": "#2B2B2B",
+    "textLink.activeForeground": "#4daafc",
+    "textLink.foreground": "#4daafc",
+    "textPreformat.foreground": "#D0D0D0",
+    "textPreformat.background": "#3C3C3C",
+    "textSeparator.foreground": "#21262D",
+    "titleBar.activeBackground": "#181818",
+    "titleBar.activeForeground": "#CCCCCC",
+    "titleBar.border": "#2B2B2B",
+    "titleBar.inactiveBackground": "#1F1F1F",
+    "titleBar.inactiveForeground": "#9D9D9D",
+    "welcomePage.tileBackground": "#2B2B2B",
+    "welcomePage.progress.foreground": "#0078D4"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#D4D4D4"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "header",
+      "settings": {
+        "foreground": "#000080"
+      }
+    },
+    {
+      "scope": "comment",
+      "settings": {
+        "foreground": "#6A9955"
+      }
+    },
+    {
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "variable.other.enummember",
+        "keyword.operator.plus.exponent",
+        "keyword.operator.minus.exponent"
+      ],
+      "settings": {
+        "foreground": "#b5cea8"
+      }
+    },
+    {
+      "scope": "constant.regexp",
+      "settings": {
+        "foreground": "#646695"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag.css",
+        "entity.name.tag.less"
+      ],
+      "settings": {
+        "foreground": "#d7ba7d"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#9cdcfe"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name.class.css",
+        "source.css entity.other.attribute-name.class",
+        "entity.other.attribute-name.id.css",
+        "entity.other.attribute-name.parent-selector.css",
+        "entity.other.attribute-name.parent.less",
+        "source.css entity.other.attribute-name.pseudo-class",
+        "entity.other.attribute-name.pseudo-element.css",
+        "source.css.less entity.other.attribute-name.id",
+        "entity.other.attribute-name.scss"
+      ],
+      "settings": {
+        "foreground": "#d7ba7d"
+      }
+    },
+    {
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#C586C0"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#b5cea8"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "punctuation.definition.quote.begin.markdown",
+      "settings": {
+        "foreground": "#6A9955"
+      }
+    },
+    {
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#6796e6"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "name": "brackets of XML/HTML tags",
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#808080"
+      }
+    },
+    {
+      "scope": [
+        "meta.preprocessor",
+        "entity.name.function.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.string",
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.numeric",
+      "settings": {
+        "foreground": "#b5cea8"
+      }
+    },
+    {
+      "scope": "meta.structure.dictionary.key.python",
+      "settings": {
+        "foreground": "#9cdcfe"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "storage.type",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier",
+        "keyword.operator.noexcept"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "meta.embedded.assembly"
+      ],
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "scope": "string.tag",
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "scope": "string.value",
+      "settings": {
+        "foreground": "#ce9178"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#d16969"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#d4d4d4"
+      }
+    },
+    {
+      "scope": [
+        "support.type.vendored.property-name",
+        "support.type.property-name",
+        "source.css variable",
+        "source.coffee.embedded"
+      ],
+      "settings": {
+        "foreground": "#9cdcfe"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#d4d4d4"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.cast",
+        "keyword.operator.sizeof",
+        "keyword.operator.alignof",
+        "keyword.operator.typeid",
+        "keyword.operator.alignas",
+        "keyword.operator.instanceof",
+        "keyword.operator.logical.python",
+        "keyword.operator.wordlike"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#b5cea8"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "punctuation.section.embedded.end.php"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "support.function.git-rebase",
+      "settings": {
+        "foreground": "#9cdcfe"
+      }
+    },
+    {
+      "scope": "constant.sha.git-rebase",
+      "settings": {
+        "foreground": "#b5cea8"
+      }
+    },
+    {
+      "name": "coloring of the Java import and package identifiers",
+      "scope": [
+        "storage.modifier.import.java",
+        "variable.language.wildcard.java",
+        "storage.modifier.package.java"
+      ],
+      "settings": {
+        "foreground": "#d4d4d4"
+      }
+    },
+    {
+      "name": "this.self",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "name": "Function declarations",
+      "scope": [
+        "entity.name.function",
+        "support.function",
+        "support.constant.handlebars",
+        "source.powershell variable.other.member",
+        "entity.name.operator.custom-literal"
+      ],
+      "settings": {
+        "foreground": "#DCDCAA"
+      }
+    },
+    {
+      "name": "Types declaration and references",
+      "scope": [
+        "support.class",
+        "support.type",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.other.attribute",
+        "entity.name.scope-resolution",
+        "entity.name.class",
+        "storage.type.numeric.go",
+        "storage.type.byte.go",
+        "storage.type.boolean.go",
+        "storage.type.string.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "storage.type.cs",
+        "storage.type.generic.cs",
+        "storage.type.modifier.cs",
+        "storage.type.variable.cs",
+        "storage.type.annotation.java",
+        "storage.type.generic.java",
+        "storage.type.java",
+        "storage.type.object.array.java",
+        "storage.type.primitive.array.java",
+        "storage.type.primitive.java",
+        "storage.type.token.java",
+        "storage.type.groovy",
+        "storage.type.annotation.groovy",
+        "storage.type.parameters.groovy",
+        "storage.type.generic.groovy",
+        "storage.type.object.array.groovy",
+        "storage.type.primitive.array.groovy",
+        "storage.type.primitive.groovy"
+      ],
+      "settings": {
+        "foreground": "#4EC9B0"
+      }
+    },
+    {
+      "name": "Types declaration and references, TS grammar specific",
+      "scope": [
+        "meta.type.cast.expr",
+        "meta.type.new.expr",
+        "support.constant.math",
+        "support.constant.dom",
+        "support.constant.json",
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "foreground": "#4EC9B0"
+      }
+    },
+    {
+      "name": "Control flow / Special keywords",
+      "scope": [
+        "keyword.control",
+        "source.cpp keyword.operator.new",
+        "keyword.operator.delete",
+        "keyword.other.using",
+        "keyword.other.directive.using",
+        "keyword.other.operator",
+        "entity.name.operator"
+      ],
+      "settings": {
+        "foreground": "#C586C0"
+      }
+    },
+    {
+      "name": "Variable and parameter name",
+      "scope": [
+        "variable",
+        "meta.definition.variable.name",
+        "support.variable",
+        "entity.name.variable",
+        "constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#9CDCFE"
+      }
+    },
+    {
+      "name": "Constants and enums",
+      "scope": [
+        "variable.other.constant",
+        "variable.other.enummember"
+      ],
+      "settings": {
+        "foreground": "#4FC1FF"
+      }
+    },
+    {
+      "name": "Object keys, TS grammar specific",
+      "scope": [
+        "meta.object-literal.key"
+      ],
+      "settings": {
+        "foreground": "#9CDCFE"
+      }
+    },
+    {
+      "name": "CSS property value",
+      "scope": [
+        "support.constant.property-value",
+        "support.constant.font-name",
+        "support.constant.media-type",
+        "support.constant.media",
+        "constant.other.color.rgb-value",
+        "constant.other.rgb-value",
+        "support.constant.color"
+      ],
+      "settings": {
+        "foreground": "#CE9178"
+      }
+    },
+    {
+      "name": "Regular expression groups",
+      "scope": [
+        "punctuation.definition.group.regexp",
+        "punctuation.definition.group.assertion.regexp",
+        "punctuation.definition.character-class.regexp",
+        "punctuation.character.set.begin.regexp",
+        "punctuation.character.set.end.regexp",
+        "keyword.operator.negation.regexp",
+        "support.other.parenthesis.regexp"
+      ],
+      "settings": {
+        "foreground": "#CE9178"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.character-class.regexp",
+        "constant.other.character-class.set.regexp",
+        "constant.other.character-class.regexp",
+        "constant.character.set.regexp"
+      ],
+      "settings": {
+        "foreground": "#d16969"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.or.regexp",
+        "keyword.control.anchor.regexp"
+      ],
+      "settings": {
+        "foreground": "#DCDCAA"
+      }
+    },
+    {
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#d7ba7d"
+      }
+    },
+    {
+      "scope": [
+        "constant.character",
+        "constant.other.option"
+      ],
+      "settings": {
+        "foreground": "#569cd6"
+      }
+    },
+    {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#d7ba7d"
+      }
+    },
+    {
+      "scope": "entity.name.label",
+      "settings": {
+        "foreground": "#C8C8C8"
+      }
+    }
+  ]
+}

--- a/themes/dracula.json
+++ b/themes/dracula.json
@@ -1,0 +1,1134 @@
+{
+  "name": "Dracula",
+  "type": "dark",
+  "colors": {
+    "terminal.background": "#282A36",
+    "terminal.foreground": "#F8F8F2",
+    "terminal.ansiBrightBlack": "#6272A4",
+    "terminal.ansiBrightRed": "#FF6E6E",
+    "terminal.ansiBrightGreen": "#69FF94",
+    "terminal.ansiBrightYellow": "#FFFFA5",
+    "terminal.ansiBrightBlue": "#D6ACFF",
+    "terminal.ansiBrightMagenta": "#FF92DF",
+    "terminal.ansiBrightCyan": "#A4FFFF",
+    "terminal.ansiBrightWhite": "#FFFFFF",
+    "terminal.ansiBlack": "#21222C",
+    "terminal.ansiRed": "#FF5555",
+    "terminal.ansiGreen": "#50FA7B",
+    "terminal.ansiYellow": "#F1FA8C",
+    "terminal.ansiBlue": "#BD93F9",
+    "terminal.ansiMagenta": "#FF79C6",
+    "terminal.ansiCyan": "#8BE9FD",
+    "terminal.ansiWhite": "#F8F8F2",
+    "focusBorder": "#6272A4",
+    "foreground": "#F8F8F2",
+    "selection.background": "#BD93F9",
+    "errorForeground": "#FF5555",
+    "button.background": "#44475A",
+    "button.foreground": "#F8F8F2",
+    "button.secondaryBackground": "#282A36",
+    "button.secondaryForeground": "#F8F8F2",
+    "button.secondaryHoverBackground": "#343746",
+    "dropdown.background": "#343746",
+    "dropdown.border": "#191A21",
+    "dropdown.foreground": "#F8F8F2",
+    "input.background": "#282A36",
+    "input.foreground": "#F8F8F2",
+    "input.border": "#191A21",
+    "input.placeholderForeground": "#6272A4",
+    "inputOption.activeBorder": "#BD93F9",
+    "inputValidation.infoBorder": "#FF79C6",
+    "inputValidation.warningBorder": "#FFB86C",
+    "inputValidation.errorBorder": "#FF5555",
+    "badge.foreground": "#F8F8F2",
+    "badge.background": "#44475A",
+    "progressBar.background": "#FF79C6",
+    "list.activeSelectionBackground": "#44475A",
+    "list.activeSelectionForeground": "#F8F8F2",
+    "list.dropBackground": "#44475A",
+    "list.focusBackground": "#44475A75",
+    "list.highlightForeground": "#8BE9FD",
+    "list.hoverBackground": "#44475A75",
+    "list.inactiveSelectionBackground": "#44475A75",
+    "list.warningForeground": "#FFB86C",
+    "list.errorForeground": "#FF5555",
+    "activityBar.background": "#343746",
+    "activityBar.inactiveForeground": "#6272A4",
+    "activityBar.foreground": "#F8F8F2",
+    "activityBar.activeBorder": "#FF79C680",
+    "activityBar.activeBackground": "#BD93F910",
+    "activityBarBadge.background": "#FF79C6",
+    "activityBarBadge.foreground": "#F8F8F2",
+    "sideBar.background": "#21222C",
+    "sideBarTitle.foreground": "#F8F8F2",
+    "sideBarSectionHeader.background": "#282A36",
+    "sideBarSectionHeader.border": "#191A21",
+    "editorGroup.border": "#BD93F9",
+    "editorGroup.dropBackground": "#44475A70",
+    "editorGroupHeader.tabsBackground": "#191A21",
+    "tab.activeBackground": "#282A36",
+    "tab.activeForeground": "#F8F8F2",
+    "tab.border": "#191A21",
+    "tab.activeBorderTop": "#FF79C680",
+    "tab.inactiveBackground": "#21222C",
+    "tab.inactiveForeground": "#6272A4",
+    "editor.foreground": "#F8F8F2",
+    "editor.background": "#282A36",
+    "editorLineNumber.foreground": "#6272A4",
+    "editor.selectionBackground": "#44475A",
+    "editor.selectionHighlightBackground": "#424450",
+    "editor.foldBackground": "#21222C80",
+    "editor.wordHighlightBackground": "#8BE9FD50",
+    "editor.wordHighlightStrongBackground": "#50FA7B50",
+    "editor.findMatchBackground": "#FFB86C80",
+    "editor.findMatchHighlightBackground": "#FFFFFF40",
+    "editor.findRangeHighlightBackground": "#44475A75",
+    "editor.hoverHighlightBackground": "#8BE9FD50",
+    "editor.lineHighlightBorder": "#44475A",
+    "editorLink.activeForeground": "#8BE9FD",
+    "editor.rangeHighlightBackground": "#BD93F915",
+    "editor.snippetTabstopHighlightBackground": "#282A36",
+    "editor.snippetTabstopHighlightBorder": "#6272A4",
+    "editor.snippetFinalTabstopHighlightBackground": "#282A36",
+    "editor.snippetFinalTabstopHighlightBorder": "#50FA7B",
+    "editorWhitespace.foreground": "#FFFFFF1A",
+    "editorIndentGuide.background": "#FFFFFF1A",
+    "editorIndentGuide.activeBackground": "#FFFFFF45",
+    "editorRuler.foreground": "#FFFFFF1A",
+    "editorCodeLens.foreground": "#6272A4",
+    "editorBracketHighlight.foreground1": "#F8F8F2",
+    "editorBracketHighlight.foreground2": "#FF79C6",
+    "editorBracketHighlight.foreground3": "#8BE9FD",
+    "editorBracketHighlight.foreground4": "#50FA7B",
+    "editorBracketHighlight.foreground5": "#BD93F9",
+    "editorBracketHighlight.foreground6": "#FFB86C",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#FF5555",
+    "editorOverviewRuler.border": "#191A21",
+    "editorOverviewRuler.selectionHighlightForeground": "#FFB86C",
+    "editorOverviewRuler.wordHighlightForeground": "#8BE9FD",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#50FA7B",
+    "editorOverviewRuler.modifiedForeground": "#8BE9FD80",
+    "editorOverviewRuler.addedForeground": "#50FA7B80",
+    "editorOverviewRuler.deletedForeground": "#FF555580",
+    "editorOverviewRuler.errorForeground": "#FF555580",
+    "editorOverviewRuler.warningForeground": "#FFB86C80",
+    "editorOverviewRuler.infoForeground": "#8BE9FD80",
+    "editorError.foreground": "#FF5555",
+    "editorWarning.foreground": "#8BE9FD",
+    "editorGutter.modifiedBackground": "#8BE9FD80",
+    "editorGutter.addedBackground": "#50FA7B80",
+    "editorGutter.deletedBackground": "#FF555580",
+    "gitDecoration.modifiedResourceForeground": "#8BE9FD",
+    "gitDecoration.deletedResourceForeground": "#FF5555",
+    "gitDecoration.untrackedResourceForeground": "#50FA7B",
+    "gitDecoration.ignoredResourceForeground": "#6272A4",
+    "gitDecoration.conflictingResourceForeground": "#FFB86C",
+    "diffEditor.insertedTextBackground": "#50FA7B20",
+    "diffEditor.removedTextBackground": "#FF555550",
+    "inlineChat.regionHighlight": "#343746",
+    "editorWidget.background": "#21222C",
+    "editorSuggestWidget.background": "#21222C",
+    "editorSuggestWidget.foreground": "#F8F8F2",
+    "editorSuggestWidget.selectedBackground": "#44475A",
+    "editorHoverWidget.background": "#282A36",
+    "editorHoverWidget.border": "#6272A4",
+    "editorMarkerNavigation.background": "#21222C",
+    "peekView.border": "#44475A",
+    "peekViewEditor.background": "#282A36",
+    "peekViewEditor.matchHighlightBackground": "#F1FA8C80",
+    "peekViewResult.background": "#21222C",
+    "peekViewResult.fileForeground": "#F8F8F2",
+    "peekViewResult.lineForeground": "#F8F8F2",
+    "peekViewResult.matchHighlightBackground": "#F1FA8C80",
+    "peekViewResult.selectionBackground": "#44475A",
+    "peekViewResult.selectionForeground": "#F8F8F2",
+    "peekViewTitle.background": "#191A21",
+    "peekViewTitleDescription.foreground": "#6272A4",
+    "peekViewTitleLabel.foreground": "#F8F8F2",
+    "merge.currentHeaderBackground": "#50FA7B90",
+    "merge.incomingHeaderBackground": "#BD93F990",
+    "editorOverviewRuler.currentContentForeground": "#50FA7B",
+    "editorOverviewRuler.incomingContentForeground": "#BD93F9",
+    "panel.background": "#282A36",
+    "panel.border": "#BD93F9",
+    "panelTitle.activeBorder": "#FF79C6",
+    "panelTitle.activeForeground": "#F8F8F2",
+    "panelTitle.inactiveForeground": "#6272A4",
+    "statusBar.background": "#191A21",
+    "statusBar.foreground": "#F8F8F2",
+    "statusBar.debuggingBackground": "#FF5555",
+    "statusBar.debuggingForeground": "#191A21",
+    "statusBar.noFolderBackground": "#191A21",
+    "statusBar.noFolderForeground": "#F8F8F2",
+    "statusBarItem.prominentBackground": "#FF5555",
+    "statusBarItem.prominentHoverBackground": "#FFB86C",
+    "statusBarItem.remoteForeground": "#282A36",
+    "statusBarItem.remoteBackground": "#BD93F9",
+    "titleBar.activeBackground": "#21222C",
+    "titleBar.activeForeground": "#F8F8F2",
+    "titleBar.inactiveBackground": "#191A21",
+    "titleBar.inactiveForeground": "#6272A4",
+    "extensionButton.prominentForeground": "#F8F8F2",
+    "extensionButton.prominentBackground": "#50FA7B90",
+    "extensionButton.prominentHoverBackground": "#50FA7B60",
+    "pickerGroup.border": "#BD93F9",
+    "pickerGroup.foreground": "#8BE9FD",
+    "debugToolBar.background": "#21222C",
+    "walkThrough.embeddedEditorBackground": "#21222C",
+    "settings.headerForeground": "#F8F8F2",
+    "settings.modifiedItemIndicator": "#FFB86C",
+    "settings.dropdownBackground": "#21222C",
+    "settings.dropdownForeground": "#F8F8F2",
+    "settings.dropdownBorder": "#191A21",
+    "settings.checkboxBackground": "#21222C",
+    "settings.checkboxForeground": "#F8F8F2",
+    "settings.checkboxBorder": "#191A21",
+    "settings.textInputBackground": "#21222C",
+    "settings.textInputForeground": "#F8F8F2",
+    "settings.textInputBorder": "#191A21",
+    "settings.numberInputBackground": "#21222C",
+    "settings.numberInputForeground": "#F8F8F2",
+    "settings.numberInputBorder": "#191A21",
+    "breadcrumb.foreground": "#6272A4",
+    "breadcrumb.background": "#282A36",
+    "breadcrumb.focusForeground": "#F8F8F2",
+    "breadcrumb.activeSelectionForeground": "#F8F8F2",
+    "breadcrumbPicker.background": "#191A21",
+    "listFilterWidget.background": "#343746",
+    "listFilterWidget.outline": "#424450",
+    "listFilterWidget.noMatchesOutline": "#FF5555"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "emphasis"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "strong"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "header"
+      ],
+      "settings": {
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "foreground": "#6272A4"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted"
+      ],
+      "settings": {
+        "foreground": "#FF5555"
+      }
+    },
+    {
+      "scope": [
+        "markup.changed"
+      ],
+      "settings": {
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "scope": [
+        "invalid"
+      ],
+      "settings": {
+        "foreground": "#FF5555",
+        "fontStyle": "underline italic"
+      }
+    },
+    {
+      "scope": [
+        "invalid.deprecated"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2",
+        "fontStyle": "underline italic"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "scope": [
+        "markup.error"
+      ],
+      "settings": {
+        "foreground": "#FF5555"
+      }
+    },
+    {
+      "name": "Underlined markup",
+      "scope": [
+        "markup.underline"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "Bold markup",
+      "scope": [
+        "markup.bold"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "Markup headings",
+      "scope": [
+        "markup.heading"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Markup italic",
+      "scope": [
+        "markup.italic"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Bullets, lists (prose)",
+      "scope": [
+        "beginning.punctuation.definition.list.markdown",
+        "beginning.punctuation.definition.quote.markdown",
+        "punctuation.definition.link.restructuredtext"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Inline code (prose)",
+      "scope": [
+        "markup.inline.raw",
+        "markup.raw.restructuredtext"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Links (prose)",
+      "scope": [
+        "markup.underline.link",
+        "markup.underline.link.image"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Link text, image alt text (prose)",
+      "scope": [
+        "meta.link.reference.def.restructuredtext",
+        "punctuation.definition.directive.restructuredtext",
+        "string.other.link.description",
+        "string.other.link.title"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Blockquotes (prose)",
+      "scope": [
+        "entity.name.directive.restructuredtext",
+        "markup.quote"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Horizontal rule (prose)",
+      "scope": [
+        "meta.separator.markdown"
+      ],
+      "settings": {
+        "foreground": "#6272A4"
+      }
+    },
+    {
+      "name": "Code blocks",
+      "scope": [
+        "fenced_code.block.language",
+        "markup.raw.inner.restructuredtext",
+        "markup.fenced_code.block.markdown punctuation.definition.markdown"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Prose constants",
+      "scope": [
+        "punctuation.definition.constant.restructuredtext"
+      ],
+      "settings": {
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Braces in markdown headings",
+      "scope": [
+        "markup.heading.markdown punctuation.definition.string.begin",
+        "markup.heading.markdown punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Braces in markdown paragraphs",
+      "scope": [
+        "meta.paragraph.markdown punctuation.definition.string.begin",
+        "meta.paragraph.markdown punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Braces in markdown blockquotes",
+      "scope": [
+        "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.begin",
+        "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "User-defined class names",
+      "scope": [
+        "entity.name.type.class",
+        "entity.name.class"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD",
+        "fontStyle": "normal"
+      }
+    },
+    {
+      "name": "this, super, self, etc.",
+      "scope": [
+        "keyword.expressions-and-types.swift",
+        "keyword.other.this",
+        "variable.language",
+        "variable.language punctuation.definition.variable.php",
+        "variable.other.readwrite.instance.ruby",
+        "variable.parameter.function.language.special"
+      ],
+      "settings": {
+        "foreground": "#BD93F9",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Inherited classes",
+      "scope": [
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": [
+        "comment",
+        "punctuation.definition.comment",
+        "unused.comment",
+        "wildcard.comment"
+      ],
+      "settings": {
+        "foreground": "#6272A4"
+      }
+    },
+    {
+      "name": "JSDoc-style keywords",
+      "scope": [
+        "comment keyword.codetag.notation",
+        "comment.block.documentation keyword",
+        "comment.block.documentation storage.type.class"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "JSDoc-style types",
+      "scope": [
+        "comment.block.documentation entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "JSDoc-style type brackets",
+      "scope": [
+        "comment.block.documentation entity.name.type punctuation.definition.bracket"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "JSDoc-style comment parameters",
+      "scope": [
+        "comment.block.documentation variable"
+      ],
+      "settings": {
+        "foreground": "#FFB86C",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": [
+        "constant",
+        "variable.other.constant"
+      ],
+      "settings": {
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Constant escape sequences",
+      "scope": [
+        "constant.character.escape",
+        "constant.character.string.escape",
+        "constant.regexp"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "HTML tags",
+      "scope": [
+        "entity.name.tag"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "CSS attribute parent selectors ('&')",
+      "scope": [
+        "entity.other.attribute-name.parent-selector"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "HTML/CSS attribute names",
+      "scope": [
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#50FA7B",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Function names",
+      "scope": [
+        "entity.name.function",
+        "meta.function-call.object",
+        "meta.function-call.php",
+        "meta.function-call.static",
+        "meta.method-call.java meta.method",
+        "meta.method.groovy",
+        "support.function.any-method.lua",
+        "keyword.operator.function.infix"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Function parameters",
+      "scope": [
+        "entity.name.variable.parameter",
+        "meta.at-rule.function variable",
+        "meta.at-rule.mixin variable",
+        "meta.function.arguments variable.other.php",
+        "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql",
+        "variable.parameter"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "Decorators",
+      "scope": [
+        "meta.decorator variable.other.readwrite",
+        "meta.decorator variable.other.property"
+      ],
+      "settings": {
+        "foreground": "#50FA7B",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Decorator Objects",
+      "scope": [
+        "meta.decorator variable.other.object"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": [
+        "keyword",
+        "punctuation.definition.keyword"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Keyword \"new\"",
+      "scope": [
+        "keyword.control.new",
+        "keyword.operator.new"
+      ],
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Generic selectors (CSS/SCSS/Less/Stylus)",
+      "scope": [
+        "meta.selector"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Language Built-ins",
+      "scope": [
+        "support"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Built-in magic functions and constants",
+      "scope": [
+        "support.function.magic",
+        "support.variable",
+        "variable.other.predefined"
+      ],
+      "settings": {
+        "fontStyle": "regular",
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Built-in functions / properties",
+      "scope": [
+        "support.function",
+        "support.type.property-name"
+      ],
+      "settings": {
+        "fontStyle": "regular"
+      }
+    },
+    {
+      "name": "Separators (key/value, namespace, inheritance, pointer, hash, slice, etc)",
+      "scope": [
+        "constant.other.symbol.hashkey punctuation.definition.constant.ruby",
+        "entity.other.attribute-name.placeholder punctuation",
+        "entity.other.attribute-name.pseudo-class punctuation",
+        "entity.other.attribute-name.pseudo-element punctuation",
+        "meta.group.double.toml",
+        "meta.group.toml",
+        "meta.object-binding-pattern-variable punctuation.destructuring",
+        "punctuation.colon.graphql",
+        "punctuation.definition.block.scalar.folded.yaml",
+        "punctuation.definition.block.scalar.literal.yaml",
+        "punctuation.definition.block.sequence.item.yaml",
+        "punctuation.definition.entity.other.inherited-class",
+        "punctuation.function.swift",
+        "punctuation.separator.dictionary.key-value",
+        "punctuation.separator.hash",
+        "punctuation.separator.inheritance",
+        "punctuation.separator.key-value",
+        "punctuation.separator.key-value.mapping.yaml",
+        "punctuation.separator.namespace",
+        "punctuation.separator.pointer-access",
+        "punctuation.separator.slice",
+        "string.unquoted.heredoc punctuation.definition.string",
+        "support.other.chomping-indicator.yaml",
+        "punctuation.separator.annotation"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Brackets, braces, parens, etc.",
+      "scope": [
+        "keyword.operator.other.powershell",
+        "keyword.other.statement-separator.powershell",
+        "meta.brace.round",
+        "meta.function-call punctuation",
+        "punctuation.definition.arguments.begin",
+        "punctuation.definition.arguments.end",
+        "punctuation.definition.entity.begin",
+        "punctuation.definition.entity.end",
+        "punctuation.definition.tag.cs",
+        "punctuation.definition.type.begin",
+        "punctuation.definition.type.end",
+        "punctuation.section.scope.begin",
+        "punctuation.section.scope.end",
+        "punctuation.terminator.expression.php",
+        "storage.type.generic.java",
+        "string.template meta.brace",
+        "string.template punctuation.accessor"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Variable interpolation operators",
+      "scope": [
+        "meta.string-contents.quoted.double punctuation.definition.variable",
+        "punctuation.definition.interpolation.begin",
+        "punctuation.definition.interpolation.end",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.coffee",
+        "punctuation.section.embedded.end",
+        "punctuation.section.embedded.end source.php",
+        "punctuation.section.embedded.end source.ruby",
+        "punctuation.definition.variable.makefile"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Keys (serializable languages)",
+      "scope": [
+        "entity.name.function.target.makefile",
+        "entity.name.section.toml",
+        "entity.name.tag.yaml",
+        "variable.other.key.toml"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Dates / timestamps (serializable languages)",
+      "scope": [
+        "constant.other.date",
+        "constant.other.timestamp"
+      ],
+      "settings": {
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "YAML aliases",
+      "scope": [
+        "variable.other.alias.yaml"
+      ],
+      "settings": {
+        "fontStyle": "italic underline",
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": [
+        "storage",
+        "meta.implementation storage.type.objc",
+        "meta.interface-or-protocol storage.type.objc",
+        "source.groovy storage.type.def"
+      ],
+      "settings": {
+        "fontStyle": "regular",
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "Types",
+      "scope": [
+        "entity.name.type",
+        "keyword.primitive-datatypes.swift",
+        "keyword.type.cs",
+        "meta.protocol-list.objc",
+        "meta.return-type.objc",
+        "source.go storage.type",
+        "source.groovy storage.type",
+        "source.java storage.type",
+        "source.powershell entity.other.attribute-name",
+        "storage.class.std.rust",
+        "storage.type.attribute.swift",
+        "storage.type.c",
+        "storage.type.core.rust",
+        "storage.type.cs",
+        "storage.type.groovy",
+        "storage.type.objc",
+        "storage.type.php",
+        "storage.type.haskell",
+        "storage.type.ocaml"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Generics, templates, and mapped type declarations",
+      "scope": [
+        "entity.name.type.type-parameter",
+        "meta.indexer.mappedtype.declaration entity.name.type",
+        "meta.type.parameters entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "Modifiers",
+      "scope": [
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "RegExp string",
+      "scope": [
+        "string.regexp",
+        "constant.other.character-class.set.regexp",
+        "constant.character.escape.backslash.regexp"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "Non-capture operators",
+      "scope": [
+        "punctuation.definition.group.capture.regexp"
+      ],
+      "settings": {
+        "foreground": "#FF79C6"
+      }
+    },
+    {
+      "name": "RegExp start and end characters",
+      "scope": [
+        "string.regexp punctuation.definition.string.begin",
+        "string.regexp punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#FF5555"
+      }
+    },
+    {
+      "name": "Character group",
+      "scope": [
+        "punctuation.definition.character-class.regexp"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Capture groups",
+      "scope": [
+        "punctuation.definition.group.regexp"
+      ],
+      "settings": {
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "Assertion operators",
+      "scope": [
+        "punctuation.definition.group.assertion.regexp",
+        "keyword.operator.negation.regexp"
+      ],
+      "settings": {
+        "foreground": "#FF5555"
+      }
+    },
+    {
+      "name": "Positive lookaheads",
+      "scope": [
+        "meta.assertion.look-ahead.regexp"
+      ],
+      "settings": {
+        "foreground": "#50FA7B"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": [
+        "string"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "String quotes (temporary vscode fix)",
+      "scope": [
+        "punctuation.definition.string.begin",
+        "punctuation.definition.string.end"
+      ],
+      "settings": {
+        "foreground": "#E9F284"
+      }
+    },
+    {
+      "name": "Property quotes (temporary vscode fix)",
+      "scope": [
+        "punctuation.support.type.property-name.begin",
+        "punctuation.support.type.property-name.end"
+      ],
+      "settings": {
+        "foreground": "#8BE9FE"
+      }
+    },
+    {
+      "name": "Docstrings",
+      "scope": [
+        "string.quoted.docstring.multi",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end",
+        "string.quoted.docstring.multi.python constant.character.escape"
+      ],
+      "settings": {
+        "foreground": "#6272A4"
+      }
+    },
+    {
+      "name": "Variables and object properties",
+      "scope": [
+        "variable",
+        "constant.other.key.perl",
+        "support.variable.property",
+        "variable.other.constant.js",
+        "variable.other.constant.ts",
+        "variable.other.constant.tsx"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Destructuring / aliasing reference name (LHS)",
+      "scope": [
+        "meta.import variable.other.readwrite",
+        "meta.variable.assignment.destructured.object.coffee variable"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#FFB86C"
+      }
+    },
+    {
+      "name": "Destructuring / aliasing variable name (RHS)",
+      "scope": [
+        "meta.import variable.other.readwrite.alias",
+        "meta.export variable.other.readwrite.alias",
+        "meta.variable.assignment.destructured.object.coffee variable variable"
+      ],
+      "settings": {
+        "fontStyle": "normal",
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "GraphQL keys",
+      "scope": [
+        "meta.selectionset.graphql variable"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "GraphQL function arguments",
+      "scope": [
+        "meta.selectionset.graphql meta.arguments variable"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "GraphQL fragment name (definition)",
+      "scope": [
+        "entity.name.fragment.graphql",
+        "variable.fragment.graphql"
+      ],
+      "settings": {
+        "foreground": "#8BE9FD"
+      }
+    },
+    {
+      "name": "Edge cases (foreground color resets)",
+      "scope": [
+        "constant.other.symbol.hashkey.ruby",
+        "keyword.operator.dereference.java",
+        "keyword.operator.navigation.groovy",
+        "meta.scope.for-loop.shell punctuation.definition.string.begin",
+        "meta.scope.for-loop.shell punctuation.definition.string.end",
+        "meta.scope.for-loop.shell string",
+        "storage.modifier.import",
+        "punctuation.section.embedded.begin.tsx",
+        "punctuation.section.embedded.end.tsx",
+        "punctuation.section.embedded.begin.jsx",
+        "punctuation.section.embedded.end.jsx",
+        "punctuation.separator.list.comma.css",
+        "constant.language.empty-list.haskell"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Shell variables prefixed with \"$\" (edge case)",
+      "scope": [
+        "source.shell variable.other"
+      ],
+      "settings": {
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Powershell constants mistakenly scoped to `support`, rather than `constant` (edge)",
+      "scope": [
+        "support.constant"
+      ],
+      "settings": {
+        "fontStyle": "normal",
+        "foreground": "#BD93F9"
+      }
+    },
+    {
+      "name": "Makefile prerequisite names",
+      "scope": [
+        "meta.scope.prerequisites.makefile"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "SCSS attibute selector strings",
+      "scope": [
+        "meta.attribute-selector.scss"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C"
+      }
+    },
+    {
+      "name": "SCSS attribute selector brackets",
+      "scope": [
+        "punctuation.definition.attribute-selector.end.bracket.square.scss",
+        "punctuation.definition.attribute-selector.begin.bracket.square.scss"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Haskell Pragmas",
+      "scope": [
+        "meta.preprocessor.haskell"
+      ],
+      "settings": {
+        "foreground": "#6272A4"
+      }
+    },
+    {
+      "name": "Log file error",
+      "scope": [
+        "log.error"
+      ],
+      "settings": {
+        "foreground": "#FF5555",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Log file warning",
+      "scope": [
+        "log.warning"
+      ],
+      "settings": {
+        "foreground": "#F1FA8C",
+        "fontStyle": "bold"
+      }
+    }
+  ]
+}

--- a/themes/github-dark.json
+++ b/themes/github-dark.json
@@ -1,0 +1,542 @@
+{
+  "name": "GitHub Dark",
+  "type": "dark",
+  "colors": {
+    "focusBorder": "#005cc5",
+    "foreground": "#d1d5da",
+    "descriptionForeground": "#959da5",
+    "errorForeground": "#f97583",
+    "textLink.foreground": "#79b8ff",
+    "textLink.activeForeground": "#c8e1ff",
+    "textBlockQuote.background": "#24292e",
+    "textBlockQuote.border": "#444d56",
+    "textCodeBlock.background": "#2f363d",
+    "textPreformat.foreground": "#d1d5da",
+    "textSeparator.foreground": "#586069",
+    "button.background": "#176f2c",
+    "button.foreground": "#dcffe4",
+    "button.hoverBackground": "#22863a",
+    "button.secondaryBackground": "#444d56",
+    "button.secondaryForeground": "#fff",
+    "button.secondaryHoverBackground": "#586069",
+    "checkbox.background": "#444d56",
+    "checkbox.border": "#1b1f23",
+    "dropdown.background": "#2f363d",
+    "dropdown.border": "#1b1f23",
+    "dropdown.foreground": "#e1e4e8",
+    "dropdown.listBackground": "#24292e",
+    "input.background": "#2f363d",
+    "input.border": "#1b1f23",
+    "input.foreground": "#e1e4e8",
+    "input.placeholderForeground": "#959da5",
+    "badge.foreground": "#c8e1ff",
+    "badge.background": "#044289",
+    "progressBar.background": "#0366d6",
+    "titleBar.activeForeground": "#e1e4e8",
+    "titleBar.activeBackground": "#24292e",
+    "titleBar.inactiveForeground": "#959da5",
+    "titleBar.inactiveBackground": "#1f2428",
+    "titleBar.border": "#1b1f23",
+    "activityBar.foreground": "#e1e4e8",
+    "activityBar.inactiveForeground": "#6a737d",
+    "activityBar.background": "#24292e",
+    "activityBarBadge.foreground": "#fff",
+    "activityBarBadge.background": "#0366d6",
+    "activityBar.activeBorder": "#f9826c",
+    "activityBar.border": "#1b1f23",
+    "sideBar.foreground": "#d1d5da",
+    "sideBar.background": "#1f2428",
+    "sideBar.border": "#1b1f23",
+    "sideBarTitle.foreground": "#e1e4e8",
+    "sideBarSectionHeader.foreground": "#e1e4e8",
+    "sideBarSectionHeader.background": "#1f2428",
+    "sideBarSectionHeader.border": "#1b1f23",
+    "list.hoverForeground": "#e1e4e8",
+    "list.inactiveSelectionForeground": "#e1e4e8",
+    "list.activeSelectionForeground": "#e1e4e8",
+    "list.hoverBackground": "#282e34",
+    "list.inactiveSelectionBackground": "#282e34",
+    "list.activeSelectionBackground": "#39414a",
+    "list.inactiveFocusBackground": "#1d2d3e",
+    "list.focusBackground": "#044289",
+    "tree.indentGuidesStroke": "#2f363d",
+    "notificationCenterHeader.foreground": "#959da5",
+    "notificationCenterHeader.background": "#24292e",
+    "notifications.foreground": "#e1e4e8",
+    "notifications.background": "#2f363d",
+    "notifications.border": "#1b1f23",
+    "notificationsErrorIcon.foreground": "#ea4a5a",
+    "notificationsWarningIcon.foreground": "#ffab70",
+    "notificationsInfoIcon.foreground": "#79b8ff",
+    "pickerGroup.border": "#444d56",
+    "pickerGroup.foreground": "#e1e4e8",
+    "quickInput.background": "#24292e",
+    "quickInput.foreground": "#e1e4e8",
+    "statusBar.foreground": "#d1d5da",
+    "statusBar.background": "#24292e",
+    "statusBar.border": "#1b1f23",
+    "statusBar.noFolderBackground": "#24292e",
+    "statusBar.debuggingBackground": "#931c06",
+    "statusBar.debuggingForeground": "#fff",
+    "statusBarItem.prominentBackground": "#282e34",
+    "statusBarItem.remoteForeground": "#d1d5da",
+    "statusBarItem.remoteBackground": "#24292e",
+    "editorGroupHeader.tabsBackground": "#1f2428",
+    "editorGroupHeader.tabsBorder": "#1b1f23",
+    "editorGroup.border": "#1b1f23",
+    "tab.activeForeground": "#e1e4e8",
+    "tab.inactiveForeground": "#959da5",
+    "tab.inactiveBackground": "#1f2428",
+    "tab.activeBackground": "#24292e",
+    "tab.hoverBackground": "#24292e",
+    "tab.unfocusedHoverBackground": "#24292e",
+    "tab.border": "#1b1f23",
+    "tab.unfocusedActiveBorderTop": "#1b1f23",
+    "tab.activeBorder": "#24292e",
+    "tab.unfocusedActiveBorder": "#24292e",
+    "tab.activeBorderTop": "#f9826c",
+    "breadcrumb.foreground": "#959da5",
+    "breadcrumb.focusForeground": "#e1e4e8",
+    "breadcrumb.activeSelectionForeground": "#d1d5da",
+    "breadcrumbPicker.background": "#2b3036",
+    "editor.foreground": "#e1e4e8",
+    "editor.background": "#24292e",
+    "editorWidget.background": "#1f2428",
+    "editor.foldBackground": "#58606915",
+    "editor.lineHighlightBackground": "#2b3036",
+    "editorLineNumber.foreground": "#444d56",
+    "editorLineNumber.activeForeground": "#e1e4e8",
+    "editorIndentGuide.background": "#2f363d",
+    "editorIndentGuide.activeBackground": "#444d56",
+    "editorWhitespace.foreground": "#444d56",
+    "editorCursor.foreground": "#c8e1ff",
+    "editorError.foreground": "#f97583",
+    "editorWarning.foreground": "#ffea7f",
+    "editor.findMatchBackground": "#ffd33d44",
+    "editor.findMatchHighlightBackground": "#ffd33d22",
+    "editor.linkedEditingBackground": "#3392FF22",
+    "editor.inactiveSelectionBackground": "#3392FF22",
+    "editor.selectionBackground": "#3392FF44",
+    "editor.selectionHighlightBackground": "#17E5E633",
+    "editor.selectionHighlightBorder": "#17E5E600",
+    "editor.wordHighlightBackground": "#17E5E600",
+    "editor.wordHighlightStrongBackground": "#17E5E600",
+    "editor.wordHighlightBorder": "#17E5E699",
+    "editor.wordHighlightStrongBorder": "#17E5E666",
+    "editorBracketMatch.background": "#17E5E650",
+    "editorBracketMatch.border": "#17E5E600",
+    "editorGutter.modifiedBackground": "#2188ff",
+    "editorGutter.addedBackground": "#28a745",
+    "editorGutter.deletedBackground": "#ea4a5a",
+    "diffEditor.insertedTextBackground": "#28a74530",
+    "diffEditor.removedTextBackground": "#d73a4930",
+    "scrollbar.shadow": "#0008",
+    "scrollbarSlider.background": "#6a737d33",
+    "scrollbarSlider.hoverBackground": "#6a737d44",
+    "scrollbarSlider.activeBackground": "#6a737d88",
+    "editorOverviewRuler.border": "#1b1f23",
+    "panel.background": "#1f2428",
+    "panel.border": "#1b1f23",
+    "panelTitle.activeBorder": "#f9826c",
+    "panelTitle.activeForeground": "#e1e4e8",
+    "panelTitle.inactiveForeground": "#959da5",
+    "panelInput.border": "#2f363d",
+    "terminal.foreground": "#d1d5da",
+    "terminal.tab.activeBorder": "#f9826c",
+    "terminalCursor.background": "#586069",
+    "terminalCursor.foreground": "#79b8ff",
+    "terminal.ansiBrightWhite": "#fafbfc",
+    "terminal.ansiWhite": "#d1d5da",
+    "terminal.ansiBrightBlack": "#959da5",
+    "terminal.ansiBlack": "#586069",
+    "terminal.ansiBlue": "#2188ff",
+    "terminal.ansiBrightBlue": "#79b8ff",
+    "terminal.ansiGreen": "#34d058",
+    "terminal.ansiBrightGreen": "#85e89d",
+    "terminal.ansiCyan": "#39c5cf",
+    "terminal.ansiBrightCyan": "#56d4dd",
+    "terminal.ansiRed": "#ea4a5a",
+    "terminal.ansiBrightRed": "#f97583",
+    "terminal.ansiMagenta": "#b392f0",
+    "terminal.ansiBrightMagenta": "#b392f0",
+    "terminal.ansiYellow": "#ffea7f",
+    "terminal.ansiBrightYellow": "#ffea7f",
+    "editorBracketHighlight.foreground1": "#79b8ff",
+    "editorBracketHighlight.foreground2": "#ffab70",
+    "editorBracketHighlight.foreground3": "#b392f0",
+    "editorBracketHighlight.foreground4": "#79b8ff",
+    "editorBracketHighlight.foreground5": "#ffab70",
+    "editorBracketHighlight.foreground6": "#b392f0",
+    "gitDecoration.addedResourceForeground": "#34d058",
+    "gitDecoration.modifiedResourceForeground": "#79b8ff",
+    "gitDecoration.deletedResourceForeground": "#ea4a5a",
+    "gitDecoration.untrackedResourceForeground": "#34d058",
+    "gitDecoration.ignoredResourceForeground": "#6a737d",
+    "gitDecoration.conflictingResourceForeground": "#ffab70",
+    "gitDecoration.submoduleResourceForeground": "#6a737d",
+    "debugToolBar.background": "#2b3036",
+    "editor.stackFrameHighlightBackground": "#C6902625",
+    "editor.focusedStackFrameHighlightBackground": "#2b6a3033",
+    "peekViewEditor.matchHighlightBackground": "#ffd33d33",
+    "peekViewResult.matchHighlightBackground": "#ffd33d33",
+    "peekViewEditor.background": "#1f242888",
+    "peekViewResult.background": "#1f2428",
+    "settings.headerForeground": "#e1e4e8",
+    "settings.modifiedItemIndicator": "#0366d6",
+    "welcomePage.buttonBackground": "#2f363d",
+    "welcomePage.buttonHoverBackground": "#444d56"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment",
+        "string.comment"
+      ],
+      "settings": {
+        "foreground": "#6a737d"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "entity.name.constant",
+        "variable.other.constant",
+        "variable.other.enummember",
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": [
+        "entity",
+        "entity.name"
+      ],
+      "settings": {
+        "foreground": "#b392f0"
+      }
+    },
+    {
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#e1e4e8"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#85e89d"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "scope": [
+        "storage",
+        "storage.type"
+      ],
+      "settings": {
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier.package",
+        "storage.modifier.import",
+        "storage.type.java"
+      ],
+      "settings": {
+        "foreground": "#e1e4e8"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string",
+        "string punctuation.section.embedded source"
+      ],
+      "settings": {
+        "foreground": "#9ecbff"
+      }
+    },
+    {
+      "scope": "support",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "meta.property-name",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "variable",
+      "settings": {
+        "foreground": "#ffab70"
+      }
+    },
+    {
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#e1e4e8"
+      }
+    },
+    {
+      "scope": "invalid.broken",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": "invalid.illegal",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": "carriage-return",
+      "settings": {
+        "fontStyle": "italic underline",
+        "background": "#f97583",
+        "foreground": "#24292e",
+        "content": "^M"
+      }
+    },
+    {
+      "scope": "message.error",
+      "settings": {
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": "string variable",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": [
+        "source.regexp",
+        "string.regexp"
+      ],
+      "settings": {
+        "foreground": "#dbedff"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp.character-class",
+        "string.regexp constant.character.escape",
+        "string.regexp source.ruby.embedded",
+        "string.regexp string.regexp.arbitrary-repitition"
+      ],
+      "settings": {
+        "foreground": "#dbedff"
+      }
+    },
+    {
+      "scope": "string.regexp constant.character.escape",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#85e89d"
+      }
+    },
+    {
+      "scope": "support.constant",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "meta.module-reference",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#ffab70"
+      }
+    },
+    {
+      "scope": [
+        "markup.heading",
+        "markup.heading entity.name"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#85e89d"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#e1e4e8"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#e1e4e8"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": [
+        "markup.strikethrough"
+      ],
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted",
+        "meta.diff.header.from-file",
+        "punctuation.definition.deleted"
+      ],
+      "settings": {
+        "background": "#86181d",
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted",
+        "meta.diff.header.to-file",
+        "punctuation.definition.inserted"
+      ],
+      "settings": {
+        "background": "#144620",
+        "foreground": "#85e89d"
+      }
+    },
+    {
+      "scope": [
+        "markup.changed",
+        "punctuation.definition.changed"
+      ],
+      "settings": {
+        "background": "#c24e00",
+        "foreground": "#ffab70"
+      }
+    },
+    {
+      "scope": [
+        "markup.ignored",
+        "markup.untracked"
+      ],
+      "settings": {
+        "foreground": "#2f363d",
+        "background": "#79b8ff"
+      }
+    },
+    {
+      "scope": "meta.diff.range",
+      "settings": {
+        "foreground": "#b392f0",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": "meta.output",
+      "settings": {
+        "foreground": "#79b8ff"
+      }
+    },
+    {
+      "scope": [
+        "brackethighlighter.tag",
+        "brackethighlighter.curly",
+        "brackethighlighter.round",
+        "brackethighlighter.square",
+        "brackethighlighter.angle",
+        "brackethighlighter.quote"
+      ],
+      "settings": {
+        "foreground": "#d1d5da"
+      }
+    },
+    {
+      "scope": "brackethighlighter.unmatched",
+      "settings": {
+        "foreground": "#fdaeb7"
+      }
+    },
+    {
+      "scope": [
+        "constant.other.reference.link",
+        "string.other.link"
+      ],
+      "settings": {
+        "foreground": "#dbedff",
+        "fontStyle": "underline"
+      }
+    }
+  ]
+}

--- a/themes/github-light.json
+++ b/themes/github-light.json
@@ -1,0 +1,538 @@
+{
+  "name": "GitHub Light",
+  "type": "light",
+  "colors": {
+    "focusBorder": "#2188ff",
+    "foreground": "#444d56",
+    "descriptionForeground": "#6a737d",
+    "errorForeground": "#cb2431",
+    "textLink.foreground": "#0366d6",
+    "textLink.activeForeground": "#005cc5",
+    "textBlockQuote.background": "#fafbfc",
+    "textBlockQuote.border": "#e1e4e8",
+    "textCodeBlock.background": "#f6f8fa",
+    "textPreformat.foreground": "#586069",
+    "textSeparator.foreground": "#d1d5da",
+    "button.background": "#159739",
+    "button.foreground": "#fff",
+    "button.hoverBackground": "#138934",
+    "button.secondaryBackground": "#e1e4e8",
+    "button.secondaryForeground": "#1b1f23",
+    "button.secondaryHoverBackground": "#d1d5da",
+    "checkbox.background": "#fafbfc",
+    "checkbox.border": "#d1d5da",
+    "dropdown.background": "#fafbfc",
+    "dropdown.border": "#e1e4e8",
+    "dropdown.foreground": "#2f363d",
+    "dropdown.listBackground": "#fff",
+    "input.background": "#fafbfc",
+    "input.border": "#e1e4e8",
+    "input.foreground": "#2f363d",
+    "input.placeholderForeground": "#959da5",
+    "badge.foreground": "#005cc5",
+    "badge.background": "#dbedff",
+    "progressBar.background": "#2188ff",
+    "titleBar.activeForeground": "#2f363d",
+    "titleBar.activeBackground": "#fff",
+    "titleBar.inactiveForeground": "#6a737d",
+    "titleBar.inactiveBackground": "#f6f8fa",
+    "titleBar.border": "#e1e4e8",
+    "activityBar.foreground": "#2f363d",
+    "activityBar.inactiveForeground": "#959da5",
+    "activityBar.background": "#fff",
+    "activityBarBadge.foreground": "#fff",
+    "activityBarBadge.background": "#2188ff",
+    "activityBar.activeBorder": "#f9826c",
+    "activityBar.border": "#e1e4e8",
+    "sideBar.foreground": "#586069",
+    "sideBar.background": "#f6f8fa",
+    "sideBar.border": "#e1e4e8",
+    "sideBarTitle.foreground": "#2f363d",
+    "sideBarSectionHeader.foreground": "#2f363d",
+    "sideBarSectionHeader.background": "#f6f8fa",
+    "sideBarSectionHeader.border": "#e1e4e8",
+    "list.hoverForeground": "#2f363d",
+    "list.inactiveSelectionForeground": "#2f363d",
+    "list.activeSelectionForeground": "#2f363d",
+    "list.hoverBackground": "#ebf0f4",
+    "list.inactiveSelectionBackground": "#e8eaed",
+    "list.activeSelectionBackground": "#e2e5e9",
+    "list.inactiveFocusBackground": "#dbedff",
+    "list.focusBackground": "#cce5ff",
+    "tree.indentGuidesStroke": "#e1e4e8",
+    "notificationCenterHeader.foreground": "#6a737d",
+    "notificationCenterHeader.background": "#e1e4e8",
+    "notifications.foreground": "#2f363d",
+    "notifications.background": "#fafbfc",
+    "notifications.border": "#e1e4e8",
+    "notificationsErrorIcon.foreground": "#d73a49",
+    "notificationsWarningIcon.foreground": "#e36209",
+    "notificationsInfoIcon.foreground": "#005cc5",
+    "pickerGroup.border": "#e1e4e8",
+    "pickerGroup.foreground": "#2f363d",
+    "quickInput.background": "#fafbfc",
+    "quickInput.foreground": "#2f363d",
+    "statusBar.foreground": "#586069",
+    "statusBar.background": "#fff",
+    "statusBar.border": "#e1e4e8",
+    "statusBar.noFolderBackground": "#fff",
+    "statusBar.debuggingBackground": "#f9826c",
+    "statusBar.debuggingForeground": "#fff",
+    "statusBarItem.prominentBackground": "#e8eaed",
+    "statusBarItem.remoteForeground": "#586069",
+    "statusBarItem.remoteBackground": "#fff",
+    "editorGroupHeader.tabsBackground": "#f6f8fa",
+    "editorGroupHeader.tabsBorder": "#e1e4e8",
+    "editorGroup.border": "#e1e4e8",
+    "tab.activeForeground": "#2f363d",
+    "tab.inactiveForeground": "#6a737d",
+    "tab.inactiveBackground": "#f6f8fa",
+    "tab.activeBackground": "#fff",
+    "tab.hoverBackground": "#fff",
+    "tab.unfocusedHoverBackground": "#fff",
+    "tab.border": "#e1e4e8",
+    "tab.unfocusedActiveBorderTop": "#e1e4e8",
+    "tab.activeBorder": "#fff",
+    "tab.unfocusedActiveBorder": "#fff",
+    "tab.activeBorderTop": "#f9826c",
+    "breadcrumb.foreground": "#6a737d",
+    "breadcrumb.focusForeground": "#2f363d",
+    "breadcrumb.activeSelectionForeground": "#586069",
+    "breadcrumbPicker.background": "#fafbfc",
+    "editor.foreground": "#24292e",
+    "editor.background": "#fff",
+    "editorWidget.background": "#f6f8fa",
+    "editor.foldBackground": "#d1d5da11",
+    "editor.lineHighlightBackground": "#f6f8fa",
+    "editorLineNumber.foreground": "#1b1f234d",
+    "editorLineNumber.activeForeground": "#24292e",
+    "editorIndentGuide.background": "#eff2f6",
+    "editorIndentGuide.activeBackground": "#d7dbe0",
+    "editorWhitespace.foreground": "#d1d5da",
+    "editorCursor.foreground": "#044289",
+    "editorError.foreground": "#cb2431",
+    "editorWarning.foreground": "#f9c513",
+    "editor.findMatchBackground": "#ffdf5d",
+    "editor.findMatchHighlightBackground": "#ffdf5d66",
+    "editor.linkedEditingBackground": "#0366d611",
+    "editor.inactiveSelectionBackground": "#0366d611",
+    "editor.selectionBackground": "#0366d625",
+    "editor.selectionHighlightBackground": "#34d05840",
+    "editor.selectionHighlightBorder": "#34d05800",
+    "editor.wordHighlightBackground": "#34d05800",
+    "editor.wordHighlightStrongBackground": "#34d05800",
+    "editor.wordHighlightBorder": "#24943e99",
+    "editor.wordHighlightStrongBorder": "#24943e50",
+    "editorBracketMatch.background": "#34d05840",
+    "editorBracketMatch.border": "#34d05800",
+    "editorGutter.modifiedBackground": "#2188ff",
+    "editorGutter.addedBackground": "#28a745",
+    "editorGutter.deletedBackground": "#d73a49",
+    "diffEditor.insertedTextBackground": "#34d05822",
+    "diffEditor.removedTextBackground": "#d73a4922",
+    "scrollbar.shadow": "#6a737d33",
+    "scrollbarSlider.background": "#959da533",
+    "scrollbarSlider.hoverBackground": "#959da544",
+    "scrollbarSlider.activeBackground": "#959da588",
+    "editorOverviewRuler.border": "#fff",
+    "panel.background": "#f6f8fa",
+    "panel.border": "#e1e4e8",
+    "panelTitle.activeBorder": "#f9826c",
+    "panelTitle.activeForeground": "#2f363d",
+    "panelTitle.inactiveForeground": "#6a737d",
+    "panelInput.border": "#e1e4e8",
+    "terminal.foreground": "#586069",
+    "terminal.tab.activeBorder": "#f9826c",
+    "terminalCursor.background": "#d1d5da",
+    "terminalCursor.foreground": "#005cc5",
+    "terminal.ansiBrightWhite": "#d1d5da",
+    "terminal.ansiWhite": "#6a737d",
+    "terminal.ansiBrightBlack": "#959da5",
+    "terminal.ansiBlack": "#24292e",
+    "terminal.ansiBlue": "#0366d6",
+    "terminal.ansiBrightBlue": "#005cc5",
+    "terminal.ansiGreen": "#28a745",
+    "terminal.ansiBrightGreen": "#22863a",
+    "terminal.ansiCyan": "#1b7c83",
+    "terminal.ansiBrightCyan": "#3192aa",
+    "terminal.ansiRed": "#d73a49",
+    "terminal.ansiBrightRed": "#cb2431",
+    "terminal.ansiMagenta": "#5a32a3",
+    "terminal.ansiBrightMagenta": "#5a32a3",
+    "terminal.ansiYellow": "#dbab09",
+    "terminal.ansiBrightYellow": "#b08800",
+    "editorBracketHighlight.foreground1": "#005cc5",
+    "editorBracketHighlight.foreground2": "#e36209",
+    "editorBracketHighlight.foreground3": "#5a32a3",
+    "editorBracketHighlight.foreground4": "#005cc5",
+    "editorBracketHighlight.foreground5": "#e36209",
+    "editorBracketHighlight.foreground6": "#5a32a3",
+    "gitDecoration.addedResourceForeground": "#28a745",
+    "gitDecoration.modifiedResourceForeground": "#005cc5",
+    "gitDecoration.deletedResourceForeground": "#d73a49",
+    "gitDecoration.untrackedResourceForeground": "#28a745",
+    "gitDecoration.ignoredResourceForeground": "#959da5",
+    "gitDecoration.conflictingResourceForeground": "#e36209",
+    "gitDecoration.submoduleResourceForeground": "#959da5",
+    "debugToolBar.background": "#fff",
+    "editor.stackFrameHighlightBackground": "#ffd33d33",
+    "editor.focusedStackFrameHighlightBackground": "#28a74525",
+    "settings.headerForeground": "#2f363d",
+    "settings.modifiedItemIndicator": "#2188ff",
+    "welcomePage.buttonBackground": "#f6f8fa",
+    "welcomePage.buttonHoverBackground": "#e1e4e8"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment",
+        "string.comment"
+      ],
+      "settings": {
+        "foreground": "#6a737d"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "entity.name.constant",
+        "variable.other.constant",
+        "variable.other.enummember",
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "entity",
+        "entity.name"
+      ],
+      "settings": {
+        "foreground": "#6f42c1"
+      }
+    },
+    {
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#d73a49"
+      }
+    },
+    {
+      "scope": [
+        "storage",
+        "storage.type"
+      ],
+      "settings": {
+        "foreground": "#d73a49"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier.package",
+        "storage.modifier.import",
+        "storage.type.java"
+      ],
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string",
+        "string punctuation.section.embedded source"
+      ],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": "support",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.property-name",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "variable",
+      "settings": {
+        "foreground": "#e36209"
+      }
+    },
+    {
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "invalid.broken",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.illegal",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "carriage-return",
+      "settings": {
+        "fontStyle": "italic underline",
+        "background": "#d73a49",
+        "foreground": "#fafbfc",
+        "content": "^M"
+      }
+    },
+    {
+      "scope": "message.error",
+      "settings": {
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": "string variable",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "source.regexp",
+        "string.regexp"
+      ],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp.character-class",
+        "string.regexp constant.character.escape",
+        "string.regexp source.ruby.embedded",
+        "string.regexp string.regexp.arbitrary-repitition"
+      ],
+      "settings": {
+        "foreground": "#032f62"
+      }
+    },
+    {
+      "scope": "string.regexp constant.character.escape",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "support.constant",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.module-reference",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#e36209"
+      }
+    },
+    {
+      "scope": [
+        "markup.heading",
+        "markup.heading entity.name"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#24292e"
+      }
+    },
+    {
+      "scope": [
+        "markup.underline"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": [
+        "markup.strikethrough"
+      ],
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted",
+        "meta.diff.header.from-file",
+        "punctuation.definition.deleted"
+      ],
+      "settings": {
+        "background": "#ffeef0",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted",
+        "meta.diff.header.to-file",
+        "punctuation.definition.inserted"
+      ],
+      "settings": {
+        "background": "#f0fff4",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "scope": [
+        "markup.changed",
+        "punctuation.definition.changed"
+      ],
+      "settings": {
+        "background": "#ffebda",
+        "foreground": "#e36209"
+      }
+    },
+    {
+      "scope": [
+        "markup.ignored",
+        "markup.untracked"
+      ],
+      "settings": {
+        "foreground": "#f6f8fa",
+        "background": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.diff.range",
+      "settings": {
+        "foreground": "#6f42c1",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": "meta.output",
+      "settings": {
+        "foreground": "#005cc5"
+      }
+    },
+    {
+      "scope": [
+        "brackethighlighter.tag",
+        "brackethighlighter.curly",
+        "brackethighlighter.round",
+        "brackethighlighter.square",
+        "brackethighlighter.angle",
+        "brackethighlighter.quote"
+      ],
+      "settings": {
+        "foreground": "#586069"
+      }
+    },
+    {
+      "scope": "brackethighlighter.unmatched",
+      "settings": {
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "scope": [
+        "constant.other.reference.link",
+        "string.other.link"
+      ],
+      "settings": {
+        "foreground": "#032f62",
+        "fontStyle": "underline"
+      }
+    }
+  ]
+}

--- a/themes/gruvbox-dark.json
+++ b/themes/gruvbox-dark.json
@@ -1,0 +1,1234 @@
+{
+  "name": "Gruvbox Dark Medium",
+  "type": "dark",
+  "colors": {
+    "focusBorder": "#3c3836",
+    "foreground": "#ebdbb2",
+    "widget.shadow": "#28282830",
+    "widget.border": "#3c3836",
+    "selection.background": "#689d6a80",
+    "errorForeground": "#fb4934",
+    "icon.foreground": "#ebdbb2",
+    "button.background": "#45858880",
+    "button.foreground": "#ebdbb2",
+    "button.hoverBackground": "#45858860",
+    "dropdown.background": "#282828",
+    "dropdown.border": "#3c3836",
+    "dropdown.foreground": "#ebdbb2",
+    "input.background": "#282828",
+    "input.border": "#3c3836",
+    "input.foreground": "#ebdbb2",
+    "input.placeholderForeground": "#ebdbb260",
+    "inputValidation.errorBorder": "#fb4934",
+    "inputValidation.errorBackground": "#cc241d",
+    "inputValidation.infoBorder": "#83a598",
+    "inputValidation.infoBackground": "#45858880",
+    "inputValidation.warningBorder": "#fabd2f",
+    "inputValidation.warningBackground": "#d79921",
+    "inputOption.activeBorder": "#ebdbb260",
+    "scrollbar.shadow": "#282828",
+    "scrollbarSlider.activeBackground": "#689d6a",
+    "scrollbarSlider.hoverBackground": "#665c54",
+    "scrollbarSlider.background": "#50494599",
+    "badge.background": "#b16286",
+    "badge.foreground": "#ebdbb2",
+    "progressBar.background": "#689d6a",
+    "list.activeSelectionBackground": "#3c383680",
+    "list.activeSelectionForeground": "#8ec07c",
+    "list.hoverBackground": "#3c383680",
+    "list.hoverForeground": "#d5c4a1",
+    "list.focusBackground": "#3c3836",
+    "list.focusForeground": "#ebdbb2",
+    "list.inactiveSelectionForeground": "#689d6a",
+    "list.inactiveSelectionBackground": "#3c383680",
+    "list.dropBackground": "#3c3836",
+    "list.highlightForeground": "#689d6a",
+    "sideBar.background": "#282828",
+    "sideBar.foreground": "#d5c4a1",
+    "sideBar.border": "#3c3836",
+    "sideBarTitle.foreground": "#ebdbb2",
+    "sideBarSectionHeader.background": "#0000",
+    "sideBarSectionHeader.foreground": "#ebdbb2",
+    "activityBar.background": "#282828",
+    "activityBar.foreground": "#ebdbb2",
+    "activityBar.border": "#3c3836",
+    "activityBarTop.background": "#282828",
+    "activityBarTop.foreground": "#ebdbb2",
+    "activityBarBadge.background": "#458588",
+    "activityBarBadge.foreground": "#ebdbb2",
+    "editorGroup.border": "#3c3836",
+    "editorGroup.dropBackground": "#3c383660",
+    "editorGroupHeader.noTabsBackground": "#282828",
+    "editorGroupHeader.tabsBackground": "#282828",
+    "editorGroupHeader.tabsBorder": "#3c3836",
+    "tab.border": "#0000",
+    "tab.activeBorder": "#689d6a",
+    "tab.activeBackground": "#3c3836",
+    "tab.activeForeground": "#ebdbb2",
+    "tab.inactiveForeground": "#a89984",
+    "tab.inactiveBackground": "#282828",
+    "tab.unfocusedActiveForeground": "#a89984",
+    "tab.unfocusedActiveBorder": "#0000",
+    "tab.unfocusedInactiveForeground": "#928374",
+    "editor.background": "#282828",
+    "editor.foreground": "#ebdbb2",
+    "editorLineNumber.foreground": "#665c54",
+    "editorCursor.foreground": "#ebdbb2",
+    "editor.selectionBackground": "#689d6a40",
+    "editor.selectionHighlightBackground": "#fabd2f40",
+    "editor.hoverHighlightBackground": "#689d6a50",
+    "editorLink.activeForeground": "#ebdbb2",
+    "editor.findMatchBackground": "#83a59870",
+    "editor.findMatchHighlightBackground": "#fe801930",
+    "editor.findRangeHighlightBackground": "#83a59870",
+    "editor.lineHighlightBackground": "#3c383660",
+    "editor.lineHighlightBorder": "#0000",
+    "editorWhitespace.foreground": "#a8998420",
+    "editorRuler.foreground": "#a8998440",
+    "editorCodeLens.foreground": "#a8998490",
+    "editorBracketMatch.border": "#0000",
+    "editorBracketMatch.background": "#92837480",
+    "editorHoverWidget.background": "#282828",
+    "editorHoverWidget.border": "#3c3836",
+    "editorOverviewRuler.border": "#0000",
+    "editorOverviewRuler.findMatchForeground": "#bdae93",
+    "editorOverviewRuler.rangeHighlightForeground": "#bdae93",
+    "editorOverviewRuler.selectionHighlightForeground": "#665c54",
+    "editorOverviewRuler.wordHighlightForeground": "#665c54",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#665c54",
+    "editorOverviewRuler.modifiedForeground": "#83a598",
+    "editorOverviewRuler.addedForeground": "#83a598",
+    "editorOverviewRuler.deletedForeground": "#83a598",
+    "editorOverviewRuler.errorForeground": "#fb4934",
+    "editorOverviewRuler.warningForeground": "#d79921",
+    "editorOverviewRuler.infoForeground": "#d3869b",
+    "editorGutter.background": "#0000",
+    "editorGutter.modifiedBackground": "#83a598",
+    "editorGutter.addedBackground": "#b8bb26",
+    "editorGutter.deletedBackground": "#fb4934",
+    "editorError.foreground": "#cc241d",
+    "editorWarning.foreground": "#d79921",
+    "editorInfo.foreground": "#458588",
+    "editorIndentGuide.activeBackground": "#665c54",
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    "editorStickyScroll.shadow": "#50494599",
+    "editorStickyScrollHover.background": "#3c383660",
+    "diffEditor.insertedTextBackground": "#b8bb2630",
+    "diffEditor.removedTextBackground": "#fb493430",
+    "editorWidget.background": "#282828",
+    "editorWidget.border": "#3c3836",
+    "editorSuggestWidget.background": "#282828",
+    "editorSuggestWidget.foreground": "#ebdbb2",
+    "editorSuggestWidget.highlightForeground": "#689d6a",
+    "editorSuggestWidget.selectedBackground": "#3c383660",
+    "editorSuggestWidget.border": "#3c3836",
+    "peekView.border": "#3c3836",
+    "peekViewEditor.background": "#3c383670",
+    "peekViewEditor.matchHighlightBackground": "#504945",
+    "peekViewEditorGutter.background": "#3c383670",
+    "peekViewResult.background": "#3c383670",
+    "peekViewResult.fileForeground": "#ebdbb2",
+    "peekViewResult.selectionBackground": "#45858820",
+    "peekViewResult.selectionForeground": "#ebdbb2",
+    "peekViewResult.lineForeground": "#ebdbb2",
+    "peekViewResult.matchHighlightBackground": "#504945",
+    "peekViewTitle.background": "#3c383670",
+    "peekViewTitleDescription.foreground": "#bdae93",
+    "peekViewTitleLabel.foreground": "#ebdbb2",
+    "merge.currentHeaderBackground": "#45858840",
+    "merge.currentContentBackground": "#45858820",
+    "merge.incomingHeaderBackground": "#689d6a40",
+    "merge.incomingContentBackground": "#689d6a20",
+    "merge.border": "#0000",
+    "editorOverviewRuler.currentContentForeground": "#458588",
+    "editorOverviewRuler.incomingContentForeground": "#689d6a",
+    "editorOverviewRuler.commonContentForeground": "#928374",
+    "panel.border": "#3c3836",
+    "panelTitle.activeForeground": "#ebdbb2",
+    "statusBar.background": "#282828",
+    "statusBar.border": "#3c3836",
+    "statusBar.foreground": "#ebdbb2",
+    "statusBar.debuggingBackground": "#fe8019",
+    "statusBar.debuggingForeground": "#282828",
+    "statusBar.debuggingBorder": "#0000",
+    "statusBar.noFolderBackground": "#282828",
+    "statusBar.noFolderBorder": "#0000",
+    "terminal.ansiBlack": "#3c3836",
+    "terminal.ansiBrightBlack": "#928374",
+    "terminal.ansiRed": "#cc241d",
+    "terminal.ansiBrightRed": "#fb4934",
+    "terminal.ansiGreen": "#98971a",
+    "terminal.ansiBrightGreen": "#b8bb26",
+    "terminal.ansiYellow": "#d79921",
+    "terminal.ansiBrightYellow": "#fabd2f",
+    "terminal.ansiBlue": "#458588",
+    "terminal.ansiBrightBlue": "#83a598",
+    "terminal.ansiMagenta": "#b16286",
+    "terminal.ansiBrightMagenta": "#d3869b",
+    "terminal.ansiCyan": "#689d6a",
+    "terminal.ansiBrightCyan": "#8ec07c",
+    "terminal.ansiWhite": "#a89984",
+    "terminal.ansiBrightWhite": "#ebdbb2",
+    "terminal.foreground": "#ebdbb2",
+    "terminal.background": "#282828",
+    "titleBar.activeBackground": "#282828",
+    "titleBar.activeForeground": "#ebdbb2",
+    "titleBar.inactiveBackground": "#282828",
+    "gitDecoration.modifiedResourceForeground": "#d79921",
+    "gitDecoration.deletedResourceForeground": "#cc241d",
+    "gitDecoration.untrackedResourceForeground": "#98971a",
+    "gitDecoration.ignoredResourceForeground": "#7c6f64",
+    "gitDecoration.conflictingResourceForeground": "#b16286",
+    "scmGraph.historyItemHoverLabelForeground": "#ebdbb2",
+    "scmGraph.historyItemHoverDefaultLabelForeground": "#ebdbb2",
+    "menu.border": "#3c3836",
+    "menu.separatorBackground": "#3c3836",
+    "extensionButton.prominentBackground": "#b8bb2680",
+    "extensionButton.prominentHoverBackground": "#b8bb2630",
+    "textLink.foreground": "#83a598",
+    "textLink.activeForeground": "#458588",
+    "debugToolBar.background": "#282828",
+    "editorGhostText.background": "#665c5460",
+    "notebook.cellEditorBackground": "#3c3836",
+    "notebook.focusedCellBorder": "#a89984",
+    "notebook.cellBorderColor": "#504945",
+    "notebook.focusedEditorBorder": "#504945",
+    "gitlens.closedAutolinkedIssueIconColor": "#b16286",
+    "gitlens.closedPullRequestIconColor": "#cc241d",
+    "gitDecoration.addedResourceForeground": "#ebdbb2",
+    "gitlens.decorations.branchAheadForegroundColor": "#98971a",
+    "gitlens.decorations.branchBehindForegroundColor": "#d65d0e",
+    "gitlens.decorations.branchDivergedForegroundColor": "#d79921",
+    "gitlens.decorations.branchMissingUpstreamForegroundColor": "#cc241d",
+    "gitlens.decorations.statusMergingOrRebasingConflictForegroundColor": "#cc241d",
+    "gitlens.decorations.statusMergingOrRebasingForegroundColor": "#d79921",
+    "gitlens.decorations.workspaceCurrentForegroundColor": "#98971a",
+    "gitlens.decorations.workspaceRepoMissingForegroundColor": "#7c6f64",
+    "gitlens.decorations.workspaceRepoOpenForegroundColor": "#98971a",
+    "gitlens.decorations.worktreeHasUncommittedChangesForegroundColor": "#928374",
+    "gitlens.decorations.worktreeMissingForegroundColor": "#cc241d",
+    "gitlens.graphChangesColumnAddedColor": "#98971a",
+    "gitlens.graphChangesColumnDeletedColor": "#cc241d",
+    "gitlens.graphLane1Color": "#83a598",
+    "gitlens.graphLane2Color": "#458588",
+    "gitlens.graphLane3Color": "#d3869b",
+    "gitlens.graphLane4Color": "#b16286",
+    "gitlens.graphLane5Color": "#8ec07c",
+    "gitlens.graphLane6Color": "#689d6a",
+    "gitlens.graphLane7Color": "#fabd2f",
+    "gitlens.graphLane8Color": "#d79921",
+    "gitlens.graphLane9Color": "#b8bb26",
+    "gitlens.graphLane10Color": "#98971a",
+    "gitlens.graphMinimapMarkerHeadColor": "#98971a",
+    "gitlens.graphMinimapMarkerHighlightsColor": "#b8bb26",
+    "gitlens.graphMinimapMarkerLocalBranchesColor": "#83a598",
+    "gitlens.graphMinimapMarkerPullRequestsColor": "#fe8019",
+    "gitlens.graphMinimapMarkerRemoteBranchesColor": "#458588",
+    "gitlens.graphMinimapMarkerStashesColor": "#b16286",
+    "gitlens.graphMinimapMarkerTagsColor": "#7c6f64",
+    "gitlens.graphMinimapMarkerUpstreamColor": "#689d6a",
+    "gitlens.graphScrollMarkerHeadColor": "#b8bb26",
+    "gitlens.graphScrollMarkerHighlightsColor": "#d79921",
+    "gitlens.graphScrollMarkerLocalBranchesColor": "#83a598",
+    "gitlens.graphScrollMarkerPullRequestsColor": "#fe8019",
+    "gitlens.graphScrollMarkerRemoteBranchesColor": "#458588",
+    "gitlens.graphScrollMarkerStashesColor": "#b16286",
+    "gitlens.graphScrollMarkerTagsColor": "#7c6f64",
+    "gitlens.graphScrollMarkerUpstreamColor": "#8ec07c",
+    "gitlens.gutterBackgroundColor": "#3c3836",
+    "gitlens.gutterForegroundColor": "#ebdbb2",
+    "gitlens.gutterUncommittedForegroundColor": "#458588",
+    "gitlens.launchpadIndicatorAttentionColor": "#fabd2f",
+    "gitlens.launchpadIndicatorAttentionHoverColor": "#d79921",
+    "gitlens.launchpadIndicatorBlockedColor": "#fb4934",
+    "gitlens.launchpadIndicatorBlockedHoverColor": "#cc241d",
+    "gitlens.launchpadIndicatorMergeableColor": "#b8bb26",
+    "gitlens.launchpadIndicatorMergeableHoverColor": "#98971a",
+    "gitlens.lineHighlightBackgroundColor": "#3c3836",
+    "gitlens.lineHighlightOverviewRulerColor": "#458588",
+    "gitlens.mergedPullRequestIconColor": "#b16286",
+    "gitlens.openAutolinkedIssueIconColor": "#98971a",
+    "gitlens.openPullRequestIconColor": "#98971a",
+    "gitlens.trailingLineBackgroundColor": "#282828a0",
+    "gitlens.trailingLineForegroundColor": "#928374a0",
+    "gitlens.unpublishedChangesIconColor": "#98971a",
+    "gitlens.unpublishedCommitIconColor": "#98971a",
+    "gitlens.unpulledChangesIconColor": "#fe8019"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "header",
+      "settings": {
+        "foreground": "#458588"
+      }
+    },
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#928374",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "support.constant",
+        "variable.arguments"
+      ],
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": "constant.rgb-value",
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": "entity.name.selector",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag",
+        "punctuation.tag"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
+      "settings": {
+        "foreground": "#cc241d"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#b16286"
+      }
+    },
+    {
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "meta.preprocessor",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.string",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.numeric",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "meta.header.diff",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": [
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "string",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "string.tag",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "string.value",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "string.escape",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": "string.quasi",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "string.entity",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "object",
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": "module.node",
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": "keyword.control.module",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "keyword.control.less",
+      "settings": {
+        "foreground": "#d79921"
+      }
+    },
+    {
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "keyword.operator.new",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "metatag.php",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "support.function.git-rebase",
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "constant.sha.git-rebase",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "name": "Types declaration and references",
+      "scope": [
+        "meta.type.name",
+        "meta.return.type",
+        "meta.return-type",
+        "meta.cast",
+        "meta.type.annotation",
+        "support.type",
+        "storage.type.cs",
+        "variable.class"
+      ],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": [
+        "variable.this",
+        "support.variable"
+      ],
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": [
+        "entity.name",
+        "entity.static",
+        "entity.name.class.static.function",
+        "entity.name.function",
+        "entity.name.class",
+        "entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "Function declarations",
+      "scope": [
+        "entity.function",
+        "entity.name.function.static"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "entity.name.function.function-call",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "support.function.builtin",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.method",
+        "entity.name.method.function-call",
+        "entity.name.static.function-call"
+      ],
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "brace",
+      "settings": {
+        "foreground": "#d5c4a1"
+      }
+    },
+    {
+      "name": "variables",
+      "scope": [
+        "meta.parameter.type.variable",
+        "variable.parameter",
+        "variable.name",
+        "variable.other",
+        "variable",
+        "string.constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": "prototype",
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": [
+        "punctuation"
+      ],
+      "settings": {
+        "foreground": "#a89984"
+      }
+    },
+    {
+      "scope": "punctuation.quoted",
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": "punctuation.quasi",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "name": "URL",
+      "scope": [
+        "*url*",
+        "*link*",
+        "*uri*"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "Python function",
+      "scope": [
+        "meta.function.python",
+        "entity.name.function.python"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "name": "Python Function and Class definition keywords",
+      "scope": [
+        "storage.type.function.python",
+        "storage.modifier.declaration",
+        "storage.type.class.python",
+        "storage.type.string.python"
+      ],
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "name": "Async keyword",
+      "scope": [
+        "storage.type.function.async.python"
+      ],
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "name": "Python Function Call",
+      "scope": "meta.function-call.generic",
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "name": "Python Function Arguments",
+      "scope": "meta.function-call.arguments",
+      "settings": {
+        "foreground": "#d5c4a1"
+      }
+    },
+    {
+      "name": "Python Function decorator",
+      "scope": "entity.name.function.decorator",
+      "settings": {
+        "foreground": "#fabd2f",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Python ALL CAPS",
+      "scope": "constant.other.caps",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "keyword.operator.logical",
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": "punctuation.definition.logical-expression",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": [
+        "string.interpolated.dollar.shell",
+        "string.interpolated.backtick.shell"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "keyword.control.directive",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "support.function.C99",
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "C# functions & namespace",
+      "scope": [
+        "meta.function.cs",
+        "entity.name.function.cs",
+        "entity.name.type.namespace.cs"
+      ],
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "name": "C# Variables",
+      "scope": [
+        "keyword.other.using.cs",
+        "entity.name.variable.field.cs",
+        "entity.name.variable.local.cs",
+        "variable.other.readwrite.cs"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "name": "C# This",
+      "scope": [
+        "keyword.other.this.cs",
+        "keyword.other.base.cs"
+      ],
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": "meta.scope.prerequisites",
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": "entity.name.function.target",
+      "settings": {
+        "foreground": "#b8bb26",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "coloring of the Java import and package identifiers",
+      "scope": [
+        "storage.modifier.import.java",
+        "storage.modifier.package.java"
+      ],
+      "settings": {
+        "foreground": "#bdae93"
+      }
+    },
+    {
+      "scope": [
+        "keyword.other.import.java",
+        "keyword.other.package.java"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "storage.type.java",
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": "storage.type.annotation",
+      "settings": {
+        "foreground": "#83a598",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "keyword.other.documentation.javadoc",
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "comment.block.javadoc variable.parameter.java",
+      "settings": {
+        "foreground": "#b8bb26",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "source.java variable.other.object",
+        "source.java variable.other.definition.java"
+      ],
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "name": "Lisp optional function parameters",
+      "scope": "meta.function-parameters.lisp",
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "string.other.link.title.markdown",
+      "settings": {
+        "foreground": "#928374",
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "markup.underline.link",
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "heading.1.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "scope": "heading.2.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "heading.3.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": "heading.4.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "heading.5.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": "heading.6.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#d65d0e"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "markup.punctuation.quote.beginning",
+      "settings": {
+        "foreground": "#98971a"
+      }
+    },
+    {
+      "scope": "markup.punctuation.list.beginning",
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": [
+        "markup.inline.raw",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": "string.quoted.double.json",
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.css",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "source.css meta.selector",
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": "support.type.property-name.css",
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.class",
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": [
+        "source.css support.function.transform",
+        "source.css support.function.timing-function",
+        "source.css support.function.misc"
+      ],
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "name": "CSS property value",
+      "scope": [
+        "support.property-value",
+        "constant.rgb-value",
+        "support.property-value.scss",
+        "constant.rgb-value.scss"
+      ],
+      "settings": {
+        "foreground": "#d65d0e"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag.css"
+      ],
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.tag"
+      ],
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": [
+        "text.html entity.name.tag",
+        "text.html punctuation.tag"
+      ],
+      "settings": {
+        "foreground": "#8ec07c",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "source.js variable.language"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": [
+        "source.ts variable.language"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.import"
+      ],
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "scope": [
+        "source.go keyword.package",
+        "source.go keyword.import"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "scope": [
+        "source.go keyword.interface",
+        "source.go keyword.struct"
+      ],
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#ebdbb2"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "scope": [
+        "keyword.control.cucumber.table"
+      ],
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "name": "ReasonML String",
+      "scope": [
+        "source.reason string.double",
+        "source.reason string.regexp"
+      ],
+      "settings": {
+        "foreground": "#b8bb26"
+      }
+    },
+    {
+      "name": "ReasonML equals sign",
+      "scope": [
+        "source.reason keyword.control.less"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    },
+    {
+      "name": "ReasonML variable",
+      "scope": [
+        "source.reason entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#83a598"
+      }
+    },
+    {
+      "name": "ReasonML property",
+      "scope": [
+        "source.reason support.property-value",
+        "source.reason entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "Powershell member",
+      "scope": [
+        "source.powershell variable.other.member.powershell"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": [
+        "source.powershell support.function.powershell"
+      ],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": [
+        "source.powershell support.function.attribute.powershell"
+      ],
+      "settings": {
+        "foreground": "#bdae93"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "LaTeX functions",
+      "scope": [
+        "support.function.be.latex",
+        "support.function.general.tex",
+        "support.function.section.latex",
+        "support.function.textbf.latex",
+        "support.function.textit.latex",
+        "support.function.texttt.latex",
+        "support.function.emph.latex",
+        "support.function.url.latex"
+      ],
+      "settings": {
+        "foreground": "#fb4934"
+      }
+    },
+    {
+      "name": "LaTeX text in math environment",
+      "scope": [
+        "support.class.math.block.tex",
+        "support.class.math.block.environment.latex"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "LaTeX preamble",
+      "scope": [
+        "keyword.control.preamble.latex",
+        "keyword.control.include.latex"
+      ],
+      "settings": {
+        "foreground": "#d3869b"
+      }
+    },
+    {
+      "name": "LaTeX packages",
+      "scope": [
+        "support.class.latex"
+      ],
+      "settings": {
+        "foreground": "#8ec07c"
+      }
+    }
+  ]
+}

--- a/themes/gruvbox-light.json
+++ b/themes/gruvbox-light.json
@@ -1,0 +1,1234 @@
+{
+  "name": "Gruvbox Light Medium",
+  "type": "light",
+  "colors": {
+    "focusBorder": "#ebdbb2",
+    "foreground": "#3c3836",
+    "widget.shadow": "#fbf1c730",
+    "widget.border": "#ebdbb2",
+    "selection.background": "#689d6a80",
+    "errorForeground": "#9d0006",
+    "icon.foreground": "#3c3836",
+    "button.background": "#45858880",
+    "button.foreground": "#3c3836",
+    "button.hoverBackground": "#45858860",
+    "dropdown.background": "#fbf1c7",
+    "dropdown.border": "#ebdbb2",
+    "dropdown.foreground": "#3c3836",
+    "input.background": "#fbf1c7",
+    "input.border": "#ebdbb2",
+    "input.foreground": "#3c3836",
+    "input.placeholderForeground": "#3c383660",
+    "inputValidation.errorBorder": "#9d0006",
+    "inputValidation.errorBackground": "#cc241d",
+    "inputValidation.infoBorder": "#076678",
+    "inputValidation.infoBackground": "#45858880",
+    "inputValidation.warningBorder": "#b57614",
+    "inputValidation.warningBackground": "#d79921",
+    "inputOption.activeBorder": "#3c383660",
+    "scrollbar.shadow": "#fbf1c7",
+    "scrollbarSlider.activeBackground": "#689d6a",
+    "scrollbarSlider.hoverBackground": "#bdae93",
+    "scrollbarSlider.background": "#d5c4a199",
+    "badge.background": "#b16286",
+    "badge.foreground": "#ebdbb2",
+    "progressBar.background": "#689d6a",
+    "list.activeSelectionBackground": "#ebdbb280",
+    "list.activeSelectionForeground": "#427b58",
+    "list.hoverBackground": "#ebdbb280",
+    "list.hoverForeground": "#504945",
+    "list.focusBackground": "#ebdbb2",
+    "list.focusForeground": "#3c3836",
+    "list.inactiveSelectionForeground": "#689d6a",
+    "list.inactiveSelectionBackground": "#ebdbb280",
+    "list.dropBackground": "#ebdbb2",
+    "list.highlightForeground": "#689d6a",
+    "sideBar.background": "#fbf1c7",
+    "sideBar.foreground": "#504945",
+    "sideBar.border": "#ebdbb2",
+    "sideBarTitle.foreground": "#3c3836",
+    "sideBarSectionHeader.background": "#0000",
+    "sideBarSectionHeader.foreground": "#3c3836",
+    "activityBar.background": "#fbf1c7",
+    "activityBar.foreground": "#3c3836",
+    "activityBar.border": "#ebdbb2",
+    "activityBarTop.background": "#fbf1c7",
+    "activityBarTop.foreground": "#3c3836",
+    "activityBarBadge.background": "#458588",
+    "activityBarBadge.foreground": "#ebdbb2",
+    "editorGroup.border": "#ebdbb2",
+    "editorGroup.dropBackground": "#ebdbb260",
+    "editorGroupHeader.noTabsBackground": "#fbf1c7",
+    "editorGroupHeader.tabsBackground": "#fbf1c7",
+    "editorGroupHeader.tabsBorder": "#ebdbb2",
+    "tab.border": "#0000",
+    "tab.activeBorder": "#689d6a",
+    "tab.activeBackground": "#ebdbb2",
+    "tab.activeForeground": "#3c3836",
+    "tab.inactiveForeground": "#7c6f64",
+    "tab.inactiveBackground": "#fbf1c7",
+    "tab.unfocusedActiveForeground": "#7c6f64",
+    "tab.unfocusedActiveBorder": "#0000",
+    "tab.unfocusedInactiveForeground": "#928374",
+    "editor.background": "#fbf1c7",
+    "editor.foreground": "#3c3836",
+    "editorLineNumber.foreground": "#bdae93",
+    "editorCursor.foreground": "#3c3836",
+    "editor.selectionBackground": "#689d6a40",
+    "editor.selectionHighlightBackground": "#b5761440",
+    "editor.hoverHighlightBackground": "#689d6a50",
+    "editorLink.activeForeground": "#3c3836",
+    "editor.findMatchBackground": "#07667870",
+    "editor.findMatchHighlightBackground": "#af3a0330",
+    "editor.findRangeHighlightBackground": "#07667870",
+    "editor.lineHighlightBackground": "#ebdbb260",
+    "editor.lineHighlightBorder": "#0000",
+    "editorWhitespace.foreground": "#7c6f6420",
+    "editorRuler.foreground": "#7c6f6440",
+    "editorCodeLens.foreground": "#7c6f6490",
+    "editorBracketMatch.border": "#0000",
+    "editorBracketMatch.background": "#92837480",
+    "editorHoverWidget.background": "#fbf1c7",
+    "editorHoverWidget.border": "#ebdbb2",
+    "editorOverviewRuler.border": "#0000",
+    "editorOverviewRuler.findMatchForeground": "#665c54",
+    "editorOverviewRuler.rangeHighlightForeground": "#665c54",
+    "editorOverviewRuler.selectionHighlightForeground": "#bdae93",
+    "editorOverviewRuler.wordHighlightForeground": "#bdae93",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#bdae93",
+    "editorOverviewRuler.modifiedForeground": "#076678",
+    "editorOverviewRuler.addedForeground": "#076678",
+    "editorOverviewRuler.deletedForeground": "#076678",
+    "editorOverviewRuler.errorForeground": "#9d0006",
+    "editorOverviewRuler.warningForeground": "#d79921",
+    "editorOverviewRuler.infoForeground": "#8f3f71",
+    "editorGutter.background": "#0000",
+    "editorGutter.modifiedBackground": "#076678",
+    "editorGutter.addedBackground": "#79740e",
+    "editorGutter.deletedBackground": "#9d0006",
+    "editorError.foreground": "#cc241d",
+    "editorWarning.foreground": "#d79921",
+    "editorInfo.foreground": "#458588",
+    "editorIndentGuide.activeBackground": "#bdae93",
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    "editorStickyScroll.shadow": "#d5c4a199",
+    "editorStickyScrollHover.background": "#ebdbb260",
+    "diffEditor.insertedTextBackground": "#79740e30",
+    "diffEditor.removedTextBackground": "#9d000630",
+    "editorWidget.background": "#fbf1c7",
+    "editorWidget.border": "#ebdbb2",
+    "editorSuggestWidget.background": "#fbf1c7",
+    "editorSuggestWidget.foreground": "#3c3836",
+    "editorSuggestWidget.highlightForeground": "#689d6a",
+    "editorSuggestWidget.selectedBackground": "#ebdbb260",
+    "editorSuggestWidget.border": "#ebdbb2",
+    "peekView.border": "#ebdbb2",
+    "peekViewEditor.background": "#ebdbb270",
+    "peekViewEditor.matchHighlightBackground": "#d5c4a1",
+    "peekViewEditorGutter.background": "#ebdbb270",
+    "peekViewResult.background": "#ebdbb270",
+    "peekViewResult.fileForeground": "#3c3836",
+    "peekViewResult.selectionBackground": "#45858820",
+    "peekViewResult.selectionForeground": "#3c3836",
+    "peekViewResult.lineForeground": "#3c3836",
+    "peekViewResult.matchHighlightBackground": "#d5c4a1",
+    "peekViewTitle.background": "#ebdbb270",
+    "peekViewTitleDescription.foreground": "#665c54",
+    "peekViewTitleLabel.foreground": "#3c3836",
+    "merge.currentHeaderBackground": "#45858840",
+    "merge.currentContentBackground": "#45858820",
+    "merge.incomingHeaderBackground": "#689d6a40",
+    "merge.incomingContentBackground": "#689d6a20",
+    "merge.border": "#0000",
+    "editorOverviewRuler.currentContentForeground": "#458588",
+    "editorOverviewRuler.incomingContentForeground": "#689d6a",
+    "editorOverviewRuler.commonContentForeground": "#928374",
+    "panel.border": "#ebdbb2",
+    "panelTitle.activeForeground": "#3c3836",
+    "statusBar.background": "#fbf1c7",
+    "statusBar.border": "#ebdbb2",
+    "statusBar.foreground": "#3c3836",
+    "statusBar.debuggingBackground": "#af3a03",
+    "statusBar.debuggingForeground": "#fbf1c7",
+    "statusBar.debuggingBorder": "#0000",
+    "statusBar.noFolderBackground": "#fbf1c7",
+    "statusBar.noFolderBorder": "#0000",
+    "terminal.ansiBlack": "#ebdbb2",
+    "terminal.ansiBrightBlack": "#928374",
+    "terminal.ansiRed": "#cc241d",
+    "terminal.ansiBrightRed": "#9d0006",
+    "terminal.ansiGreen": "#98971a",
+    "terminal.ansiBrightGreen": "#79740e",
+    "terminal.ansiYellow": "#d79921",
+    "terminal.ansiBrightYellow": "#b57614",
+    "terminal.ansiBlue": "#458588",
+    "terminal.ansiBrightBlue": "#076678",
+    "terminal.ansiMagenta": "#b16286",
+    "terminal.ansiBrightMagenta": "#8f3f71",
+    "terminal.ansiCyan": "#689d6a",
+    "terminal.ansiBrightCyan": "#427b58",
+    "terminal.ansiWhite": "#7c6f64",
+    "terminal.ansiBrightWhite": "#3c3836",
+    "terminal.foreground": "#3c3836",
+    "terminal.background": "#fbf1c7",
+    "titleBar.activeBackground": "#fbf1c7",
+    "titleBar.activeForeground": "#3c3836",
+    "titleBar.inactiveBackground": "#fbf1c7",
+    "gitDecoration.modifiedResourceForeground": "#d79921",
+    "gitDecoration.deletedResourceForeground": "#cc241d",
+    "gitDecoration.untrackedResourceForeground": "#98971a",
+    "gitDecoration.ignoredResourceForeground": "#a89984",
+    "gitDecoration.conflictingResourceForeground": "#b16286",
+    "scmGraph.historyItemHoverLabelForeground": "#ebdbb2",
+    "scmGraph.historyItemHoverDefaultLabelForeground": "#ebdbb2",
+    "menu.border": "#ebdbb2",
+    "menu.separatorBackground": "#ebdbb2",
+    "extensionButton.prominentBackground": "#79740e80",
+    "extensionButton.prominentHoverBackground": "#79740e30",
+    "textLink.foreground": "#076678",
+    "textLink.activeForeground": "#458588",
+    "debugToolBar.background": "#fbf1c7",
+    "editorGhostText.background": "#bdae9360",
+    "notebook.cellEditorBackground": "#ebdbb2",
+    "notebook.focusedCellBorder": "#7c6f64",
+    "notebook.cellBorderColor": "#d5c4a1",
+    "notebook.focusedEditorBorder": "#d5c4a1",
+    "gitlens.closedAutolinkedIssueIconColor": "#b16286",
+    "gitlens.closedPullRequestIconColor": "#cc241d",
+    "gitDecoration.addedResourceForeground": "#3c3836",
+    "gitlens.decorations.branchAheadForegroundColor": "#98971a",
+    "gitlens.decorations.branchBehindForegroundColor": "#d65d0e",
+    "gitlens.decorations.branchDivergedForegroundColor": "#d79921",
+    "gitlens.decorations.branchMissingUpstreamForegroundColor": "#cc241d",
+    "gitlens.decorations.statusMergingOrRebasingConflictForegroundColor": "#cc241d",
+    "gitlens.decorations.statusMergingOrRebasingForegroundColor": "#d79921",
+    "gitlens.decorations.workspaceCurrentForegroundColor": "#98971a",
+    "gitlens.decorations.workspaceRepoMissingForegroundColor": "#a89984",
+    "gitlens.decorations.workspaceRepoOpenForegroundColor": "#98971a",
+    "gitlens.decorations.worktreeHasUncommittedChangesForegroundColor": "#928374",
+    "gitlens.decorations.worktreeMissingForegroundColor": "#cc241d",
+    "gitlens.graphChangesColumnAddedColor": "#98971a",
+    "gitlens.graphChangesColumnDeletedColor": "#cc241d",
+    "gitlens.graphLane1Color": "#076678",
+    "gitlens.graphLane2Color": "#458588",
+    "gitlens.graphLane3Color": "#8f3f71",
+    "gitlens.graphLane4Color": "#b16286",
+    "gitlens.graphLane5Color": "#427b58",
+    "gitlens.graphLane6Color": "#689d6a",
+    "gitlens.graphLane7Color": "#b57614",
+    "gitlens.graphLane8Color": "#d79921",
+    "gitlens.graphLane9Color": "#79740e",
+    "gitlens.graphLane10Color": "#98971a",
+    "gitlens.graphMinimapMarkerHeadColor": "#98971a",
+    "gitlens.graphMinimapMarkerHighlightsColor": "#79740e",
+    "gitlens.graphMinimapMarkerLocalBranchesColor": "#076678",
+    "gitlens.graphMinimapMarkerPullRequestsColor": "#af3a03",
+    "gitlens.graphMinimapMarkerRemoteBranchesColor": "#458588",
+    "gitlens.graphMinimapMarkerStashesColor": "#b16286",
+    "gitlens.graphMinimapMarkerTagsColor": "#a89984",
+    "gitlens.graphMinimapMarkerUpstreamColor": "#689d6a",
+    "gitlens.graphScrollMarkerHeadColor": "#79740e",
+    "gitlens.graphScrollMarkerHighlightsColor": "#d79921",
+    "gitlens.graphScrollMarkerLocalBranchesColor": "#076678",
+    "gitlens.graphScrollMarkerPullRequestsColor": "#af3a03",
+    "gitlens.graphScrollMarkerRemoteBranchesColor": "#458588",
+    "gitlens.graphScrollMarkerStashesColor": "#b16286",
+    "gitlens.graphScrollMarkerTagsColor": "#a89984",
+    "gitlens.graphScrollMarkerUpstreamColor": "#427b58",
+    "gitlens.gutterBackgroundColor": "#ebdbb2",
+    "gitlens.gutterForegroundColor": "#3c3836",
+    "gitlens.gutterUncommittedForegroundColor": "#458588",
+    "gitlens.launchpadIndicatorAttentionColor": "#b57614",
+    "gitlens.launchpadIndicatorAttentionHoverColor": "#d79921",
+    "gitlens.launchpadIndicatorBlockedColor": "#9d0006",
+    "gitlens.launchpadIndicatorBlockedHoverColor": "#cc241d",
+    "gitlens.launchpadIndicatorMergeableColor": "#79740e",
+    "gitlens.launchpadIndicatorMergeableHoverColor": "#98971a",
+    "gitlens.lineHighlightBackgroundColor": "#ebdbb2",
+    "gitlens.lineHighlightOverviewRulerColor": "#458588",
+    "gitlens.mergedPullRequestIconColor": "#b16286",
+    "gitlens.openAutolinkedIssueIconColor": "#98971a",
+    "gitlens.openPullRequestIconColor": "#98971a",
+    "gitlens.trailingLineBackgroundColor": "#fbf1c7a0",
+    "gitlens.trailingLineForegroundColor": "#928374a0",
+    "gitlens.unpublishedChangesIconColor": "#98971a",
+    "gitlens.unpublishedCommitIconColor": "#98971a",
+    "gitlens.unpulledChangesIconColor": "#af3a03"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "header",
+      "settings": {
+        "foreground": "#458588"
+      }
+    },
+    {
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#928374",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "support.constant",
+        "variable.arguments"
+      ],
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": "constant.rgb-value",
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": "entity.name.selector",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag",
+        "punctuation.tag"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
+      "settings": {
+        "foreground": "#cc241d"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#b16286"
+      }
+    },
+    {
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "meta.preprocessor",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.string",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.numeric",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "meta.header.diff",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": [
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "string",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "string.tag",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "string.value",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "string.escape",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": "string.quasi",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "string.entity",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "object",
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": "module.node",
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": "keyword.control.module",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "keyword.control.less",
+      "settings": {
+        "foreground": "#d79921"
+      }
+    },
+    {
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "keyword.operator.new",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "metatag.php",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "support.function.git-rebase",
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "constant.sha.git-rebase",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "name": "Types declaration and references",
+      "scope": [
+        "meta.type.name",
+        "meta.return.type",
+        "meta.return-type",
+        "meta.cast",
+        "meta.type.annotation",
+        "support.type",
+        "storage.type.cs",
+        "variable.class"
+      ],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": [
+        "variable.this",
+        "support.variable"
+      ],
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": [
+        "entity.name",
+        "entity.static",
+        "entity.name.class.static.function",
+        "entity.name.function",
+        "entity.name.class",
+        "entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "Function declarations",
+      "scope": [
+        "entity.function",
+        "entity.name.function.static"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "entity.name.function.function-call",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "support.function.builtin",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.method",
+        "entity.name.method.function-call",
+        "entity.name.static.function-call"
+      ],
+      "settings": {
+        "foreground": "#689d6a"
+      }
+    },
+    {
+      "scope": "brace",
+      "settings": {
+        "foreground": "#504945"
+      }
+    },
+    {
+      "name": "variables",
+      "scope": [
+        "meta.parameter.type.variable",
+        "variable.parameter",
+        "variable.name",
+        "variable.other",
+        "variable",
+        "string.constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": "prototype",
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": [
+        "punctuation"
+      ],
+      "settings": {
+        "foreground": "#7c6f64"
+      }
+    },
+    {
+      "scope": "punctuation.quoted",
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": "punctuation.quasi",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "name": "URL",
+      "scope": [
+        "*url*",
+        "*link*",
+        "*uri*"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "Python function",
+      "scope": [
+        "meta.function.python",
+        "entity.name.function.python"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "name": "Python Function and Class definition keywords",
+      "scope": [
+        "storage.type.function.python",
+        "storage.modifier.declaration",
+        "storage.type.class.python",
+        "storage.type.string.python"
+      ],
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "name": "Async keyword",
+      "scope": [
+        "storage.type.function.async.python"
+      ],
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "name": "Python Function Call",
+      "scope": "meta.function-call.generic",
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "name": "Python Function Arguments",
+      "scope": "meta.function-call.arguments",
+      "settings": {
+        "foreground": "#504945"
+      }
+    },
+    {
+      "name": "Python Function decorator",
+      "scope": "entity.name.function.decorator",
+      "settings": {
+        "foreground": "#b57614",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Python ALL CAPS",
+      "scope": "constant.other.caps",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "keyword.operator.logical",
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": "punctuation.definition.logical-expression",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": [
+        "string.interpolated.dollar.shell",
+        "string.interpolated.backtick.shell"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "keyword.control.directive",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "support.function.C99",
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "C# functions & namespace",
+      "scope": [
+        "meta.function.cs",
+        "entity.name.function.cs",
+        "entity.name.type.namespace.cs"
+      ],
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "name": "C# Variables",
+      "scope": [
+        "keyword.other.using.cs",
+        "entity.name.variable.field.cs",
+        "entity.name.variable.local.cs",
+        "variable.other.readwrite.cs"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "name": "C# This",
+      "scope": [
+        "keyword.other.this.cs",
+        "keyword.other.base.cs"
+      ],
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": "meta.scope.prerequisites",
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": "entity.name.function.target",
+      "settings": {
+        "foreground": "#79740e",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "coloring of the Java import and package identifiers",
+      "scope": [
+        "storage.modifier.import.java",
+        "storage.modifier.package.java"
+      ],
+      "settings": {
+        "foreground": "#665c54"
+      }
+    },
+    {
+      "scope": [
+        "keyword.other.import.java",
+        "keyword.other.package.java"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "storage.type.java",
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": "storage.type.annotation",
+      "settings": {
+        "foreground": "#076678",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "keyword.other.documentation.javadoc",
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "comment.block.javadoc variable.parameter.java",
+      "settings": {
+        "foreground": "#79740e",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "source.java variable.other.object",
+        "source.java variable.other.definition.java"
+      ],
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "name": "Lisp optional function parameters",
+      "scope": "meta.function-parameters.lisp",
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "string.other.link.title.markdown",
+      "settings": {
+        "foreground": "#928374",
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "markup.underline.link",
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "heading.1.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "scope": "heading.2.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "heading.3.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": "heading.4.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "heading.5.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": "heading.6.markdown entity.name.section.markdown",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#d65d0e"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "markup.punctuation.quote.beginning",
+      "settings": {
+        "foreground": "#98971a"
+      }
+    },
+    {
+      "scope": "markup.punctuation.list.beginning",
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": [
+        "markup.inline.raw",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": "string.quoted.double.json",
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.css",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "source.css meta.selector",
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": "support.type.property-name.css",
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name.class",
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": [
+        "source.css support.function.transform",
+        "source.css support.function.timing-function",
+        "source.css support.function.misc"
+      ],
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "name": "CSS property value",
+      "scope": [
+        "support.property-value",
+        "constant.rgb-value",
+        "support.property-value.scss",
+        "constant.rgb-value.scss"
+      ],
+      "settings": {
+        "foreground": "#d65d0e"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.tag.css"
+      ],
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.tag"
+      ],
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": [
+        "text.html entity.name.tag",
+        "text.html punctuation.tag"
+      ],
+      "settings": {
+        "foreground": "#427b58",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": [
+        "source.js variable.language"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": [
+        "source.ts variable.language"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.import"
+      ],
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "scope": [
+        "source.go keyword.package",
+        "source.go keyword.import"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "scope": [
+        "source.go keyword.interface",
+        "source.go keyword.struct"
+      ],
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.type"
+      ],
+      "settings": {
+        "foreground": "#3c3836"
+      }
+    },
+    {
+      "scope": [
+        "source.go entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "scope": [
+        "keyword.control.cucumber.table"
+      ],
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "name": "ReasonML String",
+      "scope": [
+        "source.reason string.double",
+        "source.reason string.regexp"
+      ],
+      "settings": {
+        "foreground": "#79740e"
+      }
+    },
+    {
+      "name": "ReasonML equals sign",
+      "scope": [
+        "source.reason keyword.control.less"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    },
+    {
+      "name": "ReasonML variable",
+      "scope": [
+        "source.reason entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#076678"
+      }
+    },
+    {
+      "name": "ReasonML property",
+      "scope": [
+        "source.reason support.property-value",
+        "source.reason entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "Powershell member",
+      "scope": [
+        "source.powershell variable.other.member.powershell"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": [
+        "source.powershell support.function.powershell"
+      ],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": [
+        "source.powershell support.function.attribute.powershell"
+      ],
+      "settings": {
+        "foreground": "#665c54"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "LaTeX functions",
+      "scope": [
+        "support.function.be.latex",
+        "support.function.general.tex",
+        "support.function.section.latex",
+        "support.function.textbf.latex",
+        "support.function.textit.latex",
+        "support.function.texttt.latex",
+        "support.function.emph.latex",
+        "support.function.url.latex"
+      ],
+      "settings": {
+        "foreground": "#9d0006"
+      }
+    },
+    {
+      "name": "LaTeX text in math environment",
+      "scope": [
+        "support.class.math.block.tex",
+        "support.class.math.block.environment.latex"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "LaTeX preamble",
+      "scope": [
+        "keyword.control.preamble.latex",
+        "keyword.control.include.latex"
+      ],
+      "settings": {
+        "foreground": "#8f3f71"
+      }
+    },
+    {
+      "name": "LaTeX packages",
+      "scope": [
+        "support.class.latex"
+      ],
+      "settings": {
+        "foreground": "#427b58"
+      }
+    }
+  ]
+}

--- a/themes/light-modern.json
+++ b/themes/light-modern.json
@@ -1,0 +1,747 @@
+{
+  "name": "Light Modern",
+  "type": "light",
+  "colors": {
+    "checkbox.border": "#CECECE",
+    "editor.background": "#FFFFFF",
+    "editor.foreground": "#3B3B3B",
+    "editor.inactiveSelectionBackground": "#E5EBF1",
+    "editorIndentGuide.background1": "#D3D3D3",
+    "editorIndentGuide.activeBackground1": "#939393",
+    "editor.selectionHighlightBackground": "#ADD6FF80",
+    "editorSuggestWidget.background": "#F8F8F8",
+    "activityBarBadge.background": "#005FB8",
+    "sideBarTitle.foreground": "#3B3B3B",
+    "list.hoverBackground": "#F2F2F2",
+    "menu.border": "#CECECE",
+    "input.placeholderForeground": "#767676",
+    "searchEditor.textInputBorder": "#CECECE",
+    "settings.textInputBorder": "#CECECE",
+    "settings.numberInputBorder": "#CECECE",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.remoteBackground": "#005FB8",
+    "ports.iconRunningProcessForeground": "#369432",
+    "sideBarSectionHeader.background": "#F8F8F8",
+    "sideBarSectionHeader.border": "#E5E5E5",
+    "tab.selectedForeground": "#333333",
+    "tab.selectedBackground": "#E4E6F1",
+    "tab.lastPinnedBorder": "#D4D4D4",
+    "notebook.cellBorderColor": "#E5E5E5",
+    "notebook.selectedCellBackground": "#C8DDF150",
+    "statusBarItem.errorBackground": "#C72E0F",
+    "list.activeSelectionIconForeground": "#000000",
+    "list.focusAndSelectionOutline": "#005FB8",
+    "terminal.inactiveSelectionBackground": "#E5EBF1",
+    "widget.border": "#E5E5E5",
+    "actionBar.toggledBackground": "#dddddd",
+    "diffEditor.unchangedRegionBackground": "#f8f8f8",
+    "agentsNewSessionButton.border": "#D8D8D8",
+    "agentsChatInput.border": "#D8D8D8",
+    "surface.border": "#E0E0E0",
+    "modernActivityBar.activeBackground": "#e4e6f1",
+    "modernActivityBar.hoverBackground": "#F2F2F2",
+    "modernActivityBar.activeForeground": "#3B3B3B",
+    "modernActivityBar.hoverForeground": "#3B3B3B",
+    "activityBar.activeBorder": "#005FB8",
+    "activityBar.background": "#F8F8F8",
+    "activityBar.border": "#E5E5E5",
+    "activityBar.foreground": "#1F1F1F",
+    "activityBar.inactiveForeground": "#616161",
+    "activityBarBadge.foreground": "#FFFFFF",
+    "badge.background": "#CCCCCC",
+    "badge.foreground": "#3B3B3B",
+    "button.background": "#005FB8",
+    "button.border": "#0000001a",
+    "button.foreground": "#FFFFFF",
+    "button.hoverBackground": "#0258A8",
+    "button.secondaryBackground": "#E5E5E5",
+    "button.secondaryForeground": "#3B3B3B",
+    "button.secondaryHoverBackground": "#CCCCCC",
+    "chat.slashCommandBackground": "#ADCEFF7A",
+    "chat.slashCommandForeground": "#26569E",
+    "chat.editedFileForeground": "#895503",
+    "checkbox.background": "#F8F8F8",
+    "descriptionForeground": "#3B3B3B",
+    "dropdown.background": "#FFFFFF",
+    "dropdown.border": "#CECECE",
+    "dropdown.foreground": "#3B3B3B",
+    "dropdown.listBackground": "#FFFFFF",
+    "editorGroup.border": "#E5E5E5",
+    "editorGroupHeader.tabsBackground": "#F8F8F8",
+    "editorGroupHeader.tabsBorder": "#E5E5E5",
+    "editorGutter.addedBackground": "#2EA043",
+    "editorGutter.deletedBackground": "#F85149",
+    "editorGutter.modifiedBackground": "#005FB8",
+    "editorLineNumber.activeForeground": "#171184",
+    "editorLineNumber.foreground": "#6E7681",
+    "editorOverviewRuler.border": "#E5E5E5",
+    "editorWidget.background": "#F8F8F8",
+    "errorForeground": "#F85149",
+    "focusBorder": "#005FB8",
+    "foreground": "#3B3B3B",
+    "icon.foreground": "#3B3B3B",
+    "input.background": "#FFFFFF",
+    "input.border": "#CECECE",
+    "input.foreground": "#3B3B3B",
+    "inputOption.activeBackground": "#BED6ED",
+    "inputOption.activeBorder": "#005FB8",
+    "inputOption.activeForeground": "#000000",
+    "keybindingLabel.foreground": "#3B3B3B",
+    "list.activeSelectionBackground": "#E8E8E8",
+    "list.activeSelectionForeground": "#000000",
+    "menu.selectionBackground": "#005FB8",
+    "menu.selectionForeground": "#ffffff",
+    "notificationCenterHeader.background": "#FFFFFF",
+    "notificationCenterHeader.foreground": "#3B3B3B",
+    "notifications.background": "#FFFFFF",
+    "notifications.border": "#E5E5E5",
+    "notifications.foreground": "#3B3B3B",
+    "panel.background": "#F8F8F8",
+    "panel.border": "#E5E5E5",
+    "panelInput.border": "#E5E5E5",
+    "panelTitle.activeBorder": "#005FB8",
+    "panelTitle.activeForeground": "#3B3B3B",
+    "panelTitle.inactiveForeground": "#3B3B3B",
+    "peekViewEditor.matchHighlightBackground": "#BB800966",
+    "peekViewResult.background": "#FFFFFF",
+    "peekViewResult.matchHighlightBackground": "#BB800966",
+    "pickerGroup.border": "#E5E5E5",
+    "pickerGroup.foreground": "#8B949E",
+    "progressBar.background": "#005FB8",
+    "quickInput.background": "#F8F8F8",
+    "quickInput.foreground": "#3B3B3B",
+    "settings.dropdownBackground": "#FFFFFF",
+    "settings.dropdownBorder": "#CECECE",
+    "settings.headerForeground": "#1F1F1F",
+    "settings.modifiedItemIndicator": "#BB800966",
+    "sideBar.background": "#F8F8F8",
+    "sideBar.border": "#E5E5E5",
+    "sideBar.foreground": "#3B3B3B",
+    "sideBarSectionHeader.foreground": "#3B3B3B",
+    "statusBar.background": "#F8F8F8",
+    "statusBar.foreground": "#3B3B3B",
+    "statusBar.border": "#E5E5E5",
+    "statusBarItem.hoverBackground": "#1F1F1F11",
+    "statusBarItem.hoverForeground": "#000000",
+    "statusBarItem.compactHoverBackground": "#CCCCCC",
+    "statusBar.debuggingBackground": "#FD716C",
+    "statusBar.debuggingForeground": "#000000",
+    "statusBar.focusBorder": "#005FB8",
+    "statusBar.noFolderBackground": "#F8F8F8",
+    "statusBarItem.focusBorder": "#005FB8",
+    "statusBarItem.prominentBackground": "#6E768166",
+    "tab.activeBackground": "#FFFFFF",
+    "tab.activeBorder": "#F8F8F8",
+    "tab.activeBorderTop": "#005FB8",
+    "tab.activeForeground": "#3B3B3B",
+    "tab.selectedBorderTop": "#68a3da",
+    "tab.border": "#E5E5E5",
+    "tab.hoverBackground": "#FFFFFF",
+    "tab.inactiveBackground": "#F8F8F8",
+    "tab.inactiveForeground": "#868686",
+    "tab.unfocusedActiveBorder": "#F8F8F8",
+    "tab.unfocusedActiveBorderTop": "#E5E5E5",
+    "tab.unfocusedHoverBackground": "#F8F8F8",
+    "terminalCursor.foreground": "#005FB8",
+    "terminal.foreground": "#3B3B3B",
+    "terminal.tab.activeBorder": "#005FB8",
+    "textBlockQuote.background": "#F8F8F8",
+    "textBlockQuote.border": "#E5E5E5",
+    "textCodeBlock.background": "#F8F8F8",
+    "textLink.activeForeground": "#005FB8",
+    "textLink.foreground": "#005FB8",
+    "textPreformat.foreground": "#3B3B3B",
+    "textPreformat.background": "#0000001F",
+    "textSeparator.foreground": "#21262D",
+    "titleBar.activeBackground": "#F8F8F8",
+    "titleBar.activeForeground": "#1E1E1E",
+    "titleBar.border": "#E5E5E5",
+    "titleBar.inactiveBackground": "#F8F8F8",
+    "titleBar.inactiveForeground": "#8B949E",
+    "welcomePage.tileBackground": "#F3F3F3"
+  },
+  "tokenColors": [
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#000000ff"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#000080"
+      }
+    },
+    {
+      "scope": "comment",
+      "settings": {
+        "foreground": "#008000"
+      }
+    },
+    {
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "variable.other.enummember",
+        "keyword.operator.plus.exponent",
+        "keyword.operator.minus.exponent"
+      ],
+      "settings": {
+        "foreground": "#098658"
+      }
+    },
+    {
+      "scope": "constant.regexp",
+      "settings": {
+        "foreground": "#811f3f"
+      }
+    },
+    {
+      "name": "css tags in selectors, xml tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": "entity.name.selector",
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#e50000"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name.class.css",
+        "source.css entity.other.attribute-name.class",
+        "entity.other.attribute-name.id.css",
+        "entity.other.attribute-name.parent-selector.css",
+        "entity.other.attribute-name.parent.less",
+        "source.css entity.other.attribute-name.pseudo-class",
+        "entity.other.attribute-name.pseudo-element.css",
+        "source.css.less entity.other.attribute-name.id",
+        "entity.other.attribute-name.scss"
+      ],
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#cd3131"
+      }
+    },
+    {
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#000080"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#800080"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#098658"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#a31515"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.quote.begin.markdown",
+        "punctuation.definition.list.begin.markdown"
+      ],
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "name": "brackets of XML/HTML tags",
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": [
+        "meta.preprocessor",
+        "entity.name.function.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.string",
+      "settings": {
+        "foreground": "#a31515"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.numeric",
+      "settings": {
+        "foreground": "#098658"
+      }
+    },
+    {
+      "scope": "meta.structure.dictionary.key.python",
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "storage.type",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier",
+        "keyword.operator.noexcept"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "meta.embedded.assembly"
+      ],
+      "settings": {
+        "foreground": "#a31515"
+      }
+    },
+    {
+      "scope": [
+        "string.comment.buffered.block.pug",
+        "string.quoted.pug",
+        "string.interpolated.pug",
+        "string.unquoted.plain.in.yaml",
+        "string.unquoted.plain.out.yaml",
+        "string.unquoted.block.yaml",
+        "string.quoted.single.yaml",
+        "string.quoted.double.xml",
+        "string.quoted.single.xml",
+        "string.unquoted.cdata.xml",
+        "string.quoted.double.html",
+        "string.quoted.single.html",
+        "string.unquoted.html",
+        "string.quoted.single.handlebars",
+        "string.quoted.double.handlebars"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#811f3f"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "support.constant.property-value",
+        "support.constant.font-name",
+        "support.constant.media-type",
+        "support.constant.media",
+        "constant.other.color.rgb-value",
+        "constant.other.rgb-value",
+        "support.constant.color"
+      ],
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": [
+        "support.type.vendored.property-name",
+        "support.type.property-name",
+        "source.css variable",
+        "source.coffee.embedded"
+      ],
+      "settings": {
+        "foreground": "#e50000"
+      }
+    },
+    {
+      "scope": [
+        "support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.cast",
+        "keyword.operator.sizeof",
+        "keyword.operator.alignof",
+        "keyword.operator.typeid",
+        "keyword.operator.alignas",
+        "keyword.operator.instanceof",
+        "keyword.operator.logical.python",
+        "keyword.operator.wordlike"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#098658"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "punctuation.section.embedded.end.php"
+      ],
+      "settings": {
+        "foreground": "#800000"
+      }
+    },
+    {
+      "scope": "support.function.git-rebase",
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "scope": "constant.sha.git-rebase",
+      "settings": {
+        "foreground": "#098658"
+      }
+    },
+    {
+      "name": "coloring of the Java import and package identifiers",
+      "scope": [
+        "storage.modifier.import.java",
+        "variable.language.wildcard.java",
+        "storage.modifier.package.java"
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "name": "this.self",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "name": "Function declarations",
+      "scope": [
+        "entity.name.function",
+        "support.function",
+        "support.constant.handlebars",
+        "source.powershell variable.other.member",
+        "entity.name.operator.custom-literal"
+      ],
+      "settings": {
+        "foreground": "#795E26"
+      }
+    },
+    {
+      "name": "Types declaration and references",
+      "scope": [
+        "support.class",
+        "support.type",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.other.attribute",
+        "entity.name.scope-resolution",
+        "entity.name.class",
+        "storage.type.numeric.go",
+        "storage.type.byte.go",
+        "storage.type.boolean.go",
+        "storage.type.string.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "storage.type.cs",
+        "storage.type.generic.cs",
+        "storage.type.modifier.cs",
+        "storage.type.variable.cs",
+        "storage.type.annotation.java",
+        "storage.type.generic.java",
+        "storage.type.java",
+        "storage.type.object.array.java",
+        "storage.type.primitive.array.java",
+        "storage.type.primitive.java",
+        "storage.type.token.java",
+        "storage.type.groovy",
+        "storage.type.annotation.groovy",
+        "storage.type.parameters.groovy",
+        "storage.type.generic.groovy",
+        "storage.type.object.array.groovy",
+        "storage.type.primitive.array.groovy",
+        "storage.type.primitive.groovy"
+      ],
+      "settings": {
+        "foreground": "#267f99"
+      }
+    },
+    {
+      "name": "Types declaration and references, TS grammar specific",
+      "scope": [
+        "meta.type.cast.expr",
+        "meta.type.new.expr",
+        "support.constant.math",
+        "support.constant.dom",
+        "support.constant.json",
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "foreground": "#267f99"
+      }
+    },
+    {
+      "name": "Control flow / Special keywords",
+      "scope": [
+        "keyword.control",
+        "source.cpp keyword.operator.new",
+        "source.cpp keyword.operator.delete",
+        "keyword.other.using",
+        "keyword.other.directive.using",
+        "keyword.other.operator",
+        "entity.name.operator"
+      ],
+      "settings": {
+        "foreground": "#AF00DB"
+      }
+    },
+    {
+      "name": "Variable and parameter name",
+      "scope": [
+        "variable",
+        "meta.definition.variable.name",
+        "support.variable",
+        "entity.name.variable",
+        "constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#001080"
+      }
+    },
+    {
+      "name": "Constants and enums",
+      "scope": [
+        "variable.other.constant",
+        "variable.other.enummember"
+      ],
+      "settings": {
+        "foreground": "#0070C1"
+      }
+    },
+    {
+      "name": "Object keys, TS grammar specific",
+      "scope": [
+        "meta.object-literal.key"
+      ],
+      "settings": {
+        "foreground": "#001080"
+      }
+    },
+    {
+      "name": "CSS property value",
+      "scope": [
+        "support.constant.property-value",
+        "support.constant.font-name",
+        "support.constant.media-type",
+        "support.constant.media",
+        "constant.other.color.rgb-value",
+        "constant.other.rgb-value",
+        "support.constant.color"
+      ],
+      "settings": {
+        "foreground": "#0451a5"
+      }
+    },
+    {
+      "name": "Regular expression groups",
+      "scope": [
+        "punctuation.definition.group.regexp",
+        "punctuation.definition.group.assertion.regexp",
+        "punctuation.definition.character-class.regexp",
+        "punctuation.character.set.begin.regexp",
+        "punctuation.character.set.end.regexp",
+        "keyword.operator.negation.regexp",
+        "support.other.parenthesis.regexp"
+      ],
+      "settings": {
+        "foreground": "#d16969"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.character-class.regexp",
+        "constant.other.character-class.set.regexp",
+        "constant.other.character-class.regexp",
+        "constant.character.set.regexp"
+      ],
+      "settings": {
+        "foreground": "#811f3f"
+      }
+    },
+    {
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.or.regexp",
+        "keyword.control.anchor.regexp"
+      ],
+      "settings": {
+        "foreground": "#EE0000"
+      }
+    },
+    {
+      "scope": [
+        "constant.character",
+        "constant.other.option"
+      ],
+      "settings": {
+        "foreground": "#0000ff"
+      }
+    },
+    {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#EE0000"
+      }
+    },
+    {
+      "scope": "entity.name.label",
+      "settings": {
+        "foreground": "#000000"
+      }
+    }
+  ]
+}

--- a/themes/monokai.json
+++ b/themes/monokai.json
@@ -1,0 +1,491 @@
+{
+  "name": "monokai",
+  "type": "dark",
+  "colors": {
+    "dropdown.background": "#414339",
+    "list.activeSelectionBackground": "#75715E",
+    "quickInputList.focusBackground": "#414339",
+    "dropdown.listBackground": "#1e1f1c",
+    "list.inactiveSelectionBackground": "#414339",
+    "list.hoverBackground": "#3e3d32",
+    "list.dropBackground": "#414339",
+    "list.highlightForeground": "#f8f8f2",
+    "button.background": "#75715E",
+    "editor.background": "#272822",
+    "editor.foreground": "#f8f8f2",
+    "selection.background": "#878b9180",
+    "editor.selectionHighlightBackground": "#575b6180",
+    "editor.selectionBackground": "#878b9180",
+    "minimap.selectionHighlight": "#878b9180",
+    "editor.wordHighlightBackground": "#4a4a7680",
+    "editor.wordHighlightStrongBackground": "#6a6a9680",
+    "editor.lineHighlightBackground": "#3e3d32",
+    "editorLineNumber.activeForeground": "#c2c2bf",
+    "editorCursor.foreground": "#f8f8f0",
+    "editorWhitespace.foreground": "#464741",
+    "editorIndentGuide.background": "#464741",
+    "editorIndentGuide.activeBackground": "#767771",
+    "editorGroupHeader.tabsBackground": "#1e1f1c",
+    "editorGroup.dropBackground": "#41433980",
+    "tab.inactiveBackground": "#34352f",
+    "tab.border": "#1e1f1c",
+    "tab.inactiveForeground": "#ccccc7",
+    "tab.lastPinnedBorder": "#414339",
+    "widget.shadow": "#00000098",
+    "progressBar.background": "#75715E",
+    "badge.background": "#75715E",
+    "badge.foreground": "#f8f8f2",
+    "editorLineNumber.foreground": "#90908a",
+    "panelTitle.activeForeground": "#f8f8f2",
+    "panelTitle.activeBorder": "#75715E",
+    "panelTitle.inactiveForeground": "#75715E",
+    "panel.border": "#414339",
+    "settings.focusedRowBackground": "#4143395A",
+    "titleBar.activeBackground": "#1e1f1c",
+    "statusBar.background": "#414339",
+    "statusBar.noFolderBackground": "#414339",
+    "statusBar.debuggingBackground": "#75715E",
+    "statusBarItem.remoteBackground": "#AC6218",
+    "ports.iconRunningProcessForeground": "#ccccc7",
+    "activityBar.background": "#272822",
+    "activityBar.foreground": "#f8f8f2",
+    "sideBar.background": "#1e1f1c",
+    "sideBarSectionHeader.background": "#272822",
+    "menu.background": "#1e1f1c",
+    "menu.foreground": "#cccccc",
+    "pickerGroup.foreground": "#75715E",
+    "input.background": "#414339",
+    "inputOption.activeBorder": "#75715E",
+    "focusBorder": "#99947c",
+    "agentsPanel.border": "#414339",
+    "agentsChatInput.border": "#414339",
+    "agentsChatInput.focusBorder": "#99947c",
+    "agentsNewSessionButton.border": "#414339",
+    "editorWidget.background": "#1e1f1c",
+    "debugToolBar.background": "#1e1f1c",
+    "diffEditor.insertedTextBackground": "#4b661680",
+    "diffEditor.removedTextBackground": "#90274A70",
+    "inputValidation.errorBackground": "#90274A",
+    "inputValidation.errorBorder": "#f92672",
+    "inputValidation.warningBackground": "#848528",
+    "inputValidation.warningBorder": "#e2e22e",
+    "inputValidation.infoBackground": "#546190",
+    "inputValidation.infoBorder": "#819aff",
+    "editorHoverWidget.background": "#414339",
+    "editorHoverWidget.border": "#75715E",
+    "editorSuggestWidget.background": "#272822",
+    "editorSuggestWidget.border": "#75715E",
+    "editorGroup.border": "#34352f",
+    "peekView.border": "#75715E",
+    "peekViewEditor.background": "#272822",
+    "peekViewResult.background": "#1e1f1c",
+    "peekViewTitle.background": "#1e1f1c",
+    "peekViewResult.selectionBackground": "#414339",
+    "peekViewResult.matchHighlightBackground": "#75715E",
+    "peekViewEditor.matchHighlightBackground": "#75715E",
+    "terminal.ansiBlack": "#333333",
+    "terminal.ansiRed": "#C4265E",
+    "terminal.ansiGreen": "#86B42B",
+    "terminal.ansiYellow": "#B3B42B",
+    "terminal.ansiBlue": "#6A7EC8",
+    "terminal.ansiMagenta": "#8C6BC8",
+    "terminal.ansiCyan": "#56ADBC",
+    "terminal.ansiWhite": "#e3e3dd",
+    "terminal.ansiBrightBlack": "#666666",
+    "terminal.ansiBrightRed": "#f92672",
+    "terminal.ansiBrightGreen": "#A6E22E",
+    "terminal.ansiBrightYellow": "#e2e22e",
+    "terminal.ansiBrightBlue": "#819aff",
+    "terminal.ansiBrightMagenta": "#AE81FF",
+    "terminal.ansiBrightCyan": "#66D9EF",
+    "terminal.ansiBrightWhite": "#f8f8f2",
+    "surface.border": "#272822"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Comment",
+      "scope": "comment",
+      "settings": {
+        "foreground": "#88846f"
+      }
+    },
+    {
+      "name": "String",
+      "scope": "string",
+      "settings": {
+        "foreground": "#E6DB74"
+      }
+    },
+    {
+      "name": "Template Definition",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#AE81FF"
+      }
+    },
+    {
+      "name": "Built-in constant",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#AE81FF"
+      }
+    },
+    {
+      "name": "User-defined constant",
+      "scope": "constant.character, constant.other",
+      "settings": {
+        "foreground": "#AE81FF"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": "variable",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#F8F8F2"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "Storage type",
+      "scope": "storage.type",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#66D9EF"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.type, entity.name.class, entity.name.namespace, entity.name.scope-resolution",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "Inherited class",
+      "scope": [
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "fontStyle": "italic underline",
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "Function name",
+      "scope": "entity.name.function",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "Function argument",
+      "scope": "variable.parameter",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#FD971F"
+      }
+    },
+    {
+      "name": "Tag name",
+      "scope": "entity.name.tag",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "Library function",
+      "scope": "support.function",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#66D9EF"
+      }
+    },
+    {
+      "name": "Library constant",
+      "scope": "support.constant",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#66D9EF"
+      }
+    },
+    {
+      "name": "Library class/type",
+      "scope": "support.type, support.class",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#66D9EF"
+      }
+    },
+    {
+      "name": "Library variable",
+      "scope": "support.other.variable",
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Invalid",
+      "scope": "invalid",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#F44747"
+      }
+    },
+    {
+      "name": "Invalid deprecated",
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#F44747"
+      }
+    },
+    {
+      "name": "JSON String",
+      "scope": "meta.structure.dictionary.json string.quoted.double.json",
+      "settings": {
+        "foreground": "#CFCFC2"
+      }
+    },
+    {
+      "name": "diff.header",
+      "scope": "meta.diff, meta.diff.header",
+      "settings": {
+        "foreground": "#75715E"
+      }
+    },
+    {
+      "name": "diff.deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "diff.inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "diff.changed",
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#E6DB74"
+      }
+    },
+    {
+      "scope": "constant.numeric.line-number.find-in-files - match",
+      "settings": {
+        "foreground": "#AE81FFA0"
+      }
+    },
+    {
+      "scope": "entity.name.filename.find-in-files",
+      "settings": {
+        "foreground": "#E6DB74"
+      }
+    },
+    {
+      "name": "Markup Quote",
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#F92672"
+      }
+    },
+    {
+      "name": "Markup Lists",
+      "scope": "markup.list",
+      "settings": {
+        "foreground": "#E6DB74"
+      }
+    },
+    {
+      "name": "Markup Styling",
+      "scope": "markup.bold, markup.italic",
+      "settings": {
+        "foreground": "#66D9EF"
+      }
+    },
+    {
+      "name": "Markup Inline",
+      "scope": "markup.inline.raw",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#FD971F"
+      }
+    },
+    {
+      "name": "Markup Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "name": "Markup Setext Header",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#A6E22E",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markup Headings",
+      "scope": "markup.heading.markdown",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#75715E"
+      }
+    },
+    {
+      "name": "Markdown Bold",
+      "scope": "markup.bold.markdown",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#AE81FF"
+      }
+    },
+    {
+      "name": "Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#E6DB74"
+      }
+    },
+    {
+      "name": "Markdown Emphasis",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "Markdown Punctuation Definition Link",
+      "scope": "markup.list.unnumbered.markdown, markup.list.numbered.markdown",
+      "settings": {
+        "foreground": "#f8f8f2"
+      }
+    },
+    {
+      "name": "Markdown List Punctuation",
+      "scope": [
+        "punctuation.definition.list.begin.markdown"
+      ],
+      "settings": {
+        "foreground": "#A6E22E"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#6796e6"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#cd9731"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#b267e6"
+      }
+    },
+    {
+      "name": "this.self",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#FD971F"
+      }
+    }
+  ]
+}

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -1,0 +1,1421 @@
+{
+  "name": "Nord",
+  "type": "dark",
+  "colors": {
+    "focusBorder": "#3b4252",
+    "foreground": "#d8dee9",
+    "activityBar.background": "#2e3440",
+    "activityBar.dropBackground": "#3b4252",
+    "activityBar.foreground": "#d8dee9",
+    "activityBar.activeBorder": "#88c0d0",
+    "activityBar.activeBackground": "#3b4252",
+    "activityBarBadge.background": "#88c0d0",
+    "activityBarBadge.foreground": "#2e3440",
+    "badge.foreground": "#2e3440",
+    "badge.background": "#88c0d0",
+    "button.background": "#88c0d0ee",
+    "button.foreground": "#2e3440",
+    "button.hoverBackground": "#88c0d0",
+    "button.secondaryBackground": "#434c5e",
+    "button.secondaryForeground": "#d8dee9",
+    "button.secondaryHoverBackground": "#4c566a",
+    "charts.red": "#bf616a",
+    "charts.blue": "#81a1c1",
+    "charts.yellow": "#ebcb8b",
+    "charts.orange": "#d08770",
+    "charts.green": "#a3be8c",
+    "charts.purple": "#b48ead",
+    "charts.foreground": "#d8dee9",
+    "charts.lines": "#88c0d0",
+    "debugConsole.infoForeground": "#88c0d0",
+    "debugConsole.warningForeground": "#ebcb8b",
+    "debugConsole.errorForeground": "#bf616a",
+    "debugConsole.sourceForeground": "#616e88",
+    "debugConsoleInputIcon.foreground": "#81a1c1",
+    "debugExceptionWidget.background": "#4c566a",
+    "debugExceptionWidget.border": "#2e3440",
+    "debugToolBar.background": "#3b4252",
+    "descriptionForeground": "#d8dee9e6",
+    "diffEditor.insertedTextBackground": "#81a1c133",
+    "diffEditor.removedTextBackground": "#bf616a4d",
+    "dropdown.background": "#3b4252",
+    "dropdown.border": "#3b4252",
+    "dropdown.foreground": "#d8dee9",
+    "editorActiveLineNumber.foreground": "#d8dee9cc",
+    "editorCursor.foreground": "#d8dee9",
+    "editorHint.border": "#ebcb8b00",
+    "editorHint.foreground": "#ebcb8b",
+    "editorIndentGuide.background": "#434c5eb3",
+    "editorIndentGuide.activeBackground": "#4c566a",
+    "editorInlayHint.background": "#434c5e",
+    "editorInlayHint.foreground": "#d8dee9",
+    "editorLineNumber.foreground": "#4c566a",
+    "editorLineNumber.activeForeground": "#d8dee9",
+    "editorWhitespace.foreground": "#4c566ab3",
+    "editorWidget.background": "#2e3440",
+    "editorWidget.border": "#3b4252",
+    "editor.background": "#2e3440",
+    "editor.foreground": "#d8dee9",
+    "editor.hoverHighlightBackground": "#3b4252",
+    "editor.findMatchBackground": "#88c0d066",
+    "editor.findMatchHighlightBackground": "#88c0d033",
+    "editor.findRangeHighlightBackground": "#88c0d033",
+    "editor.lineHighlightBackground": "#3b4252",
+    "editor.lineHighlightBorder": "#3b4252",
+    "editor.inactiveSelectionBackground": "#434c5ecc",
+    "editor.inlineValuesBackground": "#4c566a",
+    "editor.inlineValuesForeground": "#eceff4",
+    "editor.selectionBackground": "#434c5ecc",
+    "editor.selectionHighlightBackground": "#434c5ecc",
+    "editor.rangeHighlightBackground": "#434c5e52",
+    "editor.wordHighlightBackground": "#81a1c166",
+    "editor.wordHighlightStrongBackground": "#81a1c199",
+    "editor.stackFrameHighlightBackground": "#5e81ac",
+    "editor.focusedStackFrameHighlightBackground": "#5e81ac",
+    "editorError.foreground": "#bf616a",
+    "editorError.border": "#bf616a00",
+    "editorWarning.foreground": "#ebcb8b",
+    "editorWarning.border": "#ebcb8b00",
+    "editorBracketMatch.background": "#2e344000",
+    "editorBracketMatch.border": "#88c0d0",
+    "editorBracketHighlight.foreground1": "#8fbcbb",
+    "editorBracketHighlight.foreground2": "#88c0d0",
+    "editorBracketHighlight.foreground3": "#81a1c1",
+    "editorBracketHighlight.foreground4": "#5e81ac",
+    "editorBracketHighlight.foreground5": "#8fbcbb",
+    "editorBracketHighlight.foreground6": "#88c0d0",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#bf616a",
+    "editorCodeLens.foreground": "#4c566a",
+    "editorGroup.background": "#2e3440",
+    "editorGroup.border": "#3b425201",
+    "editorGroup.dropBackground": "#3b425299",
+    "editorGroupHeader.border": "#3b425200",
+    "editorGroupHeader.noTabsBackground": "#2e3440",
+    "editorGroupHeader.tabsBackground": "#2e3440",
+    "editorGroupHeader.tabsBorder": "#3b425200",
+    "editorGutter.background": "#2e3440",
+    "editorGutter.modifiedBackground": "#ebcb8b",
+    "editorGutter.addedBackground": "#a3be8c",
+    "editorGutter.deletedBackground": "#bf616a",
+    "editorHoverWidget.background": "#3b4252",
+    "editorHoverWidget.border": "#3b4252",
+    "editorLink.activeForeground": "#88c0d0",
+    "editorMarkerNavigation.background": "#5e81acc0",
+    "editorMarkerNavigationError.background": "#bf616ac0",
+    "editorMarkerNavigationWarning.background": "#ebcb8bc0",
+    "editorOverviewRuler.border": "#3b4252",
+    "editorOverviewRuler.currentContentForeground": "#3b4252",
+    "editorOverviewRuler.incomingContentForeground": "#3b4252",
+    "editorOverviewRuler.findMatchForeground": "#88c0d066",
+    "editorOverviewRuler.rangeHighlightForeground": "#88c0d066",
+    "editorOverviewRuler.selectionHighlightForeground": "#88c0d066",
+    "editorOverviewRuler.wordHighlightForeground": "#88c0d066",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#88c0d066",
+    "editorOverviewRuler.modifiedForeground": "#ebcb8b",
+    "editorOverviewRuler.addedForeground": "#a3be8c",
+    "editorOverviewRuler.deletedForeground": "#bf616a",
+    "editorOverviewRuler.errorForeground": "#bf616a",
+    "editorOverviewRuler.warningForeground": "#ebcb8b",
+    "editorOverviewRuler.infoForeground": "#81a1c1",
+    "editorRuler.foreground": "#434c5e",
+    "editorSuggestWidget.background": "#2e3440",
+    "editorSuggestWidget.border": "#3b4252",
+    "editorSuggestWidget.foreground": "#d8dee9",
+    "editorSuggestWidget.focusHighlightForeground": "#88c0d0",
+    "editorSuggestWidget.highlightForeground": "#88c0d0",
+    "editorSuggestWidget.selectedBackground": "#434c5e",
+    "editorSuggestWidget.selectedForeground": "#d8dee9",
+    "extensionButton.prominentForeground": "#d8dee9",
+    "extensionButton.prominentBackground": "#434c5e",
+    "extensionButton.prominentHoverBackground": "#4c566a",
+    "errorForeground": "#bf616a",
+    "gitDecoration.modifiedResourceForeground": "#ebcb8b",
+    "gitDecoration.deletedResourceForeground": "#bf616a",
+    "gitDecoration.untrackedResourceForeground": "#a3be8c",
+    "gitDecoration.ignoredResourceForeground": "#d8dee966",
+    "gitDecoration.conflictingResourceForeground": "#5e81ac",
+    "gitDecoration.submoduleResourceForeground": "#8fbcbb",
+    "gitDecoration.stageDeletedResourceForeground": "#bf616a",
+    "gitDecoration.stageModifiedResourceForeground": "#ebcb8b",
+    "input.background": "#3b4252",
+    "input.foreground": "#d8dee9",
+    "input.placeholderForeground": "#d8dee999",
+    "input.border": "#3b4252",
+    "inputOption.activeBackground": "#5e81ac",
+    "inputOption.activeBorder": "#5e81ac",
+    "inputOption.activeForeground": "#eceff4",
+    "inputValidation.errorBackground": "#bf616a",
+    "inputValidation.errorBorder": "#bf616a",
+    "inputValidation.infoBackground": "#81a1c1",
+    "inputValidation.infoBorder": "#81a1c1",
+    "inputValidation.warningBackground": "#d08770",
+    "inputValidation.warningBorder": "#d08770",
+    "keybindingLabel.background": "#4c566a",
+    "keybindingLabel.border": "#4c566a",
+    "keybindingLabel.bottomBorder": "#4c566a",
+    "keybindingLabel.foreground": "#d8dee9",
+    "list.activeSelectionBackground": "#88c0d0",
+    "list.activeSelectionForeground": "#2e3440",
+    "list.inactiveSelectionBackground": "#434c5e",
+    "list.inactiveSelectionForeground": "#d8dee9",
+    "list.inactiveFocusBackground": "#434c5ecc",
+    "list.hoverForeground": "#eceff4",
+    "list.focusForeground": "#d8dee9",
+    "list.focusBackground": "#88c0d099",
+    "list.focusHighlightForeground": "#eceff4",
+    "list.hoverBackground": "#3b4252",
+    "list.dropBackground": "#88c0d099",
+    "list.highlightForeground": "#88c0d0",
+    "list.errorForeground": "#bf616a",
+    "list.warningForeground": "#ebcb8b",
+    "merge.currentHeaderBackground": "#81a1c166",
+    "merge.currentContentBackground": "#81a1c14d",
+    "merge.incomingHeaderBackground": "#8fbcbb66",
+    "merge.incomingContentBackground": "#8fbcbb4d",
+    "merge.border": "#3b425200",
+    "minimap.background": "#2e3440",
+    "minimap.errorHighlight": "#bf616acc",
+    "minimap.findMatchHighlight": "#88c0d0",
+    "minimap.selectionHighlight": "#88c0d0cc",
+    "minimap.warningHighlight": "#ebcb8bcc",
+    "minimapGutter.addedBackground": "#a3be8c",
+    "minimapGutter.deletedBackground": "#bf616a",
+    "minimapGutter.modifiedBackground": "#ebcb8b",
+    "minimapSlider.activeBackground": "#434c5eaa",
+    "minimapSlider.background": "#434c5e99",
+    "minimapSlider.hoverBackground": "#434c5eaa",
+    "notification.background": "#3b4252",
+    "notification.buttonBackground": "#434c5e",
+    "notification.buttonForeground": "#d8dee9",
+    "notification.buttonHoverBackground": "#4c566a",
+    "notification.errorBackground": "#bf616a",
+    "notification.errorForeground": "#2e3440",
+    "notification.foreground": "#d8dee9",
+    "notification.infoBackground": "#88c0d0",
+    "notification.infoForeground": "#2e3440",
+    "notification.warningBackground": "#ebcb8b",
+    "notification.warningForeground": "#2e3440",
+    "notificationCenter.border": "#3b425200",
+    "notificationCenterHeader.background": "#2e3440",
+    "notificationCenterHeader.foreground": "#88c0d0",
+    "notificationLink.foreground": "#88c0d0",
+    "notifications.background": "#3b4252",
+    "notifications.border": "#2e3440",
+    "notifications.foreground": "#d8dee9",
+    "notificationToast.border": "#3b425200",
+    "panel.background": "#2e3440",
+    "panel.border": "#3b4252",
+    "panelTitle.activeBorder": "#88c0d000",
+    "panelTitle.activeForeground": "#88c0d0",
+    "panelTitle.inactiveForeground": "#d8dee9",
+    "peekView.border": "#4c566a",
+    "peekViewEditor.background": "#2e3440",
+    "peekViewEditorGutter.background": "#2e3440",
+    "peekViewEditor.matchHighlightBackground": "#88c0d04d",
+    "peekViewResult.background": "#2e3440",
+    "peekViewResult.fileForeground": "#88c0d0",
+    "peekViewResult.lineForeground": "#d8dee966",
+    "peekViewResult.matchHighlightBackground": "#88c0d0cc",
+    "peekViewResult.selectionBackground": "#434c5e",
+    "peekViewResult.selectionForeground": "#d8dee9",
+    "peekViewTitle.background": "#3b4252",
+    "peekViewTitleDescription.foreground": "#d8dee9",
+    "peekViewTitleLabel.foreground": "#88c0d0",
+    "pickerGroup.border": "#3b4252",
+    "pickerGroup.foreground": "#88c0d0",
+    "progressBar.background": "#88c0d0",
+    "quickInputList.focusBackground": "#88c0d0",
+    "quickInputList.focusForeground": "#2e3440",
+    "sash.hoverBorder": "#88c0d0",
+    "scrollbar.shadow": "#00000066",
+    "scrollbarSlider.activeBackground": "#434c5eaa",
+    "scrollbarSlider.background": "#434c5e99",
+    "scrollbarSlider.hoverBackground": "#434c5eaa",
+    "selection.background": "#88c0d099",
+    "sideBar.background": "#2e3440",
+    "sideBar.foreground": "#d8dee9",
+    "sideBar.border": "#3b4252",
+    "sideBarSectionHeader.background": "#3b4252",
+    "sideBarSectionHeader.foreground": "#d8dee9",
+    "sideBarTitle.foreground": "#d8dee9",
+    "statusBar.background": "#3b4252",
+    "statusBar.debuggingBackground": "#5e81ac",
+    "statusBar.debuggingForeground": "#d8dee9",
+    "statusBar.noFolderForeground": "#d8dee9",
+    "statusBar.noFolderBackground": "#3b4252",
+    "statusBar.foreground": "#d8dee9",
+    "statusBarItem.activeBackground": "#4c566a",
+    "statusBarItem.hoverBackground": "#434c5e",
+    "statusBarItem.prominentBackground": "#3b4252",
+    "statusBarItem.prominentHoverBackground": "#434c5e",
+    "statusBarItem.errorBackground": "#3b4252",
+    "statusBarItem.errorForeground": "#bf616a",
+    "statusBarItem.warningBackground": "#ebcb8b",
+    "statusBarItem.warningForeground": "#2e3440",
+    "statusBar.border": "#3b425200",
+    "tab.activeBackground": "#3b4252",
+    "tab.activeForeground": "#d8dee9",
+    "tab.border": "#3b425200",
+    "tab.activeBorder": "#88c0d000",
+    "tab.unfocusedActiveBorder": "#88c0d000",
+    "tab.inactiveBackground": "#2e3440",
+    "tab.inactiveForeground": "#d8dee966",
+    "tab.unfocusedActiveForeground": "#d8dee999",
+    "tab.unfocusedInactiveForeground": "#d8dee966",
+    "tab.hoverBackground": "#3b4252cc",
+    "tab.unfocusedHoverBackground": "#3b4252b3",
+    "tab.hoverBorder": "#88c0d000",
+    "tab.unfocusedHoverBorder": "#88c0d000",
+    "tab.activeBorderTop": "#88c0d000",
+    "tab.unfocusedActiveBorderTop": "#88c0d000",
+    "tab.lastPinnedBorder": "#4c566a",
+    "terminal.background": "#2e3440",
+    "terminal.foreground": "#d8dee9",
+    "terminal.ansiBlack": "#3b4252",
+    "terminal.ansiRed": "#bf616a",
+    "terminal.ansiGreen": "#a3be8c",
+    "terminal.ansiYellow": "#ebcb8b",
+    "terminal.ansiBlue": "#81a1c1",
+    "terminal.ansiMagenta": "#b48ead",
+    "terminal.ansiCyan": "#88c0d0",
+    "terminal.ansiWhite": "#e5e9f0",
+    "terminal.ansiBrightBlack": "#4c566a",
+    "terminal.ansiBrightRed": "#bf616a",
+    "terminal.ansiBrightGreen": "#a3be8c",
+    "terminal.ansiBrightYellow": "#ebcb8b",
+    "terminal.ansiBrightBlue": "#81a1c1",
+    "terminal.ansiBrightMagenta": "#b48ead",
+    "terminal.ansiBrightCyan": "#8fbcbb",
+    "terminal.ansiBrightWhite": "#eceff4",
+    "terminal.tab.activeBorder": "#88c0d0",
+    "textBlockQuote.background": "#3b4252",
+    "textBlockQuote.border": "#81a1c1",
+    "textCodeBlock.background": "#4c566a",
+    "textLink.activeForeground": "#88c0d0",
+    "textLink.foreground": "#88c0d0",
+    "textPreformat.foreground": "#8fbcbb",
+    "textSeparator.foreground": "#eceff4",
+    "titleBar.activeBackground": "#2e3440",
+    "titleBar.activeForeground": "#d8dee9",
+    "titleBar.border": "#2e344000",
+    "titleBar.inactiveBackground": "#2e3440",
+    "titleBar.inactiveForeground": "#d8dee966",
+    "tree.indentGuidesStroke": "#616e88",
+    "walkThrough.embeddedEditorBackground": "#2e3440",
+    "welcomePage.buttonBackground": "#434c5e",
+    "welcomePage.buttonHoverBackground": "#4c566a",
+    "widget.shadow": "#00000066"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#d8dee9ff",
+        "background": "#2e3440ff"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Comment",
+      "scope": "comment",
+      "settings": {
+        "foreground": "#616E88"
+      }
+    },
+    {
+      "name": "Constant Character",
+      "scope": "constant.character",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Constant Character Escape",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Constant Language",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Constant Numeric",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#B48EAD"
+      }
+    },
+    {
+      "name": "Constant Regexp",
+      "scope": "constant.regexp",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Entity Name Class/Type",
+      "scope": [
+        "entity.name.class",
+        "entity.name.type.class"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Entity Name Function",
+      "scope": "entity.name.function",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "Entity Name Tag",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Entity Other Attribute Name",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Entity Other Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Invalid Deprecated",
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "background": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Invalid Illegal",
+      "scope": "invalid.illegal",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "background": "#BF616A"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Keyword Operator",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Keyword Other New",
+      "scope": "keyword.other.new",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Markup Bold",
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markup Changed",
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#BF616A"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#A3BE8C"
+      }
+    },
+    {
+      "name": "Meta Preprocessor",
+      "scope": "meta.preprocessor",
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation",
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "Punctuation Definition Parameters",
+      "scope": [
+        "punctuation.definition.method-parameters",
+        "punctuation.definition.function-parameters",
+        "punctuation.definition.parameters"
+      ],
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "Punctuation Definition Tag",
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Punctuation Definition Comment",
+      "scope": [
+        "punctuation.definition.comment",
+        "punctuation.end.definition.comment",
+        "punctuation.start.definition.comment"
+      ],
+      "settings": {
+        "foreground": "#616E88"
+      }
+    },
+    {
+      "name": "Punctuation Section",
+      "scope": "punctuation.section",
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "Punctuation Section Embedded",
+      "scope": [
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.end"
+      ],
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Punctuation Terminator",
+      "scope": "punctuation.terminator",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Punctuation Variable",
+      "scope": "punctuation.definition.variable",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "String",
+      "scope": "string",
+      "settings": {
+        "foreground": "#A3BE8C"
+      }
+    },
+    {
+      "name": "String Regexp",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "Support Class",
+      "scope": "support.class",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Support Constant",
+      "scope": "support.constant",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Support Function",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "Support Function Construct",
+      "scope": "support.function.construct",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Support Type",
+      "scope": "support.type",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Support Type Exception",
+      "scope": "support.type.exception",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "Token Debug",
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#b48ead"
+      }
+    },
+    {
+      "name": "Token Error",
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#bf616a"
+      }
+    },
+    {
+      "name": "Token Info",
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#88c0d0"
+      }
+    },
+    {
+      "name": "Token Warning",
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#ebcb8b"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "Variable Language",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "Variable Parameter",
+      "scope": "variable.parameter",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[C/CPP] Punctuation Separator Pointer-Access",
+      "scope": "punctuation.separator.pointer-access.c",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[C/CPP] Meta Preprocessor Include",
+      "scope": [
+        "source.c meta.preprocessor.include",
+        "source.c string.quoted.other.lt-gt.include"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[C/CPP] Conditional Directive",
+      "scope": [
+        "source.cpp keyword.control.directive.conditional",
+        "source.cpp punctuation.definition.directive",
+        "source.c keyword.control.directive.conditional",
+        "source.c punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#5E81AC",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[CSS] Constant Other Color RGB Value",
+      "scope": "source.css constant.other.color.rgb-value",
+      "settings": {
+        "foreground": "#B48EAD"
+      }
+    },
+    {
+      "name": "[CSS](Function) Meta Property-Value",
+      "scope": "source.css meta.property-value",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[CSS] Media Queries",
+      "scope": [
+        "source.css keyword.control.at-rule.media",
+        "source.css keyword.control.at-rule.media punctuation.definition.keyword"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "name": "[CSS] Punctuation Definition Keyword",
+      "scope": "source.css punctuation.definition.keyword",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[CSS] Support Type Property Name",
+      "scope": "source.css support.type.property-name",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[diff] Meta Range Context",
+      "scope": "source.diff meta.diff.range.context",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[diff] Meta Header From-File",
+      "scope": "source.diff meta.diff.header.from-file",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[diff] Punctuation Definition From-File",
+      "scope": "source.diff punctuation.definition.from-file",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[diff] Punctuation Definition Range",
+      "scope": "source.diff punctuation.definition.range",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[diff] Punctuation Definition Separator",
+      "scope": "source.diff punctuation.definition.separator",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Elixir](JakeBecker.elixir-ls) module names",
+      "scope": "entity.name.type.module.elixir",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Elixir](JakeBecker.elixir-ls) module attributes",
+      "scope": "variable.other.readwrite.module.elixir",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Elixir](JakeBecker.elixir-ls) atoms",
+      "scope": "constant.other.symbol.elixir",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Elixir](JakeBecker.elixir-ls) modules",
+      "scope": "variable.other.constant.elixir",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Go] String Format Placeholder",
+      "scope": "source.go constant.other.placeholder.go",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Comment Block Documentation HTML Entities",
+      "scope": "source.java comment.block.documentation.javadoc punctuation.definition.entity.html",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Constant Other",
+      "scope": "source.java constant.other",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Keyword Other Documentation",
+      "scope": "source.java keyword.other.documentation",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Keyword Other Documentation Author",
+      "scope": "source.java keyword.other.documentation.author.javadoc",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Keyword Other Documentation Directive/Custom",
+      "scope": [
+        "source.java keyword.other.documentation.directive",
+        "source.java keyword.other.documentation.custom"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Keyword Other Documentation See",
+      "scope": "source.java keyword.other.documentation.see.javadoc",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java] Meta Method-Call",
+      "scope": "source.java meta.method-call meta.method",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Meta Tag Template Link",
+      "scope": [
+        "source.java meta.tag.template.link.javadoc",
+        "source.java string.other.link.title.javadoc"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Meta Tag Template Value",
+      "scope": "source.java meta.tag.template.value.javadoc",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Punctuation Definition Keyword",
+      "scope": "source.java punctuation.definition.keyword.javadoc",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java](JavaDoc) Punctuation Definition Tag",
+      "scope": [
+        "source.java punctuation.definition.tag.begin.javadoc",
+        "source.java punctuation.definition.tag.end.javadoc"
+      ],
+      "settings": {
+        "foreground": "#616E88"
+      }
+    },
+    {
+      "name": "[Java] Storage Modifier Import",
+      "scope": "source.java storage.modifier.import",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java] Storage Modifier Package",
+      "scope": "source.java storage.modifier.package",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java] Storage Type",
+      "scope": "source.java storage.type",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java] Storage Type Annotation",
+      "scope": "source.java storage.type.annotation",
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "name": "[Java] Storage Type Generic",
+      "scope": "source.java storage.type.generic",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Java] Storage Type Primitive",
+      "scope": "source.java storage.type.primitive",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[JavaScript] Decorator",
+      "scope": [
+        "source.js punctuation.decorator",
+        "source.js meta.decorator variable.other.readwrite",
+        "source.js meta.decorator entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "name": "[JavaScript] Meta Object-Literal Key",
+      "scope": "source.js meta.object-literal.key",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[JavaScript](JSDoc) Storage Type Class",
+      "scope": "source.js storage.type.class.jsdoc",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[JavaScript] String Template Literals Punctuation",
+      "scope": [
+        "source.js string.quoted.template punctuation.quasi.element.begin",
+        "source.js string.quoted.template punctuation.quasi.element.end",
+        "source.js string.template punctuation.definition.template-expression"
+      ],
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[JavaScript] Interpolated String Template Punctuation Functions",
+      "scope": "source.js string.quoted.template meta.method-call.with-arguments",
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "[JavaScript] String Template Literal Variable",
+      "scope": [
+        "source.js string.template meta.template.expression support.variable.property",
+        "source.js string.template meta.template.expression variable.other.object"
+      ],
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[JavaScript] Support Type Primitive",
+      "scope": "source.js support.type.primitive",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[JavaScript] Variable Other Object",
+      "scope": "source.js variable.other.object",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[JavaScript] Variable Other Read-Write Alias",
+      "scope": "source.js variable.other.readwrite.alias",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[JavaScript] Parentheses in Template Strings",
+      "scope": [
+        "source.js meta.embedded.line meta.brace.square",
+        "source.js meta.embedded.line meta.brace.round",
+        "source.js string.quoted.template meta.brace.square",
+        "source.js string.quoted.template meta.brace.round"
+      ],
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "[HTML] Constant Character Entity",
+      "scope": "text.html.basic constant.character.entity.html",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "[HTML] Constant Other Inline-Data",
+      "scope": "text.html.basic constant.other.inline-data",
+      "settings": {
+        "foreground": "#D08770",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[HTML] Meta Tag SGML Doctype",
+      "scope": "text.html.basic meta.tag.sgml.doctype",
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[HTML] Punctuation Definition Entity",
+      "scope": "text.html.basic punctuation.definition.entity",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[INI] Entity Name Section Group-Title",
+      "scope": "source.properties entity.name.section.group-title.ini",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[INI] Punctuation Separator Key-Value",
+      "scope": "source.properties punctuation.separator.key-value.ini",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Fenced Code Block",
+      "scope": [
+        "text.html.markdown markup.fenced_code.block",
+        "text.html.markdown markup.fenced_code.block punctuation.definition"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Heading",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Inline",
+      "scope": [
+        "text.html.markdown markup.inline.raw",
+        "text.html.markdown markup.inline.raw punctuation.definition.raw"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Italic",
+      "scope": "text.html.markdown markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Link",
+      "scope": "text.html.markdown markup.underline.link",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "[Markdown] Markup List Numbered/Unnumbered",
+      "scope": "text.html.markdown beginning.punctuation.definition.list",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Quote Punctuation Definition",
+      "scope": "text.html.markdown beginning.punctuation.definition.quote",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Quote Punctuation Definition",
+      "scope": "text.html.markdown markup.quote",
+      "settings": {
+        "foreground": "#616E88"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Constant",
+      "scope": "text.html.markdown constant.character.math.tex",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Definition Marker",
+      "scope": [
+        "text.html.markdown punctuation.definition.math.begin",
+        "text.html.markdown punctuation.definition.math.end"
+      ],
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Function Definition Marker",
+      "scope": "text.html.markdown punctuation.definition.function.math.tex",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Markdown] Markup Math Operator",
+      "scope": "text.html.markdown punctuation.math.operator.latex",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Punctuation Definition Heading",
+      "scope": "text.html.markdown punctuation.definition.heading",
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] Punctuation Definition Constant/String",
+      "scope": [
+        "text.html.markdown punctuation.definition.constant",
+        "text.html.markdown punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Markdown] String Other Link Description/Title",
+      "scope": [
+        "text.html.markdown constant.other.reference.link",
+        "text.html.markdown string.other.link.description",
+        "text.html.markdown string.other.link.title"
+      ],
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Perl] Perl Sigils",
+      "scope": "source.perl punctuation.definition.variable",
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[PHP] Meta Function-Call Object",
+      "scope": [
+        "source.php meta.function-call",
+        "source.php meta.function-call.object"
+      ],
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Python] Decorator",
+      "scope": [
+        "source.python entity.name.function.decorator",
+        "source.python meta.function.decorator support.type"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "name": "[Python] Function Call",
+      "scope": "source.python meta.function-call.generic",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Python] Support Type",
+      "scope": "source.python support.type",
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Python] Function Parameter",
+      "scope": [
+        "source.python variable.parameter.function.language"
+      ],
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[Python] Function Parameter Special",
+      "scope": [
+        "source.python meta.function.parameters variable.parameter.function.language.special.self"
+      ],
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[Rust] Entity types",
+      "scope": "source.rust entity.name.type",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[Rust] Macro",
+      "scope": "source.rust meta.macro entity.name.function",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[Rust] Attributes",
+      "scope": [
+        "source.rust meta.attribute",
+        "source.rust meta.attribute punctuation",
+        "source.rust meta.attribute keyword.operator"
+      ],
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[Rust] Traits",
+      "scope": "source.rust entity.name.type.trait",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "[Rust] Interpolation Bracket Curly",
+      "scope": "source.rust punctuation.definition.interpolation",
+      "settings": {
+        "foreground": "#EBCB8B"
+      }
+    },
+    {
+      "name": "[SCSS] Punctuation Definition Interpolation Bracket Curly",
+      "scope": [
+        "source.css.scss punctuation.definition.interpolation.begin.bracket.curly",
+        "source.css.scss punctuation.definition.interpolation.end.bracket.curly"
+      ],
+      "settings": {
+        "foreground": "#81A1C1"
+      }
+    },
+    {
+      "name": "[SCSS] Variable Interpolation",
+      "scope": "source.css.scss variable.interpolation",
+      "settings": {
+        "foreground": "#D8DEE9",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[TypeScript] Decorators",
+      "scope": [
+        "source.ts punctuation.decorator",
+        "source.ts meta.decorator variable.other.readwrite",
+        "source.ts meta.decorator entity.name.function",
+        "source.tsx punctuation.decorator",
+        "source.tsx meta.decorator variable.other.readwrite",
+        "source.tsx meta.decorator entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#D08770"
+      }
+    },
+    {
+      "name": "[TypeScript] Object-literal keys",
+      "scope": [
+        "source.ts meta.object-literal.key",
+        "source.tsx meta.object-literal.key"
+      ],
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[TypeScript] Object-literal functions",
+      "scope": [
+        "source.ts meta.object-literal.key entity.name.function",
+        "source.tsx meta.object-literal.key entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#88C0D0"
+      }
+    },
+    {
+      "name": "[TypeScript] Type/Class",
+      "scope": [
+        "source.ts support.class",
+        "source.ts support.type",
+        "source.ts entity.name.type",
+        "source.ts entity.name.class",
+        "source.tsx support.class",
+        "source.tsx support.type",
+        "source.tsx entity.name.type",
+        "source.tsx entity.name.class"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[TypeScript] Static Class Support",
+      "scope": [
+        "source.ts support.constant.math",
+        "source.ts support.constant.dom",
+        "source.ts support.constant.json",
+        "source.tsx support.constant.math",
+        "source.tsx support.constant.dom",
+        "source.tsx support.constant.json"
+      ],
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[TypeScript] Variables",
+      "scope": [
+        "source.ts support.variable",
+        "source.tsx support.variable"
+      ],
+      "settings": {
+        "foreground": "#D8DEE9"
+      }
+    },
+    {
+      "name": "[TypeScript] Parentheses in Template Strings",
+      "scope": [
+        "source.ts meta.embedded.line meta.brace.square",
+        "source.ts meta.embedded.line meta.brace.round",
+        "source.tsx meta.embedded.line meta.brace.square",
+        "source.tsx meta.embedded.line meta.brace.round"
+      ],
+      "settings": {
+        "foreground": "#ECEFF4"
+      }
+    },
+    {
+      "name": "[XML] Entity Name Tag Namespace",
+      "scope": "text.xml entity.name.tag.namespace",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    },
+    {
+      "name": "[XML] Keyword Other Doctype",
+      "scope": "text.xml keyword.other.doctype",
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[XML] Meta Tag Preprocessor",
+      "scope": "text.xml meta.tag.preprocessor entity.name.tag",
+      "settings": {
+        "foreground": "#5E81AC"
+      }
+    },
+    {
+      "name": "[XML] Entity Name Tag Namespace",
+      "scope": [
+        "text.xml string.unquoted.cdata",
+        "text.xml string.unquoted.cdata punctuation.definition.string"
+      ],
+      "settings": {
+        "foreground": "#D08770",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[YAML] Entity Name Tag",
+      "scope": "source.yaml entity.name.tag",
+      "settings": {
+        "foreground": "#8FBCBB"
+      }
+    }
+  ]
+}

--- a/themes/one-dark-pro.json
+++ b/themes/one-dark-pro.json
@@ -1,0 +1,2323 @@
+{
+  "name": "One Dark Pro",
+  "type": "dark",
+  "colors": {
+    "actionBar.toggledBackground": "#525761",
+    "activityBar.background": "#282c34",
+    "activityBar.foreground": "#d7dae0",
+    "activityBarBadge.background": "#4d78cc",
+    "activityBarBadge.foreground": "#f8fafd",
+    "badge.background": "#282c34",
+    "button.background": "#404754",
+    "button.secondaryBackground": "#30333d",
+    "button.secondaryForeground": "#c0bdbd",
+    "checkbox.border": "#404754",
+    "debugToolBar.background": "#21252b",
+    "descriptionForeground": "#abb2bf",
+    "diffEditor.insertedTextBackground": "#00809b33",
+    "dropdown.background": "#21252b",
+    "dropdown.border": "#21252b",
+    "editor.background": "#282c34",
+    "editor.findMatchBackground": "#d19a6644",
+    "editor.findMatchBorder": "#ffffff5a",
+    "editor.findMatchHighlightBackground": "#ffffff22",
+    "editor.foreground": "#abb2bf",
+    "editor.lineHighlightBackground": "#2c313c",
+    "editor.selectionBackground": "#67769660",
+    "editor.selectionHighlightBackground": "#ffd33d44",
+    "editor.selectionHighlightBorder": "#dddddd",
+    "editor.wordHighlightBackground": "#d2e0ff2f",
+    "editor.wordHighlightBorder": "#7f848e",
+    "editor.wordHighlightStrongBackground": "#abb2bf26",
+    "editor.wordHighlightStrongBorder": "#7f848e",
+    "editorBracketHighlight.foreground1": "#d19a66",
+    "editorBracketHighlight.foreground2": "#c678dd",
+    "editorBracketHighlight.foreground3": "#56b6c2",
+    "editorBracketMatch.background": "#515a6b",
+    "editorBracketMatch.border": "#515a6b",
+    "editorCursor.background": "#ffffffc9",
+    "editorCursor.foreground": "#528bff",
+    "editorError.foreground": "#c24038",
+    "editorGroup.emptyBackground": "#282c34",
+    "editorGroup.border": "#181a1f",
+    "editorGroupHeader.tabsBackground": "#21252b",
+    "editorGutter.addedBackground": "#109868",
+    "editorGutter.deletedBackground": "#9A353D",
+    "editorGutter.modifiedBackground": "#948B60",
+    "editorHoverWidget.background": "#21252b",
+    "editorHoverWidget.border": "#181a1f",
+    "editorHoverWidget.highlightForeground": "#61afef",
+    "editorIndentGuide.activeBackground1": "#c8c8c859",
+    "editorIndentGuide.background1": "#3b4048",
+    "editorInlayHint.background": "#2c313c",
+    "editorInlayHint.foreground": "#abb2bf",
+    "editorLineNumber.activeForeground": "#abb2bf",
+    "editorLineNumber.foreground": "#495162",
+    "editorMarkerNavigation.background": "#21252b",
+    "editorOverviewRuler.addedForeground": "#109868",
+    "editorOverviewRuler.deletedForeground": "#9A353D",
+    "editorOverviewRuler.modifiedForeground": "#948B60",
+    "editorRuler.foreground": "#abb2bf26",
+    "editorSuggestWidget.background": "#21252b",
+    "editorSuggestWidget.border": "#181a1f",
+    "editorSuggestWidget.selectedBackground": "#2c313a",
+    "editorWarning.foreground": "#d19a66",
+    "editorWhitespace.foreground": "#ffffff1d",
+    "editorWidget.background": "#21252b",
+    "focusBorder": "#3e4452",
+    "gitDecoration.ignoredResourceForeground": "#636b78",
+    "input.background": "#1d1f23",
+    "input.foreground": "#abb2bf",
+    "list.activeSelectionBackground": "#2c313a",
+    "list.activeSelectionForeground": "#d7dae0",
+    "list.focusBackground": "#323842",
+    "list.focusForeground": "#f0f0f0",
+    "list.highlightForeground": "#ecebeb",
+    "list.hoverBackground": "#2c313a",
+    "list.hoverForeground": "#abb2bf",
+    "list.inactiveSelectionBackground": "#323842",
+    "list.inactiveSelectionForeground": "#d7dae0",
+    "list.warningForeground": "#d19a66",
+    "menu.foreground": "#abb2bf",
+    "menu.separatorBackground": "#343a45",
+    "minimapGutter.addedBackground": "#109868",
+    "minimapGutter.deletedBackground": "#9A353D",
+    "minimapGutter.modifiedBackground": "#948B60",
+    "multiDiffEditor.headerBackground": "#21252b",
+    "panel.border": "#3e4452",
+    "panelSectionHeader.background": "#21252b",
+    "peekViewEditor.background": "#1b1d23",
+    "peekViewEditor.matchHighlightBackground": "#29244b",
+    "peekViewResult.background": "#22262b",
+    "scrollbar.shadow": "#23252c",
+    "scrollbarSlider.activeBackground": "#747d9180",
+    "scrollbarSlider.background": "#4e566660",
+    "scrollbarSlider.hoverBackground": "#5a637580",
+    "settings.focusedRowBackground": "#282c34",
+    "settings.headerForeground": "#fff",
+    "sideBar.background": "#21252b",
+    "sideBar.foreground": "#abb2bf",
+    "sideBarSectionHeader.background": "#282c34",
+    "sideBarSectionHeader.foreground": "#abb2bf",
+    "statusBar.background": "#21252b",
+    "statusBar.debuggingBackground": "#cc6633",
+    "statusBar.debuggingBorder": "#ff000000",
+    "statusBar.debuggingForeground": "#ffffff",
+    "statusBar.foreground": "#9da5b4",
+    "statusBar.noFolderBackground": "#21252b",
+    "statusBarItem.remoteBackground": "#4d78cc",
+    "statusBarItem.remoteForeground": "#f8fafd",
+    "tab.activeBackground": "#282c34",
+    "tab.activeBorder": "#b4b4b4",
+    "tab.activeForeground": "#dcdcdc",
+    "tab.border": "#181a1f",
+    "tab.hoverBackground": "#323842",
+    "tab.inactiveBackground": "#21252b",
+    "tab.unfocusedHoverBackground": "#323842",
+    "terminal.ansiBlack": "#3f4451",
+    "terminal.ansiBlue": "#4aa5f0",
+    "terminal.ansiBrightBlack": "#4f5666",
+    "terminal.ansiBrightBlue": "#4dc4ff",
+    "terminal.ansiBrightCyan": "#4cd1e0",
+    "terminal.ansiBrightGreen": "#a5e075",
+    "terminal.ansiBrightMagenta": "#de73ff",
+    "terminal.ansiBrightRed": "#ff616e",
+    "terminal.ansiBrightWhite": "#e6e6e6",
+    "terminal.ansiBrightYellow": "#f0a45d",
+    "terminal.ansiCyan": "#42b3c2",
+    "terminal.ansiGreen": "#8cc265",
+    "terminal.ansiMagenta": "#c162de",
+    "terminal.ansiRed": "#e05561",
+    "terminal.ansiWhite": "#d7dae0",
+    "terminal.ansiYellow": "#d18f52",
+    "terminal.background": "#282c34",
+    "terminal.border": "#3e4452",
+    "terminal.foreground": "#abb2bf",
+    "terminal.selectionBackground": "#abb2bf30",
+    "textBlockQuote.background": "#2e3440",
+    "textBlockQuote.border": "#4b5362",
+    "textLink.foreground": "#61afef",
+    "textPreformat.foreground": "#d19a66",
+    "titleBar.activeBackground": "#282c34",
+    "titleBar.activeForeground": "#9da5b4",
+    "titleBar.inactiveBackground": "#282c34",
+    "titleBar.inactiveForeground": "#6b717d",
+    "tree.indentGuidesStroke": "#ffffff1d",
+    "walkThrough.embeddedEditorBackground": "#2e3440",
+    "welcomePage.tileHoverBackground": "#404754",
+    "chat.avatarBackground": "#4d78cc",
+    "chat.avatarForeground": "#f8fafd",
+    "chat.checkpointSeparator": "#343a45",
+    "chat.editedFileForeground": "#d19a66",
+    "chat.linesAddedForeground": "#8cc265",
+    "chat.linesRemovedForeground": "#e05561",
+    "chat.requestBackground": "#2c313c",
+    "chat.requestBorder": "#181a1f",
+    "chat.requestBubbleBackground": "#6776961d",
+    "chat.requestBubbleHoverBackground": "#6776963a",
+    "chat.requestCodeBorder": "#67769660",
+    "chat.slashCommandBackground": "#67769660",
+    "chat.slashCommandForeground": "#61afef",
+    "chat.thinkingShimmer": "#d7dae0",
+    "minimap.chatEditHighlight": "#67769660",
+    "inlineChat.background": "#21252b",
+    "inlineChat.border": "#181a1f",
+    "inlineChat.foreground": "#abb2bf",
+    "inlineChat.shadow": "#23252c",
+    "inlineChatDiff.inserted": "#00809b33",
+    "inlineChatDiff.removed": "#9A353D33",
+    "editorMinimap.inlineChatInserted": "#109868",
+    "editorOverviewRuler.inlineChatInserted": "#109868",
+    "editorOverviewRuler.inlineChatRemoved": "#9A353D",
+    "inlineChatInput.background": "#1d1f23",
+    "inlineChatInput.border": "#181a1f",
+    "inlineChatInput.focusBorder": "#61afef",
+    "inlineChatInput.placeholderForeground": "#6b717d",
+    "agentSessionReadIndicator.foreground": "#636b78",
+    "agentSessionSelectedBadge.border": "#d7dae0",
+    "agentSessionSelectedUnfocusedBadge.border": "#636b78",
+    "agentStatusIndicator.background": "#2c313a",
+    "agents.background": "#282c34",
+    "agentsBadge.background": "#4d78cc",
+    "agentsBadge.foreground": "#f8fafd",
+    "agentsChatInput.background": "#1d1f23",
+    "agentsChatInput.border": "#181a1f",
+    "agentsChatInput.focusBorder": "#61afef",
+    "agentsChatInput.foreground": "#abb2bf",
+    "agentsChatInput.placeholderForeground": "#6b717d",
+    "agentsGradient.tintColor": "#4d78cc",
+    "agentsNewSessionButton.background": "#ff000000",
+    "agentsNewSessionButton.border": "#181a1f",
+    "agentsNewSessionButton.foreground": "#abb2bf",
+    "agentsNewSessionButton.hoverBackground": "#2c313a",
+    "agentsPanel.background": "#21252b",
+    "agentsPanel.border": "#3e4452",
+    "agentsPanel.foreground": "#abb2bf",
+    "agentsUnreadBadge.background": "#4d78cc",
+    "agentsUnreadBadge.foreground": "#f8fafd",
+    "editorStickyScroll.background": "#282c34",
+    "editorStickyScroll.border": "#181a1f",
+    "editorStickyScroll.shadow": "#23252c",
+    "editorStickyScrollGutter.background": "#282c34",
+    "editorStickyScrollHover.background": "#2c313c",
+    "peekViewEditorStickyScroll.background": "#1b1d23",
+    "peekViewEditorStickyScrollGutter.background": "#1b1d23",
+    "sideBarStickyScroll.background": "#21252b",
+    "sideBarStickyScroll.border": "#3e4452",
+    "sideBarStickyScroll.shadow": "#23252c",
+    "terminalStickyScroll.background": "#282c34",
+    "terminalStickyScroll.border": "#3e4452",
+    "terminalStickyScrollHover.background": "#2c313c",
+    "git.blame.editorDecorationForeground": "#636b78",
+    "scmGraph.foreground1": "#d18f52",
+    "scmGraph.foreground2": "#c162de",
+    "scmGraph.foreground3": "#4aa5f0",
+    "scmGraph.foreground4": "#42b3c2",
+    "scmGraph.foreground5": "#8cc265",
+    "scmGraph.historyItemBaseRefColor": "#d18f52",
+    "scmGraph.historyItemHoverAdditionsForeground": "#8cc265",
+    "scmGraph.historyItemHoverDefaultLabelBackground": "#323842",
+    "scmGraph.historyItemHoverDefaultLabelForeground": "#f0f0f0",
+    "scmGraph.historyItemHoverDeletionsForeground": "#e05561",
+    "scmGraph.historyItemHoverLabelForeground": "#f0f0f0",
+    "scmGraph.historyItemRefColor": "#4aa5f0",
+    "scmGraph.historyItemRemoteRefColor": "#c162de",
+    "multiDiffEditor.background": "#282c34",
+    "multiDiffEditor.border": "#3e4452"
+  },
+  "tokenColors": [
+    {
+      "scope": "meta.embedded",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.cls.python",
+      "scope": "variable.parameter.function.language.special.cls.python",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "storage.modifier.lifetime.rust",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "support.function.std.rust",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "entity.name.lifetime.rust",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.language.rust",
+      "scope": "variable.language.rust",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.word"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Text",
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "c++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "c++ block",
+      "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": "keyword.operator.logical",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": "support.constant.property-value.scss,support.constant.property-value.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": "support.module.node,support.type.object.module,support.module.node",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "keyword.operator.misc.rust",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "keyword.operator.sigil.rust",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": "support.variable.dom,support.variable.property.dom",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment,keyword.operator.relational",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "C operator assignment",
+      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c,keyword.operator.assignment.cpp,keyword.operator.comparison.cpp,keyword.operator.cpp,keyword.operator.increment.cpp,keyword.operator.decrement.cpp,keyword.operator.bitwise.shift.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": "punctuation.separator.c,punctuation.separator.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "python parameter",
+      "scope": "variable.parameter.function.language.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "python logical",
+      "scope": "keyword.operator.logical.python",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "pyCs",
+      "scope": "variable.parameter.function.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators",
+      "scope": "keyword.operator.assignment.compound",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators js/ts",
+      "scope": "keyword.operator.assignment.compound.js,keyword.operator.assignment.compound.ts",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Variables",
+      "scope": "variable",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Variables",
+      "scope": "variable.c",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+      "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] toml support",
+      "scope": "support.type.property-name.toml, support.type.property-name.table.toml, support.type.property-name.array.toml",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw punctuation",
+      "scope": "punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": [
+        "beginning.punctuation.definition.list.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+      "scope": "markup.raw.monospace.asciidoc",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+      "scope": "punctuation.definition.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+      "scope": "markup.list.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+      "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc link name",
+      "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "scope": "invalid.illegal.unrecognized-tag.html",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "Deprecated",
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "html Deprecated",
+      "scope": "invalid.deprecated.entity.other.attribute-name.html",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
+      "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
+      "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Property Name",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,entity.other.alias.php,meta.interface.php",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": "function.parameter.ruby, function.parameter.cs",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "constant.language.symbol.hashkey.ruby",
+      "scope": "constant.language.symbol.hashkey.ruby",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": [
+        "keyword.operator.module"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": [
+        "support.type.type.flowtype"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": [
+        "support.type.primitive"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": [
+        "meta.property.object"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": [
+        "variable.parameter.function.js"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": [
+        "keyword.other.template.begin"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": [
+        "keyword.other.template.end"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": [
+        "keyword.other.substitution.begin"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": [
+        "keyword.other.substitution.end"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js operator.assignment",
+      "scope": [
+        "keyword.operator.assignment"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.assignment.go"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "c arithmetic",
+      "scope": [
+        "keyword.operator.arithmetic.c",
+        "keyword.operator.arithmetic.cpp"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": [
+        "entity.name.package.go"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": [
+        "support.type.prelude.elm"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": [
+        "support.constant.elm"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": [
+        "punctuation.quasi.element"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": [
+        "constant.character.entity"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": [
+        "entity.global.clojure"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": [
+        "meta.symbol.clojure"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": [
+        "constant.keyword.clojure"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": [
+        "source.ini"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": [
+        "meta.scope.prerequisites.makefile"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": [
+        "source.makefile"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": [
+        "storage.modifier.import.groovy"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": [
+        "meta.method.groovy"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": [
+        "meta.definition.variable.name.groovy"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": [
+        "meta.definition.class.inherited.classes.groovy"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": [
+        "support.variable.semantic.hlsl"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "types",
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": [
+        "entity.name.function.xi"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": [
+        "entity.name.class.xi"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": [
+        "constant.character.character-class.regexp.xi"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": [
+        "constant.regexp.xi"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": [
+        "keyword.control.xi"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": [
+        "invalid.xi"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "string",
+      "scope": [
+        "beginning.punctuation.definition.quote.markdown.xi"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": [
+        "beginning.punctuation.definition.list.markdown.xi"
+      ],
+      "settings": {
+        "foreground": "#7f848e"
+      }
+    },
+    {
+      "name": "link",
+      "scope": [
+        "constant.character.xi"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": [
+        "accent.xi"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": [
+        "wikiword.xi"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": [
+        "constant.other.color.rgb-value.xi"
+      ],
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": [
+        "punctuation.definition.tag.xi"
+      ],
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [
+        " meta.brace.square"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "foreground": "#7f848e",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "scope": [
+        "constant.language.symbol.elixir",
+        "constant.language.symbol.double-quoted.elixir"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.variable.parameter.cs"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.variable.field.cs"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "punctuation.section.embedded.begin.php",
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "punctuation.section.embedded.end.php"
+      ],
+      "settings": {
+        "foreground": "#BE5046"
+      }
+    },
+    {
+      "name": "support.other.namespace.php",
+      "scope": [
+        "support.other.namespace.php"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Latex variable parameter",
+      "scope": [
+        "variable.parameter.function.latex"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "variable.other.object",
+      "scope": [
+        "variable.other.object"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.other.constant.property",
+      "scope": [
+        "variable.other.constant.property"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "entity.other.inherited-class",
+      "scope": [
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "c variable readwrite",
+      "scope": "variable.other.readwrite.c",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "php scope",
+      "scope": "entity.name.variable.parameter.php,punctuation.separator.colon.php,constant.other.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Assembly",
+      "scope": [
+        "constant.numeric.decimal.asm.x86_64"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "scope": [
+        "support.other.parenthesis.regexp"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.escape"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": [
+        "log.info"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "scope": [
+        "log.warning"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "scope": [
+        "log.error"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": "keyword.operator.expression.is",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "scope": "entity.name.label",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": [
+        "support.class.math.block.environment.latex",
+        "constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    }
+  ]
+}

--- a/themes/solarized-dark.json
+++ b/themes/solarized-dark.json
@@ -1,0 +1,433 @@
+{
+  "name": "Solarized (dark)",
+  "type": "dark",
+  "colors": {
+    "focusBorder": "#2AA19899",
+    "agentsPanel.border": "#2b2b4a",
+    "agentsChatInput.border": "#586E7566",
+    "agentsChatInput.focusBorder": "#2AA19899",
+    "agentsNewSessionButton.border": "#586E7566",
+    "selection.background": "#2AA19899",
+    "input.background": "#003847",
+    "input.foreground": "#93A1A1",
+    "input.placeholderForeground": "#93A1A1AA",
+    "inputOption.activeBorder": "#2AA19899",
+    "inputValidation.infoBorder": "#363b5f",
+    "inputValidation.infoBackground": "#052730",
+    "inputValidation.warningBackground": "#5d5938",
+    "inputValidation.warningBorder": "#9d8a5e",
+    "inputValidation.errorBackground": "#571b26",
+    "inputValidation.errorBorder": "#a92049",
+    "errorForeground": "#ffeaea",
+    "badge.background": "#047aa6",
+    "progressBar.background": "#047aa6",
+    "dropdown.background": "#00212B",
+    "dropdown.border": "#2AA19899",
+    "button.background": "#2AA19899",
+    "list.activeSelectionBackground": "#005A6F",
+    "quickInputList.focusBackground": "#005A6F",
+    "list.hoverBackground": "#004454AA",
+    "list.inactiveSelectionBackground": "#00445488",
+    "list.dropBackground": "#00445488",
+    "list.highlightForeground": "#1ebcc5",
+    "editor.background": "#002B36",
+    "editor.foreground": "#839496",
+    "editorWidget.background": "#00212B",
+    "editorCursor.foreground": "#D30102",
+    "editorWhitespace.foreground": "#93A1A180",
+    "editor.lineHighlightBackground": "#073642",
+    "editorLineNumber.activeForeground": "#949494",
+    "editor.selectionBackground": "#274642",
+    "minimap.selectionHighlight": "#274642",
+    "editorIndentGuide.background": "#93A1A180",
+    "editorIndentGuide.activeBackground": "#C3E1E180",
+    "editorHoverWidget.background": "#004052",
+    "editorMarkerNavigationError.background": "#AB395B",
+    "editorMarkerNavigationWarning.background": "#5B7E7A",
+    "editor.selectionHighlightBackground": "#005A6FAA",
+    "editor.wordHighlightBackground": "#004454AA",
+    "editor.wordHighlightStrongBackground": "#005A6FAA",
+    "editorBracketHighlight.foreground1": "#cdcdcdff",
+    "editorBracketHighlight.foreground2": "#b58900ff",
+    "editorBracketHighlight.foreground3": "#d33682ff",
+    "peekViewResult.background": "#00212B",
+    "peekViewEditor.background": "#10192c",
+    "peekViewTitle.background": "#00212B",
+    "peekView.border": "#2b2b4a",
+    "peekViewEditor.matchHighlightBackground": "#7744AA40",
+    "titleBar.activeBackground": "#002C39",
+    "editorGroup.border": "#00212B",
+    "editorGroup.dropBackground": "#2AA19844",
+    "editorGroupHeader.tabsBackground": "#004052",
+    "tab.activeForeground": "#d6dbdb",
+    "tab.activeBackground": "#002B37",
+    "tab.inactiveForeground": "#93A1A1",
+    "tab.inactiveBackground": "#004052",
+    "tab.border": "#003847",
+    "tab.lastPinnedBorder": "#2AA19844",
+    "activityBar.background": "#003847",
+    "panel.border": "#2b2b4a",
+    "sideBar.background": "#00212B",
+    "sideBarTitle.foreground": "#93A1A1",
+    "statusBar.foreground": "#93A1A1",
+    "statusBar.background": "#00212B",
+    "statusBar.debuggingBackground": "#00212B",
+    "statusBar.noFolderBackground": "#00212B",
+    "statusBarItem.remoteBackground": "#2AA19899",
+    "ports.iconRunningProcessForeground": "#369432",
+    "statusBarItem.prominentBackground": "#003847",
+    "statusBarItem.prominentHoverBackground": "#003847",
+    "debugToolBar.background": "#00212B",
+    "debugExceptionWidget.background": "#00212B",
+    "debugExceptionWidget.border": "#AB395B",
+    "pickerGroup.foreground": "#2AA19899",
+    "pickerGroup.border": "#2AA19899",
+    "terminal.ansiBlack": "#073642",
+    "terminal.ansiRed": "#dc322f",
+    "terminal.ansiGreen": "#859900",
+    "terminal.ansiYellow": "#b58900",
+    "terminal.ansiBlue": "#268bd2",
+    "terminal.ansiMagenta": "#d33682",
+    "terminal.ansiCyan": "#2aa198",
+    "terminal.ansiWhite": "#eee8d5",
+    "terminal.ansiBrightBlack": "#002b36",
+    "terminal.ansiBrightRed": "#cb4b16",
+    "terminal.ansiBrightGreen": "#586e75",
+    "terminal.ansiBrightYellow": "#657b83",
+    "terminal.ansiBrightBlue": "#839496",
+    "terminal.ansiBrightMagenta": "#6c71c4",
+    "terminal.ansiBrightCyan": "#93a1a1",
+    "terminal.ansiBrightWhite": "#fdf6e3",
+    "surface.border": "#00222c",
+    "modernActivityBar.activeBackground": "#005A6F",
+    "modernActivityBar.hoverBackground": "#005A6F87"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#839496"
+      }
+    },
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#839496"
+      }
+    },
+    {
+      "name": "Comment",
+      "scope": "comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#586E75"
+      }
+    },
+    {
+      "name": "String",
+      "scope": "string",
+      "settings": {
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "name": "Regexp",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": [
+        "variable.language",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.name.scope-resolution"
+      ],
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Function name",
+      "scope": "entity.name.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Variable start",
+      "scope": "punctuation.definition.variable",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Embedded code markers",
+      "scope": [
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.end"
+      ],
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Built-in constant",
+      "scope": [
+        "constant.language",
+        "meta.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "name": "Support.construct",
+      "scope": [
+        "support.function.construct",
+        "keyword.other.new"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "User-defined constant",
+      "scope": [
+        "constant.character",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Inherited class",
+      "scope": [
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "foreground": "#6C71C4"
+      }
+    },
+    {
+      "name": "Function argument",
+      "scope": "variable.parameter",
+      "settings": {}
+    },
+    {
+      "name": "Tag name",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Tag start/end",
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#586E75"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "name": "Library function",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Continuation",
+      "scope": "punctuation.separator.continuation",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Library constant",
+      "scope": [
+        "support.constant",
+        "support.variable"
+      ],
+      "settings": {}
+    },
+    {
+      "name": "Library class/type",
+      "scope": [
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Library Exception",
+      "scope": "support.type.exception",
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Library variable",
+      "scope": "support.other.variable",
+      "settings": {}
+    },
+    {
+      "name": "Invalid",
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "diff: header",
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "diff: deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "diff: changed",
+      "scope": "markup.changed",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "diff: inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Markup Quote",
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Markup Lists",
+      "scope": "markup.list",
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "name": "Markup Styling",
+      "scope": [
+        "markup.bold",
+        "markup.italic"
+      ],
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "name": "Markup: Strong",
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markup: Emphasis",
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "Markup Inline",
+      "scope": "markup.inline.raw",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "name": "Markup Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Markup Setext Header",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#268BD2"
+      }
+    }
+  ]
+}

--- a/themes/solarized-light.json
+++ b/themes/solarized-light.json
@@ -1,0 +1,424 @@
+{
+  "name": "Solarized (light)",
+  "type": "light",
+  "colors": {
+    "focusBorder": "#b49471",
+    "agentsPanel.border": "#DDD6C1",
+    "agentsChatInput.border": "#DDD6C1",
+    "agentsChatInput.focusBorder": "#b49471",
+    "agentsNewSessionButton.border": "#DDD6C1",
+    "input.background": "#DDD6C1",
+    "input.foreground": "#586E75",
+    "input.placeholderForeground": "#586E75AA",
+    "inputOption.activeBorder": "#D3AF86",
+    "badge.background": "#B58900AA",
+    "progressBar.background": "#B58900",
+    "dropdown.background": "#EEE8D5",
+    "dropdown.border": "#D3AF86",
+    "button.background": "#AC9D57",
+    "selection.background": "#878b9180",
+    "list.activeSelectionBackground": "#DFCA88",
+    "list.activeSelectionForeground": "#6C6C6C",
+    "quickInputList.focusBackground": "#DFCA8866",
+    "list.hoverBackground": "#DFCA8844",
+    "list.inactiveSelectionBackground": "#D1CBB8",
+    "list.highlightForeground": "#B58900",
+    "editor.background": "#FDF6E3",
+    "editor.foreground": "#657B83",
+    "notebook.cellEditorBackground": "#F7F0E0",
+    "editorWidget.background": "#EEE8D5",
+    "editorCursor.foreground": "#657B83",
+    "editorWhitespace.foreground": "#586E7580",
+    "editor.lineHighlightBackground": "#EEE8D5",
+    "editor.selectionBackground": "#EEE8D5",
+    "minimap.selectionHighlight": "#EEE8D5",
+    "editorIndentGuide.background": "#586E7580",
+    "editorIndentGuide.activeBackground": "#081E2580",
+    "editorHoverWidget.background": "#CCC4B0",
+    "editorLineNumber.activeForeground": "#567983",
+    "peekViewResult.background": "#EEE8D5",
+    "peekViewEditor.background": "#FFFBF2",
+    "peekViewTitle.background": "#EEE8D5",
+    "peekView.border": "#B58900",
+    "peekViewEditor.matchHighlightBackground": "#7744AA40",
+    "titleBar.activeBackground": "#EEE8D5",
+    "editorGroup.border": "#DDD6C1",
+    "editorGroup.dropBackground": "#DDD6C1AA",
+    "editorGroupHeader.tabsBackground": "#D9D2C2",
+    "tab.border": "#DDD6C1",
+    "tab.activeBackground": "#FDF6E3",
+    "tab.inactiveForeground": "#586E75",
+    "tab.inactiveBackground": "#D3CBB7",
+    "tab.activeModifiedBorder": "#cb4b16",
+    "tab.lastPinnedBorder": "#FDF6E3",
+    "activityBar.background": "#DDD6C1",
+    "activityBar.foreground": "#584c27",
+    "activityBarBadge.background": "#B58900",
+    "panel.border": "#DDD6C1",
+    "sideBar.background": "#EEE8D5",
+    "sideBarTitle.foreground": "#586E75",
+    "statusBar.foreground": "#586E75",
+    "statusBar.background": "#EEE8D5",
+    "statusBar.debuggingBackground": "#EEE8D5",
+    "statusBar.noFolderBackground": "#EEE8D5",
+    "statusBarItem.remoteBackground": "#AC9D57",
+    "ports.iconRunningProcessForeground": "#2AA19899",
+    "statusBarItem.prominentBackground": "#DDD6C1",
+    "statusBarItem.prominentHoverBackground": "#DDD6C199",
+    "debugToolBar.background": "#DDD6C1",
+    "debugExceptionWidget.background": "#DDD6C1",
+    "debugExceptionWidget.border": "#AB395B",
+    "pickerGroup.border": "#2AA19899",
+    "pickerGroup.foreground": "#2AA19899",
+    "extensionButton.prominentBackground": "#b58900",
+    "extensionButton.prominentHoverBackground": "#584c27aa",
+    "terminal.ansiBlack": "#073642",
+    "terminal.ansiRed": "#dc322f",
+    "terminal.ansiGreen": "#859900",
+    "terminal.ansiYellow": "#b58900",
+    "terminal.ansiBlue": "#268bd2",
+    "terminal.ansiMagenta": "#d33682",
+    "terminal.ansiCyan": "#2aa198",
+    "terminal.ansiWhite": "#eee8d5",
+    "terminal.ansiBrightBlack": "#002b36",
+    "terminal.ansiBrightRed": "#cb4b16",
+    "terminal.ansiBrightGreen": "#586e75",
+    "terminal.ansiBrightYellow": "#657b83",
+    "terminal.ansiBrightBlue": "#839496",
+    "terminal.ansiBrightMagenta": "#6c71c4",
+    "terminal.ansiBrightCyan": "#93a1a1",
+    "terminal.ansiBrightWhite": "#fdf6e3",
+    "terminal.background": "#FDF6E3",
+    "walkThrough.embeddedEditorBackground": "#00000014",
+    "surface.border": "#ddd6c1",
+    "modernActivityBar.activeBackground": "#DFCA88"
+  },
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#657B83"
+      }
+    },
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#657B83"
+      }
+    },
+    {
+      "name": "Comment",
+      "scope": "comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "name": "String",
+      "scope": "string",
+      "settings": {
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "name": "Regexp",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": [
+        "variable.language",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#586E75"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.name.scope-resolution"
+      ],
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Function name",
+      "scope": "entity.name.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Variable start",
+      "scope": "punctuation.definition.variable",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Embedded code markers",
+      "scope": [
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.end"
+      ],
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Built-in constant",
+      "scope": [
+        "constant.language",
+        "meta.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "name": "Support.construct",
+      "scope": [
+        "support.function.construct",
+        "keyword.other.new"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "User-defined constant",
+      "scope": [
+        "constant.character",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Inherited class",
+      "scope": [
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "foreground": "#6C71C4"
+      }
+    },
+    {
+      "name": "Function argument",
+      "scope": "variable.parameter",
+      "settings": {}
+    },
+    {
+      "name": "Tag name",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Tag start/end",
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "name": "Library function",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Continuation",
+      "scope": "punctuation.separator.continuation",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "Library constant",
+      "scope": [
+        "support.constant",
+        "support.variable"
+      ],
+      "settings": {}
+    },
+    {
+      "name": "Library class/type",
+      "scope": [
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Library Exception",
+      "scope": "support.type.exception",
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "Library variable",
+      "scope": "support.other.variable",
+      "settings": {}
+    },
+    {
+      "name": "Invalid",
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "diff: header",
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "diff: deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "name": "diff: changed",
+      "scope": "markup.changed",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "name": "diff: inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Markup Quote",
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Markup Lists",
+      "scope": "markup.list",
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "name": "Markup Styling",
+      "scope": [
+        "markup.bold",
+        "markup.italic"
+      ],
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "name": "Markup: Strong",
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markup: Emphasis",
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "Markup Inline",
+      "scope": "markup.inline.raw",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "name": "Markup Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "name": "Markup Setext Header",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#268BD2"
+      }
+    }
+  ]
+}

--- a/themes/tokyo-night.json
+++ b/themes/tokyo-night.json
@@ -1,0 +1,1540 @@
+{
+  "name": "Tokyo Night",
+  "type": "dark",
+  "colors": {
+    "foreground": "#787c99",
+    "descriptionForeground": "#515670",
+    "disabledForeground": "#545c7e",
+    "focusBorder": "#545c7e33",
+    "errorForeground": "#515670",
+    "widget.shadow": "#ffffff00",
+    "scrollbar.shadow": "#00000033",
+    "badge.background": "#7e83b230",
+    "badge.foreground": "#acb0d0",
+    "icon.foreground": "#787c99",
+    "settings.headerForeground": "#6183bb",
+    "window.activeBorder": "#0d0f17",
+    "window.inactiveBorder": "#0d0f17",
+    "sash.hoverBorder": "#29355a",
+    "toolbar.activeBackground": "#202330",
+    "toolbar.hoverBackground": "#202330",
+    "extensionButton.prominentBackground": "#3d59a1DD",
+    "extensionButton.prominentHoverBackground": "#3d59a1AA",
+    "extensionButton.prominentForeground": "#ffffff",
+    "extensionBadge.remoteBackground": "#3d59a1",
+    "extensionBadge.remoteForeground": "#ffffff",
+    "button.background": "#3d59a1dd",
+    "button.hoverBackground": "#3d59a1AA",
+    "button.secondaryBackground": "#3b3e52",
+    "button.foreground": "#ffffff",
+    "progressBar.background": "#3d59a1",
+    "input.background": "#14141b",
+    "input.foreground": "#a9b1d6",
+    "input.border": "#0f0f14",
+    "input.placeholderForeground": "#787c998A",
+    "inputOption.activeForeground": "#c0caf5",
+    "inputOption.activeBackground": "#3d59a144",
+    "inputValidation.infoForeground": "#bbc2e0",
+    "inputValidation.infoBackground": "#3d59a15c",
+    "inputValidation.infoBorder": "#3d59a1",
+    "inputValidation.warningForeground": "#000000",
+    "inputValidation.warningBackground": "#c2985b",
+    "inputValidation.warningBorder": "#e0af68",
+    "inputValidation.errorForeground": "#bbc2e0",
+    "inputValidation.errorBackground": "#85353e",
+    "inputValidation.errorBorder": "#963c47",
+    "dropdown.foreground": "#787c99",
+    "dropdown.background": "#14141b",
+    "dropdown.listBackground": "#14141b",
+    "activityBar.background": "#16161e",
+    "activityBar.foreground": "#787c99",
+    "activityBar.inactiveForeground": "#3b3e52",
+    "activityBar.border": "#16161e",
+    "activityBarBadge.background": "#3d59a1",
+    "activityBarBadge.foreground": "#fff",
+    "activityBarTop.foreground": "#787c99",
+    "activityBarTop.inactiveForeground": "#3b3e52",
+    "tree.indentGuidesStroke": "#2b2b3b",
+    "sideBar.foreground": "#787c99",
+    "sideBar.background": "#16161e",
+    "sideBar.border": "#101014",
+    "sideBarTitle.foreground": "#787c99",
+    "sideBarSectionHeader.background": "#16161e",
+    "sideBarSectionHeader.foreground": "#a9b1d6",
+    "sideBarSectionHeader.border": "#101014",
+    "sideBar.dropBackground": "#1e202e",
+    "list.dropBackground": "#1e202e",
+    "list.deemphasizedForeground": "#787c99",
+    "list.activeSelectionBackground": "#202330",
+    "list.activeSelectionForeground": "#a9b1d6",
+    "list.inactiveSelectionBackground": "#1c1d29",
+    "list.inactiveSelectionForeground": "#a9b1d6",
+    "list.focusBackground": "#1c1d29",
+    "list.focusForeground": "#a9b1d6",
+    "list.hoverBackground": "#13131a",
+    "list.hoverForeground": "#a9b1d6",
+    "list.highlightForeground": "#668ac4",
+    "list.invalidItemForeground": "#c97018",
+    "list.errorForeground": "#bb616b",
+    "list.warningForeground": "#c49a5a",
+    "listFilterWidget.background": "#101014",
+    "listFilterWidget.outline": "#3d59a1",
+    "listFilterWidget.noMatchesOutline": "#a6333f",
+    "pickerGroup.foreground": "#a9b1d6",
+    "pickerGroup.border": "#101014",
+    "scrollbarSlider.background": "#868bc415",
+    "scrollbarSlider.hoverBackground": "#868bc410",
+    "scrollbarSlider.activeBackground": "#868bc422",
+    "editorBracketHighlight.foreground1": "#698cd6",
+    "editorBracketHighlight.foreground2": "#68b3de",
+    "editorBracketHighlight.foreground3": "#9a7ecc",
+    "editorBracketHighlight.foreground4": "#25aac2",
+    "editorBracketHighlight.foreground5": "#80a856",
+    "editorBracketHighlight.foreground6": "#c49a5a",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#db4b4b",
+    "editorBracketPairGuide.activeBackground1": "#698cd6",
+    "editorBracketPairGuide.activeBackground2": "#68b3de",
+    "editorBracketPairGuide.activeBackground3": "#9a7ecc",
+    "editorBracketPairGuide.activeBackground4": "#25aac2",
+    "editorBracketPairGuide.activeBackground5": "#80a856",
+    "editorBracketPairGuide.activeBackground6": "#c49a5a",
+    "selection.background": "#515c7e40",
+    "editor.background": "#1a1b26",
+    "editor.foreground": "#a9b1d6",
+    "editor.foldBackground": "#1111174a",
+    "editorLink.activeForeground": "#acb0d0",
+    "editor.selectionBackground": "#515c7e4d",
+    "editor.inactiveSelectionBackground": "#515c7e25",
+    "editor.findMatchBackground": "#3d59a166",
+    "editor.findMatchBorder": "#e0af68",
+    "editor.findMatchHighlightBackground": "#3d59a166",
+    "editor.findRangeHighlightBackground": "#515c7e33",
+    "editor.rangeHighlightBackground": "#515c7e20",
+    "editor.wordHighlightBackground": "#515c7e44",
+    "editor.wordHighlightStrongBackground": "#515c7e55",
+    "editor.selectionHighlightBackground": "#515c7e44",
+    "editorCursor.foreground": "#c0caf5",
+    "editorIndentGuide.background1": "#232433",
+    "editorIndentGuide.activeBackground1": "#363b54",
+    "editorLineNumber.foreground": "#363b54",
+    "editorLineNumber.activeForeground": "#787c99",
+    "editor.lineHighlightBackground": "#1e202e",
+    "editorWhitespace.foreground": "#363b54",
+    "editorMarkerNavigation.background": "#16161e",
+    "editorHoverWidget.background": "#16161e",
+    "editorHoverWidget.border": "#101014",
+    "editorBracketMatch.background": "#16161e",
+    "editorBracketMatch.border": "#42465d",
+    "editorOverviewRuler.border": "#101014",
+    "editorOverviewRuler.errorForeground": "#db4b4b",
+    "editorOverviewRuler.warningForeground": "#e0af68",
+    "editorOverviewRuler.infoForeground": "#1abc9c",
+    "editorOverviewRuler.bracketMatchForeground": "#101014",
+    "editorOverviewRuler.findMatchForeground": "#a9b1d644",
+    "editorOverviewRuler.rangeHighlightForeground": "#a9b1d644",
+    "editorOverviewRuler.selectionHighlightForeground": "#a9b1d622",
+    "editorOverviewRuler.wordHighlightForeground": "#bb9af755",
+    "editorOverviewRuler.wordHighlightStrongForeground": "#bb9af766",
+    "editorOverviewRuler.modifiedForeground": "#394b70",
+    "editorOverviewRuler.addedForeground": "#164846",
+    "editorOverviewRuler.deletedForeground": "#703438",
+    "editorRuler.foreground": "#101014",
+    "editorError.foreground": "#db4b4b",
+    "editorWarning.foreground": "#e0af68",
+    "editorInfo.foreground": "#0da0ba",
+    "editorHint.foreground": "#0da0ba",
+    "editorGutter.modifiedBackground": "#394b70",
+    "editorGutter.addedBackground": "#164846",
+    "editorGutter.deletedBackground": "#823c41",
+    "editorGhostText.foreground": "#646e9c",
+    "minimapGutter.modifiedBackground": "#425882",
+    "minimapGutter.addedBackground": "#1C5957",
+    "minimapGutter.deletedBackground": "#944449",
+    "editorGroup.border": "#101014",
+    "editorGroup.dropBackground": "#1e202e",
+    "editorGroupHeader.tabsBorder": "#101014",
+    "editorGroupHeader.tabsBackground": "#16161e",
+    "editorGroupHeader.noTabsBackground": "#16161e",
+    "editorGroupHeader.border": "#101014",
+    "editorPane.background": "#1a1b26",
+    "editorWidget.foreground": "#787c99",
+    "editorWidget.background": "#16161e",
+    "editorWidget.border": "#101014",
+    "editorWidget.resizeBorder": "#545c7e33",
+    "editorSuggestWidget.background": "#16161e",
+    "editorSuggestWidget.border": "#101014",
+    "editorSuggestWidget.selectedBackground": "#20222c",
+    "editorSuggestWidget.highlightForeground": "#6183bb",
+    "editorCodeLens.foreground": "#51597d",
+    "editorLightBulb.foreground": "#e0af68",
+    "editorLightBulbAutoFix.foreground": "#e0af68",
+    "editorInlayHint.foreground": "#646e9c",
+    "peekView.border": "#101014",
+    "peekViewEditor.background": "#16161e",
+    "peekViewEditor.matchHighlightBackground": "#3d59a166",
+    "peekViewTitle.background": "#101014",
+    "peekViewTitleLabel.foreground": "#a9b1d6",
+    "peekViewTitleDescription.foreground": "#787c99",
+    "peekViewResult.background": "#101014",
+    "peekViewResult.selectionForeground": "#a9b1d6",
+    "peekViewResult.selectionBackground": "#3d59a133",
+    "peekViewResult.lineForeground": "#a9b1d6",
+    "peekViewResult.fileForeground": "#787c99",
+    "peekViewResult.matchHighlightBackground": "#3d59a166",
+    "diffEditor.insertedTextBackground": "#41a6b520",
+    "diffEditor.removedTextBackground": "#db4b4b22",
+    "diffEditor.insertedLineBackground": "#41a6b520",
+    "diffEditor.removedLineBackground": "#db4b4b22",
+    "diffEditorGutter.insertedLineBackground": "#41a6b525",
+    "diffEditorGutter.removedLineBackground": "#db4b4b22",
+    "diffEditorOverview.insertedForeground": "#41a6b525",
+    "diffEditorOverview.removedForeground": "#db4b4b22",
+    "diffEditor.diagonalFill": "#292e42",
+    "diffEditor.unchangedCodeBackground": "#282a3b66",
+    "multiDiffEditor.headerBackground": "#1a1b26",
+    "multiDiffEditor.border": "#1a1b26",
+    "breadcrumb.background": "#16161e",
+    "breadcrumbPicker.background": "#16161e",
+    "breadcrumb.foreground": "#515670",
+    "breadcrumb.focusForeground": "#a9b1d6",
+    "breadcrumb.activeSelectionForeground": "#a9b1d6",
+    "tab.activeBackground": "#16161e",
+    "tab.inactiveBackground": "#16161e",
+    "tab.activeForeground": "#a9b1d6",
+    "tab.hoverForeground": "#a9b1d6",
+    "tab.activeBorder": "#3d59a1",
+    "tab.inactiveForeground": "#787c99",
+    "tab.border": "#101014",
+    "tab.unfocusedActiveForeground": "#a9b1d6",
+    "tab.unfocusedInactiveForeground": "#787c99",
+    "tab.unfocusedHoverForeground": "#a9b1d6",
+    "tab.activeModifiedBorder": "#1a1b26",
+    "tab.inactiveModifiedBorder": "#1f202e",
+    "tab.unfocusedActiveBorder": "#1f202e",
+    "tab.lastPinnedBorder": "#222333",
+    "panel.background": "#16161e",
+    "panel.border": "#101014",
+    "panelTitle.activeForeground": "#787c99",
+    "panelTitle.inactiveForeground": "#42465d",
+    "panelTitle.activeBorder": "#16161e",
+    "panelInput.border": "#16161e",
+    "statusBar.foreground": "#787c99",
+    "statusBar.background": "#16161e",
+    "statusBar.border": "#101014",
+    "statusBar.noFolderBackground": "#16161e",
+    "statusBar.debuggingBackground": "#16161e",
+    "statusBar.debuggingForeground": "#787c99",
+    "statusBarItem.activeBackground": "#101014",
+    "statusBarItem.hoverBackground": "#20222c",
+    "statusBarItem.prominentBackground": "#101014",
+    "statusBarItem.prominentHoverBackground": "#20222c",
+    "titleBar.activeForeground": "#787c99",
+    "titleBar.inactiveForeground": "#787c99",
+    "titleBar.activeBackground": "#16161e",
+    "titleBar.inactiveBackground": "#16161e",
+    "titleBar.border": "#101014",
+    "walkThrough.embeddedEditorBackground": "#16161e",
+    "textLink.foreground": "#6183bb",
+    "textLink.activeForeground": "#7dcfff",
+    "textPreformat.foreground": "#9699a8",
+    "textBlockQuote.background": "#16161e",
+    "textCodeBlock.background": "#16161e",
+    "textSeparator.foreground": "#363b54",
+    "debugExceptionWidget.border": "#963c47",
+    "debugExceptionWidget.background": "#101014",
+    "debugToolBar.background": "#101014",
+    "debugConsole.infoForeground": "#787c99",
+    "debugConsole.errorForeground": "#bb616b",
+    "debugConsole.sourceForeground": "#787c99",
+    "debugConsole.warningForeground": "#c49a5a",
+    "debugConsoleInputIcon.foreground": "#73daca",
+    "editor.stackFrameHighlightBackground": "#E2BD3A20",
+    "editor.focusedStackFrameHighlightBackground": "#73daca20",
+    "debugView.stateLabelForeground": "#787c99",
+    "debugView.stateLabelBackground": "#14141b",
+    "debugView.valueChangedHighlight": "#3d59a1aa",
+    "debugTokenExpression.name": "#7dcfff",
+    "debugTokenExpression.value": "#9aa5ce",
+    "debugTokenExpression.string": "#9ece6a",
+    "debugTokenExpression.boolean": "#ff9e64",
+    "debugTokenExpression.number": "#ff9e64",
+    "debugTokenExpression.error": "#bb616b",
+    "debugIcon.breakpointForeground": "#db4b4b",
+    "debugIcon.breakpointDisabledForeground": "#414761",
+    "debugIcon.breakpointUnverifiedForeground": "#c24242",
+    "terminal.background": "#16161e",
+    "terminal.foreground": "#787c99",
+    "terminal.selectionBackground": "#515c7e4d",
+    "terminal.ansiBlack": "#363b54",
+    "terminal.ansiRed": "#f7768e",
+    "terminal.ansiGreen": "#73daca",
+    "terminal.ansiYellow": "#e0af68",
+    "terminal.ansiBlue": "#7aa2f7",
+    "terminal.ansiMagenta": "#bb9af7",
+    "terminal.ansiCyan": "#7dcfff",
+    "terminal.ansiWhite": "#787c99",
+    "terminal.ansiBrightBlack": "#363b54",
+    "terminal.ansiBrightRed": "#f7768e",
+    "terminal.ansiBrightGreen": "#73daca",
+    "terminal.ansiBrightYellow": "#e0af68",
+    "terminal.ansiBrightBlue": "#7aa2f7",
+    "terminal.ansiBrightMagenta": "#bb9af7",
+    "terminal.ansiBrightCyan": "#7dcfff",
+    "terminal.ansiBrightWhite": "#acb0d0",
+    "gitDecoration.modifiedResourceForeground": "#6183bb",
+    "gitDecoration.ignoredResourceForeground": "#515670",
+    "gitDecoration.deletedResourceForeground": "#914c54",
+    "gitDecoration.renamedResourceForeground": "#449dab",
+    "gitDecoration.addedResourceForeground": "#449dab",
+    "gitDecoration.untrackedResourceForeground": "#449dab",
+    "gitDecoration.conflictingResourceForeground": "#e0af68cc",
+    "gitDecoration.stageDeletedResourceForeground": "#914c54",
+    "gitDecoration.stageModifiedResourceForeground": "#6183bb",
+    "notebook.editorBackground": "#1a1b26",
+    "notebook.cellEditorBackground": "#16161e",
+    "notebook.cellBorderColor": "#101014",
+    "notebook.focusedCellBorder": "#29355a",
+    "notebook.cellStatusBarItemHoverBackground": "#1c1d29",
+    "charts.red": "#f7768e",
+    "charts.blue": "#7aa2f7",
+    "charts.yellow": "#e0af68",
+    "charts.orange": "#ff9e64",
+    "charts.green": "#41a6b5",
+    "charts.purple": "#9d7cd8",
+    "charts.foreground": "#9AA5CE",
+    "charts.lines": "#16161e",
+    "scmGraph.historyItemHoverLabelForeground": "#1b1e2e",
+    "scmGraph.foreground1": "#ff9e64",
+    "scmGraph.foreground2": "#e0af68",
+    "scmGraph.foreground3": "#41a6b5",
+    "scmGraph.foreground4": "#7aa2f7",
+    "scmGraph.foreground5": "#bb9af7",
+    "scmGraph.historyItemHoverAdditionsForeground": "#41a6b5",
+    "scmGraph.historyItemHoverDeletionsForeground": "#f7768e",
+    "scmGraph.historyItemRefColor": "#506FCA",
+    "scmGraph.historyItemRemoteRefColor": "#41a6b5",
+    "scmGraph.historyItemBaseRefColor": "#9d7cd8",
+    "scmGraph.historyItemHoverDefaultLabelForeground": "#a9b1d6",
+    "merge.currentHeaderBackground": "#41a6b525",
+    "merge.currentContentBackground": "#007a7544",
+    "merge.incomingHeaderBackground": "#3d59a1aa",
+    "merge.incomingContentBackground": "#3d59a144",
+    "mergeEditor.change.background": "#41a6b525",
+    "mergeEditor.change.word.background": "#41a6b540",
+    "mergeEditor.conflict.unhandledUnfocused.border": "#e0af6888",
+    "mergeEditor.conflict.unhandledFocused.border": "#e0af68b0",
+    "mergeEditor.conflict.handledUnfocused.border": "#41a6b525",
+    "mergeEditor.conflict.handledFocused.border": "#41a6b565",
+    "mergeEditor.conflict.handled.minimapOverViewRuler": "#449dab",
+    "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#e0af68",
+    "gitlens.trailingLineForegroundColor": "#646e9c",
+    "gitlens.gutterUncommittedForegroundColor": "#7aa2f7",
+    "gitlens.gutterForegroundColor": "#787c99",
+    "gitlens.gutterBackgroundColor": "#16161e",
+    "notificationCenterHeader.background": "#101014",
+    "notifications.background": "#101014",
+    "notificationLink.foreground": "#6183bb",
+    "notificationsErrorIcon.foreground": "#bb616b",
+    "notificationsWarningIcon.foreground": "#bba461",
+    "notificationsInfoIcon.foreground": "#0da0ba",
+    "menubar.selectionForeground": "#a9b1d6",
+    "menubar.selectionBackground": "#1e202e",
+    "menubar.selectionBorder": "#1b1e2e",
+    "menu.foreground": "#787c99",
+    "menu.background": "#16161e",
+    "menu.selectionForeground": "#a9b1d6",
+    "menu.selectionBackground": "#1e202e",
+    "menu.separatorBackground": "#101014",
+    "menu.border": "#101014",
+    "chat.requestBorder": "#0f0f14",
+    "chat.avatarBackground": "#3d59a1",
+    "chat.avatarForeground": "#a9b1d6",
+    "chat.slashCommandBackground": "#14141b",
+    "chat.slashCommandForeground": "#7aa2f7",
+    "inlineChat.foreground": "#a9b1d6",
+    "inlineChatInput.background": "#14141b",
+    "inlineChatDiff.inserted": "#41a6b540",
+    "inlineChatDiff.removed": "#db4b4b42"
+  },
+  "tokenColors": [
+    {
+      "name": "Italics - Comments, Storage, Keyword Flow, Vue attributes, Decorators",
+      "scope": [
+        "comment",
+        "meta.var.expr storage.type",
+        "keyword.control.flow",
+        "keyword.control.return",
+        "meta.directive.vue punctuation.separator.key-value.html",
+        "meta.directive.vue entity.other.attribute-name.html",
+        "tag.decorator.js entity.name.tag.js",
+        "tag.decorator.js punctuation.definition.tag.js",
+        "storage.modifier",
+        "string.quoted.docstring.multi",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end",
+        "string.quoted.docstring.multi.python constant.character.escape"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Fix YAML block scalar, Python Logical",
+      "scope": [
+        "keyword.control.flow.block-scalar.literal",
+        "keyword.control.flow.python"
+      ],
+      "settings": {
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Comment",
+      "scope": [
+        "comment",
+        "comment.block.documentation",
+        "punctuation.definition.comment",
+        "comment.block.documentation punctuation",
+        "string.quoted.docstring.multi",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end",
+        "string.quoted.docstring.multi.python constant.character.escape"
+      ],
+      "settings": {
+        "foreground": "#51597d"
+      }
+    },
+    {
+      "name": "Comment Doc",
+      "scope": [
+        "keyword.operator.assignment.jsdoc",
+        "comment.block.documentation variable",
+        "comment.block.documentation storage",
+        "comment.block.documentation keyword",
+        "comment.block.documentation support",
+        "comment.block.documentation markup",
+        "comment.block.documentation markup.inline.raw.string.markdown",
+        "meta.other.type.phpdoc.php keyword.other.type.php",
+        "meta.other.type.phpdoc.php support.other.namespace.php",
+        "meta.other.type.phpdoc.php punctuation.separator.inheritance.php",
+        "meta.other.type.phpdoc.php support.class",
+        "keyword.other.phpdoc.php",
+        "log.date"
+      ],
+      "settings": {
+        "foreground": "#5a638c"
+      }
+    },
+    {
+      "name": "Comment Doc Emphasized",
+      "scope": [
+        "meta.other.type.phpdoc.php support.class",
+        "comment.block.documentation storage.type",
+        "comment.block.documentation punctuation.definition.block.tag",
+        "comment.block.documentation entity.name.type.instance"
+      ],
+      "settings": {
+        "foreground": "#646e9c"
+      }
+    },
+    {
+      "name": "Number, Boolean, Undefined, Null",
+      "scope": [
+        "variable.other.constant",
+        "punctuation.definition.constant",
+        "constant.language",
+        "constant.numeric",
+        "support.constant",
+        "constant.other.caps"
+      ],
+      "settings": {
+        "foreground": "#ff9e64"
+      }
+    },
+    {
+      "name": "String, Symbols",
+      "scope": [
+        "string",
+        "constant.other.symbol",
+        "constant.other.key",
+        "meta.attribute-selector",
+        "string constant.character"
+      ],
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#9ece6a"
+      }
+    },
+    {
+      "name": "Colors",
+      "scope": [
+        "constant.other.color",
+        "constant.other.color.rgb-value.hex punctuation.definition.constant"
+      ],
+      "settings": {
+        "foreground": "#9aa5ce"
+      }
+    },
+    {
+      "name": "Invalid",
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
+      "settings": {
+        "foreground": "#ff5370"
+      }
+    },
+    {
+      "name": "Invalid deprecated",
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Storage Type",
+      "scope": "storage.type",
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Storage - modifier, var, const, let",
+      "scope": [
+        "meta.var.expr storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#9d7cd8"
+      }
+    },
+    {
+      "name": "Interpolation, PHP tags, Smarty tags",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.section.embedded",
+        "meta.embedded.line.tag.smarty",
+        "support.constant.handlebars",
+        "punctuation.section.tag.twig"
+      ],
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "Blade, Twig, Smarty Handlebars keywords",
+      "scope": [
+        "keyword.control.smarty",
+        "keyword.control.twig",
+        "support.constant.handlebars keyword.control",
+        "keyword.operator.comparison.twig",
+        "keyword.blade",
+        "entity.name.function.blade",
+        "meta.tag.blade keyword.other.type.php"
+      ],
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "Spread",
+      "scope": [
+        "keyword.operator.spread",
+        "keyword.operator.rest"
+      ],
+      "settings": {
+        "foreground": "#f7768e",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Operator, Misc",
+      "scope": [
+        "keyword.operator",
+        "keyword.control.as",
+        "keyword.other",
+        "keyword.operator.bitwise.shift",
+        "punctuation",
+        "expression.embbeded.vue punctuation.definition.tag",
+        "text.html.twig meta.tag.inline.any.html",
+        "meta.tag.template.value.twig meta.function.arguments.twig",
+        "meta.directive.vue punctuation.separator.key-value.html",
+        "punctuation.definition.constant.markdown",
+        "punctuation.definition.string",
+        "punctuation.support.type.property-name",
+        "text.html.vue-html meta.tag",
+        "meta.attribute.directive",
+        "punctuation.definition.keyword",
+        "punctuation.terminator.rule",
+        "punctuation.definition.entity",
+        "punctuation.separator.inheritance.php",
+        "keyword.other.template",
+        "keyword.other.substitution",
+        "entity.name.operator",
+        "meta.property-list punctuation.separator.key-value",
+        "meta.at-rule.mixin punctuation.separator.key-value",
+        "meta.at-rule.function variable.parameter.url",
+        "meta.embedded.inline.phpx punctuation.definition.tag.begin.html",
+        "meta.embedded.inline.phpx punctuation.definition.tag.end.html"
+      ],
+      "settings": {
+        "foreground": "#89ddff"
+      }
+    },
+    {
+      "name": "Import, Export, From, Default",
+      "scope": [
+        "keyword.control.module.js",
+        "keyword.control.import",
+        "keyword.control.export",
+        "keyword.control.from",
+        "keyword.control.default",
+        "meta.import keyword.other"
+      ],
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.other.important"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Keyword SQL",
+      "scope": "keyword.other.DML",
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "Keyword Operator Logical, Arrow, Ternary, Comparison",
+      "scope": [
+        "keyword.operator.logical",
+        "storage.type.function",
+        "keyword.operator.bitwise",
+        "keyword.operator.ternary",
+        "keyword.operator.comparison",
+        "keyword.operator.relational",
+        "keyword.operator.or.regexp"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Tag",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Tag - Custom / Unrecognized",
+      "scope": [
+        "entity.name.tag support.class.component",
+        "meta.tag.custom entity.name.tag",
+        "meta.tag.other.unrecognized.html.derivative entity.name.tag",
+        "meta.tag"
+      ],
+      "settings": {
+        "foreground": "#de5971"
+      }
+    },
+    {
+      "name": "Tag Punctuation",
+      "scope": [
+        "punctuation.definition.tag",
+        "text.html.php meta.embedded.block.html meta.tag.metadata.script.end.html punctuation.definition.tag.begin.html text.html.basic"
+      ],
+      "settings": {
+        "foreground": "#ba3c97"
+      }
+    },
+    {
+      "name": "Globals, PHP Constants, etc",
+      "scope": [
+        "constant.other.php",
+        "variable.other.global.safer",
+        "variable.other.global.safer punctuation.definition.variable",
+        "variable.other.global",
+        "variable.other.global punctuation.definition.variable",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#e0af68"
+      }
+    },
+    {
+      "name": "Variables",
+      "scope": [
+        "variable",
+        "support.variable",
+        "string constant.other.placeholder",
+        "variable.parameter.handlebars",
+        "variable.other.object",
+        "meta.fstring",
+        "meta.function-call meta.function-call.arguments",
+        "meta.embedded.inline.phpx constant.other.php"
+      ],
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Variable Array Key",
+      "scope": "meta.array.literal variable",
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "Object Key",
+      "scope": [
+        "meta.object-literal.key",
+        "entity.name.type.hcl",
+        "string.alias.graphql",
+        "string.unquoted.graphql",
+        "string.unquoted.alias.graphql",
+        "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js",
+        "meta.field.declaration.ts variable.object.property",
+        "meta.block entity.name.label"
+      ],
+      "settings": {
+        "foreground": "#73daca"
+      }
+    },
+    {
+      "name": "Object Property",
+      "scope": [
+        "variable.other.property",
+        "support.variable.property",
+        "support.variable.property.dom",
+        "meta.function-call variable.other.object.property"
+      ],
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "Object Property",
+      "scope": "variable.other.object.property",
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Object Literal Member lvl 3 (Vue Prop Validation)",
+      "scope": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key",
+      "settings": {
+        "foreground": "#41a6b5"
+      }
+    },
+    {
+      "name": "C-related Block Level Variables",
+      "scope": "source.cpp meta.block variable.other",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Other Variable",
+      "scope": "support.other.variable",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": [
+        "meta.class-method.js entity.name.function.js",
+        "entity.name.method.js",
+        "variable.function.constructor",
+        "keyword.other.special-method",
+        "storage.type.cs"
+      ],
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "Function Definition",
+      "scope": [
+        "entity.name.function",
+        "variable.other.enummember",
+        "meta.function-call",
+        "meta.function-call entity.name.function",
+        "variable.function",
+        "meta.definition.method entity.name.function",
+        "meta.object-literal entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "Function Argument",
+      "scope": [
+        "variable.parameter.function.language.special",
+        "variable.parameter",
+        "meta.function.parameters punctuation.definition.variable",
+        "meta.function.parameter variable"
+      ],
+      "settings": {
+        "foreground": "#e0af68"
+      }
+    },
+    {
+      "name": "Constant, Tag Attribute",
+      "scope": [
+        "keyword.other.type.php",
+        "storage.type.php",
+        "constant.character",
+        "constant.escape",
+        "keyword.other.unit"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Variable Definition",
+      "scope": [
+        "meta.definition.variable variable.other.constant",
+        "meta.definition.variable variable.other.readwrite",
+        "variable.declaration.hcl variable.other.readwrite.hcl",
+        "meta.mapping.key.hcl variable.other.readwrite.hcl",
+        "variable.other.declaration"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Class, Support, DOM, etc",
+      "scope": [
+        "support.class",
+        "support.type",
+        "variable.other.readwrite.alias",
+        "support.orther.namespace.use.php",
+        "meta.use.php",
+        "support.other.namespace.php",
+        "support.type.sys-types",
+        "support.variable.dom",
+        "support.constant.math",
+        "support.type.object.module",
+        "support.constant.json",
+        "entity.name.namespace",
+        "meta.import.qualifier",
+        "variable.other.constant.object"
+      ],
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "Class Name",
+      "scope": "entity.name",
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Support Function",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "CSS Class and Support",
+      "scope": [
+        "source.css support.type.property-name",
+        "source.sass support.type.property-name",
+        "source.scss support.type.property-name",
+        "source.less support.type.property-name",
+        "source.stylus support.type.property-name",
+        "source.postcss support.type.property-name",
+        "support.type.property-name.css",
+        "support.type.vendored.property-name",
+        "support.type.map.key"
+      ],
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "CSS Font",
+      "scope": [
+        "support.constant.font-name",
+        "meta.definition.variable"
+      ],
+      "settings": {
+        "foreground": "#9ece6a"
+      }
+    },
+    {
+      "name": "CSS Class",
+      "scope": [
+        "entity.other.attribute-name.class",
+        "meta.at-rule.mixin.scss entity.name.function.scss"
+      ],
+      "settings": {
+        "foreground": "#9ece6a"
+      }
+    },
+    {
+      "name": "CSS ID",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "foreground": "#fc7b7b"
+      }
+    },
+    {
+      "name": "CSS Tag",
+      "scope": "entity.name.tag.css",
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "CSS Tag Reference, Pseudo & Class Punctuation",
+      "scope": [
+        "entity.other.attribute-name.pseudo-class punctuation.definition.entity",
+        "entity.other.attribute-name.pseudo-element punctuation.definition.entity",
+        "entity.other.attribute-name.class punctuation.definition.entity",
+        "entity.name.tag.reference"
+      ],
+      "settings": {
+        "foreground": "#e0af68"
+      }
+    },
+    {
+      "name": "CSS Punctuation",
+      "scope": "meta.property-list",
+      "settings": {
+        "foreground": "#9abdf5"
+      }
+    },
+    {
+      "name": "CSS at-rule fix",
+      "scope": [
+        "meta.property-list meta.at-rule.if",
+        "meta.at-rule.return variable.parameter.url",
+        "meta.property-list meta.at-rule.else"
+      ],
+      "settings": {
+        "foreground": "#ff9e64"
+      }
+    },
+    {
+      "name": "CSS Parent Selector Entity",
+      "scope": [
+        "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
+      ],
+      "settings": {
+        "foreground": "#73daca"
+      }
+    },
+    {
+      "name": "CSS Punctuation comma fix",
+      "scope": "meta.property-list meta.property-list",
+      "settings": {
+        "foreground": "#9abdf5"
+      }
+    },
+    {
+      "name": "SCSS @",
+      "scope": [
+        "meta.at-rule.mixin keyword.control.at-rule.mixin",
+        "meta.at-rule.include entity.name.function.scss",
+        "meta.at-rule.include keyword.control.at-rule.include"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "SCSS Mixins, Extends, Include Keyword",
+      "scope": [
+        "keyword.control.at-rule.include punctuation.definition.keyword",
+        "keyword.control.at-rule.mixin punctuation.definition.keyword",
+        "meta.at-rule.include keyword.control.at-rule.include",
+        "keyword.control.at-rule.extend punctuation.definition.keyword",
+        "meta.at-rule.extend keyword.control.at-rule.extend",
+        "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css",
+        "meta.at-rule.media keyword.control.at-rule.media",
+        "meta.at-rule.mixin keyword.control.at-rule.mixin",
+        "meta.at-rule.function keyword.control.at-rule.function",
+        "keyword.control punctuation.definition.keyword"
+      ],
+      "settings": {
+        "foreground": "#9d7cd8"
+      }
+    },
+    {
+      "name": "SCSS Include Mixin Argument",
+      "scope": "meta.property-list meta.at-rule.include",
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "CSS value",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#ff9e64"
+      }
+    },
+    {
+      "name": "Sub-methods",
+      "scope": [
+        "entity.name.module.js",
+        "variable.import.parameter.js",
+        "variable.other.class.js"
+      ],
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Language methods",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Variable punctuation",
+      "scope": "variable.other punctuation.definition.variable",
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Keyword this with Punctuation, ES7 Bind Operator",
+      "scope": [
+        "source.js constant.other.object.key.js string.unquoted.label.js",
+        "variable.language.this punctuation.definition.variable",
+        "keyword.other.this"
+      ],
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "HTML Attributes",
+      "scope": [
+        "entity.other.attribute-name",
+        "text.html.basic entity.other.attribute-name.html",
+        "text.html.basic entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "HTML Character Entity",
+      "scope": "text.html constant.character.entity",
+      "settings": {
+        "foreground": "#0DB9D7"
+      }
+    },
+    {
+      "name": "Vue (Vetur / deprecated) Template attributes",
+      "scope": [
+        "entity.other.attribute-name.id.html",
+        "meta.directive.vue entity.other.attribute-name.html"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "CSS ID's",
+      "scope": "source.sass keyword.control",
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "CSS psuedo selectors",
+      "scope": [
+        "entity.other.attribute-name.pseudo-class",
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.placeholder",
+        "meta.property-list meta.property-value"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#449dab"
+      }
+    },
+    {
+      "name": "Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#914c54"
+      }
+    },
+    {
+      "name": "Changed",
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#6183bb"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#b4f9f8"
+      }
+    },
+    {
+      "name": "Regular Expressions - Punctuation",
+      "scope": "punctuation.definition.group",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Regular Expressions - Character Class",
+      "scope": [
+        "constant.other.character-class.regexp"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Regular Expressions - Character Class Set",
+      "scope": [
+        "constant.other.character-class.set.regexp",
+        "punctuation.definition.character-class.regexp"
+      ],
+      "settings": {
+        "foreground": "#e0af68"
+      }
+    },
+    {
+      "name": "Regular Expressions - Quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#89ddff"
+      }
+    },
+    {
+      "name": "Regular Expressions - Backslash",
+      "scope": "constant.character.escape.backslash",
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Escape Characters",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#89ddff"
+      }
+    },
+    {
+      "name": "Decorators",
+      "scope": [
+        "tag.decorator.js entity.name.tag.js",
+        "tag.decorator.js punctuation.definition.tag.js"
+      ],
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "CSS Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "JSON Key - Level 0",
+      "scope": [
+        "source.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "JSON Key - Level 1",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "JSON Key - Level 2",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#7dcfff"
+      }
+    },
+    {
+      "name": "JSON Key - Level 3",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "JSON Key - Level 4",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#e0af68"
+      }
+    },
+    {
+      "name": "JSON Key - Level 5",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "JSON Key - Level 6",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#73daca"
+      }
+    },
+    {
+      "name": "JSON Key - Level 7",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "JSON Key - Level 8",
+      "scope": [
+        "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#9ece6a"
+      }
+    },
+    {
+      "name": "Plain Punctuation",
+      "scope": "punctuation.definition.list_item.markdown",
+      "settings": {
+        "foreground": "#9abdf5"
+      }
+    },
+    {
+      "name": "Block Punctuation",
+      "scope": [
+        "meta.block",
+        "meta.brace",
+        "punctuation.definition.block",
+        "punctuation.definition.use",
+        "punctuation.definition.class",
+        "punctuation.definition.begin.bracket",
+        "punctuation.definition.end.bracket",
+        "punctuation.definition.switch-expression.begin.bracket",
+        "punctuation.definition.switch-expression.end.bracket",
+        "punctuation.definition.section.switch-block.begin.bracket",
+        "punctuation.definition.section.switch-block.end.bracket",
+        "punctuation.definition.group.shell",
+        "punctuation.definition.parameters",
+        "punctuation.definition.arguments",
+        "punctuation.definition.dictionary",
+        "punctuation.definition.array",
+        "punctuation.section"
+      ],
+      "settings": {
+        "foreground": "#9abdf5"
+      }
+    },
+    {
+      "name": "Markdown - Plain",
+      "scope": [
+        "meta.embedded.block"
+      ],
+      "settings": {
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "HTML text",
+      "scope": [
+        "meta.tag JSXNested",
+        "meta.jsx.children",
+        "text.html",
+        "text.log"
+      ],
+      "settings": {
+        "foreground": "#9aa5ce"
+      }
+    },
+    {
+      "name": "Markdown - Markup Raw Inline",
+      "scope": "text.html.markdown markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#bb9af7"
+      }
+    },
+    {
+      "name": "Markdown - Markup Raw Inline Punctuation",
+      "scope": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#4E5579"
+      }
+    },
+    {
+      "name": "Markdown - Heading 1",
+      "scope": [
+        "heading.1.markdown entity.name",
+        "heading.1.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#89ddff"
+      }
+    },
+    {
+      "name": "Markdown - Heading 2",
+      "scope": [
+        "heading.2.markdown entity.name",
+        "heading.2.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#61bdf2"
+      }
+    },
+    {
+      "name": "Markdown - Heading 3",
+      "scope": [
+        "heading.3.markdown entity.name",
+        "heading.3.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#7aa2f7"
+      }
+    },
+    {
+      "name": "Markdown - Heading 4",
+      "scope": [
+        "heading.4.markdown entity.name",
+        "heading.4.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#6d91de"
+      }
+    },
+    {
+      "name": "Markdown - Heading 5",
+      "scope": [
+        "heading.5.markdown entity.name",
+        "heading.5.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#9aa5ce"
+      }
+    },
+    {
+      "name": "Markdown - Heading 6",
+      "scope": [
+        "heading.6.markdown entity.name",
+        "heading.6.markdown punctuation.definition.heading.markdown"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#747ca1"
+      }
+    },
+    {
+      "name": "Markup - Italic",
+      "scope": [
+        "markup.italic",
+        "markup.italic punctuation"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Markup - Bold",
+      "scope": [
+        "markup.bold",
+        "markup.bold punctuation"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Markup - Bold-Italic",
+      "scope": [
+        "markup.bold markup.italic",
+        "markup.bold markup.italic punctuation"
+      ],
+      "settings": {
+        "fontStyle": "bold italic",
+        "foreground": "#c0caf5"
+      }
+    },
+    {
+      "name": "Markup - Underline",
+      "scope": [
+        "markup.underline",
+        "markup.underline punctuation"
+      ],
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "Markdown - Blockquote",
+      "scope": "markup.quote punctuation.definition.blockquote.markdown",
+      "settings": {
+        "foreground": "#4e5579"
+      }
+    },
+    {
+      "name": "Markup - Quote",
+      "scope": "markup.quote",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markdown - Link",
+      "scope": [
+        "string.other.link",
+        "markup.underline.link",
+        "constant.other.reference.link.markdown",
+        "string.other.link.description.title.markdown"
+      ],
+      "settings": {
+        "foreground": "#73daca"
+      }
+    },
+    {
+      "name": "Markdown - Fenced Code Block",
+      "scope": [
+        "markup.fenced_code.block.markdown",
+        "markup.inline.raw.string.markdown",
+        "variable.language.fenced.markdown"
+      ],
+      "settings": {
+        "foreground": "#89ddff"
+      }
+    },
+    {
+      "name": "Markdown - Separator",
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#51597d"
+      }
+    },
+    {
+      "name": "Markup - Table",
+      "scope": "markup.table",
+      "settings": {
+        "foreground": "#c0cefc"
+      }
+    },
+    {
+      "name": "Token - Info",
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#0db9d7"
+      }
+    },
+    {
+      "name": "Token - Warn",
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#ffdb69"
+      }
+    },
+    {
+      "name": "Token - Error",
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#db4b4b"
+      }
+    },
+    {
+      "name": "Token - Debug",
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#b267e6"
+      }
+    },
+    {
+      "name": "Apache Tag",
+      "scope": "entity.tag.apacheconf",
+      "settings": {
+        "foreground": "#f7768e"
+      }
+    },
+    {
+      "name": "Preprocessor",
+      "scope": [
+        "meta.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#73daca"
+      }
+    },
+    {
+      "name": "ENV value",
+      "scope": "source.env",
+      "settings": {
+        "foreground": "#7aa2f7"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The desktop app had one hardcoded appearance — no theme picker, no light mode, no way to follow the OS. This adopts **VS Code colour theme JSON as the theme format** rather than inventing one: it is ubiquitous, already covers every surface we need, and makes "add a theme" mean "drop in a file you already have".

One theme file drives all four of the app's colour surfaces:

| Surface | Was | Now fed by |
| --- | --- | --- |
| UI chrome | 28 hardcoded CSS vars | theme `colors` |
| Terminal | hardcoded `THEME` object in `terminal.tsx` | `terminal.ansi*` |
| Markdown code blocks | `import 'highlight.js/styles/atom-one-dark.css'` | `tokenColors` → `hljs-vars.css` |
| Code editor | `oneDark` CodeMirror extension | `tokenColors` → `codemirror-theme.ts` |

Both replaced stylesheets become variable-driven, so all four surfaces move together. `@codemirror/theme-one-dark` is dropped as a dependency.

- **Mode**: System / Light / Dark, with separate light and dark theme slots so "System" has both answers. Follows `nativeTheme` live.
- **Terminal is a separate setting**, defaulting to "Match UI theme" — pin Gruvbox in the terminal under a different app theme if you want.
- **Preload paints the theme onto `<html>` before the first frame**, so launching does not flash.
- **15 themes vendored** into repo-root `themes/`, flattened to standalone files. Users add their own in `~/.helios/themes/`.

## The interesting part: resolution, not mapping

Themes in the wild are partial. The one theme installed on my machine has 94 colour keys but no `button.background`, no `descriptionForeground`, no `terminal.*` backgrounds, **zero** `tokenColors`, 8-digit alpha values, and declares its light/dark type via `uiTheme` in a sibling `package.json` behind an `include` chain.

So the resolver parses JSONC, resolves `include` chains, flattens alpha onto the background, infers mode from luminance when undeclared, walks alias chains per role, and derives whatever is left. Three guards came out of auditing the bundled set against contrast invariants:

- **The tonal surface ladder is derived, not read.** `sideBar.background` and friends are not ordered by elevation — plenty of dark themes make the sidebar *darker* than the editor, which would put raised surfaces below the base one. Mixing towards the foreground always climbs, in light themes too.
- **The emphatic border is grown from the subtle one.** Border keys point both ways: Nord sets `panel.border` a hair off its background, Dracula uses its accent purple. Taking one source and pushing it further is the only way `--outline` reliably out-contrasts `--outline-variant`.
- **Roles are held to a minimum contrast against whatever they sit on** — an `on-` role against its container, not the surface. A terminal yellow that reads fine as output is invisible as a six-pixel status dot on a light theme.

Every value is normalised to `#rrggbb` before reaching `style.setProperty`, so a hand-written theme file cannot smuggle anything else into a CSS property.

Remaining audit flags are the themes' own design choices, not resolver bugs — Solarized's famously low body-text contrast, Nord's dim punctuation.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 61 tests covering alpha compositing, alias fallback, ladder derivation from background+foreground alone, luminance mode inference, `uiTheme` fallback, longest-prefix scope matching, a `tokenColors`-less theme still yielding syntax roles, the border ordering guard, and `on-` roles measured against their container
- [x] All 15 bundled themes resolved and audited against contrast invariants
- [x] Ran the app and drove it over CDP: verified 48 inline vars land on `<html>` before first paint (this caught a real bug — `document.documentElement` does not exist at preload time, now handled with a `MutationObserver`)
- [x] Visually checked Dark Modern, GitHub Light and Catppuccin Mocha across sidebar, chat, terminal pane, file editor and the Settings dialog
- [x] Confirmed xterm adopts the theme background live without remounting, and CodeMirror's injected stylesheet is var-driven with no hardcoded `#282c34`