### PR TITLE
fix: upload an attachment once, however many times the send is retried

### DIFF
--- a/desktop/src/renderer/attachments.ts
+++ b/desktop/src/renderer/attachments.ts
@@ -1,0 +1,57 @@
+/**
+ * Files held in the composer on their way to a session.
+ *
+ * An attachment is uploaded once and remembers where it landed. The send that
+ * follows can fail — a cold session that never acknowledges the prompt is the
+ * common one — and the composer keeps its chips so the user can try again;
+ * without the stored path that retry would upload the same bytes a second
+ * time, and the daemon, which will not overwrite a name it already has, would
+ * leave a `shot-1.png` behind for every attempt.
+ */
+export interface Attachment {
+  id: number
+  name: string
+  type: string
+  size: number
+  bytes: Uint8Array
+  /** Object URL for images, so the chip shows what was pasted. */
+  preview: string | null
+  /** Where the daemon put it, once it has. Null until uploaded. */
+  path: string | null
+}
+
+/** Those the daemon has not stored yet. */
+export function needingUpload(attachments: Attachment[]): Attachment[] {
+  return attachments.filter((attachment) => attachment.path === null)
+}
+
+/**
+ * Writes the daemon's paths back onto the attachments that were just sent.
+ *
+ * Matched by position: the daemon answers in the order it received the parts,
+ * and names cannot be matched on because it renames a name already taken.
+ */
+export function withStoredPaths(
+  attachments: Attachment[],
+  uploaded: Attachment[],
+  paths: string[],
+): Attachment[] {
+  const stored = new Map(uploaded.map((attachment, index) => [attachment.id, paths[index]]))
+  return attachments.map((attachment) => {
+    const path = stored.get(attachment.id)
+    return path ? { ...attachment, path } : attachment
+  })
+}
+
+/**
+ * The prompt as the agent receives it: a line naming each file, then whatever
+ * was typed. The path is the whole mechanism — the agent opens it with Read,
+ * so the bytes never enter the context.
+ */
+export function promptWithAttachments(attachments: Attachment[], text: string): string {
+  const lines = attachments
+    .filter((attachment) => attachment.path !== null)
+    .map((attachment) => `Attached: ${attachment.path}`)
+  if (lines.length === 0) return text
+  return [...lines, '', text].join('\n').trim()
+}

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
+import {
+  needingUpload,
+  promptWithAttachments,
+  withStoredPaths,
+  type Attachment,
+} from '../attachments.ts'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
 import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
@@ -124,6 +130,7 @@ export function ChatPanel({
         size: file.size,
         bytes: new Uint8Array(await file.arrayBuffer()),
         preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+        path: null,
       })),
     )
     setAttachments((current) => [...current, ...read])
@@ -140,15 +147,21 @@ export function ChatPanel({
     setSending(true)
     try {
       // Upload first: a prompt naming a path the daemon never stored is worse
-      // than no prompt, and the agent would go looking for it.
-      let message = text
-      if (attachments.length > 0) {
+      // than no prompt, and the agent would go looking for it. Only what has
+      // not been stored yet — the send below may have failed once already, and
+      // uploading the same bytes again would leave a numbered copy per try.
+      let ready = attachments
+      const pending = needingUpload(attachments)
+      if (pending.length > 0) {
         const stored = await api(hostId).uploadFiles(
           session.session_id,
-          attachments.map(({ name, type, bytes }) => ({ name, type, bytes })),
+          pending.map(({ name, type, bytes }) => ({ name, type, bytes })),
         )
-        message = [...stored.map((file) => `Attached: ${file.path}`), '', text].join('\n').trim()
+        ready = withStoredPaths(attachments, pending, stored.map((file) => file.path))
+        // Recorded before the send, which is the call that fails.
+        setAttachments(ready)
       }
+      const message = promptWithAttachments(ready, text)
 
       const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')
@@ -365,17 +378,6 @@ export function ChatPanel({
       )}
     </div>
   )
-}
-
-/** A file held in the composer, read into memory and not yet uploaded. */
-interface Attachment {
-  id: number
-  name: string
-  type: string
-  size: number
-  bytes: Uint8Array
-  /** Object URL for images, so the chip shows what was pasted. */
-  preview: string | null
 }
 
 /** A pasted image has no name of its own, and the name becomes the path. */

--- a/desktop/test/attachments.test.ts
+++ b/desktop/test/attachments.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  needingUpload,
+  promptWithAttachments,
+  withStoredPaths,
+  type Attachment,
+} from '../src/renderer/attachments.ts'
+
+function attachment(id: number, name: string, path: string | null = null): Attachment {
+  return { id, name, type: 'image/png', size: 1, bytes: new Uint8Array([1]), preview: null, path }
+}
+
+test('a fresh attachment has to be uploaded', () => {
+  const list = [attachment(1, 'a.png')]
+  assert.equal(needingUpload(list).length, 1)
+})
+
+// The send after an upload can fail — a cold session that never acknowledges
+// the prompt is the common one — and the composer keeps its chips for a retry.
+test('one already stored is not uploaded again', () => {
+  const list = [attachment(1, 'a.png', '/uploads/s1/a.png'), attachment(2, 'b.png')]
+  const pending = needingUpload(list)
+  assert.deepEqual(
+    pending.map((a) => a.name),
+    ['b.png'],
+  )
+})
+
+test('stored paths land on the attachments they belong to', () => {
+  const list = [attachment(1, 'a.png', '/uploads/s1/a.png'), attachment(2, 'b.png')]
+  const pending = needingUpload(list)
+  const next = withStoredPaths(list, pending, ['/uploads/s1/b.png'])
+
+  assert.equal(next[0]?.path, '/uploads/s1/a.png', 'the one already stored is untouched')
+  assert.equal(next[1]?.path, '/uploads/s1/b.png')
+})
+
+// The daemon renames a name it already holds, so the path it answers with is
+// not derivable from what was sent — only its position is.
+test('paths are matched by position, not by name', () => {
+  const list = [attachment(1, 'shot.png'), attachment(2, 'shot.png')]
+  const next = withStoredPaths(list, list, ['/uploads/s1/shot.png', '/uploads/s1/shot-1.png'])
+
+  assert.equal(next[0]?.path, '/uploads/s1/shot.png')
+  assert.equal(next[1]?.path, '/uploads/s1/shot-1.png')
+})
+
+test('the prompt names every stored file before the typed text', () => {
+  const list = [attachment(1, 'a.png', '/uploads/s1/a.png'), attachment(2, 'b.png', '/uploads/s1/b.png')]
+  assert.equal(
+    promptWithAttachments(list, 'what is wrong here?'),
+    'Attached: /uploads/s1/a.png\nAttached: /uploads/s1/b.png\n\nwhat is wrong here?',
+  )
+})
+
+test('attachments with no text still make a prompt', () => {
+  assert.equal(promptWithAttachments([attachment(1, 'a.png', '/uploads/s1/a.png')], ''), 'Attached: /uploads/s1/a.png')
+})
+
+test('no attachments leaves the text alone', () => {
+  assert.equal(promptWithAttachments([], 'plain prompt'), 'plain prompt')
+})

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -296,16 +296,16 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     final sse = _sse;
 
     // Upload first. A prompt naming a path the daemon never stored sends the
-    // agent looking for a file that is not there.
+    // agent looking for a file that is not there. Only what has not been
+    // stored yet: the send below may have failed once already, and uploading
+    // the same bytes again would leave a numbered copy behind per attempt.
     var message = text;
-    if (_attachments.isNotEmpty) {
+    final pending = _attachments.where((f) => f.storedPath == null).toList();
+    if (pending.isNotEmpty) {
       final paths = sse == null
           ? null
-          : await sse.uploadSessionFiles(
-              widget.session.sessionId,
-              _attachments,
-            );
-      if (paths == null) {
+          : await sse.uploadSessionFiles(widget.session.sessionId, pending);
+      if (paths == null || paths.length != pending.length) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Could not upload the attachments')),
@@ -314,7 +314,17 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
         }
         return;
       }
-      message = [...paths.map((p) => 'Attached: $p'), '', text].join('\n').trim();
+      // Recorded before the send, which is the call that fails.
+      for (var i = 0; i < pending.length; i++) {
+        pending[i].storedPath = paths[i];
+      }
+    }
+    if (_attachments.isNotEmpty) {
+      message = [
+        ..._attachments.map((f) => 'Attached: ${f.storedPath}'),
+        '',
+        text,
+      ].join('\n').trim();
     }
 
     final error = sse == null

--- a/mobile/lib/services/api_client.dart
+++ b/mobile/lib/services/api_client.dart
@@ -182,7 +182,16 @@ class UploadFile {
   final String name;
   final Uint8List bytes;
 
-  const UploadFile({required this.name, required this.bytes});
+  /// Where the daemon put it, once it has.
+  ///
+  /// Set means uploaded, and a retry leaves it alone. The send after an upload
+  /// can fail — a cold session that never acknowledges the prompt is the common
+  /// one — and the composer keeps its chips so the user can try again; without
+  /// this the retry would upload the same bytes and the daemon, which will not
+  /// overwrite a name it already holds, would leave a copy behind per attempt.
+  String? storedPath;
+
+  UploadFile({required this.name, required this.bytes});
 
   int get size => bytes.length;
 


### PR DESCRIPTION
## Summary

Follow-up to #50, from testing it against a live daemon.

The send after an upload can fail, and the composer deliberately keeps its chips so the prompt can be sent again. But every retry uploaded the same bytes, and the daemon will not overwrite a name it already holds — so each attempt left another `shot-1.png`, `shot-2.png` on disk, with only the last one named in the prompt that finally landed.

An attachment now remembers where the daemon put it, and only the ones with nowhere yet are uploaded. The path is recorded **before** the send, because the send is the call that fails.

Paths are matched to attachments by position, not by name: the daemon renames a name already taken, so what comes back is not derivable from what went up.

### The failure that prompted this

Real log from the session that hit it — upload fine, send timed out against a session with no live terminal:

```
19:59:42 session-upload: stored 1 file(s)
19:59:42 session-send:   status=idle live=false
19:59:46 hook: received claude.session.start
19:59:54 session-send: ... never acknowledged the prompt
```

## Test plan

- [x] 7 new unit tests over the pure logic in `attachments.ts` — a fresh attachment uploads, a stored one does not, paths land on the right attachments, positional matching survives two files with the same name, prompt shape with and without text
- [x] `npm run build`, full desktop suite 68 pass
- [x] `flutter analyze` clean
- [x] Browser harness, end to end: paste a file, send with the stub throwing (a cold session that never acknowledges), then retry with it succeeding — **1 upload call total**, same path in both prompts, chips kept after the failure and cleared after the success. Before this change that path uploaded twice.

Still open by design: an attachment that is picked and then abandoned, or one whose send is never retried, leaves its bytes in `~/.helios/uploads/<session>/`. Nothing prunes that directory yet.