### PR TITLE
feat(desktop): reach Settings and Quit from the sidebar

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -62,6 +62,7 @@ export interface IpcDeps {
   notifier: Notifier
   prefs: PrefsStore
   themes: ThemeRegistry
+  quit: () => void
   window: () => BrowserWindow | null
 }
 
@@ -74,7 +75,7 @@ export interface IpcDeps {
  * string otherwise.
  */
 export function registerIpc(deps: IpcDeps): void {
-  const { hosts, terminals, notifier, prefs, themes } = deps
+  const { hosts, terminals, notifier, prefs, themes, quit } = deps
 
   const send = (channel: string, payload: unknown): void => {
     const window = deps.window()
@@ -136,6 +137,10 @@ export function registerIpc(deps: IpcDeps): void {
   handle('prefs:setSound', async (_e, enabled: boolean) => prefs.setSound(enabled))
   handle('prefs:setAlert', async (_e, type: string, enabled: boolean) => prefs.setAlert(type, enabled))
   handle('prefs:reset', async () => prefs.reset())
+
+  // Quitting for real, as opposed to closing the window, which leaves the app
+  // on the tray waiting for approvals.
+  handle('app:quit', async () => quit())
 
   // ─── Appearance ────────────────────────────────────────────────────────
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -63,12 +63,15 @@ async function start(): Promise<void> {
   themes = new ThemeRegistry(path.join(distDir, 'themes'))
   themes.load()
   hud = new Hud(rendererDir, path.join(distDir, 'preload', 'preload.js'), activateNotification)
-  notifier = new Notifier(hosts, hud, prefs, activateNotification, openSettings, () => {
+  // Shared with the tray and the sidebar menu: closing the window leaves the
+  // app resident, so quitting has to be something the user asks for by name.
+  const quit = (): void => {
     quitting = true
     app.quit()
-  })
+  }
+  notifier = new Notifier(hosts, hud, prefs, activateNotification, openSettings, quit)
 
-  registerIpc({ hosts, terminals, notifier, prefs, themes, window: () => window })
+  registerIpc({ hosts, terminals, notifier, prefs, themes, quit, window: () => window })
 
   // The HUD is shown without focus, so nothing reaches its keyboard handlers
   // until the user asks for it.

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -123,6 +123,7 @@ const helios = {
     onRetract: (fn: (payload: unknown) => void) => on('hud:retract', fn),
   },
   app: {
+    quit: () => call<void>('app:quit'),
     onActivateNotification: (fn: (payload: unknown) => void) => on('app:activate-notification', fn),
     onOpenPairing: (fn: (payload: unknown) => void) => on('app:open-pairing', fn),
     onOpenSettings: (fn: () => void) => on('app:open-settings', () => fn()),

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -66,7 +66,11 @@ export function App(): JSX.Element {
     <div className="app">
       <div className="titlebar" />
       <div className="body">
-        <Sidebar onNewSession={() => setDialog('new')} onAddHost={() => setDialog('hosts')} />
+        <Sidebar
+          onNewSession={() => setDialog('new')}
+          onAddHost={() => setDialog('hosts')}
+          onSettings={() => setDialog('settings')}
+        />
         <main className="main">
           <Detail />
         </main>

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -112,6 +112,8 @@ interface RawBridge {
     onRetract(fn: (key: string) => void): Unsubscribe
   }
   app: {
+    /** Quits for real; closing the window only hides it behind the tray. */
+    quit(): Promise<void>
     onActivateNotification(
       fn: (payload: { hostId: string; sessionId: string; notificationId: string; command?: string }) => void,
     ): Unsubscribe

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
@@ -30,7 +31,15 @@ interface Group {
   loading: boolean
 }
 
-export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void; onAddHost: () => void }): JSX.Element {
+export function Sidebar({
+  onNewSession,
+  onAddHost,
+  onSettings,
+}: {
+  onNewSession: () => void
+  onAddHost: () => void
+  onSettings: () => void
+}): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
   const sessions = useStore((s) => s.sessions)
@@ -202,8 +211,57 @@ export function Sidebar({ onNewSession, onAddHost }: { onNewSession: () => void;
         <button className="link" onClick={onAddHost}>
           Add host
         </button>
+        <AppMenu onSettings={onSettings} />
       </footer>
     </aside>
+  )
+}
+
+/**
+ * Settings and Quit, which otherwise live only on the tray and the app menu —
+ * neither of which is where the eye goes, and the app menu is not somewhere a
+ * user looks on the platforms where the window is the whole of the app.
+ */
+function AppMenu({ onSettings }: { onSettings: () => void }): JSX.Element {
+  const menu = useRef<HTMLDetailsElement | null>(null)
+
+  // <details> only closes on its own summary, so a menu left open stays open
+  // over whatever the user clicks next.
+  useEffect(() => {
+    const close = (event: Event): void => {
+      const element = menu.current
+      if (!element?.open) return
+      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
+      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
+      element.open = false
+    }
+    window.addEventListener('mousedown', close)
+    window.addEventListener('keydown', close)
+    window.addEventListener('blur', close)
+    return () => {
+      window.removeEventListener('mousedown', close)
+      window.removeEventListener('keydown', close)
+      window.removeEventListener('blur', close)
+    }
+  }, [])
+
+  return (
+    <details className="menu drop-up" ref={menu}>
+      <summary title="More">⋯</summary>
+      <div
+        className="menu-body"
+        onClick={() => {
+          if (menu.current) menu.current.open = false
+        }}
+      >
+        <button onClick={onSettings}>Settings…</button>
+        {/* Closing the window leaves the app on the tray so approvals keep
+            arriving; this is the one control that actually ends it. */}
+        <button className="danger" onClick={() => void bridge.app.quit()}>
+          Quit Helios
+        </button>
+      </div>
+    </details>
   )
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -531,12 +531,24 @@ small {
 
 .sidebar-foot {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   gap: 8px;
   padding: 8px 8px 8px 16px;
   color: var(--on-surface-variant);
   font-size: 12px;
+}
+
+/* The checkbox takes the slack so the link and the menu stay together on the
+   right, rather than each drifting to its own third of the bar. */
+.sidebar-foot .check {
+  margin-right: auto;
+}
+
+/* Smaller than the one in the session header: this bar is 12px text, and a
+   36px target would set the height of the whole footer. */
+.sidebar-foot .menu summary {
+  width: 28px;
+  height: 28px;
 }
 
 .host-group {
@@ -882,6 +894,14 @@ small {
   border-radius: var(--r-md);
   padding: 8px;
   box-shadow: 0 8px 24px var(--shadow-soft);
+}
+
+/* Anchored to the bottom of the sidebar, where a menu dropping downwards would
+   open off the window. */
+.menu.drop-up .menu-body {
+  top: auto;
+  bottom: 100%;
+  margin: 0 0 6px;
 }
 
 .menu-body button {


### PR DESCRIPTION
## Summary

Settings and Quit lived only on the tray and the app menu. Neither is where the eye goes, and on the platforms where the window *is* the whole of the app the menu bar is not somewhere a user thinks to look — so the app had a settings screen with no visible way in, and no visible way out either.

This adds a `⋯` overflow menu to the sidebar footer carrying both.

- Reuses the `<details className="menu">` pattern already used by the session header — same glyph, same close-on-outside-click / Escape / blur behaviour — with a new `.menu.drop-up` variant, because a footer menu opening downwards falls off the window.
- **Settings…** flips the dialog state `app.tsx` already had wired for the tray and menu-bar paths. No new dialog.
- **Quit Helios** needed a channel of its own. Closing the window deliberately leaves the app resident so approvals keep arriving, so ending it has to be something asked for by name. The quit path `main.ts` had inline in the `Notifier` constructor call is now a named callback shared by the tray and the menu, rather than a second copy that could drift.
- The footer was `justify-content: space-between`, which with three children would have stranded "Add host" in the middle of the bar. The checkbox now takes the slack so the link and the menu sit together on the right.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 61 pass (see note below)
- [x] Ran the app and drove it over CDP:
  - menu renders in the footer and opens **upward**, staying inside the window (bottom 1616px against a 1666px window)
  - both items present: `Settings… | Quit Helios`
  - clicking Settings opens the dialog *and* closes the menu behind it
  - clicking Quit exits the process cleanly

## Note, unrelated to this change

`npm test` uses `--experimental-strip-types`, which needs Node ≥22. My shell's `node` is currently v20.19 via nvm, where the script fails with `node: bad option: --experimental-strip-types` on any branch. I ran the suite under Node 25 to get the 61 passes. An `.nvmrc` or an `engines` field would stop this recurring.