### PR TITLE
fix(desktop): drop the Terminal button the tab strip already covers

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -413,9 +413,16 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
             Resume
           </button>
         ) : (
-          <button className="filled" onClick={() => void store.openTerminal(hostId, session, !live)}>
-            {live ? 'Terminal' : 'Wake'}
-          </button>
+          // Only while the host is cold. Waking one is not something the tab
+          // strip does — showTerminal refuses to start a host on its own — so
+          // this is the one-click way in. Once it is live the tab is the way
+          // back to the terminal, and a second control beside it that does the
+          // same thing is just another thing to read.
+          !live && (
+            <button className="filled" onClick={() => void store.openTerminal(hostId, session, true)}>
+              Wake
+            </button>
+          )
         )}
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}


### PR DESCRIPTION
## Summary

The session header carried a **Terminal** button sitting a few pixels from a tab strip whose terminal tab does the same thing. `store.showTerminal` selects the terminal panel and attaches to a live host — exactly what the button's `openTerminal(…, false)` did. Two controls with one behaviour is a question the reader has to answer before acting.

**Only the live case is removed.** The same button read **Wake** while the host was cold, and that is genuinely not redundant: `showTerminal` deliberately refuses to start a host, so without it the only way in is the button inside the terminal pane — which you can't reach without first clicking the tab.

So the header now shows:

| Session state | Before | After |
| --- | --- | --- |
| Live | `Terminal` | — (tab strip) |
| Cold | `Wake` | `Wake` |
| Terminated | `Resume` | `Resume` |

`Wake` and `Terminate` still appear together on a cold, non-terminated session — their conditions (`!live`, `!terminated`) are independent and neither changed.

## Test plan

- [x] `npm run typecheck`
- [x] Ran the app against a live session and inspected the DOM: header is now `Stop | Terminate | Regenerate title | Pin | Archive | Delete`, with no Terminal button
- [x] Confirmed the terminal is still reachable — clicking the terminal tab mounts an attached xterm in the active pane