### PR TITLE
fix(desktop): drop the Wake button, which nothing needed

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -11,7 +11,6 @@ import { TerminalPanes } from './terminal.tsx'
 import {
   BUSY_STATUSES,
   canResume,
-  hasTerminal,
   needsRecovery,
   sessionLabel,
   statusLabel,
@@ -321,7 +320,6 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(session.title ?? '')
   const overflow = useRef<HTMLDetailsElement | null>(null)
-  const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
   const terminated = canResume(session)
   const cold = needsRecovery(session)
@@ -403,26 +401,19 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
 
         <PermissionMode hostId={hostId} session={session} />
 
-        {/* Resume, not Wake: waking a terminated session starts its host but
-            leaves the daemon refusing every prompt. */}
-        {terminated ? (
-          <button
-            className="filled"
-            onClick={() => void store.resumeSession(hostId, session.session_id)}
-          >
+        {/* Resume has no equivalent anywhere else, so it stays. Terminated is
+            the one state the daemon refuses prompts for outright, and this is
+            the only control that clears it.
+
+            Waking is not like that. A cold session wakes itself the moment it
+            is given something to do: the daemon starts a host on send, and the
+            composer already says so. The terminal pane offers its own button
+            for the case where a terminal is what you want. A header button as
+            well was a third way to say the same thing. */}
+        {terminated && (
+          <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
             Resume
           </button>
-        ) : (
-          // Only while the host is cold. Waking one is not something the tab
-          // strip does — showTerminal refuses to start a host on its own — so
-          // this is the one-click way in. Once it is live the tab is the way
-          // back to the terminal, and a second control beside it that does the
-          // same thing is just another thing to read.
-          !live && (
-            <button className="filled" onClick={() => void store.openTerminal(hostId, session, true)}>
-              Wake
-            </button>
-          )
         )}
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}


### PR DESCRIPTION
## Summary

Follows #55, which removed the header's Terminal button. This removes the other half of that control — **Wake** — because a cold session already wakes itself.

Three things already cover it:

- **Sending a prompt wakes the host.** `internal/server/api.go:507` — *"Idle with no terminal: wake the agent and type into it."* The composer knows, and its send button reads **"Wake and send"** for a cold session.
- **The terminal pane has its own button**, "Wake and attach", for when a terminal is the thing you actually want.
- The header button was a third way of saying what those two already say.

**Resume stays**, because it is not the same thing. `terminated` is the one state the daemon refuses prompts for outright — `api.go:497` answers 409 `session_terminated` — and `POST /resume` is the only thing that clears it. Waking a terminated session would start its host and leave every prompt still refused.

The tab strip continues to decline to wake a cold host. Attaching would start an agent, and clicking a tab to *look* at a session shouldn't spawn a process — which is exactly why the pane asks first.

Header, by state:

| Session state | Before | After |
| --- | --- | --- |
| Live | — | — |
| Cold | `Wake` | — (send, or the pane's button) |
| Terminated | `Resume` | `Resume` |

Also drops the now-dead `live` binding and the `hasTerminal` import it was the only user of.

## Test plan

- [x] `npm run typecheck`
- [x] Ran the app against a live session: header is `Stop | Terminate | Regenerate title | Pin | Archive | Delete`, no Wake anywhere in it
- [x] Confirmed the two remaining wake paths are untouched — the composer's "Wake and send" and the terminal pane's "Wake and attach"