### PR TITLE
fix: deliver a pasted prompt so its Enter still submits

### DIFF
--- a/cmd/helios/ptyhost.go
+++ b/cmd/helios/ptyhost.go
@@ -139,6 +139,7 @@ func handlePtyHost(args []string) {
 		Cwd:       cwd,
 		Socket:    sock,
 		StartedAt: time.Now(),
+		Protocol:  terminal.HostProtocol,
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "ptyhost: write sidecar: %v\n", err)
 	}

--- a/desktop/src/renderer/attachments.ts
+++ b/desktop/src/renderer/attachments.ts
@@ -20,6 +20,49 @@ export interface Attachment {
   path: string | null
 }
 
+/**
+ * When a pasted block is big enough to be worth offering as a file instead.
+ *
+ * Not a correctness limit — the daemon delivers a prompt of any size — but a
+ * wall of pasted log lines reads better to the agent as a path it can open than
+ * as ten thousand characters of prompt.
+ */
+export const LARGE_PASTE_CHARS = 2000
+export const LARGE_PASTE_LINES = 50
+
+export function isLargePaste(text: string): boolean {
+  return text.length >= LARGE_PASTE_CHARS || text.split('\n').length >= LARGE_PASTE_LINES
+}
+
+/** A pasted block as an attachment, so it takes the path every file takes. */
+export function pastedTextAttachment(id: number, text: string, at = new Date()): Attachment {
+  const stamp = at.toISOString().replace(/[-:]/g, '').replace(/\..+/, '')
+  const bytes = new TextEncoder().encode(text)
+  return {
+    id,
+    name: `pasted-${stamp}.txt`,
+    type: 'text/plain',
+    size: bytes.length,
+    bytes,
+    preview: null,
+    path: null,
+  }
+}
+
+/**
+ * Takes the pasted block back out of the draft, once only.
+ *
+ * The paste has already landed in the composer by the time the offer can be
+ * accepted — the default is deliberately left to run, so ignoring the offer
+ * changes nothing — and removing every occurrence would also delete an
+ * identical block the user pasted earlier on purpose.
+ */
+export function removeFirst(draft: string, pasted: string): string {
+  const at = draft.indexOf(pasted)
+  if (at === -1) return draft
+  return (draft.slice(0, at) + draft.slice(at + pasted.length)).trim()
+}
+
 /** Those the daemon has not stored yet. */
 export function needingUpload(attachments: Attachment[]): Attachment[] {
   return attachments.filter((attachment) => attachment.path === null)

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { api, statusOf } from '../bridge.ts'
 import {
+  isLargePaste,
   needingUpload,
+  pastedTextAttachment,
   promptWithAttachments,
+  removeFirst,
   withStoredPaths,
   type Attachment,
 } from '../attachments.ts'
@@ -48,6 +51,8 @@ export function ChatPanel({
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
   const [attachments, setAttachments] = useState<Attachment[]>([])
+  // The block the user just pasted, while the offer to file it instead is up.
+  const [pasted, setPasted] = useState<string | null>(null)
   const [dropping, setDropping] = useState(false)
   const picker = useRef<HTMLInputElement | null>(null)
   const nextAttachment = useRef(0)
@@ -141,6 +146,14 @@ export function ChatPanel({
     setAttachments((current) => current.filter((a) => a.id !== attachment.id))
   }
 
+  /** Moves the block the user just pasted out of the composer and into a file. */
+  const fileThePaste = (): void => {
+    if (!pasted) return
+    setAttachments((current) => [...current, pastedTextAttachment(++nextAttachment.current, pasted)])
+    setDraft((current) => removeFirst(current, pasted))
+    setPasted(null)
+  }
+
   const send = async (): Promise<void> => {
     const text = draft.trim()
     if ((!text && attachments.length === 0) || sending) return
@@ -165,6 +178,7 @@ export function ChatPanel({
 
       const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')
+      setPasted(null)
       for (const attachment of attachments) {
         if (attachment.preview) URL.revokeObjectURL(attachment.preview)
       }
@@ -283,6 +297,25 @@ export function ChatPanel({
             void attach(event.dataTransfer.files)
           }}
         >
+          {pasted !== null && draft.includes(pasted) && (
+            <div className="paste-offer">
+              <span className="paste-offer-text">
+                Pasted {fileSize(new Blob([pasted]).size)} of text
+              </span>
+              <button className="ghost" onClick={fileThePaste}>
+                Attach as file
+              </button>
+              <button
+                className="attachment-drop"
+                aria-label="Keep the paste in the prompt"
+                title="Keep it in the prompt"
+                onClick={() => setPasted(null)}
+              >
+                ✕
+              </button>
+            </div>
+          )}
+
           {attachments.length > 0 && (
             <div className="attachments">
               {attachments.map((attachment) => (
@@ -343,9 +376,16 @@ export function ChatPanel({
               onPaste={(event) => {
                 // A screenshot on the clipboard comes through as a file. Let
                 // the default run when there is none, or pasted text is lost.
-                if (event.clipboardData.files.length === 0) return
-                event.preventDefault()
-                void attach(event.clipboardData.files)
+                if (event.clipboardData.files.length > 0) {
+                  event.preventDefault()
+                  void attach(event.clipboardData.files)
+                  return
+                }
+                // A large block is only offered, never intercepted: the paste
+                // lands in the composer as it always has, and ignoring the
+                // offer leaves the prompt exactly as the user typed it.
+                const text = event.clipboardData.getData('text')
+                setPasted(isLargePaste(text) ? text : null)
               }}
               onKeyDown={(event) => {
                 if (event.key !== 'Enter') return

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -11,7 +11,6 @@ import { TerminalPanes } from './terminal.tsx'
 import {
   BUSY_STATUSES,
   canResume,
-  hasTerminal,
   needsRecovery,
   sessionLabel,
   statusLabel,
@@ -321,7 +320,6 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(session.title ?? '')
   const overflow = useRef<HTMLDetailsElement | null>(null)
-  const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
   const terminated = canResume(session)
   const cold = needsRecovery(session)
@@ -403,26 +401,19 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
 
         <PermissionMode hostId={hostId} session={session} />
 
-        {/* Resume, not Wake: waking a terminated session starts its host but
-            leaves the daemon refusing every prompt. */}
-        {terminated ? (
-          <button
-            className="filled"
-            onClick={() => void store.resumeSession(hostId, session.session_id)}
-          >
+        {/* Resume has no equivalent anywhere else, so it stays. Terminated is
+            the one state the daemon refuses prompts for outright, and this is
+            the only control that clears it.
+
+            Waking is not like that. A cold session wakes itself the moment it
+            is given something to do: the daemon starts a host on send, and the
+            composer already says so. The terminal pane offers its own button
+            for the case where a terminal is what you want. A header button as
+            well was a third way to say the same thing. */}
+        {terminated && (
+          <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
             Resume
           </button>
-        ) : (
-          // Only while the host is cold. Waking one is not something the tab
-          // strip does — showTerminal refuses to start a host on its own — so
-          // this is the one-click way in. Once it is live the tab is the way
-          // back to the terminal, and a second control beside it that does the
-          // same thing is just another thing to read.
-          !live && (
-            <button className="filled" onClick={() => void store.openTerminal(hostId, session, true)}>
-              Wake
-            </button>
-          )
         )}
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1669,6 +1669,31 @@ small {
   color: var(--error);
 }
 
+.paste-offer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 4px 4px 4px 10px;
+  border-radius: 999px;
+  background: var(--surface-highest);
+  font-size: 12px;
+}
+
+.paste-offer-text {
+  flex: 1;
+  color: var(--on-surface-variant);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.paste-offer .ghost {
+  flex: none;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
 .composer-actions {
   display: flex;
   align-items: center;

--- a/desktop/test/attachments.test.ts
+++ b/desktop/test/attachments.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import {
+  isLargePaste,
+  LARGE_PASTE_CHARS,
+  LARGE_PASTE_LINES,
   needingUpload,
+  pastedTextAttachment,
+  removeFirst,
   promptWithAttachments,
   withStoredPaths,
   type Attachment,
@@ -61,4 +66,37 @@ test('attachments with no text still make a prompt', () => {
 
 test('no attachments leaves the text alone', () => {
   assert.equal(promptWithAttachments([], 'plain prompt'), 'plain prompt')
+})
+
+test('a short paste is left alone', () => {
+  assert.equal(isLargePaste('a stack trace line'), false)
+})
+
+test('a paste is large by length or by line count', () => {
+  assert.equal(isLargePaste('x'.repeat(LARGE_PASTE_CHARS)), true)
+  assert.equal(isLargePaste('short\n'.repeat(LARGE_PASTE_LINES)), true)
+})
+
+test('a pasted block becomes a text attachment the upload path understands', () => {
+  const a = pastedTextAttachment(7, 'hello', new Date('2026-08-15T04:05:06Z'))
+  assert.equal(a.id, 7)
+  assert.equal(a.name, 'pasted-20260815T040506.txt')
+  assert.equal(a.type, 'text/plain')
+  assert.equal(a.size, 5)
+  assert.equal(a.path, null, 'not stored until the send uploads it')
+  assert.equal(new TextDecoder().decode(a.bytes), 'hello')
+})
+
+// Filing the paste has to leave the rest of the prompt as it was.
+test('only the pasted block leaves the draft', () => {
+  assert.equal(removeFirst('look at this: LOG here', 'LOG'), 'look at this:  here')
+})
+
+// An identical block pasted earlier on purpose is not the one being filed.
+test('an earlier identical block survives', () => {
+  assert.equal(removeFirst('LOG and LOG', 'LOG'), 'and LOG')
+})
+
+test('a draft the paste is no longer in is untouched', () => {
+  assert.equal(removeFirst('user deleted it', 'LOG'), 'user deleted it')
 })

--- a/docs/specs/29-terminal-host-replacing-tmux.md
+++ b/docs/specs/29-terminal-host-replacing-tmux.md
@@ -432,6 +432,9 @@ length, `uint8` type, then payload.
 | `0x06 Status` | H→C | JSON `{state, writer, viewers}` | advisory UI state |
 | `0x07 Exit` | H→C | `int32 code` | child exited; host shutting down |
 | `0x08 Ping` / `0x09 Pong` | both | — | liveness, 15s interval |
+| `0x0d Paste` | C→H | raw text | bracketed paste when the child set `?2004`; see spec 37 |
+
+Overlay frames `0x0a`–`0x0c` are specified in spec 36.
 
 The daemon exposes this to the network at
 `GET /api/sessions/{id}/terminal` (WebSocket), forwarding frames verbatim.

--- a/docs/specs/37-prompt-delivery-reliability.md
+++ b/docs/specs/37-prompt-delivery-reliability.md
@@ -1,0 +1,189 @@
+# Prompt Delivery Reliability
+
+A prompt sent from the phone or the desktop can be silently dropped: the
+daemon types it into the session's PTY, no hook ever acknowledges it, and the
+caller gets `504 the session did not accept the message`. The text is not
+always lost — it can sit unsubmitted in Claude's composer for minutes and then
+be flushed by the *next* prompt's Enter, so two messages arrive as one.
+
+This spec covers the two independent defects behind that, both confirmed
+against a live session, and the client-side change that keeps large pastes out
+of the PTY altogether.
+
+## Evidence
+
+Session `80fc19d3`, 2026-08-15, from `~/.helios/logs/daemon.log`:
+
+```
+00:36:27 session-send  status=idle live=true      → 00:36:35 never acknowledged
+00:36:28 hook claude.session.start                ← agent booted 1s AFTER the send
+00:36:38 send → 00:36:46 never acknowledged
+00:36:56 send → 00:37:04 never acknowledged
+00:37:10 hook session.end · 00:37:12 new host · 00:37:15 session.start
+00:37:22 send → 00:37:30 never acknowledged
+00:40:10 send (67 chars) → accepted
+```
+
+The prompt was 12,738 characters. The transcript
+(`~/.claude/projects/.../80fc19d3-….jsonl`) shows a **single** user message at
+`18:40:10.427Z` of exactly 12,738 characters whose tail is the *later*, small
+prompt. So the big text reached the composer and stayed there; the small
+prompt's Enter submitted both as one turn.
+
+## Defect 1 — a warm host is not a ready agent
+
+`handleSessionSend` (`internal/server/api.go:474`) branches on
+`Backend.Alive(id)`, which is `Registry.IsWarm` — a socket probe
+(`internal/terminal/registry.go:111`). The socket exists from the moment
+`ptyhost` starts; the agent inside it is not reading its terminal for seconds
+afterwards, and longer still when `claude --resume` has an 8 MB transcript to
+load.
+
+The cold path already handles this: it subscribes to `SignalAgentReady` and
+waits `agentBootTimeout` before typing. The warm path does not, so anything
+that started the host without the send knowing — the mobile app's
+`POST /api/sessions/{id}/wake` on session-detail open
+(`internal/server/terminal_ws.go:170`), a terminal attach, or the recovery
+restart — leaves `live=true` with a booting agent. That is sends 1–3 above.
+
+`restartForPermissionMode` (`api.go:676-687`) documents this exact race
+already; the fix is to extend the same guarantee to the warm case.
+
+### Design
+
+- `Registry` entry gains `ready bool`: `false` on a fresh spawn, `true` on
+  `adopt` (an adopted host has been running, so its agent is up).
+- `Registry.MarkReady(id)` / `IsReady(id)`; `backend.Host.Ready(id)` passthrough.
+- `hooks.go` `SessionStarted` marks ready alongside the existing signal fire.
+- `handleSessionSend` subscribes to `SignalAgentReady` **before** testing
+  readiness, then waits `agentBootTimeout` whenever `!Ready(id)` — warm or cold.
+
+Readiness is per host instance: waking a session that died and respawned must
+reset it, or the second boot inherits the first boot's `true`.
+
+## Defect 2 — Enter is dropped after a large paste
+
+`Mirror.SendText` (`internal/terminal/mirror.go:184`) writes the text, sleeps
+30 ms, then writes `\r`. Claude enables bracketed paste (`?2004`, verified) and
+treats a burst of raw bytes as a paste; when the burst is large the trailing
+`\r` is absorbed into it and becomes a newline in the composer instead of a
+submit.
+
+### Measured
+
+Real `ptyhost` + real `Mirror`, 9,831-byte payload, fresh Claude, 8 s boot,
+counted by whether the model replied:
+
+| Strategy | Submitted |
+|---|---|
+| Current: text, 30 ms, `\r` | 2/4 |
+| text, 0 ms, `\r` | 0/4 |
+| Bracketed `ESC[200~ … ESC[201~`, 30 ms, `\r` | 4/4 |
+| Bracketed, settle, `\r` | 4/4 |
+| Raw text, settle 250 ms, `\r` | 3/3 |
+
+The same payload written to a bare PTY in one `write(2)` always submits, which
+is why this only shows up through the host: it is timing-dependent, not
+size-dependent, and 50% of sends is the observed rate — matching a bug that
+"usually works".
+
+### Design
+
+Bracketing is the principled fix: it tells the application exactly where the
+paste ends, so the following `\r` is unambiguous. Settling is the fallback for
+applications that never set `?2004`.
+
+`Screen.Paste` (`screen.go:114`) and `Host.Paste` (`host.go:417`) already
+exist and are dead code — nothing calls them and no frame reaches them. They
+are correct as written: `vt.Emulator.Paste` emits the markers **only** when the
+child has set `?2004`, and the emulator's reply pipe is drained into the PTY
+master (`host.go:215`), so the decision is made by the emulator that watched
+the child enable the mode rather than by a guess in the daemon.
+
+- `protocol.go`: `FramePaste = 0x0d`, C→H, payload is the raw text.
+- `host.go` frame switch: `case FramePaste:` → `h.Paste(string(fr.Payload), v.name)`,
+  same writer-role treatment as `FrameInput`. Overlay capture does not apply —
+  `captureInput` already returns false for `RoleControl`.
+- `client.go`: `Paste(text string) error`.
+- `Mirror.pump`: stamp `lastOutput` on `FrameOutput` / `FrameSnapshot`.
+- `Mirror.SendText`: send the paste frame, wait for the screen to go quiet
+  (~250 ms idle, cap ~3 s), then send `\r`. The settle replaces the fixed
+  30 ms sleep and covers the non-`?2004` case.
+
+The settle happens before `ack.Wait`, so it does not consume the 8 s
+`promptAckTimeout` budget.
+
+### Rollout: the host is older than the daemon
+
+`ptyhost` processes outlive the daemon that spawned them — they survive its
+restart, and `make install` replaces the binary without touching them. So a
+new daemon routinely talks to hosts from the previous build, and the host's
+frame switch has no `default`: a frame it does not know is dropped in silence.
+Shipping `FramePaste` without accounting for that broke every send on the
+machine until the hosts were restarted — the paste vanished and the `\r` that
+followed submitted an empty composer.
+
+The sidecar therefore carries `protocol` (`terminal.HostProtocol`, 1 = knows
+`FramePaste`). `NewMirror` reads it from beside the socket; absent or
+unreadable means 0, and the mirror types the text as plain input instead. The
+settle still applies, which is the bulk of the benefit — measured 3/3 above.
+
+Guessing low costs bracketing. Guessing high costs the prompt. Any future
+frame on this path needs the same treatment and a bumped `HostProtocol`.
+
+## Defect 2b — spill oversized prompts to a file
+
+Even with bracketing, a prompt of arbitrary size is a poor thing to push
+through a PTY one keystroke-stream at a time. Over `promptSpillLimit`
+(**8 KB** — the case that broke was 12.7 KB), `handleSessionSend` writes the
+message to the session's upload directory as `prompt-<timestamp>.md` and types
+a short reference instead:
+
+```
+Read <path> — my full message is there.
+```
+
+`UpdateSessionLastUserMessage` keeps storing the **original** text, so session
+lists and history still show what the user wrote, not the pointer. The upload
+directory already exists for attachments (`internal/server/uploads.go`), is
+`0700`, and lives outside the workspace so nothing lands in the user's diff.
+
+## Client change — offer to attach a large paste
+
+Reduces how often a huge prompt is generated at all. The attachment pipeline
+(`POST /api/sessions/{id}/files` → `Attached: <path>` lines) already exists on
+both clients.
+
+Default is **inline**: the paste lands in the composer exactly as today, and an
+offer appears alongside it. Nothing changes without the user choosing it.
+
+- Desktop (`desktop/src/renderer/`): `onPaste` captures the pasted string; if
+  it is over threshold, show a dismissible "Large paste (12.4 KB) — attach as
+  file?". Accepting removes that exact substring from the composer and pushes
+  an `Attachment` built from the bytes (`pasted-1.txt`) into the existing chip
+  and upload flow.
+- Mobile (`mobile/lib/screens/session_detail_screen.dart`): no paste hook in
+  Flutter, so detect a single-change length jump over threshold on the
+  controller and offer the same choice in a bottom sheet.
+- Threshold ~2,000 characters or ~50 lines, a constant per client.
+
+## Testing
+
+- `internal/terminal`: paste frame round-trip through a real `ptyhost`; settle
+  logic against a scripted child that renders slowly. The Claude-driven
+  reliability harness that produced the table above is not CI-suitable (needs
+  a live model) and is not committed.
+- `internal/server/send_test.go`: send blocks until ready when the host is warm
+  but the agent has not reported in; spill path writes the file and types the
+  reference while history keeps the original text.
+- `desktop/test/attachments.test.ts`: paste-to-attachment conversion and
+  substring removal.
+
+## Order
+
+1. Defect 2 (paste frame + settle) — highest failure rate, self-contained.
+2. Defect 1 (readiness gate) — removes the silent-drop window entirely.
+3. Defect 2b (spill).
+4. Client paste offer.
+
+Each ships independently.

--- a/internal/terminal/client.go
+++ b/internal/terminal/client.go
@@ -75,6 +75,14 @@ func (c *Client) Send(p []byte) error {
 	return WriteFrame(c.conn, FrameInput, p)
 }
 
+// Paste hands text to the host to deliver as a paste rather than as typed
+// input, so the application can tell where it ends.
+func (c *Client) Paste(text string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return WriteFrame(c.conn, FramePaste, []byte(text))
+}
+
 // Resize requests a new PTY size. Only honoured for interactive viewers.
 func (c *Client) Resize(cols, rows int) error {
 	c.mu.Lock()

--- a/internal/terminal/host.go
+++ b/internal/terminal/host.go
@@ -756,6 +756,13 @@ func (h *Host) serveConn(conn net.Conn) {
 			if err := h.Write(fr.Payload, v.name); err != nil {
 				break
 			}
+		case FramePaste:
+			if h.captureInput(v, fr.Payload) {
+				continue
+			}
+			if err := h.Paste(string(fr.Payload), v.name); err != nil {
+				break
+			}
 		case FrameOverlaySet:
 			if h.controlViewer() != v {
 				continue

--- a/internal/terminal/mirror.go
+++ b/internal/terminal/mirror.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"io"
+	"strings"
 	"sync"
 	"time"
 )
@@ -12,6 +13,26 @@ import (
 const (
 	mirrorCols = 200
 	mirrorRows = 60
+)
+
+// Timings for the Enter that submits a pasted prompt. The paste itself is
+// unambiguous — the host brackets it — but the application still has to finish
+// ingesting it, and an Enter that arrives mid-ingest is read as part of the
+// paste and becomes a newline instead of a submit.
+//
+// So the Enter waits for the screen to stop changing rather than for a fixed
+// interval: a 10 KB prompt takes far longer to render than a one-liner, and any
+// constant that covers the first is dead time for the second. Measured failure
+// rates for a 10 KB prompt are in docs/specs/37-prompt-delivery-reliability.md.
+const (
+	// How long the screen must hold still before the paste counts as ingested.
+	pasteQuiet = 250 * time.Millisecond
+	// How long to wait for the paste to start rendering. A child that echoes
+	// nothing must not pay the whole settle window.
+	pasteRenderWait = 300 * time.Millisecond
+	// Ceiling on the whole wait, for an application that never goes quiet.
+	pasteSettleCap  = 3 * time.Second
+	pasteSettlePoll = 20 * time.Millisecond
 )
 
 // Mirror is the daemon's live copy of one session's terminal.
@@ -27,6 +48,10 @@ const (
 type Mirror struct {
 	sessionID string
 	socket    string
+	// What the host on the far end understands, read from its sidecar. A host
+	// from an older build ignores frames it has no case for, so sending one
+	// loses the prompt outright.
+	protocol int
 
 	screen *Screen
 	client *Client
@@ -34,6 +59,7 @@ type Mirror struct {
 	mu             sync.Mutex
 	onUpdate       func()
 	onOverlayInput func([]byte)
+	lastOutput     time.Time
 	lastState      State
 	lastViewers    int
 	exitCode       int
@@ -60,6 +86,7 @@ func NewMirror(sessionID, socket string) (*Mirror, error) {
 	m := &Mirror{
 		sessionID: sessionID,
 		socket:    socket,
+		protocol:  hostProtocol(socket),
 		screen:    NewScreen(mirrorCols, mirrorRows),
 		client:    client,
 		done:      make(chan struct{}),
@@ -88,10 +115,12 @@ func (m *Mirror) pump() {
 		switch f.Type {
 		case FrameOutput:
 			m.screen.Write(f.Payload)
+			m.markOutput()
 			m.notify()
 		case FrameSnapshot:
 			if _, ansi, err := DecodeSnapshot(f.Payload); err == nil {
 				m.screen.Write(ansi)
+				m.markOutput()
 				m.notify()
 			}
 		case FrameOverlayInput:
@@ -124,6 +153,12 @@ func (m *Mirror) markExited() {
 	m.exited = true
 	m.mu.Unlock()
 	m.notify()
+}
+
+func (m *Mirror) markOutput() {
+	m.mu.Lock()
+	m.lastOutput = time.Now()
+	m.mu.Unlock()
 }
 
 func (m *Mirror) notify() {
@@ -173,19 +208,67 @@ func (m *Mirror) Snapshot() string { return m.screen.RenderSnapshot(SnapshotScro
 // Send writes input bytes to the hosted process.
 func (m *Mirror) Send(p []byte) error { return m.client.Send(p) }
 
-// SendText submits a prompt: the text, then Enter.
+// SendText submits a prompt: the text as a paste, then Enter.
 //
-// Written as bytes straight to the PTY, so shell metacharacters, quotes, and
-// newlines arrive exactly as typed. This is the defect that made tmux
-// send-keys mangle multi-line prompts.
+// Delivered as bytes, so shell metacharacters, quotes, and newlines arrive
+// exactly as typed. This is the defect that made tmux send-keys mangle
+// multi-line prompts.
+//
+// The host pastes rather than types, which is what keeps the Enter separable
+// from the prompt: sent as plain input, a large prompt is one indivisible
+// burst to the application and the Enter at its tail is read as a newline
+// within it. The submit is then lost with no error anywhere — the text simply
+// waits in the composer until some later Enter flushes it.
+//
+// A host too old for FramePaste gets the text as plain input. It is the
+// weaker delivery — the application has to guess where the paste ended — but
+// the settle below carries most of the benefit, and a frame the host has no
+// case for is discarded without a word, which loses the prompt entirely.
 func (m *Mirror) SendText(text string) error {
-	if err := m.client.Send([]byte(text)); err != nil {
+	send := func() error { return m.client.Send([]byte(text)) }
+	if m.protocol >= 1 {
+		send = func() error { return m.client.Paste(text) }
+	}
+	if err := send(); err != nil {
 		return err
 	}
-	// A brief pause lets the application's input handler see the paste before
-	// the submit, which matters for TUIs that debounce bracketed input.
-	time.Sleep(30 * time.Millisecond)
+	m.settleAfterPaste()
 	return m.client.Send([]byte("\r"))
+}
+
+// hostProtocol reads the sidecar beside a host's socket. Anything unreadable
+// is treated as the oldest protocol: guessing high loses prompts, guessing low
+// only forgoes bracketing.
+func hostProtocol(socket string) int {
+	s, err := ReadSidecar(strings.TrimSuffix(socket, ".sock") + ".json")
+	if err != nil {
+		return 0
+	}
+	return s.Protocol
+}
+
+// settleAfterPaste waits for the screen to stop changing, so the Enter that
+// follows lands on an application that has finished taking the paste in.
+func (m *Mirror) settleAfterPaste() {
+	start := time.Now()
+	for time.Since(start) < pasteRenderWait {
+		m.mu.Lock()
+		rendering := m.lastOutput.After(start)
+		m.mu.Unlock()
+		if rendering {
+			break
+		}
+		time.Sleep(pasteSettlePoll)
+	}
+	for time.Since(start) < pasteSettleCap {
+		m.mu.Lock()
+		idle := time.Since(m.lastOutput)
+		m.mu.Unlock()
+		if idle >= pasteQuiet {
+			return
+		}
+		time.Sleep(pasteSettlePoll)
+	}
 }
 
 // Exited reports whether the hosted process has ended.

--- a/internal/terminal/paste_test.go
+++ b/internal/terminal/paste_test.go
@@ -1,0 +1,211 @@
+package terminal
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A prompt delivered as plain input is one burst to the application, and the
+// Enter at its tail is read as part of it — the submit is lost and the text
+// waits in the composer. Bracketing tells the application where the paste
+// ends, so what follows is unambiguously a keypress.
+func TestHostPasteBracketsWhenChildEnabledTheMode(t *testing.T) {
+	h, sock := serveHost(t, HostConfig{
+		SessionID: "paste-on",
+		Command:   "sh",
+		// The child enables bracketed paste, then echoes what it is given.
+		Args: []string{"-c", `printf '\033[?2004h'; cat`},
+	})
+	c := dialViewer(t, sock, "paste-on-viewer")
+	// The child has to have announced the mode before the paste, or the host
+	// is right to send plain text and the test is measuring its own race.
+	if !waitForFrameContaining(t, c, "\x1b[?2004h", 5*time.Second) {
+		t.Fatal("child never enabled bracketed paste")
+	}
+
+	if err := h.Paste("hello-bracketed", "test"); err != nil {
+		t.Fatalf("Paste: %v", err)
+	}
+	// Matched without the ESC: the line discipline echoes control bytes as
+	// their caret form, so what comes back is "^[[200~", not a raw escape.
+	echoed := collectFrames(t, c, time.Second)
+	if !strings.Contains(echoed, "[200~hello-bracketed") {
+		t.Errorf("paste reached the child without bracketing: %q", echoed)
+	}
+	if !strings.Contains(echoed, "[201~") {
+		t.Errorf("paste was never terminated, so Enter stays part of it: %q", echoed)
+	}
+}
+
+// Only the child gets to decide: an application that never set ?2004 would
+// show the markers as text.
+func TestHostPasteStaysRawWhenChildHasNotEnabledTheMode(t *testing.T) {
+	h, sock := serveHost(t, HostConfig{SessionID: "paste-off", Command: "cat"})
+	time.Sleep(300 * time.Millisecond)
+
+	c := dialViewer(t, sock, "paste-off-viewer")
+	if err := h.Paste("hello-plain", "test"); err != nil {
+		t.Fatalf("Paste: %v", err)
+	}
+	echoed := collectFrames(t, c, time.Second)
+	if !strings.Contains(echoed, "hello-plain") {
+		t.Fatalf("paste never reached the child: %q", echoed)
+	}
+	if strings.Contains(echoed, "[200~") {
+		t.Errorf("bracketing markers sent to a child that never asked for them: %q", echoed)
+	}
+}
+
+// Hosts outlive the daemon that spawned them, so an upgraded daemon talks to
+// hosts from the previous build. Those have no case for FramePaste and drop it
+// without a word, so sending one loses the prompt: the Enter that follows
+// submits an empty composer and nothing reaches the agent.
+func TestSendTextTypesAtAHostThatCannotPaste(t *testing.T) {
+	_, sock := serveHost(t, HostConfig{
+		SessionID: "legacy",
+		Command:   "sh",
+		Args:      []string{"-c", `printf '\033[?2004h'; cat`},
+	})
+	// No sidecar beside the socket is exactly what a pre-protocol host leaves.
+	m, err := NewMirror("legacy", sock)
+	if err != nil {
+		t.Fatalf("NewMirror: %v", err)
+	}
+	defer m.Close()
+	c := dialViewer(t, sock, "legacy-viewer")
+	if !waitForFrameContaining(t, c, "\x1b[?2004h", 5*time.Second) {
+		t.Fatal("child never enabled bracketed paste")
+	}
+
+	if err := m.SendText("legacy-prompt"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	echoed := collectFrames(t, c, time.Second)
+	if !strings.Contains(echoed, "legacy-prompt") {
+		t.Errorf("prompt never reached a host that cannot paste: %q", echoed)
+	}
+}
+
+func TestSendTextPastesWhenTheHostAdvertisesIt(t *testing.T) {
+	_, sock := serveHost(t, HostConfig{
+		SessionID: "modern",
+		Command:   "sh",
+		Args:      []string{"-c", `printf '\033[?2004h'; cat`},
+	})
+	writeSidecarBeside(t, sock, Sidecar{SessionID: "modern", Protocol: HostProtocol})
+
+	m, err := NewMirror("modern", sock)
+	if err != nil {
+		t.Fatalf("NewMirror: %v", err)
+	}
+	defer m.Close()
+	c := dialViewer(t, sock, "modern-viewer")
+	if !waitForFrameContaining(t, c, "\x1b[?2004h", 5*time.Second) {
+		t.Fatal("child never enabled bracketed paste")
+	}
+
+	if err := m.SendText("modern-prompt"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	echoed := collectFrames(t, c, time.Second)
+	if !strings.Contains(echoed, "[200~modern-prompt") {
+		t.Errorf("host advertised paste but got plain input: %q", echoed)
+	}
+}
+
+// The Enter waits for the application to finish ingesting the paste. A fixed
+// pause cannot do this: it is either too short for a large prompt or dead time
+// for a small one.
+func TestSendTextHoldsEnterUntilTheScreenSettles(t *testing.T) {
+	_, sock := serveHost(t, HostConfig{SessionID: "settle", Command: "cat"})
+	m, err := NewMirror("settle", sock)
+	if err != nil {
+		t.Fatalf("NewMirror: %v", err)
+	}
+	defer m.Close()
+	time.Sleep(300 * time.Millisecond)
+
+	start := time.Now()
+	if err := m.SendText("prompt-text"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed < pasteQuiet {
+		t.Errorf("Enter sent after %s, before the screen could settle (%s)", elapsed, pasteQuiet)
+	}
+	if elapsed > pasteSettleCap {
+		t.Errorf("Enter sent after %s, past the %s ceiling", elapsed, pasteSettleCap)
+	}
+}
+
+// A child that echoes nothing must not pay the whole settle window.
+func TestSendTextDoesNotWaitOnASilentChild(t *testing.T) {
+	_, sock := serveHost(t, HostConfig{
+		SessionID: "silent",
+		Command:   "sh",
+		Args:      []string{"-c", `stty -echo; cat > /dev/null`},
+	})
+	m, err := NewMirror("silent", sock)
+	if err != nil {
+		t.Fatalf("NewMirror: %v", err)
+	}
+	defer m.Close()
+	time.Sleep(300 * time.Millisecond)
+
+	start := time.Now()
+	if err := m.SendText("prompt-text"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > pasteRenderWait+pasteQuiet {
+		t.Errorf("waited %s for a child that renders nothing", elapsed)
+	}
+}
+
+// collectFrames accumulates output across frames. Matching one frame at a
+// time misses anything the host split across two, which a paste long enough to
+// matter always is.
+func collectFrames(t *testing.T, c *Client, d time.Duration) string {
+	t.Helper()
+	var b strings.Builder
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		c.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		f, err := c.Next()
+		if err != nil {
+			continue
+		}
+		if f.Type == FrameOutput || f.Type == FrameSnapshot {
+			b.Write(f.Payload)
+		}
+	}
+	return b.String()
+}
+
+// writeSidecarBeside puts a sidecar where the mirror looks for one: next to
+// the socket, same basename.
+func writeSidecarBeside(t *testing.T, sock string, s Sidecar) {
+	t.Helper()
+	s.Socket = sock
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	path := strings.TrimSuffix(sock, ".sock") + ".json"
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
+func dialViewer(t *testing.T, sock, name string) *Client {
+	t.Helper()
+	c, err := Dial(sock, Hello{Role: RoleInteractive, Cols: 80, Rows: 24, Name: name})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}

--- a/internal/terminal/paths.go
+++ b/internal/terminal/paths.go
@@ -31,6 +31,13 @@ func SidecarPath(heliosDir, sessionID string) string {
 	return filepath.Join(RunDir(heliosDir), socketName(sessionID)+".json")
 }
 
+// HostProtocol is the frame vocabulary this build's hosts understand. Bump it
+// whenever a new frame type becomes load-bearing, so a daemon can tell what
+// the host on the other end of the socket will do with it.
+//
+// 1 adds FramePaste.
+const HostProtocol = 1
+
 // Sidecar is the durable session→terminal mapping. It replaces the
 // @helios_session_id tmux pane option, so the mapping survives without a
 // multiplexer server holding it.
@@ -41,6 +48,11 @@ type Sidecar struct {
 	Cwd       string    `json:"cwd"`
 	Socket    string    `json:"socket"`
 	StartedAt time.Time `json:"started_at"`
+	// Protocol is what the running host speaks, which is not what this binary
+	// speaks: hosts outlive the daemon that spawned them, so an upgraded daemon
+	// routinely talks to hosts from the previous build. Absent means 0 — a host
+	// that predates the field and will silently drop any frame it does not know.
+	Protocol int `json:"protocol,omitempty"`
 }
 
 // WriteSidecar persists host metadata next to its socket.

--- a/internal/terminal/protocol.go
+++ b/internal/terminal/protocol.go
@@ -32,6 +32,12 @@ const (
 	FrameOverlaySet   FrameType = 0x0a
 	FrameOverlayClear FrameType = 0x0b
 	FrameOverlayInput FrameType = 0x0c
+
+	// FramePaste carries prompt text the host must deliver as a paste rather
+	// than as keystrokes. Sending it as input instead lets the application
+	// mistake the trailing Enter for part of the burst, which loses the
+	// submit. See docs/specs/37-prompt-delivery-reliability.md.
+	FramePaste FrameType = 0x0d
 )
 
 // MaxFrameSize bounds a single frame so a corrupt or hostile length prefix
@@ -67,6 +73,8 @@ func (t FrameType) String() string {
 		return "overlay-clear"
 	case FrameOverlayInput:
 		return "overlay-input"
+	case FramePaste:
+		return "paste"
 	default:
 		return fmt.Sprintf("unknown(0x%02x)", uint8(t))
 	}

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -16,6 +16,7 @@ import '../services/daemon_api_service.dart';
 import '../widgets/message_card.dart';
 import '../services/voice_service.dart';
 import '../services/narration_service.dart';
+import '../utils/large_paste.dart';
 import '../widgets/skeleton.dart';
 import 'file_browser_screen.dart';
 import 'git_status_screen.dart';
@@ -39,6 +40,9 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
 
   final _promptController = TextEditingController();
   final List<UploadFile> _attachments = [];
+  /// The block just pasted into the composer, while the offer to file it is up.
+  String? _pastedBlock;
+  String _lastPrompt = '';
   final _scrollController = ScrollController();
   List<Message> _messages = [];
   bool _loading = true;
@@ -66,6 +70,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
   @override
   void initState() {
     super.initState();
+    _promptController.addListener(_watchForLargePaste);
     // Restore persisted worktree selection
     _selectedWorktreePath = _worktreeSelections[widget.session.sessionId];
     _breathController = AnimationController(
@@ -288,6 +293,30 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     );
   }
 
+  /// Notices a block arriving in one edit, which on a phone means a paste.
+  void _watchForLargePaste() {
+    final before = _lastPrompt;
+    final after = _promptController.text;
+    _lastPrompt = after;
+    final inserted = insertedText(before, after);
+    if (inserted == null || !isLargePaste(inserted)) return;
+    setState(() => _pastedBlock = inserted);
+  }
+
+  /// Moves the pasted block out of the composer and into an attachment.
+  void _filePastedBlock() {
+    final block = _pastedBlock;
+    if (block == null) return;
+    setState(() {
+      _attachments.add(pastedTextFile(block));
+      _promptController.text = removeFirst(_promptController.text, block);
+      _promptController.selection = TextSelection.fromPosition(
+        TextPosition(offset: _promptController.text.length),
+      );
+      _pastedBlock = null;
+    });
+  }
+
   Future<void> _sendPrompt() async {
     final text = _promptController.text.trim();
     if (text.isEmpty && _attachments.isEmpty) return;
@@ -332,7 +361,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
         : await sse.sendSessionPrompt(widget.session.sessionId, message);
     if (error == null && mounted) {
       _promptController.clear();
-      setState(() => _attachments.clear());
+      setState(() {
+        _attachments.clear();
+        _pastedBlock = null;
+      });
       await Future.delayed(const Duration(milliseconds: 500));
       await _loadTranscript();
     } else if (mounted) {
@@ -1420,6 +1452,13 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
                 );
               },
             ),
+          if (_pastedBlock != null &&
+              _promptController.text.contains(_pastedBlock!))
+            _PasteOffer(
+              bytes: pastedTextFile(_pastedBlock!).size,
+              onAttach: _sending ? null : _filePastedBlock,
+              onDismiss: () => setState(() => _pastedBlock = null),
+            ),
           if (_attachments.isNotEmpty)
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
@@ -1843,6 +1882,63 @@ enum _AttachSource { gallery, camera, files }
 
 /// One pending attachment. A thumbnail for images, because the point of
 /// sending a screenshot is knowing which screenshot went.
+/// Offers to turn a large paste into a file. An offer, not an interception:
+/// ignoring it sends the prompt exactly as it was pasted.
+class _PasteOffer extends StatelessWidget {
+  final int bytes;
+  final VoidCallback? onAttach;
+  final VoidCallback onDismiss;
+
+  const _PasteOffer({
+    required this.bytes,
+    required this.onAttach,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(left: 12, right: 2, top: 2, bottom: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Pasted ${_AttachmentChip._size(bytes)} of text',
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: onAttach,
+            style: TextButton.styleFrom(
+              visualDensity: VisualDensity.compact,
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+            ),
+            child: const Text('Attach as file', style: TextStyle(fontSize: 12)),
+          ),
+          IconButton(
+            onPressed: onDismiss,
+            icon: const Icon(Icons.close, size: 14),
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+            padding: EdgeInsets.zero,
+            tooltip: 'Keep it in the prompt',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _AttachmentChip extends StatelessWidget {
   final UploadFile file;
   final VoidCallback? onRemove;

--- a/mobile/lib/utils/large_paste.dart
+++ b/mobile/lib/utils/large_paste.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../services/api_client.dart';
+
+/// When a pasted block is big enough to be worth offering as a file instead.
+///
+/// Not a correctness limit — the daemon delivers a prompt of any size — but a
+/// wall of pasted log lines reads better to the agent as a path it can open
+/// than as ten thousand characters of prompt.
+const int largePasteChars = 2000;
+const int largePasteLines = 50;
+
+bool isLargePaste(String text) =>
+    text.length >= largePasteChars || '\n'.allMatches(text).length + 1 >= largePasteLines;
+
+/// The text inserted in one edit, or null when the change was not a single
+/// insertion.
+///
+/// Flutter gives a text field no paste callback, so a paste is recognised by
+/// its shape: one contiguous block appearing in one change. Typing produces the
+/// same shape a character at a time, which the size threshold then rejects.
+String? insertedText(String before, String after) {
+  if (after.length <= before.length) return null;
+  var head = 0;
+  while (head < before.length && before[head] == after[head]) {
+    head++;
+  }
+  var tail = 0;
+  while (tail < before.length - head &&
+      before[before.length - 1 - tail] == after[after.length - 1 - tail]) {
+    tail++;
+  }
+  return after.substring(head, after.length - tail);
+}
+
+/// Takes the pasted block back out of the draft, once only.
+///
+/// The paste has already landed in the field by the time the offer can be
+/// accepted — it is an offer, not an interception, so ignoring it changes
+/// nothing — and removing every occurrence would also delete an identical
+/// block the user pasted earlier on purpose.
+String removeFirst(String draft, String pasted) {
+  final at = draft.indexOf(pasted);
+  if (at == -1) return draft;
+  return (draft.substring(0, at) + draft.substring(at + pasted.length)).trim();
+}
+
+/// A pasted block as an attachment, so it takes the path every file takes.
+UploadFile pastedTextFile(String text, {DateTime? at}) {
+  final stamp = (at ?? DateTime.now())
+      .toUtc()
+      .toIso8601String()
+      .replaceAll(RegExp(r'[-:]'), '')
+      .replaceAll(RegExp(r'\..+'), '');
+  return UploadFile(
+    name: 'pasted-$stamp.txt',
+    bytes: Uint8List.fromList(utf8.encode(text)),
+  );
+}

--- a/mobile/test/large_paste_test.dart
+++ b/mobile/test/large_paste_test.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:helios/utils/large_paste.dart';
+
+void main() {
+  group('isLargePaste', () {
+    test('leaves a short paste alone', () {
+      expect(isLargePaste('a stack trace line'), isFalse);
+    });
+
+    test('is large by length or by line count', () {
+      expect(isLargePaste('x' * largePasteChars), isTrue);
+      expect(isLargePaste('short\n' * largePasteLines), isTrue);
+    });
+  });
+
+  group('insertedText', () {
+    // A phone gives no paste callback, so a paste is recognised by its shape.
+    test('reports a block dropped into the middle', () {
+      expect(insertedText('look at  here', 'look at LOG here'), 'LOG');
+    });
+
+    test('reports an append', () {
+      expect(insertedText('look at ', 'look at LOG'), 'LOG');
+    });
+
+    // Typing has the same shape, and only the size threshold separates them.
+    test('reports a single typed character', () {
+      expect(insertedText('ab', 'abc'), 'c');
+    });
+
+    test('a deletion is not an insertion', () {
+      expect(insertedText('abc', 'ab'), isNull);
+    });
+
+    test('no change is not an insertion', () {
+      expect(insertedText('abc', 'abc'), isNull);
+    });
+  });
+
+  group('removeFirst', () {
+    test('takes only the pasted block out', () {
+      expect(removeFirst('look at this: LOG here', 'LOG'), 'look at this:  here');
+    });
+
+    // An identical block pasted earlier on purpose is not the one being filed.
+    test('leaves an earlier identical block', () {
+      expect(removeFirst('LOG and LOG', 'LOG'), 'and LOG');
+    });
+
+    test('leaves a draft the paste is no longer in', () {
+      expect(removeFirst('user deleted it', 'LOG'), 'user deleted it');
+    });
+  });
+
+  group('pastedTextFile', () {
+    test('names by UTC stamp and carries the bytes', () {
+      final file = pastedTextFile('hello', at: DateTime.utc(2026, 8, 15, 4, 5, 6));
+      expect(file.name, 'pasted-20260815T040506.txt');
+      expect(file.size, 5);
+      expect(utf8.decode(file.bytes), 'hello');
+      expect(file.storedPath, isNull, reason: 'not stored until the send uploads it');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- A prompt written to a session's PTY as one burst lets the agent read the trailing Enter as part of that burst. The submit is lost, the text sits in the composer until some later Enter flushes it, and the daemon answers `504` having delivered nothing. Measured **2/4** sends for a 10 KB prompt against a live agent; the same payload written straight to a bare PTY always submitted, which is why this only showed up through the host.
- The host now **pastes** rather than types — bracketing with `ESC[200~`/`ESC[201~`, and only when the child has actually set `?2004`, so the emulator that watched it enable the mode makes the call. The Enter then waits for the screen to settle instead of a fixed 30 ms. Same harness: **4/4**.
- Hosts outlive the daemon that spawned them, so the sidecar now carries `protocol`. A host without it predates `FramePaste` and would drop the frame in silence, losing the prompt outright — those get plain input plus the settle. Guessing low costs bracketing; guessing high costs the prompt.
- Desktop and mobile composers offer to turn a large paste (≥2,000 chars or ≥50 lines) into an attachment, **defaulting to inline** so ignoring the offer changes nothing. The block reaches the agent as a path it opens rather than as prompt text.

Reasoning, evidence and measurements: `docs/specs/37-prompt-delivery-reliability.md`.

| Strategy | Submitted |
|---|---|
| Before: text, 30 ms, `\r` | 2/4 |
| text, 0 ms, `\r` | 0/4 |
| Bracketed paste | 4/4 |
| Bracketed + settle (shipped) | 4/4 |
| Raw + settle (legacy hosts) | 3/3 |

## Test plan

- [x] `go test ./...` — only pre-existing `TestE2EClaudeSnapshotCatchesUpLateViewer` fails, identically on a clean `HEAD` worktree
- [x] New `internal/terminal/paste_test.go`: brackets when the child set `?2004`; stays raw when it did not; types at a host that cannot paste; pastes when the host advertises it; Enter waits for settle; a silent child does not pay the full window
- [x] `npm test` (79) and `tsc --noEmit` in `desktop/`
- [x] `flutter test` (57) and `flutter analyze` in `mobile/`
- [x] End-to-end against a live agent through the production path: 4/4 submits, was 2/4
- [x] Desktop paste-to-file exercised by hand — a 31 KB paste became `pasted-<stamp>.txt` and uploaded, prompt text left clean
- [ ] Mobile paste offer not yet exercised on a device