### PR TITLE
feat: title sessions with Nerd Font glyphs, and let the prompt be replaced

### DIFF
--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -241,6 +241,8 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
 interface TitlePrefs {
   enabled: boolean
   emoji: boolean
+  /** Empty means the built-in prompt. Anything else replaces it outright. */
+  prompt: string
 }
 
 /**
@@ -265,9 +267,10 @@ function SessionTitles(): JSX.Element {
             ...current,
             [host.id]: {
               enabled: values['autotitle.enabled'] === 'true',
-              // Only an explicit false turns the emoji off, which is how the
-              // daemon reads it (claude/autotitle.go:104).
+              // Only an explicit false turns the icon off, which is how the
+              // daemon reads it (claude/autotitle.go).
               emoji: values['autotitle.emoji'] !== 'false',
+              prompt: values['autotitle.prompt'] ?? '',
             },
           }))
         })
@@ -286,6 +289,7 @@ function SessionTitles(): JSX.Element {
       await api(hostId).updateSettings({
         'autotitle.enabled': String(after.enabled),
         'autotitle.emoji': String(after.emoji),
+        'autotitle.prompt': after.prompt,
       })
     } catch (err) {
       setPrefs((all) => ({ ...all, [hostId]: before }))
@@ -333,15 +337,64 @@ function SessionTitles(): JSX.Element {
                   onChange={(event) => void change(host.id, { emoji: event.target.checked })}
                 />
                 <span>
-                  Emoji prefix
-                  <small>🐛 [FIX] rather than [FIX].</small>
+                  Icon prefix
+                  <small>A Nerd Font glyph per category —  [FIX] rather than [FIX]. Needs a Nerd Font to show.</small>
                 </span>
               </label>
+
+              <CustomPrompt
+                value={value.prompt}
+                disabled={!value.enabled}
+                onSave={(prompt) => void change(host.id, { prompt })}
+              />
             </div>
           )
         })
       )}
     </section>
+  )
+}
+
+/**
+ * The system prompt the titler runs with.
+ *
+ * Saved on blur rather than per keystroke: this is a round trip to the daemon,
+ * and a prompt is written a sentence at a time. Empty restores the built-in.
+ */
+function CustomPrompt({
+  value,
+  disabled,
+  onSave,
+}: {
+  value: string
+  disabled: boolean
+  onSave: (prompt: string) => void
+}): JSX.Element {
+  const [draft, setDraft] = useState(value)
+
+  // The saved value wins when it changes underneath — another client editing
+  // the same daemon, or the host list reloading.
+  useEffect(() => setDraft(value), [value])
+
+  return (
+    <div className="title-prompt">
+      <span className="theme-picker-label">Custom prompt</span>
+      <p className="modal-note">
+        Replaces the built-in instructions entirely, so the format, the categories and the rule that skips
+        greetings all become yours to state. Leave it empty to use the built-in one.
+      </p>
+      <textarea
+        rows={5}
+        disabled={disabled}
+        value={draft}
+        placeholder="Using the built-in prompt."
+        spellCheck={false}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => {
+          if (draft !== value) onSave(draft)
+        }}
+      />
+    </div>
   )
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3413,6 +3413,26 @@ hr {
   margin-top: 16px;
 }
 
+.title-prompt {
+  margin-top: 14px;
+}
+
+.title-prompt textarea {
+  width: 100%;
+  margin-top: 6px;
+  border-radius: var(--r-md);
+  /* A prompt is read as much as it is written, and the glyphs it names only
+     line up in a monospaced font. */
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.title-prompt textarea:disabled {
+  opacity: 0.5;
+}
+
 .settings-group {
   margin-top: 20px;
 }

--- a/internal/provider/claude/autotitle.go
+++ b/internal/provider/claude/autotitle.go
@@ -17,24 +17,55 @@ const maxAutoTitleAttempts = 5
 
 var categories = []string{"DB", "AUTH", "API", "UI", "TEST", "DOCS", "INFRA", "REFACTOR", "FIX", "FEAT"}
 
+// The glyph that goes in front of each category, from the Nerd Font range.
+//
+// Emoji were the model's own choice and no two sessions agreed: the same
+// refactor came back a hammer one time and a broom the next, at double width,
+// aligning badly down a column of monospaced titles. A glyph per category is
+// one cell wide, the same for the same kind of work, and sits in a terminal
+// font without pushing the text off its grid.
+//
+// Named in the prompt rather than prefixed afterwards, because the model is the
+// one choosing the category — asking for the pair keeps the two agreeing.
+var categoryGlyphs = map[string]string{
+	"DB":       "", // database
+	"AUTH":     "", // lock
+	"API":      "", // exchange
+	"UI":       "", // display
+	"TEST":     "", // flask
+	"DOCS":     "", // book
+	"INFRA":    "", // server
+	"REFACTOR": "", // cycle
+	"FIX":      "", // bug
+	"FEAT":     "", // star
+}
+
+// glyphList renders the pairs for the prompt, in the order of `categories` so
+// the list reads the same way on every call.
+func glyphList() string {
+	var sb strings.Builder
+	for _, category := range categories {
+		sb.WriteString(fmt.Sprintf("\n  %s %s", categoryGlyphs[category], category))
+	}
+	return sb.String()
+}
+
 func autoTitleSystemPrompt(forceTitle bool) string {
-	categoryList := strings.Join(categories, ", ")
 	skipLine := ""
 	if !forceTitle {
 		skipLine = `- If the session is a greeting, test message, or non-substantive (e.g. "hi", "hello", "thanks", "test"), respond with exactly: SKIP` + "\n"
 	}
 
-	emojiLine := "- Start with one relevant emoji, then the category tag, then the title."
 	return fmt.Sprintf(`You are a session title generator for a coding assistant.
 
 Given a session context (project, user message, assistant response), generate a concise title.
 
 Rules:
-%s- Pick one category from: [%s]
-- %s
+%s- Pick the one category that fits, and use the glyph written beside it:%s
+- Copy the glyph exactly. Do not replace it with an emoji or a description.
 - Keep the title 5-8 words.
-- Format: EMOJI [CATEGORY] Short title here
-- No explanation, no quotes, nothing else.`, skipLine, categoryList, emojiLine)
+- Format: GLYPH [CATEGORY] Short title here
+- No explanation, no quotes, nothing else.`, skipLine, glyphList())
 }
 
 func autoTitleSystemPromptNoEmoji(forceTitle bool) string {
@@ -53,6 +84,25 @@ Rules:
 - Keep the title 5-8 words.
 - Format: [CATEGORY] Short title here
 - No explanation, no quotes, nothing else.`, skipLine, categoryList)
+}
+
+// titleSystemPrompt picks the instructions the model is given.
+//
+// A custom prompt replaces the built-in one outright rather than being appended
+// to it. Someone who writes their own wants their own format — a house style, a
+// ticket number, another language — and leaving the built-in rules underneath
+// would have the two contradict each other over the format line.
+//
+// The cost of that is theirs to carry: SKIP and the glyph list are ours, so a
+// custom prompt that does not mention SKIP will title every "hi" it sees.
+func titleSystemPrompt(custom string, glyphs, forceTitle bool) string {
+	if trimmed := strings.TrimSpace(custom); trimmed != "" {
+		return trimmed
+	}
+	if glyphs {
+		return autoTitleSystemPrompt(forceTitle)
+	}
+	return autoTitleSystemPromptNoEmoji(forceTitle)
 }
 
 // TriggerAutoTitle checks eligibility and fires async title generation if appropriate.
@@ -100,18 +150,9 @@ func generateTitle(db *store.Store, sessionID, cwd, transcriptPath string, notif
 
 	prompt := buildTitlePrompt(project, userMsg, recentPairs)
 
-	emojiEnabled := true
-	val, _ := db.GetSetting("autotitle.emoji")
-	if val == "false" {
-		emojiEnabled = false
-	}
-
-	var systemPrompt string
-	if emojiEnabled {
-		systemPrompt = autoTitleSystemPrompt(forceTitle)
-	} else {
-		systemPrompt = autoTitleSystemPromptNoEmoji(forceTitle)
-	}
+	custom, _ := db.GetSetting("autotitle.prompt")
+	emoji, _ := db.GetSetting("autotitle.emoji")
+	systemPrompt := titleSystemPrompt(custom, emoji != "false", forceTitle)
 
 	caller := provider.GetSmallModelCaller("claude")
 	if caller == nil {

--- a/internal/provider/claude/autotitle_test.go
+++ b/internal/provider/claude/autotitle_test.go
@@ -1,0 +1,88 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTitlePrompt_NamesAGlyphForEveryCategory(t *testing.T) {
+	prompt := autoTitleSystemPrompt(false)
+
+	for _, category := range categories {
+		glyph, ok := categoryGlyphs[category]
+		if !ok {
+			t.Errorf("category %s has no glyph", category)
+			continue
+		}
+		// The pair, not just the two separately: the model is told to use the
+		// glyph beside the category, so they have to arrive together.
+		if !strings.Contains(prompt, glyph+" "+category) {
+			t.Errorf("prompt does not pair %q with %s", glyph, category)
+		}
+	}
+}
+
+// Two categories sharing a glyph would make the prefix meaningless as a signal.
+func TestTitlePrompt_GlyphsAreDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for category, glyph := range categoryGlyphs {
+		if other, clash := seen[glyph]; clash {
+			t.Errorf("%s and %s share the glyph %q", other, category, glyph)
+		}
+		seen[glyph] = category
+	}
+}
+
+// The emoji instruction is what the glyphs replaced; leaving it in would invite
+// the model to reach for one anyway.
+func TestTitlePrompt_DoesNotAskForEmoji(t *testing.T) {
+	prompt := autoTitleSystemPrompt(false)
+	if strings.Contains(prompt, "EMOJI") {
+		t.Error("prompt still asks for an EMOJI")
+	}
+	if !strings.Contains(prompt, "GLYPH [CATEGORY]") {
+		t.Error("prompt does not state the glyph format")
+	}
+}
+
+func TestTitlePrompt_SkipIsOfferedUntilTheLastAttempt(t *testing.T) {
+	if !strings.Contains(autoTitleSystemPrompt(false), "SKIP") {
+		t.Error("a normal attempt should be allowed to skip a greeting")
+	}
+	if strings.Contains(autoTitleSystemPrompt(true), "SKIP") {
+		t.Error("the forced attempt must not be offered a way out")
+	}
+}
+
+func TestTitlePrompt_CustomReplacesTheBuiltIn(t *testing.T) {
+	custom := "Name the session in Bengali. Nothing else."
+	got := titleSystemPrompt(custom, true, false)
+
+	if got != custom {
+		t.Errorf("custom prompt not used verbatim: %q", got)
+	}
+	// Appending would leave two format rules contradicting each other.
+	if strings.Contains(got, "GLYPH") {
+		t.Error("the built-in rules leaked into a custom prompt")
+	}
+}
+
+func TestTitlePrompt_BlankCustomFallsBack(t *testing.T) {
+	for _, blank := range []string{"", "   ", "\n\t "} {
+		got := titleSystemPrompt(blank, true, false)
+		if !strings.Contains(got, "GLYPH [CATEGORY]") {
+			t.Errorf("blank custom prompt %q did not fall back to the built-in", blank)
+		}
+	}
+}
+
+func TestTitlePrompt_GlyphsOffDropsThePrefix(t *testing.T) {
+	got := titleSystemPrompt("", false, false)
+
+	if strings.Contains(got, "GLYPH") {
+		t.Error("glyphs were turned off but the prompt still asks for one")
+	}
+	if !strings.Contains(got, "Format: [CATEGORY]") {
+		t.Errorf("expected the bare category format, got: %q", got)
+	}
+}

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -20,7 +20,7 @@ var generalSettingsKeys = []struct {
 	section string
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
-	{key: "autotitle.emoji", label: "Title emoji prefix", section: ""},
+	{key: "autotitle.emoji", label: "Title icon prefix", section: ""},
 }
 
 var generalSettingDefaults = map[string]bool{

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -308,8 +308,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 if (_autoTitleEnabled)
                   SwitchListTile(
                     secondary: const Icon(Icons.emoji_emotions_outlined),
-                    title: const Text('Title emoji'),
-                    subtitle: const Text('Prefix titles with a category emoji'),
+                    title: const Text('Title icon'),
+                    subtitle: const Text('Prefix titles with a Nerd Font category glyph'),
                     value: _autoTitleEmoji,
                     onChanged: (value) {
                       setState(() => _autoTitleEmoji = value);


### PR DESCRIPTION
## Summary

Stacked on #57 — base is `feat/desktop-settings-nav`, so this diff is only the titler. Both branches are rebased on `main` @ `2b3edce`.

**Glyphs instead of emoji.** Emoji were the model's own choice and no two sessions agreed: the same refactor came back a hammer one time and a broom the next, at double width, aligning badly down a column of monospaced titles. Each category now has one Nerd Font glyph — one cell wide, the same for the same kind of work.

They are named in the prompt *beside* their category rather than prefixed afterwards. The model chooses the category, so asking for the pair keeps the two from disagreeing, and the prompt says to copy the glyph rather than substitute an emoji, which is what it does otherwise.

```
 [FEAT] Add file upload to composer
 [FIX]  Stop double upload on retry
 [DB]   Add uploads table migration
```

**The prompt can be replaced.** New `autotitle.prompt` setting, with a box in the desktop Session titles pane. Replaced rather than appended: someone writing their own wants their own format, and leaving the built-in rules underneath would have the two contradict each other over the format line. The cost is theirs to carry — `SKIP` and the glyph list are ours, so a custom prompt that never mentions SKIP will title every "hi" it sees. Said as much in the UI.

Saved on blur, not per keystroke — it is a round trip to the daemon, and a prompt is written a sentence at a time.

The emoji toggle keeps its key (`autotitle.emoji`, for anyone who already set it) but is relabelled to **icon** across desktop, phone and TUI.

## Test plan

- [x] `go build ./...`, `go test ./internal/provider/claude/ ./internal/tui/`
- [x] 7 new Go tests: every category has a glyph and the prompt pairs the two; glyphs are distinct; the prompt no longer asks for an EMOJI; SKIP is offered until the forced attempt; a custom prompt is used verbatim with no built-in rules leaking; blank/whitespace falls back; icons-off drops the prefix
- [x] `tsc --noEmit`, `npm run build`, desktop suite 79 pass
- [x] Browser: prompt box disabled until titles are on, placeholder reads "Using the built-in prompt.", a real blur saves once and sends all three keys together

Caveat worth stating: glyphs render as tofu without a Nerd Font — including on the phone, which is why the toggle stays.