### PR TITLE
fix: refuse to start a second daemon instead of racing the first

### DIFF
--- a/cmd/helios/main.go
+++ b/cmd/helios/main.go
@@ -113,6 +113,14 @@ func handleDaemon(args []string) {
 				}
 			}
 		}
+		// Before forking, not after: a background start would otherwise report a
+		// pid that is already on its way out, and the failure would only appear
+		// in a log the user has no reason to open.
+		if pid, running := daemon.AlreadyRunning(cfg); running {
+			fmt.Fprintln(os.Stderr, daemon.RunningError(pid, cfg))
+			os.Exit(1)
+		}
+
 		if background {
 			exe, _ := os.Executable()
 			// Rebuild args without -d/--daemonize

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -192,7 +192,14 @@ func startDaemon(cfg *Config) error {
 	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
 		return fmt.Errorf("write pid: %w", err)
 	}
-	defer os.Remove(pidPath)
+	// Only if it is still ours. A daemon that failed to bind used to remove the
+	// file on its way out, taking the running daemon's pid with it — which is
+	// why the machine that logged this had a live daemon and no pid file.
+	defer func() {
+		if pidFromFile() == os.Getpid() {
+			os.Remove(pidPath)
+		}
+	}()
 
 	log.Printf("helios daemon starting")
 	log.Printf("  internal: 127.0.0.1:%d (hooks + admin)", cfg.Server.InternalPort)

--- a/internal/daemon/running.go
+++ b/internal/daemon/running.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// AlreadyRunning reports whether a daemon already holds the ports, and the pid
+// of the one that does when it can be named.
+//
+// Nothing used to check. A second daemon would start, fail to bind, and exit
+// with "address already in use" — which is fine once, from a terminal, and
+// ruinous under a launchd agent with KeepAlive: the agent restarts what it
+// thinks crashed, the new copy hits the same bound port, and the pair spin at
+// about a restart a second, filling daemon.log with thousands of lines while
+// the daemon that actually works sits there untouched. One machine here had
+// logged 264 restarts.
+//
+// The port is the thing worth testing rather than the pid file: the file is
+// left behind by a daemon that was killed, and a pid can be reused, but a
+// socket in use is the conflict itself.
+func AlreadyRunning(cfg *Config) (int, bool) {
+	if !portInUse(cfg.Server.InternalPort) && !portInUse(cfg.Server.PublicPort) {
+		return 0, false
+	}
+	// Something holds a port. The pid file names it when the holder is ours,
+	// and a bare "in use" is still the right answer when it is not.
+	return pidFromFile(), true
+}
+
+// portInUse reports whether anything is listening on the loopback port.
+func portInUse(port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return true
+	}
+	listener.Close()
+	return false
+}
+
+// pidFromFile reads the running daemon's pid, or 0 when there is no usable one.
+func pidFromFile() int {
+	data, err := os.ReadFile(filepath.Join(HeliosDir(), "daemon.pid"))
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// RunningError describes the daemon that is in the way, in the words the CLI
+// should print.
+func RunningError(pid int, cfg *Config) error {
+	if pid > 0 {
+		return fmt.Errorf("helios daemon is already running (pid %d) — stop it with `helios daemon stop`", pid)
+	}
+	return fmt.Errorf(
+		"port %d or %d is already in use — another helios daemon, or something else holding it",
+		cfg.Server.InternalPort, cfg.Server.PublicPort,
+	)
+}

--- a/internal/daemon/running_test.go
+++ b/internal/daemon/running_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// freePort takes a port and hands it back, so a test can name one nothing is
+// listening on.
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return port
+}
+
+func configOn(internal, public int) *Config {
+	cfg := DefaultConfig()
+	cfg.Server.InternalPort = internal
+	cfg.Server.PublicPort = public
+	return cfg
+}
+
+func TestAlreadyRunning_NothingListening(t *testing.T) {
+	cfg := configOn(freePort(t), freePort(t))
+
+	if _, running := AlreadyRunning(cfg); running {
+		t.Error("reported a daemon with both ports free")
+	}
+}
+
+// The conflict this exists to catch: the internal port taken by a daemon that
+// is already up.
+func TestAlreadyRunning_InternalPortTaken(t *testing.T) {
+	cfg := configOn(freePort(t), freePort(t))
+
+	holder, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.Server.InternalPort))
+	if err != nil {
+		t.Fatalf("hold the port: %v", err)
+	}
+	defer holder.Close()
+
+	if _, running := AlreadyRunning(cfg); !running {
+		t.Error("did not notice the internal port was taken")
+	}
+}
+
+// Either port is enough. The daemon needs both, so binding one of them is
+// already a failed start.
+func TestAlreadyRunning_PublicPortTaken(t *testing.T) {
+	cfg := configOn(freePort(t), freePort(t))
+
+	holder, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.Server.PublicPort))
+	if err != nil {
+		t.Fatalf("hold the port: %v", err)
+	}
+	defer holder.Close()
+
+	if _, running := AlreadyRunning(cfg); !running {
+		t.Error("did not notice the public port was taken")
+	}
+}
+
+func TestAlreadyRunning_NamesThePidWhenItCan(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".helios"), 0o755); err != nil {
+		t.Fatalf("make helios dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".helios", "daemon.pid"), []byte("4321\n"), 0o644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	cfg := configOn(freePort(t), freePort(t))
+	holder, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.Server.InternalPort))
+	if err != nil {
+		t.Fatalf("hold the port: %v", err)
+	}
+	defer holder.Close()
+
+	pid, running := AlreadyRunning(cfg)
+	if !running {
+		t.Fatal("did not notice the port was taken")
+	}
+	if pid != 4321 {
+		t.Errorf("pid: got %d, want 4321", pid)
+	}
+	if msg := RunningError(pid, cfg).Error(); !strings.Contains(msg, "4321") || !strings.Contains(msg, "helios daemon stop") {
+		t.Errorf("message does not say which daemon or how to stop it: %q", msg)
+	}
+}
+
+// Something else on the port is still a reason not to start, and the message
+// has to say so without inventing a pid.
+func TestRunningError_WithoutAPid(t *testing.T) {
+	cfg := configOn(7654, 7655)
+
+	msg := RunningError(0, cfg).Error()
+	if !strings.Contains(msg, strconv.Itoa(cfg.Server.InternalPort)) {
+		t.Errorf("message does not name the port: %q", msg)
+	}
+	if strings.Contains(msg, "pid") {
+		t.Errorf("message claims a pid it does not have: %q", msg)
+	}
+}

--- a/internal/daemon/supervisor.go
+++ b/internal/daemon/supervisor.go
@@ -32,6 +32,12 @@ func NewSupervisor(cfg *Config) *Supervisor {
 // It restarts the daemon on panic/error with exponential backoff.
 // It exits when receiving SIGTERM/SIGINT or when max restarts are exceeded.
 func (s *Supervisor) Run() error {
+	// A supervisor that starts beside a running daemon restarts its own copy
+	// against a bound port for as long as it is left alone. Refuse instead.
+	if pid, running := AlreadyRunning(s.cfg); running {
+		return RunningError(pid, s.cfg)
+	}
+
 	// Write supervisor PID file
 	pidPath := filepath.Join(HeliosDir(), "supervisor.pid")
 	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {


### PR DESCRIPTION
## Summary

Nothing checked whether a daemon was already running. The second one started, failed to bind, and exited with `address already in use` — survivable from a terminal, ruinous under a launchd agent with `KeepAlive`. The agent restarts what it believes crashed, the new copy meets the same bound port, and the two spin at roughly a restart a second.

Measured on the machine this came from:

```
launchctl print gui/501/com.helios.daemon
    state = running
    runs  = 264          ← restarts
    pid   = 21336        ← dies immediately, cannot bind

lsof -iTCP:7655 -sTCP:LISTEN
    helios  71126        ← the daemon that actually works, untouched
```

Thousands of `daemon exited with error: public server: listen tcp 127.0.0.1:7655: bind: address already in use` in `daemon.log`, while the working daemon sat there unnoticed.

**`helios daemon start` now looks first** and says what is in the way — the pid when the pid file can supply one, the ports when it cannot:

```
$ helios daemon start
helios daemon is already running (pid 71126) — stop it with `helios daemon stop`
$ echo $?
1
```

The check runs *before* the fork too, so `-d` reports the conflict instead of printing a pid that is already on its way out into a log nobody opens. The supervisor keeps its own copy, since launchd invokes it directly.

The **port** is what gets tested, not the pid file: a killed daemon leaves the file behind, a pid can be reused, and a bound socket is the conflict itself.

### The pid file was collateral

A daemon that failed to bind wrote `daemon.pid` before it failed and removed it on the way out — deleting the *running* daemon's pid along with it. That is why the affected machine had a live daemon and no `daemon.pid` at all, which is also why the message above falls back to naming ports. It now removes the file only while it is still its own.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./internal/daemon/` — 5 new tests: both ports free, internal taken, public taken, pid named from the file, and the message naming ports without inventing a pid
- [x] Live, against the daemon actually running on this machine: `helios daemon start` and `helios daemon start -d` both refuse with exit 1 and spawn nothing

## Note

The `~/Library/LaunchAgents/com.helios.daemon.plist` agent is what turned a one-off conflict into a loop. I have unloaded it on this machine and moved it to `~/.helios/disabled/`. It is not generated by anything in this repo — it was installed by hand — so nothing here recreates it.