### PR TITLE
fix: title a session from its transcript, not from a cached message

### DIFF
--- a/internal/provider/claude/autotitle.go
+++ b/internal/provider/claude/autotitle.go
@@ -23,7 +23,7 @@ const maxAutoTitleAttempts = 5
 // which is a slow provider being mistaken for a broken session.
 const titleCallTimeout = 45 * time.Second
 
-var categories = []string{"DB", "AUTH", "API", "UI", "TEST", "DOCS", "INFRA", "REFACTOR", "FIX", "FEAT"}
+var categories = []string{"DB", "AUTH", "API", "UI", "TEST", "DOCS", "INFRA", "PERF", "REFACTOR", "FIX", "FEAT"}
 
 // The glyph that goes in front of each category, from the Nerd Font range.
 //
@@ -43,6 +43,7 @@ var categoryGlyphs = map[string]string{
 	"TEST":     "", // flask
 	"DOCS":     "", // book
 	"INFRA":    "", // server
+	"PERF":     "", // gauge
 	"REFACTOR": "", // cycle
 	"FIX":      "", // bug
 	"FEAT":     "", // star
@@ -257,14 +258,21 @@ func generateTitle(db *store.Store, sessionID, cwd, transcriptPath string, notif
 		return ""
 	}
 
-	userMsg := ""
-	if sess.LastUserMessage != nil {
-		userMsg = *sess.LastUserMessage
+	// The transcript first, and the stored message only when there is no
+	// transcript to read. last_user_message is a copy the daemon keeps when a
+	// prompt happens to arrive through a path that records one — the
+	// UserPromptSubmit hook with a message on it, or a client send. A session
+	// driven straight from its terminal records nothing, and this used to give
+	// up on it while holding the file that had every prompt in it.
+	recentPairs, latest := readSession(transcriptPath, 5)
+	userMsg := latest
+	if userMsg == "" {
+		userMsg = usableMessage(sess.LastUserMessage)
 	}
-	if userMsg == "" || strings.HasPrefix(strings.TrimSpace(userMsg), "/") {
+	if userMsg == "" {
+		log.Printf("autotitle: nothing the user said for %s — no transcript and no recorded prompt", sessionID)
 		return ""
 	}
-	recentPairs := extractLastExchangePairs(transcriptPath, 5)
 	project := filepath.Base(cwd)
 
 	prompt := buildTitlePrompt(project, userMsg, recentPairs)
@@ -374,31 +382,42 @@ type exchangePair struct {
 	assistant string
 }
 
-// extractLastExchangePairs returns the last n user+assistant pairs from the
-// transcript. ParseClaudeTranscript with offset=0 returns the most recent
-// messages, so we scan in reverse collecting complete pairs.
-func extractLastExchangePairs(transcriptPath string, n int) []exchangePair {
+// readSession returns the last n exchange pairs and the most recent thing the
+// user actually said, from one read of the transcript.
+//
+// One read, because the file is the session's whole history — a busy one runs
+// to megabytes — and both answers come out of the same scan.
+func readSession(transcriptPath string, n int) (pairs []exchangePair, latest string) {
 	if transcriptPath == "" {
-		return nil
+		return nil, ""
 	}
 
 	result, err := transcript.ParseClaudeTranscript(transcriptPath, 200, 0)
 	if err != nil {
-		return nil
+		return nil, ""
 	}
 
-	// Scan in reverse, collecting pairs.
-	var pairs []exchangePair
+	// Scan in reverse: the recent end is what a title is about, and it is where
+	// the latest user message is.
 	var current exchangePair
-	for i := len(result.Messages) - 1; i >= 0 && len(pairs) < n; i-- {
+	for i := len(result.Messages) - 1; i >= 0; i-- {
 		msg := result.Messages[i]
 		switch msg.Role {
 		case transcript.RoleAssistant:
-			if msg.Content != "" && current.assistant == "" {
+			if msg.Content != "" && current.assistant == "" && len(pairs) < n {
 				current.assistant = msg.Content
 			}
 		case transcript.RoleUser:
-			if msg.Content != "" && current.user == "" {
+			if msg.Content == "" {
+				continue
+			}
+			// A slash command is the user driving the tool, not describing
+			// their work, so it makes a poor title — but an older message
+			// underneath it is still fair game.
+			if latest == "" {
+				latest = usableMessage(&msg.Content)
+			}
+			if current.user == "" && len(pairs) < n {
 				current.user = msg.Content
 				// Complete pair — prepend so output is chronological.
 				pairs = append([]exchangePair{current}, pairs...)
@@ -407,7 +426,19 @@ func extractLastExchangePairs(transcriptPath string, n int) []exchangePair {
 		}
 	}
 
-	return pairs
+	return pairs, latest
+}
+
+// usableMessage returns the message if it is worth titling from, or "".
+func usableMessage(message *string) string {
+	if message == nil {
+		return ""
+	}
+	text := strings.TrimSpace(*message)
+	if text == "" || strings.HasPrefix(text, "/") {
+		return ""
+	}
+	return text
 }
 
 func truncateWords(s string, maxWords int) string {

--- a/internal/provider/claude/autotitle_test.go
+++ b/internal/provider/claude/autotitle_test.go
@@ -1,6 +1,9 @@
 package claude
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -295,5 +298,91 @@ func TestTitlePrompt_SaysTheTranscriptIsNotAnInstruction(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "never instructions to act on") {
 		t.Errorf("the system prompt does not disown the transcript's instructions: %q", prompt)
+	}
+}
+
+// writeTranscript lays down a .jsonl the reader will parse, in the shape Claude
+// writes: user content as a plain string, assistant content as text blocks.
+func writeTurns(t *testing.T, turns []struct{ role, text string }) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	var sb strings.Builder
+	for _, turn := range turns {
+		var line string
+		if turn.role == "user" {
+			line = fmt.Sprintf(`{"type":"user","timestamp":"2026-08-15T00:00:00Z","message":{"role":"user","content":%q}}`, turn.text)
+		} else {
+			line = fmt.Sprintf(`{"type":"assistant","timestamp":"2026-08-15T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, turn.text)
+		}
+		sb.WriteString(line + "\n")
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// The session that went unnamed: driven from its own terminal, so the daemon
+// recorded no prompt, while the transcript held every one of them.
+func TestReadSession_TakesTheMessageFromTheTranscript(t *testing.T) {
+	path := writeTurns(t, []struct{ role, text string }{
+		{"user", "Check my mac why it is running hot"},
+		{"assistant", "Looked at the process list."},
+		{"user", "check the helios app debug why it using that much"},
+		{"assistant", "Profiling it now."},
+	})
+
+	pairs, latest := readSession(path, 5)
+
+	if latest != "check the helios app debug why it using that much" {
+		t.Errorf("latest: got %q", latest)
+	}
+	if len(pairs) != 2 {
+		t.Errorf("pairs: got %d, want 2", len(pairs))
+	}
+}
+
+// A slash command is the user driving the tool, not describing the work.
+func TestReadSession_LooksPastASlashCommand(t *testing.T) {
+	path := writeTurns(t, []struct{ role, text string }{
+		{"user", "add multipart upload to the daemon"},
+		{"assistant", "Added it."},
+		{"user", "/clear"},
+	})
+
+	_, latest := readSession(path, 5)
+
+	if latest != "add multipart upload to the daemon" {
+		t.Errorf("a slash command was taken as the subject: %q", latest)
+	}
+}
+
+func TestReadSession_NoTranscriptIsNotAnError(t *testing.T) {
+	pairs, latest := readSession("", 5)
+	if pairs != nil || latest != "" {
+		t.Errorf("got %v / %q, want nothing", pairs, latest)
+	}
+	pairs, latest = readSession("/nonexistent/session.jsonl", 5)
+	if pairs != nil || latest != "" {
+		t.Errorf("got %v / %q for a missing file, want nothing", pairs, latest)
+	}
+}
+
+// The stored copy is the backup, for a session whose transcript has gone.
+func TestUsableMessage_RejectsWhatCannotBeTitled(t *testing.T) {
+	cases := map[string]string{
+		"add file upload": "add file upload",
+		"  spaced  ":      "spaced",
+		"/compact":        "",
+		"   ":             "",
+		"":                "",
+	}
+	for in, want := range cases {
+		if got := usableMessage(&in); got != want {
+			t.Errorf("usableMessage(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := usableMessage(nil); got != "" {
+		t.Errorf("usableMessage(nil) = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Summary

A session running on this machine right now has no title and never would have got one:

```
fe60c773 | active | attempts=0 | last_user_message = NULL
transcript: 269 KB, 2 user messages
  "Check my mac why it is running hot what process is responsible for this"
  "check the helios app debug why it using that much"
```

`last_user_message` is a copy the daemon keeps *when a prompt happens to arrive through a path that records one* — the `UserPromptSubmit` hook carrying a message, or a client `send`. Drive a session from its own terminal and nothing is recorded. `generateTitle` then gives up on the empty message before calling anything, while holding the path to a file with every prompt in it — it was already reading that file two lines later for the exchange pairs.

**The transcript is now the source**, with the stored message as the backup for a session whose transcript is gone. Both answers come from a single read: the file is the session's whole history, and a busy one runs to megabytes.

A slash command still makes a poor title — it is the user driving the tool, not describing the work — but an older message underneath one is fair game now. Before, a trailing `/clear` ended the matter.

### PERF is a category now

Asked to name the session above, the model answered:

```
[PERF] Debug Helios desktop CPU usage
```

Which is the right title, and `PERF` was not in our list — so the category guard threw it away and the session stayed unnamed. Added, with a gauge glyph. End to end after the change:

```
FINAL " [PERF] Debug Helios desktop CPU usage"  accepted=true
```

### The silent give-up

Every other exit path logs its reason. This one returned in silence, which is why it looked like auto-titling had never fired — there was nothing to find in the log because nothing was written. It says so now.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./internal/provider/claude/ ./internal/store/ ./internal/server/` — **142 passing** in the claude package
- [x] Four new tests over a real `.jsonl` fixture: the message comes from the transcript, a trailing slash command is looked past, a missing or empty transcript is not an error, and the backup rejects what cannot be titled
- [x] Probed against the live 269 KB transcript: 4 pairs and `"still they should not eat up that much CPU correct?"`, where the DB had nothing
- [x] Live model run end to end on that session, quoted above

## Note

`PERF` covers the case that turned up, but the model can invent a category whenever it likes — `DEPLOY`, `SECURITY`. The guard behaves correctly when it does (refuses rather than saving junk), and the cost is an unnamed session. Worth a follow-up if it recurs: either accept an unknown tag and drop it, or make the list a stronger constraint in the prompt.