### PR TITLE
feat: leave title icons off until a Nerd Font is there to draw them

### DIFF
--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -269,7 +269,9 @@ function SessionTitles(): JSX.Element {
               enabled: values['autotitle.enabled'] === 'true',
               // Only an explicit false turns the icon off, which is how the
               // daemon reads it (claude/autotitle.go).
-              emoji: values['autotitle.emoji'] !== 'false',
+              // Off unless turned on: without a Nerd Font every category
+              // renders as the same missing-character box.
+              emoji: values['autotitle.emoji'] === 'true',
               prompt: values['autotitle.prompt'] ?? '',
             },
           }))
@@ -338,7 +340,12 @@ function SessionTitles(): JSX.Element {
                 />
                 <span>
                   Icon prefix
-                  <small>A Nerd Font glyph per category —  [FIX] rather than [FIX]. Needs a Nerd Font to show.</small>
+                  <small>
+                    A glyph per category —  [FIX] rather than [FIX]. Off by default: the glyphs come from a
+                    patched <a href="https://www.nerdfonts.com" target="_blank" rel="noreferrer noopener">Nerd
+                    Font</a>, and without one installed every category shows the same empty box. The phone has no
+                    Nerd Font, so titles made here appear boxed there.
+                  </small>
                 </span>
               </label>
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -97,6 +97,41 @@ body,
   margin: 0;
 }
 
+/**
+ * The category glyph on a session title, and nothing else.
+ *
+ * Titles are drawn in the UI sans stack, which has no Nerd Font in it, so every
+ * glyph landed on the same missing-character box — three different codepoints,
+ * one identical square, and an icon that says nothing is worse than none.
+ *
+ * unicode-range is what keeps this to the glyph: name a whole monospace family
+ * on the title and the words go monospace with it. Restricted to the Private
+ * Use Area, the browser reaches for this font only when a character falls in
+ * that range and leaves the rest of the title alone.
+ *
+ * Symbols Nerd Font first because it carries the glyphs and no letters; the
+ * patched families are the usual ones people already have. If none is
+ * installed the box comes back, which is what the icon toggle is for.
+ *
+ * These are PostScript names, not family names. local() matches on the
+ * PostScript or full name, so local('FiraCode Nerd Font') — the family, and the
+ * obvious thing to write — silently matches nothing and the face loads with
+ * status "error". The name to give is FiraCodeNF-Reg.
+ */
+@font-face {
+  font-family: 'Helios Glyphs';
+  src:
+    local('SymbolsNerdFont-Regular'),
+    local('SymbolsNerdFontMono-Regular'),
+    local('FiraCodeNF-Reg'),
+    local('JetBrainsMonoNF-Regular'),
+    local('Hack Nerd Font'),
+    local('HackNF-Regular'),
+    local('MesloLGSNF-Regular'),
+    local('MesloLGS NF Regular');
+  unicode-range: U+E000-F8FF, U+F0000-FFFFD, U+100000-10FFFD;
+}
+
 body {
   background: var(--surface);
   color: var(--on-surface);
@@ -747,6 +782,9 @@ small {
 
 .card-title {
   margin-top: 8px;
+  /* The glyph font is first, but only claims the Private Use Area — the words
+     fall through to the stack behind it. */
+  font-family: 'Helios Glyphs', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif;
   font-size: 14px;
   font-weight: 600;
   line-height: 1.35;
@@ -873,6 +911,7 @@ small {
 
 .detail-title h1 {
   margin: 0;
+  font-family: 'Helios Glyphs', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif;
   font-size: 17px;
   font-weight: 600;
   letter-spacing: -0.01em;

--- a/internal/provider/claude/autotitle.go
+++ b/internal/provider/claude/autotitle.go
@@ -319,7 +319,11 @@ func generateTitle(db *store.Store, sessionID, cwd, transcriptPath string, notif
 	// Only for our own prompt: a custom one owns its format, and rewriting it
 	// into ours would ignore the whole point of setting it.
 	if strings.TrimSpace(custom) == "" {
-		normalized, ok := normalizeTitle(title, emoji != "false")
+		// Off unless asked for. The glyphs come from the Private Use Area, so
+		// they need a patched Nerd Font to render — and where there is none,
+		// every category collapses to the same missing-character box, which
+		// says less than no icon at all.
+		normalized, ok := normalizeTitle(title, emoji == "true")
 		if !ok {
 			// Our prompt always asks for a category. Without one this is not a
 			// title — usually the model asking for more context than the

--- a/internal/provider/claude/autotitle_test.go
+++ b/internal/provider/claude/autotitle_test.go
@@ -386,3 +386,26 @@ func TestUsableMessage_RejectsWhatCannotBeTitled(t *testing.T) {
 		t.Errorf("usableMessage(nil) = %q, want empty", got)
 	}
 }
+
+// Icons are off unless asked for. The glyphs live in the Private Use Area, so
+// a machine without a patched Nerd Font draws the same empty box for every
+// category — an icon that distinguishes nothing is worse than none.
+func TestNormalizeTitle_IconsAreOptIn(t *testing.T) {
+	// The daemon reads the setting as `emoji == "true"`, so anything else —
+	// unset, "false", nonsense — means off.
+	for _, setting := range []string{"", "false", "0", "yes"} {
+		on := setting == "true"
+		got, ok := normalizeTitle("[FIX] Stop the double upload", on)
+		if !ok {
+			t.Fatalf("setting %q: title rejected", setting)
+		}
+		if got != "[FIX] Stop the double upload" {
+			t.Errorf("setting %q: got %q, want no glyph", setting, got)
+		}
+	}
+
+	got, _ := normalizeTitle("[FIX] Stop the double upload", true)
+	if want := categoryGlyphs["FIX"] + " [FIX] Stop the double upload"; got != want {
+		t.Errorf("turned on: got %q, want %q", got, want)
+	}
+}

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -20,12 +20,12 @@ var generalSettingsKeys = []struct {
 	section string
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
-	{key: "autotitle.emoji", label: "Title icon prefix", section: ""},
+	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
 }
 
 var generalSettingDefaults = map[string]bool{
 	"autotitle.enabled": false,
-	"autotitle.emoji":   true,
+	"autotitle.emoji":   false,
 }
 
 func loadGeneralSettings(c *client) tea.Cmd {

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -107,7 +107,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _globalFilterJson = settings['reporter.filter.global'] as String?;
           _sessionFilterJson = settings['reporter.filter.session'] as String?;
           _autoTitleEnabled = (settings['autotitle.enabled'] as String?) == 'true';
-          _autoTitleEmoji = (settings['autotitle.emoji'] as String?) != 'false';
+          // Off unless turned on: Flutter ships no Nerd Font, so the glyphs
+          // render as empty boxes on the phone.
+          _autoTitleEmoji = (settings['autotitle.emoji'] as String?) == 'true';
           _settingsLoaded = true;
         });
       }
@@ -309,7 +311,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   SwitchListTile(
                     secondary: const Icon(Icons.emoji_emotions_outlined),
                     title: const Text('Title icon'),
-                    subtitle: const Text('Prefix titles with a Nerd Font category glyph'),
+                    subtitle: const Text('Needs a Nerd Font — boxes without one'),
                     value: _autoTitleEmoji,
                     onChanged: (value) {
                       setState(() => _autoTitleEmoji = value);


### PR DESCRIPTION
## Summary

Every title showed the same icon. Not a bug in the titler — the data was right all along:

```
EF8688 = U+F188  bug     FIX
EF83A4 = U+F0E4  gauge   PERF
EF8085 = U+F005  star    FEAT
```

Three different codepoints collapsing to one box, because the glyphs live in the Private Use Area and nothing on the render path could draw them. An icon that distinguishes nothing is worse than no icon, and they were **on by default**, so a machine without a patched Nerd Font got boxed titles and no explanation.

### Off by default

All three places that decide it now agree — the daemon reads the setting as `== "true"` rather than `!= "false"`, and the TUI and desktop and phone match. Turning it on is a deliberate act by someone who knows they have the font.

### The desktop can now render them at all

The box was ours, not the font's. `local()` in `@font-face` matches a **PostScript or full name**, not a family:

```
family(1):  FiraCode Nerd Font        ← what the CSS said
psname(6):  FiraCodeNF-Reg            ← what local() wanted
```

So the face loaded with `status: "error"` and every PUA character fell through to macOS's LastResort font, which draws one box for the entire range. With the right name, the four glyphs render distinct ink (89522 / 121343 / 86740 / 140166); with the fallback all four measure identically (50632).

`unicode-range` keeps the face to the Private Use Area, so only the glyph comes from the Nerd Font and the title's words stay in the UI sans — naming a monospace family outright would drag every card into monospace.

### What the setting now says

> A glyph per category —  [FIX] rather than [FIX]. Off by default: the glyphs come from a patched Nerd Font, and without one installed every category shows the same empty box. The phone has no Nerd Font, so titles made here appear boxed there.

That last sentence is the part no toggle fixes: the glyph is stored *in the title*, so every client displaying the title needs the font. Flutter ships Roboto and no PUA coverage.

## Test plan

- [x] `go build ./...`, `go test ./internal/provider/claude/ ./internal/tui/`
- [x] New test pinning the default: unset, `"false"`, `"0"` and `"yes"` all yield a title with no glyph; only `"true"` adds one
- [x] `tsc --noEmit`, desktop build, 79 desktop tests
- [x] `flutter analyze` clean
- [x] Browser: both toggles default off, icon toggle disabled until auto-titling is on, copy renders as quoted above
- [x] Browser, with icons on: four categories render four visibly different glyphs, words still in the UI font

## The open question

Shipping a subset Nerd Font (~5 KB woff2 for the 11 glyphs we use) would make icons work everywhere without depending on what the user installed — mobile included. The alternative is to stop storing the glyph in the title and let each client draw its own icon from the category, which removes the font problem entirely and keeps presentation out of the data. Not done here; this PR only stops the feature misleading people by default.