### PR TITLE
feat: hold the session list still and let it be arranged by hand

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -217,6 +217,11 @@ export class ApiClient {
     })
   }
 
+  /** The whole arrangement, first id first. See store.SetSessionOrder. */
+  setSessionOrder(order: string[]): Promise<unknown> {
+    return this.request('POST', '/api/sessions/order', { order })
+  }
+
   stop(id: string): Promise<unknown> {
     return this.request('POST', `/api/sessions/${encodeURIComponent(id)}/stop`)
   }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -21,6 +21,7 @@ const API_METHODS = new Set<keyof ApiClient>([
   'transcript',
   'subagents',
   'sendPrompt',
+  'setSessionOrder',
   'uploadFiles',
   'stop',
   'terminate',

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -180,6 +180,9 @@ export class HostApi {
   uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
     return this.call('uploadFiles', id, files)
   }
+  setSessionOrder(order: string[]): Promise<unknown> {
+    return this.call('setSessionOrder', order)
+  }
   stop(id: string): Promise<unknown> {
     return this.call('stop', id)
   }

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -47,6 +47,10 @@ export function Sidebar({
   const selection = useStore((s) => s.selection)
   const query = useStore((s) => s.query)
   const showArchived = useStore((s) => s.showArchived)
+  const sortMode = useStore((s) => s.sortMode)
+  // The card being dragged, so the row under the pointer can show where it
+  // would land. Held per host: a drag never crosses from one daemon to another.
+  const [dragging, setDragging] = useState<{ hostId: string; sessionId: string } | null>(null)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   // Per host, not global: a machine kept for finished work and one being
   // worked in want opposite answers, and the setting is one click away.
@@ -75,7 +79,7 @@ export function Sidebar({
       const rows: Row[] = visible
         .filter((session) => !hideTerminated || !isTerminated(session))
         .map((session) => ({ host, session, pending: pendingByCwd.get(session.session_id) ?? 0 }))
-        .sort(compareRows)
+        .sort(sortMode[host.id] === 'manual' ? byHand : compareRows)
 
       const hidden = hideTerminated ? visible.filter(isTerminated).length : 0
       // An unfetched host has no entry at all, an empty one has []. Without the
@@ -84,7 +88,11 @@ export function Sidebar({
       const loading = sessions[host.id] === undefined
       return { host, rows, hidden, loading }
     })
-  }, [hosts, sessions, notifications, query, showArchived, showTerminated])
+  }, [hosts, sessions, notifications, query, showArchived, showTerminated, sortMode])
+
+  // One host answering "manual" is enough to show the switch as on: the click
+  // writes the other way to every host, which settles any disagreement.
+  const manual = hosts.some((host) => sortMode[host.id] === 'manual')
 
   return (
     <aside className="sidebar">
@@ -100,6 +108,18 @@ export function Sidebar({
             onChange={(event) => store.setQuery(event.target.value)}
           />
         </div>
+        <button
+          className={manual ? 'fab sort-toggle on' : 'fab sort-toggle'}
+          aria-label={manual ? 'Sorting by hand' : 'Sorting by activity'}
+          title={
+            manual
+              ? 'Sort: Manual — drag a session to move it.\nClick to sort by activity instead.'
+              : 'Sort: Activity — approvals first, then live, then most recent.\nClick to arrange them by hand instead.'
+          }
+          onClick={() => void store.setSortModeEverywhere(manual ? 'activity' : 'manual')}
+        >
+          ⇅
+        </button>
         <button className="fab" title="New session (⌘N)" onClick={onNewSession}>
           +
         </button>
@@ -147,6 +167,22 @@ export function Sidebar({
                     selected={
                       selection?.hostId === host.id && selection.sessionId === session.session_id
                     }
+                    draggable={sortMode[host.id] === 'manual'}
+                    dragging={dragging?.sessionId === session.session_id}
+                    onDragStart={() => setDragging({ hostId: host.id, sessionId: session.session_id })}
+                    onDragEnd={() => setDragging(null)}
+                    onDropBefore={(draggedId) => {
+                      // The id off the drag itself, not React state: the drop
+                      // can arrive in the same tick as the drag start, before
+                      // a setState has committed, and then nothing moves.
+                      const ids = rows.map((row) => row.session.session_id)
+                      const from = ids.indexOf(draggedId)
+                      const to = ids.indexOf(session.session_id)
+                      setDragging(null)
+                      if (from === -1 || to === -1 || from === to) return
+                      ids.splice(to, 0, ids.splice(from, 1)[0] as string)
+                      void store.reorderSessions(host.id, ids)
+                    }}
                   />
                 ))}
 
@@ -270,11 +306,22 @@ function SessionRow({
   session,
   pending,
   selected,
+  draggable,
+  dragging,
+  onDragStart,
+  onDragEnd,
+  onDropBefore,
 }: {
   hostId: string
   session: Session
   pending: number
   selected: boolean
+  /** Only in manual mode: dragging a card in an auto-sorted list means nothing. */
+  draggable: boolean
+  dragging: boolean
+  onDragStart: () => void
+  onDragEnd: () => void
+  onDropBefore: (draggedId: string) => void
 }): JSX.Element {
   const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
@@ -282,7 +329,27 @@ function SessionRow({
   const cold = needsRecovery(session)
   return (
     <article
-      className={`session-card ${session.status} ${selected ? 'selected' : ''}`}
+      className={`session-card ${session.status} ${selected ? 'selected' : ''}${dragging ? ' dragging' : ''}${draggable ? ' movable' : ''}`}
+      draggable={draggable}
+      onDragStart={(event) => {
+        // Firefox and Chromium both want data on the transfer or the drag never
+        // starts; the id is also what makes the drop unambiguous.
+        event.dataTransfer.effectAllowed = 'move'
+        event.dataTransfer.setData('text/plain', session.session_id)
+        onDragStart()
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={(event) => {
+        if (!draggable) return
+        // Without this the drop never fires: the default is to refuse.
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+      }}
+      onDrop={(event) => {
+        if (!draggable) return
+        event.preventDefault()
+        onDropBefore(event.dataTransfer.getData('text/plain'))
+      }}
       onClick={() => store.select(hostId, session.session_id)}
       // A terminated session has to be resumed before it has a terminal worth
       // opening, so the shortcut resumes instead of waking one it will refuse.
@@ -347,6 +414,20 @@ function SessionRow({
 }
 
 /** Pending approvals first, then live sessions, then most recent activity. */
+/**
+ * The order the user put them in, and nothing else.
+ *
+ * No tie-breaking on activity: the whole point is that a card does not move
+ * when a session does something. Sessions the daemon has not numbered yet sort
+ * by creation, newest first, which is where a new one belongs.
+ */
+function byHand(a: Row, b: Row): number {
+  const left = a.session.sort_order ?? 0
+  const right = b.session.sort_order ?? 0
+  if (left !== right) return left - right
+  return b.session.created_at.localeCompare(a.session.created_at)
+}
+
 function compareRows(a: Row, b: Row): number {
   if (a.pending !== b.pending) return b.pending - a.pending
   if (a.session.pinned !== b.session.pinned) return a.session.pinned ? -1 : 1

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -47,6 +47,9 @@ export function sessionKey(hostId: string, sessionId: string): string {
 
 export type RightPanel = 'chat' | 'terminal' | 'approvals' | 'git' | 'files'
 
+/** Sorted by what the sessions are doing, or by hand. */
+export type SortMode = 'activity' | 'manual'
+
 /**
  * A file the user asked to see, from a chip in the transcript. The counter is
  * what makes clicking the same chip twice reopen it: the path alone would not
@@ -99,6 +102,14 @@ export interface State {
   /** Sidebar filter, matched against title, project and cwd. */
   query: string
   showArchived: boolean
+  /**
+   * How each host's session list is ordered, by host id.
+   *
+   * 'activity' recomputes the order from what the sessions are doing —
+   * approvals first, then live, then most recent. 'manual' leaves them where
+   * they were put. The daemon holds it, so every client agrees.
+   */
+  sortMode: Record<string, SortMode>
   loading: boolean
   toast: { text: string; kind: 'info' | 'error' } | null
   pairingLink: string | null
@@ -120,6 +131,7 @@ const initial: State = {
   promptDraft: null,
   query: '',
   showArchived: false,
+  sortMode: {},
   loading: true,
   terminalTheme: bridge.theme.boot().terminal,
   toast: null,
@@ -127,6 +139,26 @@ const initial: State = {
 }
 
 type Listener = () => void
+
+/**
+ * The order the sidebar shows before it is frozen — approvals first, then
+ * pinned, then live, then most recent.
+ *
+ * Duplicated from the sidebar's own comparator on purpose: that one sorts rows
+ * it has already built, and this has to answer the same question from the store
+ * before any row exists. They must agree, or turning manual on would rearrange
+ * the list at the moment it promised to stop.
+ */
+function byActivity(a: Session, b: Session, pending: Map<string, number>): number {
+  const aPending = pending.get(a.session_id) ?? 0
+  const bPending = pending.get(b.session_id) ?? 0
+  if (aPending !== bPending) return bPending - aPending
+  if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+  const aLive = hasTerminal(a)
+  const bLive = hasTerminal(b)
+  if (aLive !== bLive) return aLive ? -1 : 1
+  return (b.last_event_at ?? b.created_at).localeCompare(a.last_event_at ?? a.created_at)
+}
 
 /** Matches the mobile app's coalescing window (daemon_api_service.dart:348). */
 const REFRESH_DEBOUNCE = 500
@@ -222,7 +254,84 @@ class Store {
   // ─── Data ──────────────────────────────────────────────────────────────
 
   async refreshHost(hostId: string): Promise<void> {
-    await Promise.all([this.refreshSessions(hostId), this.refreshNotifications(hostId)])
+    await Promise.all([this.refreshSessions(hostId), this.refreshNotifications(hostId), this.refreshSortMode(hostId)])
+  }
+
+  /** The daemon owns the sort mode, so a second window opens on the same one. */
+  async refreshSortMode(hostId: string): Promise<void> {
+    try {
+      const body = (await api(hostId).settings()) as { settings?: Record<string, string> }
+      const mode: SortMode = body.settings?.['sessions.sort'] === 'manual' ? 'manual' : 'activity'
+      this.set((s) => ({ sortMode: { ...s.sortMode, [hostId]: mode } }))
+    } catch {
+      // Offline. The list falls back to sorting by activity, which needs
+      // nothing from the daemon.
+    }
+  }
+
+  /**
+   * One switch for every host: the arrangement is stored per daemon, but a
+   * sidebar that sorts one group by activity and holds another still is a
+   * sidebar with no answer to "why did that move".
+   */
+  async setSortModeEverywhere(mode: SortMode): Promise<void> {
+    await Promise.all(this.state.hosts.map((host) => this.setSortMode(host.id, mode)))
+  }
+
+  async setSortMode(hostId: string, mode: SortMode): Promise<void> {
+    const before = this.state.sortMode[hostId] ?? 'activity'
+    this.set((s) => ({ sortMode: { ...s.sortMode, [hostId]: mode } }))
+    try {
+      await api(hostId).updateSettings({ 'sessions.sort': mode })
+      // Switching to manual freezes what is on screen, so the order the user
+      // was looking at is the order they keep.
+      if (mode === 'manual') await this.freezeOrder(hostId)
+    } catch (err) {
+      this.set((s) => ({ sortMode: { ...s.sortMode, [hostId]: before } }))
+      this.fail(err)
+    }
+  }
+
+  /**
+   * Writes the order the sessions are in right now.
+   *
+   * Without this, turning manual on would sort by a sort_order nobody has set
+   * — every session at 0, or at whatever negative number it was created with —
+   * and the list would jump the moment it was supposed to stop moving.
+   */
+  private async freezeOrder(hostId: string): Promise<void> {
+    const sessions = this.state.sessions[hostId] ?? []
+    if (sessions.length === 0) return
+    const pending = new Map<string, number>()
+    for (const notification of this.state.notifications[hostId] ?? []) {
+      pending.set(notification.source_session, (pending.get(notification.source_session) ?? 0) + 1)
+    }
+    const ordered = [...sessions]
+      .sort((a, b) => byActivity(a, b, pending))
+      .map((session) => session.session_id)
+    await api(hostId).setSessionOrder(ordered)
+    await this.refreshSessions(hostId)
+  }
+
+  /** Applies a drag: the whole arrangement, in the order the user left it. */
+  async reorderSessions(hostId: string, orderedIds: string[]): Promise<void> {
+    const before = this.state.sessions[hostId] ?? []
+    // Locally first: a card that snaps back while the daemon answers reads as
+    // a drag that failed.
+    const byId = new Map(before.map((session) => [session.session_id, session]))
+    const next: Session[] = []
+    orderedIds.forEach((id, index) => {
+      const session = byId.get(id)
+      if (session) next.push({ ...session, sort_order: index })
+    })
+    this.set((s) => ({ sessions: { ...s.sessions, [hostId]: next } }))
+
+    try {
+      await api(hostId).setSessionOrder(orderedIds)
+    } catch (err) {
+      this.set((s) => ({ sessions: { ...s.sessions, [hostId]: before } }))
+      this.fail(err)
+    }
   }
 
   async refreshSessions(hostId: string): Promise<void> {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -705,6 +705,34 @@ small {
   font-weight: 500;
 }
 
+/* Quieter than the new-session button beside it, and filled only while it is
+   the one holding the list still. */
+.sort-toggle {
+  background: transparent;
+  color: var(--on-surface-variant);
+  font-size: 16px;
+}
+
+.sort-toggle:hover:not(:disabled) {
+  background: var(--surface-container);
+}
+
+.sort-toggle.on {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+}
+
+/* Only in manual mode: a card that offers to be dragged in a list that
+   rearranges itself would be lying about what the drag achieves. */
+.session-card.movable {
+  cursor: grab;
+}
+
+.session-card.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
 /* Session card — the mobile list item, one column narrower. */
 .session-card {
   position: relative;

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -16,6 +16,9 @@ export interface Session {
   last_event_at?: string
   last_user_message?: string
   pinned: boolean
+  /** Place in a hand-arranged list; only meaningful in manual sort mode.
+   *  Absent from a daemon older than the feature, which sorts by activity. */
+  sort_order?: number
   archived: boolean
   managed: boolean
   permission_mode?: string

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -989,6 +989,39 @@ func (s *PublicServer) handleGenerateSessionTitle(w http.ResponseWriter, r *http
 	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true, "title": title})
 }
 
+// handleSessionOrder records a hand-arranged order for the session list.
+//
+// The whole arrangement in one request: dragging one card shifts every card it
+// passed, and the client knows the result it wants. Sending positions one at a
+// time would leave the list half-reordered if the second call failed.
+func (s *PublicServer) handleSessionOrder(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Order []string `json:"order"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Order) == 0 {
+		jsonError(w, "missing order", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.shared.DB.SetSessionOrder(req.Order); err != nil {
+		log.Printf("session-order: %v", err)
+		jsonError(w, "failed to save order", http.StatusInternalServerError)
+		return
+	}
+
+	// Every client is looking at the same list, so they all need to hear about
+	// it — the one that did the dragging has already moved the card itself.
+	s.shared.SSE.Broadcast(SSEEvent{Type: "session_updated", Data: map[string]interface{}{
+		"reordered": len(req.Order),
+	}})
+
+	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
+}
+
 func extractSessionID(path, suffix string) string {
 	path = strings.TrimPrefix(path, "/api/sessions/")
 	path = strings.TrimSuffix(path, suffix)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,6 +152,9 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 	protectedMux := http.NewServeMux()
 	protectedMux.HandleFunc("GET /api/sessions", s.handleListSessions)
 	protectedMux.HandleFunc("GET /api/sessions/directories", s.handleListDirectories)
+	// Registered before the /api/sessions/ catch-all below, which would take
+	// "order" for a session id.
+	protectedMux.HandleFunc("POST /api/sessions/order", s.handleSessionOrder)
 	protectedMux.HandleFunc("GET /api/files", s.handleListFiles)
 	protectedMux.HandleFunc("GET /api/files/search", s.handleSearchFiles)
 	protectedMux.HandleFunc("GET /api/files/grep", s.handleGrepFiles)

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
@@ -20,8 +21,12 @@ type Session struct {
 	LastEventAt     *string `json:"last_event_at,omitempty"`
 	LastUserMessage *string `json:"last_user_message,omitempty"`
 	Pinned          bool    `json:"pinned"`
-	Archived        bool    `json:"archived"`
-	Managed         bool    `json:"managed"`
+	// SortOrder is the session's place in a hand-arranged list. Lower sorts
+	// first and the scale is arbitrary — only the relative order is meaningful,
+	// and it is ignored entirely unless the list is set to sort manually.
+	SortOrder int  `json:"sort_order"`
+	Archived  bool `json:"archived"`
+	Managed   bool `json:"managed"`
 	// PermissionMode is the agent's permission mode. It is stored because the
 	// mode is a per-invocation flag rather than conversation state: without a
 	// record of it, a session that goes cold comes back in the default mode
@@ -80,8 +85,8 @@ func (s *Store) UpsertSession(sess *Session) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	_, err := s.db.Exec(
-		`INSERT INTO sessions (session_id, source, cwd, project, title, transcript_path, model, status, last_event, last_event_at, managed)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO sessions (session_id, source, cwd, project, title, transcript_path, model, status, last_event, last_event_at, managed, sort_order)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT MIN(sort_order) FROM sessions), 0) - 1)
 		 ON CONFLICT(session_id) DO UPDATE SET
 		   cwd = COALESCE(excluded.cwd, sessions.cwd),
 		   project = COALESCE(excluded.project, sessions.project),
@@ -167,12 +172,12 @@ func (s *Store) GetSession(sessionID string) (*Session, error) {
 	sess := &Session{}
 	err := s.db.QueryRow(
 		`SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-		        last_event, last_event_at, last_user_message, pinned, archived, managed,
+		        last_event, last_event_at, last_user_message, pinned, archived, managed, sort_order,
 		        permission_mode, created_at, ended_at
 		 FROM sessions WHERE session_id = ?`, sessionID,
 	).Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 		&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-		&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.Managed,
+		&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.Managed, &sess.SortOrder,
 		&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -226,7 +231,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 	}
 
 	q := `SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-	        last_event, last_event_at, last_user_message, pinned, archived, managed,
+	        last_event, last_event_at, last_user_message, pinned, archived, managed, sort_order,
 	        permission_mode, created_at, ended_at
 	 FROM sessions`
 	if len(where) > 0 {
@@ -245,7 +250,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 		var sess Session
 		if err := rows.Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 			&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-			&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.Managed,
+			&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.Managed, &sess.SortOrder,
 			&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt); err != nil {
 			return nil, err
 		}
@@ -313,6 +318,34 @@ func (s *Store) IncrementAutoTitleAttempts(sessionID string) (int, error) {
 	var count int
 	err = s.db.QueryRow(`SELECT autotitle_attempts FROM sessions WHERE session_id = ?`, sessionID).Scan(&count)
 	return count, err
+}
+
+// SetSessionOrder writes a hand-arranged order, first id first.
+//
+// The whole list at once and in one transaction, rather than a position per
+// session: dragging one card shifts every card it passed, so the client
+// already knows the arrangement it wants, and sending it whole is both simpler
+// and atomic. Numbering starts at zero, and a new session is given one less
+// than the smallest, so anything the client did not mention stays above.
+func (s *Store) SetSessionOrder(sessionIDs []string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`UPDATE sessions SET sort_order = ? WHERE session_id = ?`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for position, id := range sessionIDs {
+		if _, err := stmt.Exec(position, id); err != nil {
+			return fmt.Errorf("order %s: %w", id, err)
+		}
+	}
+	return tx.Commit()
 }
 
 // AutoTitleAttempts reports how many attempts a session has already spent,

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -226,3 +226,77 @@ func TestAutoTitleAttempts_ReadingDoesNotSpend(t *testing.T) {
 		t.Errorf("after one increment: got %d, want 1", spent)
 	}
 }
+
+// A hand-arranged order is written whole, and numbering starts at zero.
+func TestSetSessionOrder_WritesTheArrangement(t *testing.T) {
+	s := setupTestStore(t)
+	for _, id := range []string{"a", "b", "c"} {
+		if err := s.UpsertSession(&Session{SessionID: id, Source: "claude", CWD: "/tmp", Status: "idle"}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	if err := s.SetSessionOrder([]string{"c", "a", "b"}); err != nil {
+		t.Fatalf("set order: %v", err)
+	}
+
+	for want, id := range []string{"c", "a", "b"} {
+		sess, err := s.GetSession(id)
+		if err != nil || sess == nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if sess.SortOrder != want {
+			t.Errorf("%s: sort_order %d, want %d", id, sess.SortOrder, want)
+		}
+	}
+}
+
+// A session created after an arrangement belongs on top, without renumbering
+// everything that was already placed.
+func TestUpsertSession_NewSessionSortsAboveTheArrangement(t *testing.T) {
+	s := setupTestStore(t)
+	for _, id := range []string{"a", "b"} {
+		if err := s.UpsertSession(&Session{SessionID: id, Source: "claude", CWD: "/tmp", Status: "idle"}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	if err := s.SetSessionOrder([]string{"a", "b"}); err != nil {
+		t.Fatalf("set order: %v", err)
+	}
+
+	if err := s.UpsertSession(&Session{SessionID: "fresh", Source: "claude", CWD: "/tmp", Status: "idle"}); err != nil {
+		t.Fatalf("seed fresh: %v", err)
+	}
+
+	fresh, _ := s.GetSession("fresh")
+	first, _ := s.GetSession("a")
+	if fresh.SortOrder >= first.SortOrder {
+		t.Errorf("new session sorts at %d, not above the arranged %d", fresh.SortOrder, first.SortOrder)
+	}
+
+	// And the arrangement it landed above is untouched.
+	second, _ := s.GetSession("b")
+	if first.SortOrder != 0 || second.SortOrder != 1 {
+		t.Errorf("arrangement moved: a=%d b=%d, want 0 and 1", first.SortOrder, second.SortOrder)
+	}
+}
+
+// An update to an existing session must not shuffle it back to the top.
+func TestUpsertSession_UpdateKeepsItsPlace(t *testing.T) {
+	s := setupTestStore(t)
+	if err := s.UpsertSession(&Session{SessionID: "a", Source: "claude", CWD: "/tmp", Status: "idle"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := s.SetSessionOrder([]string{"a"}); err != nil {
+		t.Fatalf("set order: %v", err)
+	}
+
+	if err := s.UpsertSession(&Session{SessionID: "a", Source: "claude", CWD: "/tmp", Status: "active"}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	sess, _ := s.GetSession("a")
+	if sess.SortOrder != 0 {
+		t.Errorf("an update moved it to %d, want 0", sess.SortOrder)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -146,6 +146,9 @@ func (s *Store) migrate() error {
 		{"add_sessions_autotitle_attempts", `ALTER TABLE sessions ADD COLUMN autotitle_attempts INTEGER NOT NULL DEFAULT 0`},
 		{"add_sessions_managed", `ALTER TABLE sessions ADD COLUMN managed INTEGER NOT NULL DEFAULT 0`},
 		{"add_sessions_permission_mode", `ALTER TABLE sessions ADD COLUMN permission_mode TEXT`},
+		// Lower sorts first, and it goes negative: a new session takes one less
+		// than the smallest, which puts it on top without renumbering the rest.
+		{"add_sessions_sort_order", `ALTER TABLE sessions ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`},
 	}
 
 	for _, cm := range columnMigrations {

--- a/mobile/lib/models/session.dart
+++ b/mobile/lib/models/session.dart
@@ -27,6 +27,10 @@ class Session {
   final String createdAt;
   final String? endedAt;
 
+  /// Where the session sits when the host is ordered by hand. Lower first, and
+  /// it goes negative: a new session takes one less than the smallest.
+  final int sortOrder;
+
   Session({
     this.hostId = '',
     required this.sessionId,
@@ -48,6 +52,7 @@ class Session {
     this.supportsPromptQueue = false,
     required this.createdAt,
     this.endedAt,
+    this.sortOrder = 0,
   });
 
   factory Session.fromJson(Map<String, dynamic> json, {String hostId = ''}) {
@@ -72,6 +77,7 @@ class Session {
       supportsPromptQueue: json['supports_prompt_queue'] == true,
       createdAt: json['created_at'] as String,
       endedAt: json['ended_at'] as String?,
+      sortOrder: (json['sort_order'] as num?)?.toInt() ?? 0,
     );
   }
 
@@ -117,6 +123,7 @@ class Session {
     bool? pinned,
     bool? archived,
     String? permissionMode,
+    int? sortOrder,
   }) {
     return Session(
       hostId: hostId,
@@ -139,6 +146,7 @@ class Session {
       supportsPromptQueue: supportsPromptQueue,
       createdAt: createdAt,
       endedAt: endedAt,
+      sortOrder: sortOrder ?? this.sortOrder,
     );
   }
 

--- a/mobile/lib/screens/sessions_screen.dart
+++ b/mobile/lib/screens/sessions_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../models/session.dart';
+import '../services/daemon_api_service.dart';
 import '../services/host_manager.dart';
 import '../widgets/skeleton.dart';
 import 'session_detail_screen.dart';
@@ -61,8 +62,13 @@ class _SessionsScreenState extends State<SessionsScreen> {
     return 3;
   }
 
-  List<Session> _sortSessions(List<Session> sessions) {
+  List<Session> _sortSessions(List<Session> sessions, {bool manual = false}) {
     sessions.sort((a, b) {
+      if (manual) {
+        final handCmp = a.sortOrder.compareTo(b.sortOrder);
+        if (handCmp != 0) return handCmp;
+        return b.createdAt.compareTo(a.createdAt);
+      }
       final orderCmp = _statusOrder(a).compareTo(_statusOrder(b));
       if (orderCmp != 0) return orderCmp;
       final aTime = a.lastEventAt ?? a.createdAt;
@@ -70,6 +76,30 @@ class _SessionsScreenState extends State<SessionsScreen> {
       return bTime.compareTo(aTime);
     });
     return sessions;
+  }
+
+  /// Dragging needs one host in view: the arrangement lives per host, and a
+  /// list mixing two of them has no order either daemon could be told about.
+  DaemonAPIService? _orderableService(HostManager hm) {
+    if (hm.activeHostId == null) return null;
+    if (_cwdFilter != null) return null;
+    if (_searchExpanded && _searchController.text.trim().isNotEmpty) return null;
+    return hm.serviceFor(hm.activeHostId!);
+  }
+
+  Future<void> _toggleManualOrder(HostManager hm, List<Session> visible) async {
+    final byHost = <String, List<String>>{};
+    for (final session in visible) {
+      byHost.putIfAbsent(session.hostId, () => []).add(session.sessionId);
+    }
+    await hm.setManualOrder(!hm.manualOrder, byHost);
+  }
+
+  Future<void> _onReorder(DaemonAPIService service, List<Session> visible, int from, int to) async {
+    final ids = visible.map((s) => s.sessionId).toList();
+    if (to > from) to -= 1;
+    ids.insert(to, ids.removeAt(from));
+    await service.setSessionOrder(ids);
   }
 
   String get _filterParam {
@@ -287,12 +317,14 @@ class _SessionsScreenState extends State<SessionsScreen> {
           return _buildEmptyState();
         }
 
-        final filtered = _sortSessions(_filterSessions(sessions));
+        final manual = hm.manualOrder;
+        final orderable = manual ? _orderableService(hm) : null;
+        final filtered = _sortSessions(_filterSessions(sessions), manual: manual);
 
         return Column(
           children: [
             if (_multiSelect) _buildMultiSelectBar(),
-            _buildFilterRow(sessions),
+            _buildFilterRow(sessions, hm, filtered),
             if (_cwdFilter != null) _buildActiveFiltersRow(),
             Expanded(
               child: filtered.isEmpty
@@ -301,12 +333,20 @@ class _SessionsScreenState extends State<SessionsScreen> {
                       onRefresh: () => hm.activeHostId != null
                           ? hm.refreshHost(hm.activeHostId!)
                           : hm.refreshAll(),
-                      child: ListView.builder(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        itemCount: filtered.length,
-                        itemBuilder: (context, index) =>
-                            _buildSwipeableCard(filtered[index], hm),
-                      ),
+                      child: manual && orderable != null
+                          ? ReorderableListView.builder(
+                              padding: const EdgeInsets.symmetric(horizontal: 12),
+                              itemCount: filtered.length,
+                              onReorder: (from, to) => _onReorder(orderable, filtered, from, to),
+                              itemBuilder: (context, index) =>
+                                  _buildSwipeableCard(filtered[index], hm),
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.symmetric(horizontal: 12),
+                              itemCount: filtered.length,
+                              itemBuilder: (context, index) =>
+                                  _buildSwipeableCard(filtered[index], hm),
+                            ),
                     ),
             ),
           ],
@@ -344,19 +384,19 @@ class _SessionsScreenState extends State<SessionsScreen> {
     );
   }
 
-  Widget _buildFilterRow(List<Session> allSessions) {
+  Widget _buildFilterRow(List<Session> allSessions, HostManager hm, List<Session> visible) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
       child: AnimatedCrossFade(
         duration: const Duration(milliseconds: 200),
         crossFadeState: _searchExpanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-        firstChild: _buildFilterChips(allSessions),
+        firstChild: _buildFilterChips(allSessions, hm, visible),
         secondChild: _buildSearchBar(),
       ),
     );
   }
 
-  Widget _buildFilterChips(List<Session> allSessions) {
+  Widget _buildFilterChips(List<Session> allSessions, HostManager hm, List<Session> visible) {
     final allCount = allSessions.where((s) => !s.archived).length;
     final pinnedCount = allSessions.where((s) => s.pinned && !s.archived).length;
     final archivedCount = allSessions.where((s) => s.archived).length;
@@ -369,6 +409,18 @@ class _SessionsScreenState extends State<SessionsScreen> {
         const SizedBox(width: 8),
         _filterChip('Archived', archivedCount, SessionFilter.archived),
         const Spacer(),
+        IconButton(
+          icon: Icon(
+            hm.manualOrder ? Icons.swap_vert : Icons.sort,
+            size: 20,
+            color: hm.manualOrder ? Theme.of(context).colorScheme.primary : null,
+          ),
+          tooltip: hm.manualOrder
+              ? 'Sort: Manual — long-press a session to move it. Tap to sort by activity instead.'
+              : 'Sort: Activity — active first, then most recent. Tap to arrange them by hand instead.',
+          visualDensity: VisualDensity.compact,
+          onPressed: () => _toggleManualOrder(hm, visible),
+        ),
         IconButton(
           icon: const Icon(Icons.folder_outlined, size: 20),
           tooltip: 'Filter by directory',

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -170,6 +170,7 @@ class DaemonAPIService extends ChangeNotifier {
     fetchNotifications();
     fetchProviders();
     fetchCommands();
+    fetchSortMode();
     if (!_connected) _startPolling();
   }
 
@@ -847,6 +848,53 @@ class DaemonAPIService extends ChangeNotifier {
     } catch (e) {
       debugPrint('[$hostId] updateSettings error: $e');
     }
+    return false;
+  }
+
+  // ==================== Session order ====================
+
+  /// The daemon owns the mode, so every client of this host agrees on it.
+  static const _sortModeSetting = 'sessions.sort';
+  bool _manualOrder = false;
+  bool get manualOrder => _manualOrder;
+
+  Future<void> fetchSortMode() async {
+    final body = await getSettings();
+    if (body == null) return;
+    final settings = body['settings'] as Map<String, dynamic>?;
+    final manual = settings?[_sortModeSetting] == 'manual';
+    if (manual == _manualOrder) return;
+    _manualOrder = manual;
+    notifyListeners();
+  }
+
+  /// Switching to manual freezes [visibleOrder] as it stands, so the list does
+  /// not jump the moment it stops sorting itself.
+  Future<void> setManualOrder(bool manual, {List<String> visibleOrder = const []}) async {
+    if (manual && visibleOrder.isNotEmpty) await setSessionOrder(visibleOrder);
+    final ok = await updateSettings({_sortModeSetting: manual ? 'manual' : 'activity'});
+    if (!ok) return;
+    _manualOrder = manual;
+    notifyListeners();
+  }
+
+  /// Writes the arrangement, painting it locally first so the drag lands
+  /// without waiting for the round trip.
+  Future<bool> setSessionOrder(List<String> sessionIds) async {
+    final previous = _sessions;
+    final positions = {for (var i = 0; i < sessionIds.length; i++) sessionIds[i]: i};
+    _sessions = _sessions
+        .map((s) => positions.containsKey(s.sessionId) ? s.copyWith(sortOrder: positions[s.sessionId]) : s)
+        .toList();
+    notifyListeners();
+    try {
+      final resp = await _api.post('/api/sessions/order', body: {'order': sessionIds});
+      if (resp.statusCode == 200) return true;
+    } catch (e) {
+      debugPrint('[$hostId] setSessionOrder error: $e');
+    }
+    _sessions = previous;
+    notifyListeners();
     return false;
   }
 

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -105,6 +105,19 @@ class HostManager extends ChangeNotifier {
     return _services[_activeHostId]?.notifications ?? [];
   }
 
+  /// One switch for every host: the arrangement is stored per daemon, but a
+  /// list that sorts itself on one host and holds still on another is neither.
+  bool get manualOrder => _services.values.any((s) => s.manualOrder);
+
+  /// [visibleByHost] is what each host shows right now, frozen as the starting
+  /// arrangement so nothing jumps as the sorting stops.
+  Future<void> setManualOrder(bool manual, Map<String, List<String>> visibleByHost) async {
+    await Future.wait(_services.entries.map(
+      (e) => e.value.setManualOrder(manual, visibleOrder: visibleByHost[e.key] ?? const []),
+    ));
+    notifyListeners();
+  }
+
   /// Whether sessions have been loaded (any host for "all", specific for filtered).
   bool get sessionsLoaded {
     if (_activeHostId == null) {
@@ -182,6 +195,7 @@ class HostManager extends ChangeNotifier {
       service.fetchSessions();
       service.fetchCommands();
       service.fetchProviders();
+      service.fetchSortMode();
       await service.startActive();
     } else {
       await service.startBackground();


### PR DESCRIPTION
## Summary

- The list re-sorts on every approval and status change, moving cards out from under the pointer. A **sort mode** stored on the daemon (`sessions.sort` = `activity` | `manual`) turns that off, and a `sort_order` column per session records the arrangement so every client sees the same one.
- **Daemon:** `sort_order` column + `POST /api/sessions/order`. New sessions take one less than the smallest order, so they land on top without renumbering the rest.
- **Desktop:** one toggle beside the + button, switching every host at once. In manual mode a card can be dragged anywhere in its host group.
- **Mobile:** the same single toggle in the filter row; long-press to drag when a single host is in view.

Switching to manual first freezes the order as it stands, so nothing jumps at the moment it promised to stop moving.

## Test plan

- [x] `go test ./internal/store/... ./internal/server/...` — three new store tests cover the write, the new-session position, and an update keeping its place
- [x] `flutter analyze` + `flutter test` clean
- [x] `tsc --noEmit` clean
- [x] Browser harness: toggle freezes the visible order (1 order call, no movement), marks cards draggable; dragging the bottom card to the top sends the new arrangement; an approval arriving in manual mode badges the card but leaves it in place; flipping back to activity jumps it to the top
- [ ] Drag on a real phone