### PR TITLE
fix: store an attachment under a name with no spaces in it

### DIFF
--- a/internal/server/uploads.go
+++ b/internal/server/uploads.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -142,8 +143,13 @@ func safeName(name string) string {
 	}
 	// Control characters and separators have no business in a filename, and the
 	// path goes on to be pasted into a prompt.
+	//
+	// Whitespace goes with them: the agent reads the path out of a line of
+	// prose, and "Screenshot 2026-08-15 at 2.33.50 PM.png" — what macOS calls
+	// every screenshot — is four words the agent cannot tell from the sentence
+	// around them.
 	base = strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f || r == '/' {
+		if r < 0x20 || r == 0x7f || r == '/' || unicode.IsSpace(r) {
 			return '-'
 		}
 		return r

--- a/internal/server/uploads_test.go
+++ b/internal/server/uploads_test.go
@@ -131,6 +131,21 @@ func TestUpload_FilenameCannotEscapeTheUploadDirectory(t *testing.T) {
 	}
 }
 
+// The path is handed to the agent in a line of prose, and a macOS screenshot
+// is named in four words that read as part of the sentence.
+func TestUpload_SpacesInTheNameAreNotKept(t *testing.T) {
+	s, shared, home := newUploadTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+
+	_, payload := upload(t, s, "sess-1", part{name: "Screenshot 2026-08-15 at 2.33.50 PM.png", content: "x"})
+	paths := uploadedPaths(t, payload)
+
+	want := filepath.Join(home, ".helios", "uploads", "sess-1", "Screenshot-2026-08-15-at-2.33.50-PM.png")
+	if paths[0] != want {
+		t.Errorf("path: got %q, want %q", paths[0], want)
+	}
+}
+
 // Two screenshots are both called Screenshot.png. Neither may overwrite the
 // other: the first one's path is already in a prompt by then.
 func TestUpload_SameNameTwiceKeepsBothFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

An image attached from the desktop reached the agent as a bare `Attached:` line with no path. The upload itself was fine — the daemon logged the file stored and the prompt sent with the full path:

```
14:33:58 session-upload: stored 1 file(s) in ~/.helios/uploads/<session>
14:33:58 session-send: message="Attached: /Users/…/Screenshot 2026-08-15 at 2.33.50 PM.png…"
```

What differs from the attachments that worked a day earlier is the name: macOS calls every screenshot `Screenshot 2026-08-15 at 2.33.50 PM.png`, and a path made of four words cannot be told apart from the prose around it. The same screenshot renamed with underscores arrived whole.

`safeName` already replaces control characters and separators; whitespace now goes with them.

## Test plan

- [x] `go test ./internal/server/ -run TestUpload` — new case asserts `Screenshot 2026-08-15 at 2.33.50 PM.png` is stored as `Screenshot-2026-08-15-at-2.33.50-PM.png`
- [ ] Attach a freshly taken macOS screenshot from the desktop app and confirm the agent can read it (needs the daemon reinstalled)