### PR TITLE
fix: quote an attachment's path so the agent's composer keeps it

### DIFF
--- a/desktop/src/renderer/attachments.ts
+++ b/desktop/src/renderer/attachments.ts
@@ -90,11 +90,16 @@ export function withStoredPaths(
  * The prompt as the agent receives it: a line naming each file, then whatever
  * was typed. The path is the whole mechanism — the agent opens it with Read,
  * so the bytes never enter the context.
+ *
+ * Backticked because the prompt is delivered by pasting it into the agent's
+ * own composer, and a bare path to an image is taken there as an attachment to
+ * be made rather than text to be kept: the path is removed from the prompt and
+ * nothing arrives in its place. Quoting it leaves it as the words it is.
  */
 export function promptWithAttachments(attachments: Attachment[], text: string): string {
   const lines = attachments
     .filter((attachment) => attachment.path !== null)
-    .map((attachment) => `Attached: ${attachment.path}`)
+    .map((attachment) => `Attached: \`${attachment.path}\``)
   if (lines.length === 0) return text
   return [...lines, '', text].join('\n').trim()
 }

--- a/desktop/test/attachments.test.ts
+++ b/desktop/test/attachments.test.ts
@@ -56,12 +56,17 @@ test('the prompt names every stored file before the typed text', () => {
   const list = [attachment(1, 'a.png', '/uploads/s1/a.png'), attachment(2, 'b.png', '/uploads/s1/b.png')]
   assert.equal(
     promptWithAttachments(list, 'what is wrong here?'),
-    'Attached: /uploads/s1/a.png\nAttached: /uploads/s1/b.png\n\nwhat is wrong here?',
+    'Attached: `/uploads/s1/a.png`\nAttached: `/uploads/s1/b.png`\n\nwhat is wrong here?',
   )
 })
 
-test('attachments with no text still make a prompt', () => {
-  assert.equal(promptWithAttachments([attachment(1, 'a.png', '/uploads/s1/a.png')], ''), 'Attached: /uploads/s1/a.png')
+// A bare path to an image is eaten by the agent's composer, which takes it for
+// an attachment to make rather than text to keep.
+test('the path is quoted so the composer leaves it alone', () => {
+  assert.equal(
+    promptWithAttachments([attachment(1, 'a.png', '/uploads/s1/a.png')], ''),
+    'Attached: `/uploads/s1/a.png`',
+  )
 })
 
 test('no attachments leaves the text alone', () => {

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -350,7 +350,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     }
     if (_attachments.isNotEmpty) {
       message = [
-        ..._attachments.map((f) => 'Attached: ${f.storedPath}'),
+        // Backticked: pasted bare into the agent's composer, a path to an
+        // image is taken for an attachment to make rather than text to keep,
+        // and vanishes from the prompt with nothing in its place.
+        ..._attachments.map((f) => 'Attached: `${f.storedPath}`'),
         '',
         text,
       ].join('\n').trim();


### PR DESCRIPTION
## Summary

An image attached from the desktop reached the agent as a bare `Attached:` line with no path, while a `.md` file sent moments later arrived whole. The upload and the send were both correct — the daemon logged the file stored and the prompt sent with the full path.

The prompt is delivered by pasting it into the agent's own composer, and **a bare path to an image is taken there as an attachment to make rather than text to keep**: the path is stripped out of the prompt and nothing arrives in its place.

Reproduced outside helios — pasting the same line into a plain pty running the CLI, with three seconds before the Enter, so it is not a settle race in the delivery:

```
bare:     'Attached:\nreply with exactly: GOT-IT'
backtick: 'Attached: `/Users/…/university_spending_chart-1.png`\n\nreply with exactly: GOT-IT'
```

So both clients now quote the path. The agent still opens it with Read.

## Test plan

- [x] `npm test` in `desktop/` (79 pass) — the prompt-format tests assert the backticks
- [x] `flutter analyze` clean
- [x] pty repro above: bare path eaten, quoted path intact
- [ ] Attach a screenshot from the rebuilt desktop app and confirm the agent can read it