### PR TITLE
fix: read the transcript again after sending a prompt

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -46,6 +46,8 @@ export function ChatPanel({
   // show the previous transcript until the new one arrives, and "No transcript
   // yet." for a session whose transcript is merely still loading.
   const [loadedFor, setLoadedFor] = useState('')
+  // Bumped to re-read a transcript that has not moved by any other measure.
+  const [reload, setReload] = useState(0)
   const [hasMore, setHasMore] = useState(false)
   const [total, setTotal] = useState(0)
   const [draft, setDraft] = useState('')
@@ -55,6 +57,7 @@ export function ChatPanel({
   const [pasted, setPasted] = useState<string | null>(null)
   const [dropping, setDropping] = useState(false)
   const picker = useRef<HTMLInputElement | null>(null)
+  const retries = useRef<ReturnType<typeof setTimeout>[]>([])
   const nextAttachment = useRef(0)
   const scroller = useRef<HTMLDivElement | null>(null)
   const composer = useRef<HTMLTextAreaElement | null>(null)
@@ -91,7 +94,7 @@ export function ChatPanel({
     }
     // Reloads as the agent works: last_event_at moves on every hook, and the
     // transcript is a file the daemon re-reads rather than a stream.
-  }, [hostId, session.session_id, session.last_event_at, status, active])
+  }, [hostId, session.session_id, session.last_event_at, status, active, reload])
 
   // Lines picked in the Files panel arrive here rather than being sent: what to
   // ask about them is still to be typed.
@@ -110,6 +113,8 @@ export function ChatPanel({
       scroller.current.scrollTop = scroller.current.scrollHeight
     }
   }, [messages])
+
+  useEffect(() => () => retries.current.forEach(clearTimeout), [])
 
   const loadOlder = async (): Promise<void> => {
     try {
@@ -185,6 +190,15 @@ export function ChatPanel({
       setAttachments([])
       if (result.queued) store.notify('Queued — the agent is mid-turn')
       void store.refreshSessions(hostId)
+      // The agent writes the prompt to its transcript a moment after accepting
+      // it, and the reads triggered by the status change land before that. A
+      // turn that then does nothing hook-worthy moves last_event_at no further,
+      // so without these the message the user just sent stays invisible until
+      // the panel is reopened.
+      retries.current.forEach(clearTimeout)
+      retries.current = [5_000, 10_000].map((delay) =>
+        setTimeout(() => setReload((n) => n + 1), delay),
+      )
     } catch (err) {
       // 409 is an answer, not a fault: the session is busy without a queue, or
       // it ended between this render and the click. Refreshing swaps the

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -53,6 +53,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
   String _currentVerb = randomClaudeVerb();
   Timer? _verbTimer;
   Timer? _transcriptDebounce;
+  List<Timer> _resendReads = [];
   late final AnimationController _breathController;
   bool _breathingActive = false;
   bool _isRecording = false;
@@ -119,6 +120,9 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     _eventSub?.cancel();
     _verbTimer?.cancel();
     _transcriptDebounce?.cancel();
+    for (final timer in _resendReads) {
+      timer.cancel();
+    }
     if (_isRecording) VoiceService.instance.stopListening();
     if (_isVoiceActive) {
       VoiceService.instance.setActiveSession(null);
@@ -370,6 +374,17 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       });
       await Future.delayed(const Duration(milliseconds: 500));
       await _loadTranscript();
+      // The agent writes the prompt to its transcript a moment after accepting
+      // it, so the read above can land before the line exists — and a turn
+      // that does nothing hook-worthy afterwards never prompts another.
+      for (final timer in _resendReads) {
+        timer.cancel();
+      }
+      _resendReads = [5, 10]
+          .map((seconds) => Timer(Duration(seconds: seconds), () {
+                if (mounted) _loadTranscript();
+              }))
+          .toList();
     } else if (mounted) {
       // The prompt stays in the box: it never reached the session, so the
       // user should not have to retype it.


### PR DESCRIPTION
## Summary

A sent prompt sometimes never showed in the Agent tab until the panel was reopened. Timeline of a send, measured in a stubbed harness:

| t | what happens |
|---|---|
| 0 ms | prompt accepted |
| ~200 ms | `session_status: active` arrives → transcript read #2 |
| ~700 ms | debounced session refresh moves `last_event_at` → read #3 |
| ~900 ms | the agent writes the user turn to its transcript file |
| after | nothing reads again |

The transcript is re-read when `last_event_at` or the status changes, and both move on the submit hook — which the agent fires *before* it appends the prompt to its own file. A turn that then does nothing hook-worthy moves neither again, so the message stays invisible.

Two more reads now follow a send, at five and ten seconds, on desktop and mobile alike. The timers are cancelled on unmount and replaced on the next send.

## Test plan

- [x] Harness repro, before: 3 reads, message never appears through 6 s
- [x] Harness repro, after: message appears at the 5 s read, second read at 10 s
- [x] `tsc --noEmit` clean, `flutter analyze` clean
- [ ] Send a prompt from the rebuilt desktop app and watch it appear without touching anything