### PR TITLE
Set markdown reading size from settings

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -151,9 +151,16 @@ export function registerIpc(deps: IpcDeps): void {
 
   // Every window, not just the main one: the HUD draws its cards from the same
   // variables and would otherwise keep the old theme until it next opened.
-  const themePayload = (): { theme: unknown; terminal: unknown; glass: boolean; glassSupported: boolean } => ({
+  const themePayload = (): {
+    theme: unknown
+    terminal: unknown
+    glass: boolean
+    glassSupported: boolean
+    proseSize: number
+  } => ({
     theme: themes.active(),
     terminal: themes.activeTerminal(),
+    proseSize: themes.getPrefs().proseSize,
     // A property of the chosen theme, not a setting of its own: picking a
     // glass theme is the whole of the request. Gated on the platform, because
     // a preference to show a backdrop that does not exist is not showing one.

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -12,6 +12,18 @@ export const DEFAULT_APPEARANCE: AppearancePrefs = {
   lightTheme: 'light-modern',
   darkTheme: 'dark-modern',
   terminalTheme: 'match',
+  proseSize: 14,
+}
+
+/* Clamped rather than trusted: the file is hand-editable, and a zero or a
+   thousand there is a window with no readable way back to the setting. */
+const MIN_PROSE = 10
+const MAX_PROSE = 28
+
+function proseSize(value: unknown): number {
+  const size = Math.round(Number(value))
+  if (!Number.isFinite(size)) return DEFAULT_APPEARANCE.proseSize
+  return Math.min(Math.max(size, MIN_PROSE), MAX_PROSE)
 }
 
 /**
@@ -44,6 +56,7 @@ export class ThemeRegistry {
         lightTheme: parsed.lightTheme ?? DEFAULT_APPEARANCE.lightTheme,
         darkTheme: parsed.darkTheme ?? DEFAULT_APPEARANCE.darkTheme,
         terminalTheme: parsed.terminalTheme ?? DEFAULT_APPEARANCE.terminalTheme,
+        proseSize: proseSize(parsed.proseSize ?? DEFAULT_APPEARANCE.proseSize),
       }
     } catch {
       this.prefs = { ...DEFAULT_APPEARANCE }
@@ -99,6 +112,7 @@ export class ThemeRegistry {
 
   setPrefs(next: Partial<AppearancePrefs>): AppearancePrefs {
     this.prefs = { ...this.prefs, ...next }
+    this.prefs.proseSize = proseSize(this.prefs.proseSize)
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
     fs.writeFileSync(this.file, JSON.stringify(this.prefs, null, 2))
     return this.getPrefs()

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-import { applyTheme } from '../shared/theme/apply.ts'
+import { applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
 
 interface ThemeBoot {
@@ -8,6 +8,7 @@ interface ThemeBoot {
   terminal: XtermTheme
   glass: boolean
   glassSupported: boolean
+  proseSize: number
 }
 
 /**
@@ -55,8 +56,13 @@ function on(channel: string, listener: (payload: unknown) => void): () => void {
  */
 const boot = ipcRenderer.sendSync('theme:boot') as ThemeBoot
 
-if (document.documentElement) {
+const paint = (): void => {
   applyTheme(document.documentElement, boot.theme, boot.glass)
+  applyProseSize(document.documentElement, boot.proseSize)
+}
+
+if (document.documentElement) {
+  paint()
 } else {
   // Usually this branch: a preload runs before the parser has built <html>, so
   // there is nothing to write to yet. Waiting for DOMContentLoaded would be too
@@ -64,7 +70,7 @@ if (document.documentElement) {
   // observer fires the moment <html> appears, which is still before <head>.
   const observer = new MutationObserver(() => {
     if (!document.documentElement) return
-    applyTheme(document.documentElement, boot.theme, boot.glass)
+    paint()
     observer.disconnect()
   })
   observer.observe(document, { childList: true })

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -8,6 +8,8 @@ export interface ThemePayload {
   glass: boolean
   /** This platform can show it at all; false hides the toggle entirely. */
   glassSupported: boolean
+  /** Reading size for rendered markdown, in px. */
+  proseSize: number
 }
 import type {
   AppearancePrefs,

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -573,7 +573,11 @@ function FileView({
     const done = (): void => {
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', done)
-      writeReadingWidth(latest)
+      // Widened to the edge means "fill the panel", not "999 pixels": a number
+      // taken from today's window would leave gutters in a wider one.
+      const filled = latest >= room
+      if (filled) setWidth(null)
+      writeReadingWidth(filled ? null : latest)
     }
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', done)

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -175,6 +175,8 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           onPick={(id) => void setTheme({ terminalTheme: id })}
         />
 
+        <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
+
         <button className="ghost" onClick={() => void reloadThemes()}>
           Reload themes
         </button>
@@ -453,6 +455,43 @@ function ThemePicker({
           </button>
         ))}
       </div>
+    </div>
+  )
+}
+
+/**
+ * The size rendered markdown is read at, in px — the transcript and the file
+ * preview both. Committed on blur or Enter rather than on every keystroke: a
+ * half-typed "1" would otherwise repaint the app at the smallest size allowed.
+ */
+function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {
+  const [draft, setDraft] = useState('')
+  const shown = draft || String(size ?? '')
+
+  const commit = (): void => {
+    setDraft('')
+    const next = Number(shown)
+    if (Number.isFinite(next) && next !== size) onPick(Math.min(Math.max(Math.round(next), 10), 28))
+  }
+
+  return (
+    <div className="theme-picker">
+      <span className="theme-picker-label">Text size</span>
+      <input
+        className="prose-size"
+        type="number"
+        min={10}
+        max={28}
+        step={1}
+        value={shown}
+        disabled={size === undefined}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') event.currentTarget.blur()
+        }}
+      />
+      <span className="modal-note">px — chat and file previews.</span>
     </div>
   )
 }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from 'react'
 
 import { api, bridge, statusOf } from './bridge.ts'
-import { applyTheme } from '../shared/theme/apply.ts'
+import { applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
 import type { XtermTheme } from '../shared/theme/resolve.ts'
@@ -195,8 +195,9 @@ class Store {
     // The preload painted the boot theme already; this keeps up with changes
     // made afterwards, whether from the settings dialog or the OS switching
     // between light and dark underneath us.
-    bridge.theme.onChanged(({ theme, terminal, glass }) => {
+    bridge.theme.onChanged(({ theme, terminal, glass, proseSize }) => {
       applyTheme(document.documentElement, theme, glass)
+      applyProseSize(document.documentElement, proseSize)
       this.set({ terminalTheme: terminal })
     })
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1255,9 +1255,12 @@ small {
 
 /* ─── Markdown ──────────────────────────────────────────────────────────── */
 
-/* The agent writes markdown, so the transcript renders it — same as mobile. */
+/* The agent writes markdown, so the transcript renders it — same as mobile.
+   Prose is the one thing here the reader sets the size of, so everything
+   inside is em: one setting moves headings, tables and code with the body. */
 .md {
   white-space: normal;
+  font-size: var(--prose-size, 14px);
 }
 
 .md > *:first-child {
@@ -1286,19 +1289,19 @@ small {
 }
 
 .md h1 {
-  font-size: 18px;
+  font-size: 1.29em;
 }
 
 .md h2 {
-  font-size: 16px;
+  font-size: 1.14em;
 }
 
 .md h3 {
-  font-size: 14.5px;
+  font-size: 1.04em;
 }
 
 .md h4 {
-  font-size: 13.5px;
+  font-size: 0.96em;
   color: var(--on-surface-variant);
 }
 
@@ -1338,7 +1341,7 @@ small {
 
 .md table {
   border-collapse: collapse;
-  font-size: 12.5px;
+  font-size: 0.89em;
 }
 
 .md th,
@@ -1356,7 +1359,7 @@ small {
 /* Inline code, but not the code inside a highlighted block. */
 .md code:not(.hljs) {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: 0.86em;
   background: var(--surface-highest);
   border-radius: 4px;
   padding: 1px 5px;
@@ -3594,6 +3597,11 @@ hr {
   font-size: 12px;
   color: var(--on-surface-variant);
   margin-bottom: 6px;
+}
+
+.prose-size {
+  width: 72px;
+  margin-right: 8px;
 }
 
 .theme-grid {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -474,6 +474,8 @@ export interface AppearancePrefs {
   darkTheme: string
   /** A theme id, or 'match' to follow whichever UI theme is active. */
   terminalTheme: string
+  /** Body size of rendered markdown, in px; headings and tables scale with it. */
+  proseSize: number
 }
 
 /** A theme as the picker lists it; `swatch` is a handful of representative colours. */

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -11,6 +11,11 @@ import type { HeliosTheme } from './resolve.ts'
  * by the resolver, so a hand-written theme file cannot smuggle anything else
  * into a property here.
  */
+/** The reading size for rendered markdown, which the .md rules scale from. */
+export function applyProseSize(root: HTMLElement, size: number): void {
+  root.style.setProperty('--prose-size', `${size}px`)
+}
+
 export function applyTheme(root: HTMLElement, theme: Pick<HeliosTheme, 'vars'>, glass = false): void {
   for (const [name, value] of Object.entries(theme.vars)) root.style.setProperty(name, value)
   // An attribute rather than more variables: the backdrop changes which


### PR DESCRIPTION
## Summary
- Appearance settings gain a **Text size** field, in px, for rendered markdown — the transcript and the file preview both. Stored in `AppearancePrefs` beside the themes, clamped 10–28 on load and save, painted as `--prose-size` in the preload so there is no flash on launch. Heading, table and inline-code sizes became `em`, so one number scales the document; the em values equal the old px at 14, leaving the default look unchanged.
- A markdown column dragged to the panel's edge now saves "fill" rather than the pixel width it happened to reach. A width taken from today's window left gutters in a wider one, and only a double-click on the grip could clear it.

## Test plan
- [ ] Settings → Appearance → Text size: type a size, blur, and see the transcript and a markdown preview both change
- [ ] Reopen the app; the size survives, and the first frame is already at it
- [ ] Leave it at 14 and confirm prose looks as it did before
- [ ] Drag a preview column to the panel edge, widen the window, and confirm the column widens with it