### PR TITLE
fix: draw the disclosure arrow, and reflow hard wraps in the preview

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -12,6 +12,7 @@ import {
 } from '../attachments.ts'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
+import { Chevron } from './icons.tsx'
 import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
 import {
   extractFilePaths,
@@ -554,7 +555,7 @@ function FileChip({
         title={`Find ${name} in the Files panel`}
         onClick={() => store.findFile(hostId, resolved)}
       >
-        <span className="file-chip-icon">{isDir ? '▸' : '⌕'}</span>
+        <span className="file-chip-icon">{isDir ? <Chevron dir="right" /> : '⌕'}</span>
         {name}
       </button>
       <button className="file-chip-act" title={`Open ${resolved}`} onClick={() => store.openFile(hostId, resolved)}>
@@ -621,7 +622,7 @@ function ToolUse({ message, hostId, cwd }: MessageProps): JSX.Element {
         <span className="tool-icon">{TOOL_ICONS[tool] ?? '⚙'}</span>
         <span className="tool-name">{tool}</span>
         <span className="tool-summary">{message.summary ?? ''}</span>
-        <span className="chevron">{open ? '▾' : '▸'}</span>
+        <Chevron className="chevron" open={open} />
       </button>
       {open && (
         <div className="tool-detail">

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { DiffView } from './diff-view.tsx'
+import { Chevron } from './icons.tsx'
 import { PathLabel } from './path-label.tsx'
 import { timeAgo, type Commit, type GitChanges, type GitDiff, type GitLog, type GitStatus } from '../../shared/models.ts'
 
@@ -83,7 +84,7 @@ export function ScopePicker({
         {scope.kind === 'working' && dirtyCount(status) > 0 && (
           <span className="pill">{dirtyCount(status)}</span>
         )}
-        <span className="scope-caret">▾</span>
+        <Chevron className="scope-caret" dir="down" />
       </button>
 
       {at && (

--- a/desktop/src/renderer/components/file-tree.tsx
+++ b/desktop/src/renderer/components/file-tree.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import type { FileEntry } from '../../shared/models.ts'
+import { Chevron } from './icons.tsx'
 
 interface Props {
   hostId: string
@@ -101,7 +102,7 @@ export function FileTree({ hostId, root, selected, reveal, onOpen }: Props): JSX
           title={entry.name}
           onClick={() => (entry.is_dir ? toggle(entry.path) : onOpen(entry.path))}
         >
-          <span className="tree-twist">{entry.is_dir ? (open ? '▾' : '▸') : ''}</span>
+          <span className="tree-twist">{entry.is_dir && <Chevron open={open} />}</span>
           <span className={`tree-name ${entry.is_dir ? 'dir' : ''}`}>{entry.name}</span>
           {busy.has(entry.path) && <span className="tree-busy">…</span>}
         </button>,

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -7,6 +7,7 @@ import { byLastTouched, type Worktree } from '../../shared/models.ts'
 import { CodeEditor, type Cursor } from './editor.tsx'
 import { FileTree } from './file-tree.tsx'
 import { FindInFiles } from './find-in-files.tsx'
+import { Chevron } from './icons.tsx'
 import { PathLabel } from './path-label.tsx'
 import { QuickOpen } from './quick-open.tsx'
 import { RootPicker } from './root-picker.tsx'
@@ -377,7 +378,7 @@ export function FilesPanel({
             title="Choose a worktree or another folder"
             onClick={() => setRootPicker(true)}
           >
-            ▾
+            <Chevron dir="down" />
           </button>
           {root !== sessionRoot && (
             <button className="pill" title="Back to this session's own folder" onClick={() => setRootOverride(null)}>
@@ -653,7 +654,7 @@ function FileView({
                         })
                       }
                     >
-                      {folded ? '▸' : '▾'}
+                      <Chevron open={!folded} />
                     </button>
                   )}
                   <div className="md-block-body" dangerouslySetInnerHTML={{ __html: block.html }} />

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -1,0 +1,41 @@
+/**
+ * Drawn icons, not typed ones.
+ *
+ * The disclosure arrows used to be `▸` and `▾` — U+25B8 and U+25BE, whose
+ * Unicode names begin with "small". They occupy a fraction of their em box, so
+ * every site that used one had to oversize it to read as an arrow at all, and
+ * still got a speck. A path scales with its box instead.
+ */
+
+/** Which way the chevron points. `open` is the disclosure shorthand for down. */
+export type ChevronDir = 'right' | 'down' | 'left' | 'up'
+
+const PATHS: Record<ChevronDir, string> = {
+  right: 'M9 5l7 7-7 7',
+  down: 'M5 9l7 7 7-7',
+  left: 'M15 5l-7 7 7 7',
+  up: 'M5 15l7-7 7 7',
+}
+
+/**
+ * Sized in `em`, so it follows whatever the surrounding row is set to rather
+ * than pinning a pixel size the reader cannot change.
+ */
+export function Chevron({
+  open,
+  dir,
+  className = '',
+}: {
+  /** Disclosure state: down when open, right when closed. */
+  open?: boolean
+  /** Explicit direction, for carets that do not disclose anything. */
+  dir?: ChevronDir
+  className?: string
+}): JSX.Element {
+  const facing = dir ?? (open ? 'down' : 'right')
+  return (
+    <svg className={`chevron-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d={PATHS[facing]} />
+    </svg>
+  )
+}

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   type HostRecord,
   type Session,
 } from '../../shared/models.ts'
+import { Chevron } from './icons.tsx'
 
 interface Row {
   host: HostRecord
@@ -140,7 +141,7 @@ export function Sidebar({
                 {/* No count until there is one: a 0 that turns into 12 reads as
                     an answer, and it was not one. */}
                 {!loading && <span className="host-count">{rows.length}</span>}
-                <span className="chevron">{isCollapsed ? '▸' : '▾'}</span>
+                <Chevron className="chevron" open={!isCollapsed} />
               </button>
 
               {/* Above the list, not below it: revealed sessions are appended,

--- a/desktop/src/renderer/markdown.ts
+++ b/desktop/src/renderer/markdown.ts
@@ -159,27 +159,41 @@ export function highlightCode(code: string, language?: string | null): string {
   }
 }
 
-const marked = new Marked({
-  gfm: true,
-  breaks: true,
-  renderer: {
-    code({ text, lang }): string {
-      const name = normalizeLanguage(lang)
-      return (
-        `<pre class="code-block"><code class="hljs${name ? ` language-${name}` : ''}">` +
-        `${highlightCode(text, name)}</code></pre>`
-      )
+/**
+ * Two parsers, differing only in what a lone newline means.
+ *
+ * An agent writing into a transcript ends a line because it meant to end one,
+ * so `breaks` honours it. A file on disk is hard-wrapped by its author at
+ * whatever column they favour, and honouring those would print the document at
+ * the width it was typed at rather than the width it is read at — GitHub
+ * reflows them, and so does the preview.
+ */
+function parser(breaks: boolean): Marked {
+  return new Marked({
+    gfm: true,
+    breaks,
+    renderer: {
+      code({ text, lang }): string {
+        const name = normalizeLanguage(lang)
+        return (
+          `<pre class="code-block"><code class="hljs${name ? ` language-${name}` : ''}">` +
+          `${highlightCode(text, name)}</code></pre>`
+        )
+      },
+      link(token): string {
+        // The renderer has no network of its own and never navigates: an
+        // external link is handed to the OS browser by the main process's
+        // window-open handler, which only fires for target=_blank.
+        const href = escapeHtml(token.href)
+        const title = token.title ? ` title="${escapeHtml(token.title)}"` : ''
+        return `<a href="${href}"${title} target="_blank" rel="noreferrer noopener">${this.parser.parseInline(token.tokens)}</a>`
+      },
     },
-    link(token): string {
-      // The renderer has no network of its own and never navigates: an external
-      // link is handed to the OS browser by the main process's window-open
-      // handler, which only fires for target=_blank.
-      const href = escapeHtml(token.href)
-      const title = token.title ? ` title="${escapeHtml(token.title)}"` : ''
-      return `<a href="${href}"${title} target="_blank" rel="noreferrer noopener">${this.parser.parseInline(token.tokens)}</a>`
-    },
-  },
-})
+  })
+}
+
+const marked = parser(true)
+const fileParser = parser(false)
 
 /**
  * Markdown to HTML, sanitized.
@@ -212,13 +226,13 @@ export interface MarkdownBlock {
 export function renderMarkdownBlocks(source: string): MarkdownBlock[] {
   const blocks: MarkdownBlock[] = []
   let line = 1
-  for (const token of marked.lexer(source)) {
+  for (const token of fileParser.lexer(source)) {
     const startLine = line
     const newlines = (token.raw.match(/\n/g) ?? []).length
     line += newlines
     // Blank lines between blocks belong to neither, and have nothing to render.
     if (token.type === 'space') continue
-    const html = DOMPurify.sanitize(marked.parser([token], { async: false }), { ADD_ATTR: ['target'] })
+    const html = DOMPurify.sanitize(fileParser.parser([token], { async: false }), { ADD_ATTR: ['target'] })
     blocks.push({
       html,
       startLine,

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -700,9 +700,21 @@ small {
 }
 
 .host-count,
+/* Drawn, so it fills its box: sized in em to follow the row it sits in rather
+   than pinning a size of its own. See components/icons.tsx. */
+.chevron-icon {
+  flex: none;
+  width: 1em;
+  height: 1em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .chevron {
   opacity: 0.7;
-  font-weight: 500;
 }
 
 /* Quieter than the new-session button beside it, and filled only while it is
@@ -1249,7 +1261,7 @@ small {
   min-width: 22px;
   height: 22px;
   padding: 0;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1;
 }
 
@@ -1447,6 +1459,8 @@ small {
 }
 
 .file-chip-icon {
+  display: inline-flex;
+  align-items: center;
   opacity: 0.7;
 }
 
@@ -2168,12 +2182,14 @@ small {
 }
 
 .md-fold {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: none;
   width: 16px;
   padding: 0;
   background: transparent;
   color: var(--on-surface-variant);
-  font-size: 12px;
   line-height: 1;
 }
 
@@ -2343,6 +2359,9 @@ small {
 }
 
 .ws-root-more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: none;
   width: 22px;
   height: 22px;
@@ -2397,9 +2416,12 @@ small {
 }
 
 .tree-twist {
-  width: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
   flex: none;
-  font-size: 11px;
+  line-height: 1;
   color: var(--on-surface-variant);
 }
 
@@ -2982,7 +3004,6 @@ hr {
 }
 
 .scope-caret {
-  font-size: 10px;
   color: var(--on-surface-variant);
 }
 


### PR DESCRIPTION
Two fixes to the markdown/file panel.

## 1 — The `>` was a speck

The file tree, sidebar, tool rows, scope caret and fold buttons all used `▸` and `▾` — U+25B8 and U+25BE, whose Unicode names literally begin with "small". They occupy a fraction of their em box, so every site oversized them to compensate and still lost. `styles.css` said so out loud:

```css
/* The glyph is a small one inside its em box, so it needs a size above the
   row's to read as an arrow rather than a speck. */
.tree-twist { font-size: 15px; }   /* in a 12.5px row */
```

Swapping to the full-size codepoints `▶`/`▼` trades one problem for another: those have emoji presentations and macOS may render them as colored play buttons.

So: one `<Chevron>` in `components/icons.tsx` drawing an SVG path, sized in `em`. Seven call sites converted, each dropping its compensating font-size. Because it is `em`, the fold buttons in a preview now track the reading size from #71 instead of sitting at a fixed 15px.

`chat.tsx`'s `⌕` magnifier is left alone — different icon, different concern.

## 2 — The preview printed at the width the file was typed at

One parser served both the transcript and the file preview, with `breaks` on. That is right for a transcript: an agent ends a line because it meant to. It is wrong for a file on disk, which its author hard-wrapped at whatever column they favour — honouring those wraps prints the document at the width it was written at rather than the width it is being read at.

Split into two parsers differing only in `breaks`. The preview reflows, as GitHub does. The transcript is unchanged.

## Verified

Built the renderer and rendered the real `dist/renderer/renderer.css` against markup matching each call site, old glyph beside new:

- tree rows legible at 12.5px, open and closed, including the selected row where the icon picks up `currentColor`
- scope caret no longer pinned at 10px
- fold button visibly larger at prose 20px than at 14px

`npm run typecheck` and `npm run build` clean. The unit tests could not run locally — `node --test --experimental-strip-types` is unsupported on the Node in this environment, which is unrelated to these changes.

## Test plan

- [ ] File tree chevrons read as arrows at the default size
- [ ] Sidebar host collapse, tool-call rows, commit scope caret, worktree root caret
- [ ] Fold buttons grow with Settings → Text size
- [ ] Light and dark themes — the icon is `currentColor`, so it should follow
- [ ] A hard-wrapped `.md` file reflows to the panel width; widening the panel reflows again
- [ ] The transcript still breaks on single newlines