### PR TITLE
Paint the glass backdrop instead of borrowing the desktop

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -6,7 +6,9 @@ import type { Notifier } from './notify.ts'
 import type { PrefsStore } from './prefs.ts'
 import type { TerminalManager } from './terminals.ts'
 import type { ThemeRegistry } from './themes.ts'
-import type { AppearancePrefs } from '../shared/models.ts'
+import { DEFAULT_INTENSITY } from '../shared/theme/backdrop.ts'
+import type { BackdropSpec } from '../shared/theme/vscode.ts'
+import type { AppearancePrefs, BackdropState } from '../shared/models.ts'
 
 /**
  * REST calls the renderer may make. An allow-list rather than a reflective
@@ -162,9 +164,10 @@ export function registerIpc(deps: IpcDeps): void {
     terminal: themes.activeTerminal(),
     proseSize: themes.getPrefs().proseSize,
     // A property of the chosen theme, not a setting of its own: picking a
-    // glass theme is the whole of the request. Gated on the platform, because
-    // a preference to show a backdrop that does not exist is not showing one.
-    glass: glassSupported && themes.active().glass !== null,
+    // glass theme is the whole of the request. A theme with no backdrop of its
+    // own is gated on the platform, because a preference to show a backdrop
+    // that does not exist is not showing one.
+    glass: themes.active().glass !== null && (themes.active().backdrop !== null || glassSupported),
     glassSupported,
   })
 
@@ -198,6 +201,30 @@ export function registerIpc(deps: IpcDeps): void {
     themes.reload()
     broadcastTheme()
     return themes.list()
+  })
+
+  // The backdrop belongs to the theme, so the picker reads and writes whichever
+  // theme is showing rather than a slot of its own.
+  const backdropState = (): BackdropState => {
+    const theme = themes.active()
+    return {
+      themeId: theme.id,
+      themeName: theme.name,
+      glass: theme.glass !== null,
+      style: theme.backdrop?.style ?? 'desktop',
+      intensity: theme.backdrop?.intensity ?? DEFAULT_INTENSITY,
+      // Offering the desktop where there is no way to show it would be
+      // offering an opaque window under a different name.
+      desktopSupported: glassSupported,
+    }
+  }
+
+  handle('theme:backdrop', async () => backdropState())
+  handle('theme:setBackdrop', async (_e, spec: BackdropSpec) => {
+    themes.setBackdrop(themes.active().id, spec)
+    onAppearanceChange()
+    broadcastTheme()
+    return backdropState()
   })
 
   // ─── Terminals ─────────────────────────────────────────────────────────

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -131,7 +131,17 @@ async function start(): Promise<void> {
 const GLASS_SUPPORTED = process.platform === 'darwin'
 
 function glassOn(): boolean {
-  return GLASS_SUPPORTED && Boolean(themes?.active().glass)
+  const theme = themes?.active()
+  if (!theme?.glass) return false
+  // A theme that carries its own gradient needs nothing from the OS, so it is
+  // glass on every platform. One that does not is asking for the desktop, which
+  // only macOS can hand over.
+  return theme.backdrop !== null || GLASS_SUPPORTED
+}
+
+/** Whether the window itself has to let anything through to show the backdrop. */
+function vibrancyOn(): boolean {
+  return GLASS_SUPPORTED && glassOn() && themes?.active().backdrop === null
 }
 
 /**
@@ -147,11 +157,13 @@ function applyWindowMaterial(): void {
   if (!themes) return
   nativeTheme.themeSource = themes.getPrefs().mode
   if (!window || window.isDestroyed()) return
-  const on = glassOn()
-  if (GLASS_SUPPORTED) window.setVibrancy(on ? 'under-window' : null)
-  // An opaque background sits in front of the material and hides it, so the
-  // window has to stop painting one for the backdrop to be visible at all.
-  window.setBackgroundColor(on ? '#00000000' : (themes.active().vars['--surface'] ?? '#101014'))
+  const clear = vibrancyOn()
+  if (GLASS_SUPPORTED) window.setVibrancy(clear ? 'under-window' : null)
+  // An opaque background sits in front of the material and hides it, so a
+  // window showing the desktop has to stop painting one. A window painting its
+  // own gradient keeps it: the renderer draws over it either way, and a clear
+  // window would show the desktop through the app's own backdrop.
+  window.setBackgroundColor(clear ? '#00000000' : (themes.active().vars['--surface'] ?? '#101014'))
 }
 
 function createWindow(): void {
@@ -164,8 +176,8 @@ function createWindow(): void {
     icon: appIcon,
     // The frame is painted before the renderer runs, so it has to come from the
     // theme too or the window flashes the old dark grey on every open.
-    backgroundColor: glassOn() ? '#00000000' : (themes?.active().vars['--surface'] ?? '#101014'),
-    ...(glassOn() ? { vibrancy: 'under-window' as const } : {}),
+    backgroundColor: vibrancyOn() ? '#00000000' : (themes?.active().vars['--surface'] ?? '#101014'),
+    ...(vibrancyOn() ? { vibrancy: 'under-window' as const } : {}),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       preload: path.join(distDir, 'preload', 'preload.js'),

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { resolveTheme, type HeliosTheme, type ThemeMode } from '../shared/theme/resolve.ts'
-import { parseJsonc, type VSCodeTheme } from '../shared/theme/vscode.ts'
+import { mergeThemes, resolveTheme, type HeliosTheme, type ThemeMode } from '../shared/theme/resolve.ts'
+import { parseJsonc, type BackdropSpec, type VSCodeTheme } from '../shared/theme/vscode.ts'
 import type { AppearancePrefs, ThemeSummary } from '../shared/models.ts'
 
 export const DEFAULT_APPEARANCE: AppearancePrefs = {
@@ -81,12 +81,35 @@ export class ThemeRegistry {
       if (!entry.endsWith('.json')) continue
       const id = entry.slice(0, -'.json'.length)
       try {
-        const raw = parseJsonc(fs.readFileSync(path.join(dir, entry), 'utf8')) as VSCodeTheme
+        const raw = this.read(path.join(dir, entry))
         this.themes.set(id, resolveTheme(id, raw))
       } catch (err) {
         console.error(`theme ${id} failed to load:`, err)
       }
     }
+  }
+
+  /**
+   * A theme file, with whatever it includes layered underneath it.
+   *
+   * `include` names a sibling, and a user file may name a bundled one — which
+   * is how the backdrop picker saves: a handful of lines in ~/.helios/themes
+   * over the bundled theme's several hundred colours, so the override keeps
+   * working when those colours change under it.
+   */
+  private read(file: string, depth = 0): VSCodeTheme {
+    const raw = parseJsonc(fs.readFileSync(file, 'utf8')) as VSCodeTheme
+    // A file that includes itself is the shape this takes when a user copies an
+    // override next to the theme it overrode; the depth cap makes it a theme
+    // with no parent rather than a hang at startup.
+    if (!raw.include || depth >= 4) return raw
+    const sibling = path.basename(raw.include)
+    for (const dir of [path.dirname(file), this.bundledDir]) {
+      const parent = path.join(dir, sibling)
+      if (parent === file || !fs.existsSync(parent)) continue
+      return mergeThemes(this.read(parent, depth + 1), raw)
+    }
+    return raw
   }
 
   list(): ThemeSummary[] {
@@ -108,6 +131,39 @@ export class ThemeRegistry {
 
   getPrefs(): AppearancePrefs {
     return { ...this.prefs }
+  }
+
+  /**
+   * Saves a theme's backdrop, as a file in ~/.helios/themes rather than a
+   * preference of its own.
+   *
+   * The backdrop is a property of the theme — a mesh drawn from one theme's
+   * palette means nothing under another — so it belongs beside the colours it
+   * is derived from, where a user can also hand-edit it and where exporting the
+   * theme takes the backdrop with it.
+   *
+   * A bundled theme is not written to. The override includes it and states only
+   * what the picker changed, so the bundled colours stay the source and keep
+   * being updated by the app.
+   */
+  setBackdrop(id: string, spec: BackdropSpec): HeliosTheme {
+    if (!this.themes.has(id)) throw new Error(`unknown theme: ${id}`)
+    const file = path.join(this.userDir, `${id}.json`)
+    let doc: VSCodeTheme = { include: `${id}.json` }
+    if (fs.existsSync(file)) {
+      // Their own theme, or an override written by an earlier pick: edited in
+      // place, so nothing else the file says is lost.
+      try {
+        doc = parseJsonc(fs.readFileSync(file, 'utf8')) as VSCodeTheme
+      } catch {
+        // A file we cannot parse is one the user cannot have meant to keep.
+      }
+    }
+    doc['helios.backdrop'] = spec
+    fs.mkdirSync(this.userDir, { recursive: true })
+    fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`)
+    this.reload()
+    return this.themes.get(id) as HeliosTheme
   }
 
   setPrefs(next: Partial<AppearancePrefs>): AppearancePrefs {

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -120,6 +120,8 @@ const helios = {
     prefs: () => call('theme:prefs'),
     set: (next: unknown) => call('theme:set', next),
     reload: () => call('theme:reload'),
+    backdrop: () => call('theme:backdrop'),
+    setBackdrop: (spec: unknown) => call('theme:setBackdrop', spec),
     onChanged: (fn: (payload: unknown) => void) => on('theme:changed', fn),
   },
   hud: {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -1,10 +1,11 @@
 import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
+import type { BackdropSpec } from '../shared/theme/vscode.ts'
 
 /** What the main process hands over whenever the appearance changes. */
 export interface ThemePayload {
   theme: HeliosTheme
   terminal: XtermTheme
-  /** The OS backdrop is on: some surfaces stop painting so it shows through. */
+  /** A backdrop is on: some surfaces stop painting so it shows through. */
   glass: boolean
   /** This platform can show it at all; false hides the toggle entirely. */
   glassSupported: boolean
@@ -13,6 +14,7 @@ export interface ThemePayload {
 }
 import type {
   AppearancePrefs,
+  BackdropState,
   CommandInfo,
   DeviceInfo,
   DirectoryInfo,
@@ -113,6 +115,9 @@ interface RawBridge {
     prefs(): Promise<AppearancePrefs>
     set(next: Partial<AppearancePrefs>): Promise<ThemePayload>
     reload(): Promise<ThemeSummary[]>
+    /** The active theme's backdrop, which lives in the theme file itself. */
+    backdrop(): Promise<BackdropState>
+    setBackdrop(spec: BackdropSpec): Promise<BackdropState>
     onChanged(fn: (payload: ThemePayload) => void): Unsubscribe
   }
   hud: {

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -4,7 +4,10 @@ import { api, bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
 import { Modal } from './newsession.tsx'
 import { ALERT_TYPES } from '../../shared/notifications.ts'
-import type { AppearancePrefs, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
+import { BACKDROP_STYLES, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
+import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
+import type { HeliosTheme } from '../../shared/theme/resolve.ts'
+import type { AppearancePrefs, BackdropState, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
 
 /**
  * Which types can be silenced, in the order the phone lists them. Keeping the
@@ -176,6 +179,8 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         />
 
         <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
+
+        <Backdrop />
 
         <button className="ghost" onClick={() => void reloadThemes()}>
           Reload themes
@@ -464,6 +469,118 @@ function ThemePicker({
  * preview both. Committed on blur or Enter rather than on every keystroke: a
  * half-typed "1" would otherwise repaint the app at the smallest size allowed.
  */
+const BACKDROP_LABELS: Record<BackdropStyle, string> = {
+  desktop: 'Desktop',
+  mesh: 'Mesh',
+  corner: 'Corner',
+  wash: 'Wash',
+  aurora: 'Aurora',
+}
+
+/**
+ * What sits behind the glass, for whichever theme is showing.
+ *
+ * Saved into the theme file rather than into this window's preferences, so the
+ * choice travels with the theme it was made against — the gradients are drawn
+ * from that theme's own palette.
+ */
+function Backdrop(): JSX.Element | null {
+  const [state, setState] = useState<BackdropState | null>(null)
+  const [theme, setActive] = useState<HeliosTheme>(() => bridge.theme.boot().theme)
+  /** Held while the slider is under the pointer; saving each step would rewrite
+      the theme file on every frame of a drag. */
+  const [dragging, setDragging] = useState<number | null>(null)
+
+  // The active theme changes with the pickers above and with the OS switching
+  // between light and dark, and each is a different file to edit.
+  useEffect(() => {
+    void bridge.theme.backdrop().then(setState)
+    return bridge.theme.onChanged((payload) => {
+      setActive(payload.theme)
+      void bridge.theme.backdrop().then(setState)
+    })
+  }, [])
+
+  const save = async (spec: BackdropSpec): Promise<void> => {
+    if (!state) return
+    setState({ ...state, style: spec.style ?? state.style, intensity: spec.intensity ?? state.intensity })
+    try {
+      setState(await bridge.theme.setBackdrop(spec))
+    } catch (err) {
+      store.fail(err)
+      setState(await bridge.theme.backdrop())
+    }
+  }
+
+  const commit = (): void => {
+    if (dragging === null || !state) return
+    const next = dragging
+    setDragging(null)
+    if (next !== state.intensity) void save({ style: state.style, intensity: next })
+  }
+
+  // An opaque theme has nothing to show a backdrop through, and a picker that
+  // changes nothing visible is worse than no picker.
+  if (!state?.glass) return null
+
+  const styles: BackdropStyle[] = [
+    ...(state.desktopSupported ? (['desktop'] as BackdropStyle[]) : []),
+    ...BACKDROP_STYLES,
+  ]
+  const intensity = dragging ?? state.intensity
+
+  return (
+    <div className="theme-picker">
+      <span className="theme-picker-label">Backdrop</span>
+      <div className="theme-grid">
+        {styles.map((style) => (
+          <button
+            key={style}
+            className={state.style === style ? 'theme-chip selected' : 'theme-chip'}
+            onClick={() => void save({ style, intensity })}
+            title={style === 'desktop' ? 'Show the desktop through the window' : `Paint a ${style} gradient`}
+          >
+            <span
+              className={style === 'desktop' ? 'backdrop-swatch desktop' : 'backdrop-swatch'}
+              style={style === 'desktop' ? undefined : { background: previewOf(theme, style, intensity) }}
+            />
+            {BACKDROP_LABELS[style]}
+          </button>
+        ))}
+      </div>
+      {state.style !== 'desktop' && (
+        <input
+          className="backdrop-intensity"
+          type="range"
+          min={MIN_INTENSITY}
+          max={MAX_INTENSITY}
+          step={0.05}
+          value={intensity}
+          onChange={(event) => setDragging(Number(event.target.value))}
+          // The swatches follow the thumb; the window and the file wait for it
+          // to be let go.
+          onPointerUp={() => commit()}
+          onKeyUp={() => commit()}
+          onBlur={() => commit()}
+        />
+      )}
+      <span className="modal-note">Saved in {state.themeName}.</span>
+    </div>
+  )
+}
+
+/**
+ * The same value the theme would resolve to, drawn small.
+ *
+ * Built by the generator the window itself uses, from the palette the resolver
+ * derived, so a swatch cannot disagree with the result of clicking it.
+ */
+function previewOf(theme: HeliosTheme, style: BackdropStyle, intensity: number): string {
+  const stops = theme.backdropPalette.map(parseColor).filter((c): c is Rgb => c !== null)
+  const base = parseColor(theme.vars['--surface'] ?? '') ?? (parseColor('#101014') as Rgb)
+  return backdropValue({ style, intensity }, base, stops)
+}
+
 function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {
   const [draft, setDraft] = useState('')
   const shown = draft || String(size ?? '')

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -516,14 +516,17 @@ small {
 
 /* ─── Backdrop ──────────────────────────────────────────────────────────── */
 
-/* With the OS material behind the window, the surfaces in front of it have to
-   stop painting for any of it to be seen. Only two do: the page itself, which
-   turns the window's margins and the strip behind the title bar into glass, and
-   the sidebar. The transcript, the terminal and the editor stay opaque on
-   purpose — they are for reading, and reading off a moving desktop is not
-   worth the look. */
+/* With a backdrop behind the window, the surfaces in front of it have to stop
+   painting for any of it to be seen. Only two do: the page itself, which turns
+   the window's margins and the strip behind the title bar into glass, and the
+   sidebar. The transcript, the terminal and the editor stay opaque on purpose —
+   they are for reading, and reading off a moving desktop is not worth the look.
+
+   The theme's own gradient when it declares one, and transparent when it does
+   not, which is the case where the OS material behind the window is the
+   backdrop and anything painted here would hide it. */
 [data-glass='on'] body {
-  background: transparent;
+  background: var(--backdrop, transparent);
 }
 
 /* Tinted rather than clear: the material supplies the blur, the tint keeps the
@@ -3684,6 +3687,33 @@ hr {
     var(--surface-high) 0 4px,
     var(--surface-highest) 4px 8px
   );
+}
+
+/* Wider than a theme swatch and in the window's own proportions: these are
+   scale models of the backdrop, and a gradient judged in a 40px strip is not
+   the one that ends up behind the app. */
+.backdrop-swatch {
+  flex: 0 0 auto;
+  width: 52px;
+  height: 30px;
+  border-radius: 4px;
+  border: 1px solid var(--outline-variant);
+}
+
+/* The desktop is not ours to draw, so the chip says so rather than guessing at
+   a wallpaper. */
+.backdrop-swatch.desktop {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--surface-high) 0 5px,
+    var(--surface-highest) 5px 10px
+  );
+}
+
+.backdrop-intensity {
+  width: 100%;
+  margin-top: 8px;
+  accent-color: var(--primary);
 }
 
 .modal-note {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -3,6 +3,8 @@
 // Go names, and optional fields are optional here for the same reason they are
 // pointers there.
 
+import type { BackdropStyle } from './theme/vscode.ts'
+
 export interface Session {
   session_id: string
   source: string
@@ -476,6 +478,23 @@ export interface AppearancePrefs {
   terminalTheme: string
   /** Body size of rendered markdown, in px; headings and tables scale with it. */
   proseSize: number
+}
+
+/**
+ * What the backdrop picker shows, for whichever theme is active.
+ *
+ * Not part of AppearancePrefs: the backdrop is saved into the theme file, since
+ * a gradient drawn from one theme's palette means nothing under another.
+ */
+export interface BackdropState {
+  themeId: string
+  themeName: string
+  /** False for an opaque theme, where a backdrop would never be seen. */
+  glass: boolean
+  style: BackdropStyle
+  intensity: number
+  /** Whether this platform can show the desktop behind the window. */
+  desktopSupported: boolean
 }
 
 /** A theme as the picker lists it; `swatch` is a handful of representative colours. */

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -18,8 +18,13 @@ export function applyProseSize(root: HTMLElement, size: number): void {
 
 export function applyTheme(root: HTMLElement, theme: Pick<HeliosTheme, 'vars'>, glass = false): void {
   for (const [name, value] of Object.entries(theme.vars)) root.style.setProperty(name, value)
-  // An attribute rather than more variables: the backdrop changes which
-  // surfaces paint at all, not what colour they are.
+  // Every other variable is emitted by every theme, so writing over them is
+  // enough. The backdrop is the one a theme may decline to set, and a stale
+  // gradient left behind is the app painting over the desktop it was just
+  // asked to show.
+  if (!theme.vars['--backdrop']) root.style.removeProperty('--backdrop')
+  // An attribute rather than more variables: glass changes which surfaces
+  // paint at all, not what colour they are.
   if (glass) root.dataset.glass = 'on'
   else delete root.dataset.glass
 }

--- a/desktop/src/shared/theme/backdrop.ts
+++ b/desktop/src/shared/theme/backdrop.ts
@@ -1,0 +1,156 @@
+/**
+ * The backdrop a glass theme paints behind itself.
+ *
+ * Glass began as the macOS window material, which means the wallpaper decides
+ * what the app looks like and no other platform gets anything at all. A theme
+ * that carries its own backdrop answers both: the window stays opaque, the
+ * translucent surfaces have something of the app's own to sit on, and it looks
+ * the same everywhere.
+ *
+ * Static by design. The value is a plain list of gradients, so the compositor
+ * paints it once and never again — an animated backdrop would run a repaint
+ * behind every session for as long as the window is open.
+ */
+
+import { withLightness, parseColor, toRgba, type BackdropSpec, type BackdropStyle, type Rgb } from './vscode.ts'
+
+/**
+ * A blob or a band, and how strongly it paints relative to the intensity.
+ *
+ * `colour` indexes the palette, so two layers may share one colour: a style
+ * with more layers than the four derived colours repeats rather than inventing.
+ */
+type Layer =
+  | { kind: 'radial'; at: string; size: string; colour: number; weight: number }
+  | { kind: 'linear'; angle: string; from: string; peak: string; to: string; colour: number; weight: number }
+
+/**
+ * Two opposing corners carry the mesh and the other two fill the diagonal,
+ * which is what keeps it from reading as a plain vignette. The rest are the
+ * quieter arrangements of the same idea.
+ */
+const STYLES: Record<Exclude<BackdropStyle, 'desktop'>, Layer[]> = {
+  mesh: [
+    { kind: 'radial', at: '12% 8%', size: '70% 60%', colour: 0, weight: 1 },
+    { kind: 'radial', at: '88% 18%', size: '60% 55%', colour: 1, weight: 0.5 },
+    { kind: 'radial', at: '72% 95%', size: '75% 65%', colour: 2, weight: 0.8 },
+    { kind: 'radial', at: '25% 88%', size: '60% 50%', colour: 3, weight: 0.5 },
+  ],
+  corner: [
+    { kind: 'radial', at: '8% 0%', size: '120% 90%', colour: 0, weight: 1 },
+    { kind: 'radial', at: '98% 100%', size: '110% 85%', colour: 1, weight: 0.55 },
+  ],
+  wash: [
+    { kind: 'radial', at: '50% -10%', size: '150% 70%', colour: 0, weight: 0.7 },
+    { kind: 'radial', at: '50% 110%', size: '140% 60%', colour: 2, weight: 0.35 },
+  ],
+  aurora: [
+    { kind: 'linear', angle: '115deg', from: '20%', peak: '38%', to: '55%', colour: 0, weight: 0.9 },
+    { kind: 'linear', angle: '115deg', from: '45%', peak: '62%', to: '78%', colour: 1, weight: 0.5 },
+    { kind: 'radial', at: '50% 120%', size: '100% 100%', colour: 2, weight: 0.75 },
+  ],
+}
+
+export const BACKDROP_STYLES = Object.keys(STYLES) as Exclude<BackdropStyle, 'desktop'>[]
+
+/* Below the floor the backdrop is a waste of a layer; above the ceiling it
+   reaches the text, which is the one thing the surfaces above it are for. */
+export const MIN_INTENSITY = 0.05
+export const MAX_INTENSITY = 0.6
+export const DEFAULT_INTENSITY = 0.45
+
+/**
+ * A pair of percentages and nothing else.
+ *
+ * These strings come from a hand-written theme file and end up inside an inline
+ * style, so anything that is not plainly a position is dropped rather than
+ * passed through — `at` is the one field in the format that is not a colour the
+ * parser has already vetted.
+ */
+const POSITION = /^-?\d{1,3}(?:\.\d+)?% -?\d{1,3}(?:\.\d+)?%$/
+
+function position(value: string | undefined, fallback: string): string {
+  return value && POSITION.test(value.trim()) ? value.trim() : fallback
+}
+
+export function clampIntensity(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_INTENSITY
+  return Math.max(MIN_INTENSITY, Math.min(MAX_INTENSITY, value as number))
+}
+
+/** 'desktop' for a theme that asks for the OS material, or has asked for nothing. */
+export function styleOf(spec: BackdropSpec | undefined): BackdropStyle {
+  if (!spec) return 'desktop'
+  if (spec.style === 'desktop') return 'desktop'
+  return spec.style && spec.style in STYLES ? spec.style : 'mesh'
+}
+
+/**
+ * Two lightnesses per mode: the one a layer is drawn at when it carries the
+ * composition, and the lighter one for those filling in behind it. Both sit
+ * further from the background in a light theme, where a colour has white to
+ * stand against rather than near-black.
+ */
+const LEVELS = {
+  dark: { strong: 0.42, soft: 0.62 },
+  light: { strong: 0.5, soft: 0.6 },
+}
+
+/**
+ * The four colours a theme gets when it asks for a backdrop without naming any.
+ *
+ * The primary twice, at both lightnesses, so the result reads as one palette
+ * lit from two sides rather than two themes fighting; magenta and cyan fill the
+ * other diagonal. Those two come from the terminal set, which every theme
+ * states an opinion about, unlike the chart or badge colours.
+ */
+export function derivedStops(primary: Rgb, magenta: Rgb, cyan: Rgb, isDark: boolean): Rgb[] {
+  const level = isDark ? LEVELS.dark : LEVELS.light
+  return [
+    withLightness(primary, level.strong, 0.55),
+    withLightness(primary, level.soft, 0.55),
+    withLightness(magenta, level.strong, 0.5),
+    withLightness(cyan, level.soft, 0.45),
+  ]
+}
+
+/**
+ * The `background` shorthand for the backdrop layer: the style's gradients, and
+ * the theme's own surface underneath as the bed they fade into.
+ *
+ * Empty for 'desktop', which is the theme saying it wants whatever is behind
+ * the window rather than anything of its own.
+ */
+export function backdropValue(spec: BackdropSpec, base: Rgb, derived: Rgb[]): string {
+  const style = styleOf(spec)
+  if (style === 'desktop') return ''
+
+  const intensity = clampIntensity(spec.intensity)
+  const declared = spec.stops?.length ? spec.stops : null
+  const palette: (Rgb | null)[] = declared
+    ? declared.map((stop) => (stop.color ? parseColor(stop.color) : null))
+    : derived
+
+  const layers: string[] = []
+  for (const layer of STYLES[style]) {
+    // A style may have more layers than the palette has colours, and a stop
+    // whose colour does not parse is left out rather than guessed at: one
+    // missing blob is a quieter failure than a grey one in the wrong place.
+    const colour = palette[layer.colour % Math.max(palette.length, 1)]
+    if (!colour) continue
+    const alpha = Math.min(1, intensity * layer.weight)
+    const paint = toRgba(colour, alpha)
+    if (layer.kind === 'linear') {
+      layers.push(
+        `linear-gradient(${layer.angle}, transparent ${layer.from}, ${paint} ${layer.peak}, transparent ${layer.to})`,
+      )
+      continue
+    }
+    const stop = declared?.[layer.colour]
+    layers.push(
+      `radial-gradient(${position(stop?.size, layer.size)} at ${position(stop?.at, layer.at)}, ${paint} 0%, transparent 60%)`,
+    )
+  }
+
+  return [...layers, toRgba(base, 1)].join(', ')
+}

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -18,6 +18,7 @@ import {
   type AnsiName,
   type DeriveContext,
 } from './mapping.ts'
+import { backdropValue, clampIntensity, derivedStops, styleOf } from './backdrop.ts'
 import {
   composite,
   contrast,
@@ -29,6 +30,7 @@ import {
   parseColor,
   rgb,
   toHex,
+  type BackdropStyle,
   type GlassSpec,
   type Rgb,
   type VSCodeTheme,
@@ -55,6 +57,18 @@ export interface HeliosTheme {
    * and means every surface stays opaque.
    */
   glass: GlassSpec | null
+  /**
+   * The gradient the theme paints behind its glass. Null is the theme asking
+   * for whatever the OS puts behind the window instead, which is the macOS
+   * material or, anywhere else, nothing.
+   */
+  backdrop: { style: BackdropStyle; intensity: number } | null
+  /**
+   * The colours a backdrop of this theme is drawn from, whether or not one is
+   * showing — the picker draws its swatches from them, and a swatch has to be
+   * able to show a style the theme is not currently using.
+   */
+  backdropPalette: string[]
 }
 
 const FALLBACK_BG: Record<ThemeMode, Rgb> = { dark: rgb(0x11, 0x13, 0x18), light: rgb(0xff, 0xff, 0xff) }
@@ -211,6 +225,18 @@ export function resolveTheme(
     vars['--glass-container'] = toRgba(resolved.get('surface-container') ?? bg, glass.panel)
   }
 
+  // Only meaningful under glass: the backdrop is what the translucent surfaces
+  // are translucent onto, and painting one behind an opaque app would be work
+  // no pixel ever shows.
+  const palette = derivedStops(resolved.get('primary') ?? bg, ansi.magenta, ansi.cyan, mode === 'dark')
+  const spec = glass ? theme['helios.backdrop'] : undefined
+  const style = styleOf(spec)
+  let backdrop: HeliosTheme['backdrop'] = null
+  if (spec && style !== 'desktop') {
+    vars['--backdrop'] = backdropValue(spec, resolved.get('surface') ?? bg, palette)
+    backdrop = { style, intensity: clampIntensity(spec.intensity) }
+  }
+
   const terminalBg = colour('terminal.background') ?? bg
   const ansiTheme = {
     // Eight-digit hex rather than rgb(): xterm parses this itself, and does
@@ -224,7 +250,16 @@ export function resolveTheme(
   } as XtermTheme
   for (const name of ANSI_NAMES) ansiTheme[name] = toHex(ansi[name])
 
-  return { id, name: options.name ?? theme.name ?? id, mode, vars, ansi: ansiTheme, glass }
+  return {
+    id,
+    name: options.name ?? theme.name ?? id,
+    mode,
+    vars,
+    ansi: ansiTheme,
+    glass,
+    backdrop,
+    backdropPalette: palette.map(toHex),
+  }
 }
 
 /**
@@ -236,6 +271,7 @@ export function mergeThemes(parent: VSCodeTheme, child: VSCodeTheme): VSCodeThem
     name: child.name ?? parent.name,
     type: child.type ?? parent.type,
     'helios.glass': child['helios.glass'] ?? parent['helios.glass'],
+    'helios.backdrop': child['helios.backdrop'] ?? parent['helios.backdrop'],
     colors: { ...(parent.colors ?? {}), ...(child.colors ?? {}) },
     tokenColors: [...(parent.tokenColors ?? []), ...(child.tokenColors ?? [])],
   }

--- a/desktop/src/shared/theme/vscode.ts
+++ b/desktop/src/shared/theme/vscode.ts
@@ -28,9 +28,39 @@ export interface GlassSpec {
   terminal: number
 }
 
+/** One soft blob of the backdrop. Omitted fields fall back to the slot's own. */
+export interface BackdropStop {
+  /** Hex, as everywhere else in a theme file. Omitted means the derived colour. */
+  color?: string
+  /** CSS position, `<x>% <y>%`. */
+  at?: string
+  /** CSS size, `<w>% <h>%`. */
+  size?: string
+}
+
+/**
+ * How the gradients are arranged, or 'desktop' for a theme that would rather
+ * show whatever is behind the window than paint anything itself.
+ */
+export type BackdropStyle = 'desktop' | 'mesh' | 'corner' | 'wash' | 'aurora'
+
+/**
+ * The gradient a glass theme paints behind itself, so the look does not depend
+ * on the desktop showing through. Namespaced like `helios.glass`, and ignored
+ * by VS Code for the same reason.
+ */
+export interface BackdropSpec {
+  style?: BackdropStyle
+  /** Alpha of the strongest layer; the rest are scaled from it. */
+  intensity?: number
+  /** Replaces the derived palette outright. */
+  stops?: BackdropStop[]
+}
+
 export interface VSCodeTheme {
   name?: string
   'helios.glass'?: Partial<GlassSpec>
+  'helios.backdrop'?: BackdropSpec
   /** Absent more often than not; the resolver falls back to luminance. */
   type?: string
   /** A sibling theme file this one layers on top of. */
@@ -190,6 +220,56 @@ export function ensureContrast(colour: Rgb, background: Rgb, target: number): Rg
     if (contrast(result, background) >= target) break
   }
   return result
+}
+
+/**
+ * Recolours to a fixed lightness, keeping the hue and raising the saturation to
+ * at least `minSaturation`.
+ *
+ * A theme's palette is chosen to be read as text, which makes it pale: most
+ * dark themes state their blue somewhere around 75% lightness. Painted at
+ * partial alpha over a near-black background that pale blue composites to grey,
+ * and the hue the stop was chosen for disappears. Pinning the lightness where
+ * the colour is at its most saturated is what keeps a blob recognisably blue.
+ */
+export function withLightness(c: Rgb, lightness: number, minSaturation: number): Rgb {
+  const r = c.r / 255
+  const g = c.g / 255
+  const b = c.b / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  const delta = max - min
+
+  let h = 0
+  if (delta > 0) {
+    if (max === r) h = ((g - b) / delta) % 6
+    else if (max === g) h = (b - r) / delta + 2
+    else h = (r - g) / delta + 4
+    h *= 60
+    if (h < 0) h += 360
+  }
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1))
+
+  return fromHsl(h, Math.max(s, minSaturation), lightness)
+}
+
+function fromHsl(h: number, s: number, l: number): Rgb {
+  const chroma = (1 - Math.abs(2 * l - 1)) * s
+  const x = chroma * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - chroma / 2
+  const sextant = Math.floor(h / 60) % 6
+  const [r, g, b] = (
+    [
+      [chroma, x, 0],
+      [x, chroma, 0],
+      [0, chroma, x],
+      [0, x, chroma],
+      [x, 0, chroma],
+      [chroma, 0, x],
+    ] as [number, number, number][]
+  )[sextant] as [number, number, number]
+  return { r: clamp((r + m) * 255), g: clamp((g + m) * 255), b: clamp((b + m) * 255), a: 1 }
 }
 
 export function toHex(c: Rgb): string {

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -16,6 +16,8 @@ import {
   parseJsonc,
   pickReadable,
   toHex,
+  type BackdropStyle,
+  type Rgb,
 } from '../src/shared/theme/vscode.ts'
 
 test('parseJsonc tolerates comments and trailing commas', () => {
@@ -285,6 +287,139 @@ test('an omitted surface in the glass block gets a default rather than nothing',
 test('the glass block survives an include chain', () => {
   const merged = mergeThemes({ 'helios.glass': { sidebar: 0.5 }, colors: {} }, { name: 'Child', colors: {} })
   assert.equal(merged['helios.glass']?.sidebar, 0.5)
+})
+
+const GLASS = { sidebar: 0.34, panel: 0.42, terminal: 0.34 }
+const DARK = { 'editor.background': '#0d0f13', 'editor.foreground': '#e8eaed', 'textLink.foreground': '#7cb7ff' }
+
+test('a glass theme with no backdrop block leaves the window to the OS', () => {
+  const theme = resolveTheme('os-glass', { 'helios.glass': GLASS, colors: DARK })
+  assert.equal(theme.backdrop, null)
+  assert.equal(theme.vars['--backdrop'], undefined)
+})
+
+test('a backdrop block becomes one gradient per layer over the theme surface', () => {
+  const theme = resolveTheme('meshy', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { intensity: 0.45 },
+    colors: DARK,
+  })
+  // Mesh is what a block with no style asked for.
+  assert.deepEqual(theme.backdrop, { style: 'mesh', intensity: 0.45 })
+  const value = theme.vars['--backdrop'] as string
+  assert.equal(value.match(/radial-gradient\(/g)?.length, 4)
+  // The strongest layer is the intensity itself, and the theme's own surface is
+  // the bed the gradients fade into.
+  assert.match(value, /rgb\(.* \/ 45%\) 0%/)
+  assert.match(value, /, rgb\(13 15 19 \/ 100%\)$/)
+})
+
+test('each style lays its own gradients out', () => {
+  const value = (style: BackdropStyle): string =>
+    resolveTheme('styled', {
+      'helios.glass': GLASS,
+      'helios.backdrop': { style, intensity: 0.4 },
+      colors: DARK,
+    }).vars['--backdrop'] as string
+
+  assert.equal(value('corner').match(/radial-gradient\(/g)?.length, 2)
+  assert.equal(value('wash').match(/radial-gradient\(/g)?.length, 2)
+  // Aurora is the one style with bands rather than blobs.
+  assert.equal(value('aurora').match(/linear-gradient\(/g)?.length, 2)
+  assert.equal(value('aurora').match(/radial-gradient\(/g)?.length, 1)
+})
+
+test('the desktop style paints nothing, so the OS shows through', () => {
+  const theme = resolveTheme('to-the-os', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { style: 'desktop' },
+    colors: DARK,
+  })
+  assert.equal(theme.backdrop, null)
+  assert.equal(theme.vars['--backdrop'], undefined)
+})
+
+test('a backdrop with no glass block is not painted', () => {
+  const theme = resolveTheme('opaque', { 'helios.backdrop': { intensity: 0.5 }, colors: DARK })
+  assert.equal(theme.backdrop, null)
+  assert.equal(theme.vars['--backdrop'], undefined)
+})
+
+test('the palette a picker draws its swatches from survives an opaque theme', () => {
+  const theme = resolveTheme('solid', { colors: DARK })
+  assert.equal(theme.backdropPalette.length, 4)
+  for (const colour of theme.backdropPalette) assert.match(colour, /^#[0-9a-f]{6}$/)
+})
+
+// A theme's palette is picked to be read as text, which makes it pale; painted
+// at partial alpha over near-black a pale blue composites to grey.
+test('derived stops are pulled to a lightness that still reads as a hue', () => {
+  const theme = resolveTheme('pastel', {
+    'helios.glass': GLASS,
+    colors: { ...DARK, 'textLink.foreground': '#cfe3ff' },
+  })
+  const [strong] = theme.backdropPalette as [string]
+  assert.notEqual(strong, '#cfe3ff')
+  assert.ok(luminance(parseColor(strong) as Rgb) < luminance(parseColor('#cfe3ff') as Rgb))
+})
+
+test('backdrop intensity is clamped short of drowning the text', () => {
+  const loud = resolveTheme('loud', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { intensity: 4 },
+    colors: DARK,
+  })
+  assert.match(loud.vars['--backdrop'] as string, /rgb\(.* \/ 60%\) 0%/)
+})
+
+test('declared stops replace the derived palette, and place themselves', () => {
+  const theme = resolveTheme('custom', {
+    'helios.glass': GLASS,
+    'helios.backdrop': {
+      intensity: 0.4,
+      stops: [{ color: '#ff0000', at: '10% 20%', size: '50% 40%' }, { color: '#00ff00' }],
+    },
+    colors: DARK,
+  })
+  const value = theme.vars['--backdrop'] as string
+  assert.match(value, /radial-gradient\(50% 40% at 10% 20%, rgb\(255 0 0 \/ 40%\)/)
+  assert.match(value, /rgb\(0 255 0 \//)
+  // Fewer colours than the style has layers: they repeat rather than leaving a
+  // corner of the window bare.
+  assert.equal(value.match(/radial-gradient\(/g)?.length, 4)
+})
+
+// The strings in a stop reach an inline style untouched by any parser, so a
+// position that is not plainly a pair of percentages is replaced rather than
+// passed on.
+test('a stop position that is not a pair of percentages falls back to the layout', () => {
+  const theme = resolveTheme('sneaky', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { stops: [{ color: '#ff0000', at: '0 0), url(https://example.com/x' }] },
+    colors: DARK,
+  })
+  const value = theme.vars['--backdrop'] as string
+  assert.ok(!value.includes('url('))
+  assert.match(value, /at 12% 8%/)
+})
+
+test('a stop whose colour does not parse is left out', () => {
+  const theme = resolveTheme('bad-stop', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { stops: [{ color: 'rebeccapurple' }, { color: '#00ff00' }] },
+    colors: DARK,
+  })
+  const value = theme.vars['--backdrop'] as string
+  // Two of the four mesh layers land on the unparseable stop and are dropped;
+  // the other two are the green one.
+  assert.equal(value.match(/radial-gradient\(/g)?.length, 2)
+  assert.ok(!value.includes('rebeccapurple'))
+  assert.match(value, /rgb\(0 255 0/)
+})
+
+test('the backdrop block survives an include chain', () => {
+  const merged = mergeThemes({ 'helios.backdrop': { intensity: 0.3 }, colors: {} }, { name: 'Child', colors: {} })
+  assert.equal(merged['helios.backdrop']?.intensity, 0.3)
 })
 
 test('mergeThemes layers a child over what its include supplied', () => {

--- a/themes/liquid-glass-light.json
+++ b/themes/liquid-glass-light.json
@@ -6,6 +6,10 @@
     "panel": 0.8,
     "terminal": 0.85
   },
+  "helios.backdrop": {
+    "style": "mesh",
+    "intensity": 0.35
+  },
   "colors": {
     "checkbox.border": "#CECECE",
     "editor.background": "#ffffff",

--- a/themes/liquid-glass.json
+++ b/themes/liquid-glass.json
@@ -6,6 +6,10 @@
     "panel": 0.42,
     "terminal": 0.34
   },
+  "helios.backdrop": {
+    "style": "mesh",
+    "intensity": 0.45
+  },
   "colors": {
     "checkbox.border": "#3C3C3C",
     "editor.background": "#0d0f13",


### PR DESCRIPTION
## Summary

Glass was the macOS window material (`vibrancy: 'under-window'` plus a transparent window), which meant the wallpaper decided what the app looked like, and Linux and Windows got nothing at all. A glass theme can now paint its own gradient behind itself, and **Settings → Appearance → Backdrop** picks which one.

- `helios.backdrop` in a theme file, beside the existing `helios.glass`: `style`, `intensity`, and optional `stops`.
- Five choices: **Desktop** (the old macOS material, offered only where it exists), **Mesh**, **Corner**, **Wash**, **Aurora**. Mesh is the new default for both Liquid Glass themes.
- Colours are derived from the theme's own palette — primary at two lightnesses, plus terminal magenta and cyan — so a backdrop always belongs to the theme it sits under. A theme file may name `stops` outright instead.
- Nothing animates. The value is a list of gradients the compositor paints once; there is no repaint behind a session while the window is open.

### Where the choice is saved

Into the theme, not into this window's preferences: a mesh drawn from one theme's palette means nothing under another. Picking one writes `~/.helios/themes/<id>.json` as a small include-override:

```json
{
  "include": "liquid-glass.json",
  "helios.backdrop": { "style": "mesh", "intensity": 0.45 }
}
```

The bundled theme keeps supplying the several hundred colours and keeps being updated by the app; the override states only what was changed. This needed `include` resolution in `ThemeRegistry` (depth-capped, self-reference guarded) — `mergeThemes` already existed and was already tested, but nothing had called it.

### Rendering path is unchanged

The resolver emits one `--backdrop` variable and `body` paints it under `[data-glass='on']`, falling back to `transparent` so a theme asking for **Desktop** still shows the OS material. A theme that paints its own backdrop no longer needs a transparent window, so vibrancy and the clear background colour are now applied only for **Desktop**.

### Notes

- Pale palettes composite to grey at partial alpha over near-black, which made the first cut look like grey smudges rather than colour. `withLightness` pins each derived stop to a lightness where its hue survives.
- Stop positions from a theme file reach an inline style, so they are matched against a strict `<x>% <y>%` pattern and replaced with the layout default otherwise. Covered by a test that feeds it a `url(...)` payload.
- Fixed along the way: `applyTheme` never removed a variable, so switching from a painted backdrop back to Desktop left the old gradient on `<html>` and the app kept painting over the desktop it had just been asked to show.

## Test plan

- [x] `npm run typecheck` and `npm test` in `desktop/` — 91 pass, 14 of them new
- [x] Ran the app (separate `--user-data-dir`, driven over CDP) on Liquid Glass: mesh paints, sidebar and panels tint over it, code blocks and the terminal stay opaque
- [x] Picker: all five chips render live gradient swatches built by the same generator the window uses
- [x] Mesh → Aurora → Desktop → Mesh, checking the written file and the repainted window each time
- [x] Intensity slider previews on the swatches while dragging and writes the file only on release
- [ ] Not checked: Windows and Linux, where this is the first backdrop those platforms have had
- [ ] Not checked: the `ThemeRegistry` include resolution has no unit test — it imports `electron`, and there is no harness for that yet