### PR TITLE
Choose the backdrop's colours, not just its arrangement

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -207,12 +207,17 @@ export function registerIpc(deps: IpcDeps): void {
   // theme is showing rather than a slot of its own.
   const backdropState = (): BackdropState => {
     const theme = themes.active()
+    const named = theme.backdrop?.stops ?? null
     return {
       themeId: theme.id,
       themeName: theme.name,
       glass: theme.glass !== null,
       style: theme.backdrop?.style ?? 'desktop',
       intensity: theme.backdrop?.intensity ?? DEFAULT_INTENSITY,
+      // Padded to the derived length, so a theme that named two colours still
+      // gives the picker a full set of wells to edit.
+      palette: theme.backdropPalette.map((derived, i) => named?.[i] ?? derived),
+      custom: named !== null,
       // Offering the desktop where there is no way to show it would be
       // offering an opaque window under a different name.
       desktopSupported: glassSupported,

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { api, bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
@@ -490,6 +490,11 @@ function Backdrop(): JSX.Element | null {
   /** Held while the slider is under the pointer; saving each step would rewrite
       the theme file on every frame of a drag. */
   const [dragging, setDragging] = useState<number | null>(null)
+  /** The same, for the colour wells: an OS colour panel streams changes as the
+      user moves around it, and only the one they settle on is worth saving. */
+  const [picking, setPicking] = useState<string[] | null>(null)
+  const settle = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => clearTimeout(settle.current ?? undefined), [])
 
   // The active theme changes with the pickers above and with the OS switching
   // between light and dark, and each is a different file to edit.
@@ -506,6 +511,7 @@ function Backdrop(): JSX.Element | null {
     setState({ ...state, style: spec.style ?? state.style, intensity: spec.intensity ?? state.intensity })
     try {
       setState(await bridge.theme.setBackdrop(spec))
+      setPicking(null)
     } catch (err) {
       store.fail(err)
       setState(await bridge.theme.backdrop())
@@ -519,6 +525,24 @@ function Backdrop(): JSX.Element | null {
     if (next !== state.intensity) void save({ style: state.style, intensity: next })
   }
 
+  /**
+   * A colour edit, held back until the user stops moving.
+   *
+   * The wells follow every change so the swatches stay live, but each save
+   * rewrites the theme file and repaints every window, which is not something
+   * to do on each step through a colour wheel.
+   */
+  const pick = (index: number, colour: string): void => {
+    if (!state) return
+    const next = [...(picking ?? state.palette)]
+    next[index] = colour
+    setPicking(next)
+    clearTimeout(settle.current ?? undefined)
+    settle.current = setTimeout(() => {
+      void save({ style: state.style, intensity: state.intensity, stops: next.map((color) => ({ color })) })
+    }, 400)
+  }
+
   // An opaque theme has nothing to show a backdrop through, and a picker that
   // changes nothing visible is worse than no picker.
   if (!state?.glass) return null
@@ -528,6 +552,7 @@ function Backdrop(): JSX.Element | null {
     ...BACKDROP_STYLES,
   ]
   const intensity = dragging ?? state.intensity
+  const palette = picking ?? state.palette
 
   return (
     <div className="theme-picker">
@@ -537,12 +562,18 @@ function Backdrop(): JSX.Element | null {
           <button
             key={style}
             className={state.style === style ? 'theme-chip selected' : 'theme-chip'}
-            onClick={() => void save({ style, intensity })}
+            onClick={() =>
+              void save({
+                style,
+                intensity,
+                ...(state.custom ? { stops: palette.map((color) => ({ color })) } : {}),
+              })
+            }
             title={style === 'desktop' ? 'Show the desktop through the window' : `Paint a ${style} gradient`}
           >
             <span
               className={style === 'desktop' ? 'backdrop-swatch desktop' : 'backdrop-swatch'}
-              style={style === 'desktop' ? undefined : { background: previewOf(theme, style, intensity) }}
+              style={style === 'desktop' ? undefined : { background: previewOf(theme, style, intensity, palette) }}
             />
             {BACKDROP_LABELS[style]}
           </button>
@@ -564,6 +595,30 @@ function Backdrop(): JSX.Element | null {
           onBlur={() => commit()}
         />
       )}
+      {state.style !== 'desktop' && (
+        <div className="backdrop-colours">
+          {palette.map((colour, index) => (
+            <input
+              key={index}
+              type="color"
+              value={colour}
+              // Four wells whichever style is showing: Wash draws two of them
+              // and Mesh all four, and switching between the two should not
+              // throw away a colour that was chosen.
+              title={`Backdrop colour ${index + 1}`}
+              onChange={(event) => pick(index, event.target.value)}
+            />
+          ))}
+          {state.custom && (
+            <button
+              className="ghost"
+              onClick={() => void save({ style: state.style, intensity: state.intensity })}
+            >
+              Use theme colours
+            </button>
+          )}
+        </div>
+      )}
       <span className="modal-note">Saved in {state.themeName}.</span>
     </div>
   )
@@ -575,8 +630,8 @@ function Backdrop(): JSX.Element | null {
  * Built by the generator the window itself uses, from the palette the resolver
  * derived, so a swatch cannot disagree with the result of clicking it.
  */
-function previewOf(theme: HeliosTheme, style: BackdropStyle, intensity: number): string {
-  const stops = theme.backdropPalette.map(parseColor).filter((c): c is Rgb => c !== null)
+function previewOf(theme: HeliosTheme, style: BackdropStyle, intensity: number, palette: string[]): string {
+  const stops = palette.map(parseColor).filter((c): c is Rgb => c !== null)
   const base = parseColor(theme.vars['--surface'] ?? '') ?? (parseColor('#101014') as Rgb)
   return backdropValue({ style, intensity }, base, stops)
 }

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3716,6 +3716,29 @@ hr {
   accent-color: var(--primary);
 }
 
+.backdrop-colours {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+/* The platform draws the swatch inside a colour input and will not be told
+   otherwise, so the chrome around it is all there is to style. */
+.backdrop-colours input[type='color'] {
+  width: 40px;
+  height: 26px;
+  padding: 2px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-sm);
+  background: var(--surface-container);
+  cursor: pointer;
+}
+
+.backdrop-colours .ghost {
+  margin-left: auto;
+}
+
 .modal-note {
   margin: 4px 0 0;
   font-size: 12px;

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -493,6 +493,10 @@ export interface BackdropState {
   glass: boolean
   style: BackdropStyle
   intensity: number
+  /** What the gradients are drawn from, whether named by the theme or derived. */
+  palette: string[]
+  /** True when those colours were named rather than derived from the theme. */
+  custom: boolean
   /** Whether this platform can show the desktop behind the window. */
   desktopSupported: boolean
 }

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -62,7 +62,12 @@ export interface HeliosTheme {
    * for whatever the OS puts behind the window instead, which is the macOS
    * material or, anywhere else, nothing.
    */
-  backdrop: { style: BackdropStyle; intensity: number } | null
+  backdrop: {
+    style: BackdropStyle
+    intensity: number
+    /** Colours the theme named itself, or null where they are derived. */
+    stops: string[] | null
+  } | null
   /**
    * The colours a backdrop of this theme is drawn from, whether or not one is
    * showing — the picker draws its swatches from them, and a swatch has to be
@@ -234,7 +239,14 @@ export function resolveTheme(
   let backdrop: HeliosTheme['backdrop'] = null
   if (spec && style !== 'desktop') {
     vars['--backdrop'] = backdropValue(spec, resolved.get('surface') ?? bg, palette)
-    backdrop = { style, intensity: clampIntensity(spec.intensity) }
+    // Normalised to plain hex on the way out: the picker puts these in a colour
+    // input, which takes nothing else.
+    const named = spec.stops?.map((stop) => parseColor(stop.color ?? '')).filter((c): c is Rgb => c !== null)
+    backdrop = {
+      style,
+      intensity: clampIntensity(spec.intensity),
+      stops: named?.length ? named.map(toHex) : null,
+    }
   }
 
   const terminalBg = colour('terminal.background') ?? bg

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -304,8 +304,8 @@ test('a backdrop block becomes one gradient per layer over the theme surface', (
     'helios.backdrop': { intensity: 0.45 },
     colors: DARK,
   })
-  // Mesh is what a block with no style asked for.
-  assert.deepEqual(theme.backdrop, { style: 'mesh', intensity: 0.45 })
+  // Mesh is what a block with no style asked for, from the derived palette.
+  assert.deepEqual(theme.backdrop, { style: 'mesh', intensity: 0.45, stops: null })
   const value = theme.vars['--backdrop'] as string
   assert.equal(value.match(/radial-gradient\(/g)?.length, 4)
   // The strongest layer is the intensity itself, and the theme's own surface is
@@ -401,6 +401,17 @@ test('a stop position that is not a pair of percentages falls back to the layout
   const value = theme.vars['--backdrop'] as string
   assert.ok(!value.includes('url('))
   assert.match(value, /at 12% 8%/)
+})
+
+// The picker puts these in a colour input, which takes #rrggbb and nothing
+// else — including the shorthand and alpha forms a theme file may use.
+test('named stops are reported back as plain hex', () => {
+  const theme = resolveTheme('named', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { stops: [{ color: '#f0a' }, { color: '#00ff0080' }] },
+    colors: DARK,
+  })
+  assert.deepEqual(theme.backdrop?.stops, ['#ff00aa', '#00ff00'])
 })
 
 test('a stop whose colour does not parse is left out', () => {


### PR DESCRIPTION
## Summary

Follow-up to #74. `helios.backdrop.stops` already accepted named colours — the resolver read them, the position validator guarded them, the tests covered them — but nothing in the UI could write them. This adds the wells.

- Four colour inputs under the style chips in **Settings → Appearance → Backdrop**, seeded from the palette the resolver derives from the theme.
- Editing one writes `stops` into the same `~/.helios/themes/<id>.json` override that already holds the style and the intensity.
- **Use theme colours** removes the key again, so the palette goes back to being derived and keeps tracking the theme.
- Four wells whichever style is showing. Wash draws two of them and Mesh all four; tying the count to the style would discard a colour on every switch.
- `HeliosTheme.backdrop` now reports the named colours back as plain `#rrggbb`, since a colour input accepts nothing else — a theme file writing `#f0a` or an 8-digit hex would otherwise land in the well as blank.

Colour edits are held for 400ms before saving. An OS colour panel streams a change per step through the wheel, and each save rewrites the theme file and repaints every window; the wells and the swatches follow every step, only the file waits.

## Test plan

- [x] `npm run typecheck` and `npm test` — 92 pass, one new for the hex normalisation
- [x] Ran the app on Liquid Glass (separate `--user-data-dir`, driven over CDP): wells seed from the derived palette, `#0060d6 #3d94ff #6a00d6 #64d8d8`
- [x] Picked a custom colour — window repaints, every style swatch rebuilds from the new palette, `stops` appears in the override
- [x] **Use theme colours** — key removed from the file, wells return to derived, window repaints
- [x] Custom palette survives a style switch: picked a green third stop, switched Mesh → Wash, all four colours still in the file
- [ ] Not checked: what a colour input looks like on Windows and Linux, where the platform draws its own panel