### PR TITLE
Frost the glass, and let a picture sit behind it

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent } from 'electron'
 
 import { ApiError, type ApiClient } from './api.ts'
 import type { HostRegistry } from './hosts.ts'
@@ -214,10 +214,12 @@ export function registerIpc(deps: IpcDeps): void {
       glass: theme.glass !== null,
       style: theme.backdrop?.style ?? 'desktop',
       intensity: theme.backdrop?.intensity ?? DEFAULT_INTENSITY,
+      blur: theme.backdropBlur,
       // Padded to the derived length, so a theme that named two colours still
       // gives the picker a full set of wells to edit.
       palette: theme.backdropPalette.map((derived, i) => named?.[i] ?? derived),
       custom: named !== null,
+      image: theme.backdrop?.image ?? null,
       // Offering the desktop where there is no way to show it would be
       // offering an opaque window under a different name.
       desktopSupported: glassSupported,
@@ -225,6 +227,38 @@ export function registerIpc(deps: IpcDeps): void {
   }
 
   handle('theme:backdrop', async () => backdropState())
+
+  /**
+   * Picks an image, copies it in, and switches the theme to it in one step.
+   *
+   * One call rather than a pick followed by a save: a chosen file that failed
+   * to become a backdrop would leave a copy in the media directory and nothing
+   * pointing at it.
+   */
+  handle('theme:pickBackdropImage', async () => {
+    const parent = deps.window()
+    const options = {
+      title: 'Choose a backdrop image',
+      properties: ['openFile' as const],
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp'] }],
+    }
+    const picked =
+      parent && !parent.isDestroyed()
+        ? await dialog.showOpenDialog(parent, options)
+        : await dialog.showOpenDialog(options)
+    const source = picked.filePaths[0]
+    if (picked.canceled || !source) return backdropState()
+    const theme = themes.active()
+    themes.setBackdrop(theme.id, {
+      style: 'image',
+      intensity: theme.backdrop?.intensity ?? DEFAULT_INTENSITY,
+      blur: theme.backdropBlur,
+      image: themes.importImage(theme.id, source),
+    })
+    onAppearanceChange()
+    broadcastTheme()
+    return backdropState()
+  })
   handle('theme:setBackdrop', async (_e, spec: BackdropSpec) => {
     themes.setBackdrop(themes.active().id, spec)
     onAppearanceChange()

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1,5 +1,6 @@
-import { app, BrowserWindow, globalShortcut, Menu, nativeTheme, session, shell } from 'electron'
+import { app, BrowserWindow, globalShortcut, Menu, nativeTheme, net, protocol, session, shell } from 'electron'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { HostRegistry } from './hosts.ts'
 import { Hud } from './hud.ts'
@@ -26,6 +27,22 @@ let quitting = false
 
 /** Brings the HUD forward and gives it the keyboard, since it opens unfocused. */
 const ANSWER_SHORTCUT = 'CommandOrControl+Shift+A'
+
+/**
+ * How a backdrop image reaches the page.
+ *
+ * The renderer is a file:// document with `img-src 'self'`, which does not
+ * cover another file somewhere in the user's home. Rather than widen that to
+ * `file:`, which would let anything the page can be talked into requesting read
+ * the disk, one scheme serves one directory and refuses everything else.
+ *
+ * Must be declared before the app is ready, which is why it is out here.
+ */
+const MEDIA_SCHEME = 'helios-backdrop'
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: MEDIA_SCHEME, privileges: { standard: true, secure: true, supportFetchAPI: true } },
+])
 
 /**
  * One window at a time. A second launch — or a `helios://` link handed to the
@@ -55,6 +72,7 @@ async function start(): Promise<void> {
 
   await app.whenReady()
   hardenSession()
+  serveBackdrops()
 
   hosts = new HostRegistry()
   terminals = new TerminalManager(hosts)
@@ -218,7 +236,7 @@ function hardenSession(): void {
         ...details.responseHeaders,
         'Content-Security-Policy': [
           "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data:; font-src 'self' data:; connect-src 'none'; " +
+            `img-src 'self' data: ${MEDIA_SCHEME}:; font-src 'self' data:; connect-src 'none'; ` +
             "object-src 'none'; base-uri 'none'; form-action 'none'",
         ],
       },
@@ -226,6 +244,23 @@ function hardenSession(): void {
   })
 
   session.defaultSession.setPermissionRequestHandler((_wc, _permission, callback) => callback(false))
+}
+
+/**
+ * Serves the backdrop images the user has imported, and nothing else.
+ *
+ * The path is resolved and then checked to be inside the directory, so a
+ * request dressed up with `..` lands outside and is refused rather than
+ * followed.
+ */
+function serveBackdrops(): void {
+  const root = ThemeRegistry.mediaDir()
+  protocol.handle(MEDIA_SCHEME, async (request) => {
+    const name = decodeURIComponent(new URL(request.url).pathname).replace(/^\/+/, '')
+    const file = path.resolve(root, name)
+    if (file !== path.join(root, path.basename(file))) return new Response('not found', { status: 404 })
+    return net.fetch(pathToFileURL(file).toString())
+  })
 }
 
 function focusWindow(): void {

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -20,6 +20,9 @@ export const DEFAULT_APPEARANCE: AppearancePrefs = {
 const MIN_PROSE = 10
 const MAX_PROSE = 28
 
+/** What a backdrop image may be, and therefore what the media scheme serves. */
+const IMAGE_TYPES = new Set(['.png', '.jpg', '.jpeg', '.webp'])
+
 function proseSize(value: unknown): number {
   const size = Math.round(Number(value))
   if (!Number.isFinite(size)) return DEFAULT_APPEARANCE.proseSize
@@ -37,12 +40,14 @@ function proseSize(value: unknown): number {
 export class ThemeRegistry {
   private readonly bundledDir: string
   private readonly userDir: string
+  private readonly home: string
   private readonly file: string
   private themes = new Map<string, HeliosTheme>()
   private prefs: AppearancePrefs = { ...DEFAULT_APPEARANCE }
 
   constructor(bundledDir: string, userDataDir = app.getPath('userData'), home = os.homedir()) {
     this.bundledDir = bundledDir
+    this.home = home
     this.userDir = path.join(home, '.helios', 'themes')
     this.file = path.join(userDataDir, 'appearance.json')
   }
@@ -131,6 +136,33 @@ export class ThemeRegistry {
 
   getPrefs(): AppearancePrefs {
     return { ...this.prefs }
+  }
+
+  /** Where imported backdrop images live, next to the themes that name them. */
+  static mediaDir(home = os.homedir()): string {
+    return path.join(home, '.helios', 'backdrops')
+  }
+
+  /**
+   * Takes a copy of an image the user chose, and answers with the name a theme
+   * file refers to it by.
+   *
+   * Copied rather than linked: a backdrop that vanishes because the original
+   * was in a folder the user later tidied is a window that silently loses its
+   * look. One image per theme, overwritten, so choosing repeatedly does not
+   * leave a directory of abandoned wallpapers.
+   */
+  importImage(id: string, source: string): string {
+    const extension = path.extname(source).toLowerCase()
+    if (!IMAGE_TYPES.has(extension)) throw new Error(`unsupported image type: ${extension || 'none'}`)
+    const dir = ThemeRegistry.mediaDir(this.home)
+    fs.mkdirSync(dir, { recursive: true })
+    for (const stale of IMAGE_TYPES) {
+      if (stale !== extension) fs.rmSync(path.join(dir, `${id}${stale}`), { force: true })
+    }
+    const name = `${id}${extension}`
+    fs.copyFileSync(source, path.join(dir, name))
+    return name
   }
 
   /**

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -122,6 +122,7 @@ const helios = {
     reload: () => call('theme:reload'),
     backdrop: () => call('theme:backdrop'),
     setBackdrop: (spec: unknown) => call('theme:setBackdrop', spec),
+    pickBackdropImage: () => call('theme:pickBackdropImage'),
     onChanged: (fn: (payload: unknown) => void) => on('theme:changed', fn),
   },
   hud: {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -118,6 +118,8 @@ interface RawBridge {
     /** The active theme's backdrop, which lives in the theme file itself. */
     backdrop(): Promise<BackdropState>
     setBackdrop(spec: BackdropSpec): Promise<BackdropState>
+    /** Opens a file dialog, imports the chosen image, and switches to it. */
+    pickBackdropImage(): Promise<BackdropState>
     onChanged(fn: (payload: ThemePayload) => void): Unsubscribe
   }
   hud: {

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -4,7 +4,7 @@ import { api, bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
 import { Modal } from './newsession.tsx'
 import { ALERT_TYPES } from '../../shared/notifications.ts'
-import { BACKDROP_STYLES, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
+import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
 import type { AppearancePrefs, BackdropState, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
@@ -475,6 +475,7 @@ const BACKDROP_LABELS: Record<BackdropStyle, string> = {
   corner: 'Corner',
   wash: 'Wash',
   aurora: 'Aurora',
+  image: 'Image',
 }
 
 /**
@@ -487,9 +488,9 @@ const BACKDROP_LABELS: Record<BackdropStyle, string> = {
 function Backdrop(): JSX.Element | null {
   const [state, setState] = useState<BackdropState | null>(null)
   const [theme, setActive] = useState<HeliosTheme>(() => bridge.theme.boot().theme)
-  /** Held while the slider is under the pointer; saving each step would rewrite
+  /** Held while a slider is under the pointer; saving each step would rewrite
       the theme file on every frame of a drag. */
-  const [dragging, setDragging] = useState<number | null>(null)
+  const [dragging, setDragging] = useState<{ intensity?: number; blur?: number }>({})
   /** The same, for the colour wells: an OS colour panel streams changes as the
       user moves around it, and only the one they settle on is worth saving. */
   const [picking, setPicking] = useState<string[] | null>(null)
@@ -506,9 +507,23 @@ function Backdrop(): JSX.Element | null {
     })
   }, [])
 
-  const save = async (spec: BackdropSpec): Promise<void> => {
+  /**
+   * Writes the whole block, not the field that changed.
+   *
+   * Saving replaces `helios.backdrop` in the theme file outright, so a partial
+   * spec is how the blur disappears the next time someone moves the intensity.
+   * Dropping `stops` is therefore also how the reset works.
+   */
+  const save = async (patch: Partial<BackdropSpec> & { stops?: BackdropSpec['stops'] }): Promise<void> => {
     if (!state) return
-    setState({ ...state, style: spec.style ?? state.style, intensity: spec.intensity ?? state.intensity })
+    const spec: BackdropSpec = {
+      style: state.style,
+      intensity: state.intensity,
+      blur: state.blur,
+      ...(state.custom ? { stops: state.palette.map((color) => ({ color })) } : {}),
+      ...patch,
+    }
+    setState({ ...state, ...patch, stops: undefined } as BackdropState)
     try {
       setState(await bridge.theme.setBackdrop(spec))
       setPicking(null)
@@ -518,11 +533,11 @@ function Backdrop(): JSX.Element | null {
     }
   }
 
-  const commit = (): void => {
-    if (dragging === null || !state) return
-    const next = dragging
-    setDragging(null)
-    if (next !== state.intensity) void save({ style: state.style, intensity: next })
+  const commit = (field: 'intensity' | 'blur'): void => {
+    const next = dragging[field]
+    if (next === undefined || !state) return
+    setDragging((held) => ({ ...held, [field]: undefined }))
+    if (next !== state[field]) void save({ [field]: next })
   }
 
   /**
@@ -538,9 +553,15 @@ function Backdrop(): JSX.Element | null {
     next[index] = colour
     setPicking(next)
     clearTimeout(settle.current ?? undefined)
-    settle.current = setTimeout(() => {
-      void save({ style: state.style, intensity: state.intensity, stops: next.map((color) => ({ color })) })
-    }, 400)
+    settle.current = setTimeout(() => void save({ stops: next.map((color) => ({ color })) }), 400)
+  }
+
+  const chooseImage = async (): Promise<void> => {
+    try {
+      setState(await bridge.theme.pickBackdropImage())
+    } catch (err) {
+      store.fail(err)
+    }
   }
 
   // An opaque theme has nothing to show a backdrop through, and a picker that
@@ -550,8 +571,10 @@ function Backdrop(): JSX.Element | null {
   const styles: BackdropStyle[] = [
     ...(state.desktopSupported ? (['desktop'] as BackdropStyle[]) : []),
     ...BACKDROP_STYLES,
+    'image',
   ]
-  const intensity = dragging ?? state.intensity
+  const intensity = dragging.intensity ?? state.intensity
+  const blur = dragging.blur ?? state.blur
   const palette = picking ?? state.palette
 
   return (
@@ -562,40 +585,46 @@ function Backdrop(): JSX.Element | null {
           <button
             key={style}
             className={state.style === style ? 'theme-chip selected' : 'theme-chip'}
-            onClick={() =>
-              void save({
-                style,
-                intensity,
-                ...(state.custom ? { stops: palette.map((color) => ({ color })) } : {}),
-              })
-            }
-            title={style === 'desktop' ? 'Show the desktop through the window' : `Paint a ${style} gradient`}
+            // Choosing the image style means choosing an image: a chip that
+            // selected an empty one and left the user to find a second control
+            // would be a chip that appears to do nothing.
+            onClick={() => (style === 'image' ? void chooseImage() : void save({ style }))}
+            title={CHIP_HINTS[style]}
           >
             <span
               className={style === 'desktop' ? 'backdrop-swatch desktop' : 'backdrop-swatch'}
-              style={style === 'desktop' ? undefined : { background: previewOf(theme, style, intensity, palette) }}
+              style={
+                style === 'desktop' ? undefined : { background: swatchOf(theme, style, intensity, palette, state.image) }
+              }
             />
             {BACKDROP_LABELS[style]}
           </button>
         ))}
       </div>
       {state.style !== 'desktop' && (
-        <input
-          className="backdrop-intensity"
-          type="range"
+        <Slider
+          label={state.style === 'image' ? 'Dim' : 'Colour'}
           min={MIN_INTENSITY}
           max={MAX_INTENSITY}
           step={0.05}
           value={intensity}
-          onChange={(event) => setDragging(Number(event.target.value))}
-          // The swatches follow the thumb; the window and the file wait for it
-          // to be let go.
-          onPointerUp={() => commit()}
-          onKeyUp={() => commit()}
-          onBlur={() => commit()}
+          onDrag={(next) => setDragging((held) => ({ ...held, intensity: next }))}
+          onSettle={() => commit('intensity')}
         />
       )}
-      {state.style !== 'desktop' && (
+      {/* Offered for the desktop too: the frosting is a property of the glass,
+          and a window showing a wallpaper wants it at least as much as one
+          showing a gradient. */}
+      <Slider
+        label="Blur"
+        min={0}
+        max={MAX_BLUR}
+        step={2}
+        value={blur}
+        onDrag={(next) => setDragging((held) => ({ ...held, blur: next }))}
+        onSettle={() => commit('blur')}
+      />
+      {state.style !== 'desktop' && state.style !== 'image' && (
         <div className="backdrop-colours">
           {palette.map((colour, index) => (
             <input
@@ -624,16 +653,82 @@ function Backdrop(): JSX.Element | null {
   )
 }
 
+const CHIP_HINTS: Record<BackdropStyle, string> = {
+  desktop: 'Show the desktop through the window',
+  mesh: 'Paint a mesh of four soft blobs',
+  corner: 'Paint two opposing corner glows',
+  wash: 'Paint a single wash from the top',
+  aurora: 'Paint diagonal bands',
+  image: 'Choose a picture to sit behind the glass',
+}
+
+/** A labelled range that reports while it moves and again when it is let go. */
+function Slider({
+  label,
+  min,
+  max,
+  step,
+  value,
+  onDrag,
+  onSettle,
+}: {
+  label: string
+  min: number
+  max: number
+  step: number
+  value: number
+  onDrag: (value: number) => void
+  onSettle: () => void
+}): JSX.Element {
+  return (
+    <label className="backdrop-slider">
+      <span>{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onDrag(Number(event.target.value))}
+        // The swatches follow the thumb; the window and the file wait for it to
+        // be let go.
+        onPointerUp={onSettle}
+        onKeyUp={onSettle}
+        onBlur={onSettle}
+      />
+    </label>
+  )
+}
+
 /**
  * The same value the theme would resolve to, drawn small.
  *
  * Built by the generator the window itself uses, from the palette the resolver
  * derived, so a swatch cannot disagree with the result of clicking it.
  */
-function previewOf(theme: HeliosTheme, style: BackdropStyle, intensity: number, palette: string[]): string {
+function swatchOf(
+  theme: HeliosTheme,
+  style: BackdropStyle,
+  intensity: number,
+  palette: string[],
+  image: string | null,
+): string {
+  if (style !== 'image') return previewOf(theme, style, intensity, palette)
+  // Nothing imported yet: the chip is an invitation rather than a preview.
+  if (!image) return `repeating-linear-gradient(45deg, ${theme.vars['--surface-high']} 0 5px, ${theme.vars['--surface-highest']} 5px 10px)`
+  return previewOf(theme, style, intensity, palette, image)
+}
+
+function previewOf(
+  theme: HeliosTheme,
+  style: BackdropStyle,
+  intensity: number,
+  palette: string[],
+  image?: string,
+): string {
   const stops = palette.map(parseColor).filter((c): c is Rgb => c !== null)
   const base = parseColor(theme.vars['--surface'] ?? '') ?? (parseColor('#101014') as Rgb)
-  return backdropValue({ style, intensity }, base, stops)
+  return backdropValue({ style, intensity, ...(image ? { image } : {}) }, base, stops)
 }
 
 function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -529,12 +529,23 @@ small {
   background: var(--backdrop, transparent);
 }
 
-/* Tinted rather than clear: the material supplies the blur, the tint keeps the
+/* Tinted rather than clear: the blur softens what is behind, the tint keeps the
    theme's own colour in the mix so a panel still belongs to the app. The
-   hairline is what stops two adjacent translucent panels reading as one. */
+   hairline is what stops two adjacent translucent panels reading as one.
+
+   The blur is ours rather than the OS material's, so a painted backdrop frosts
+   the same way the desktop one does — and it is what makes a panel read as a
+   sheet in front of the backdrop rather than a tinted hole in it. Saturation
+   goes up with it because blurring towards an average pulls the colour out.
+
+   The whole filter arrives as one variable rather than a radius this rule
+   builds on: a theme that asks for no blur emits nothing, the reference goes
+   unresolved, and the property falls back to `none` — where a `blur(0px)` would
+   still have promoted every glass surface to its own compositing layer. */
 [data-glass='on'] .sidebar,
 [data-glass='on'] .detail {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--on-surface) 9%, transparent);
+  backdrop-filter: var(--glass-frost);
 }
 
 [data-glass='on'] .sidebar {
@@ -560,6 +571,9 @@ small {
    obvious than the transparency itself. */
 [data-glass='on'] .session-card {
   background: var(--glass-container);
+  /* Half the panel's blur. A card is a sheet on a sheet, and blurring it as
+     hard again flattens the difference between the two. */
+  backdrop-filter: var(--glass-frost-soft);
 }
 
 /* Code and diffs keep a solid bed. They are the one thing in the window that
@@ -3710,9 +3724,21 @@ hr {
   );
 }
 
-.backdrop-intensity {
-  width: 100%;
+.backdrop-slider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   margin-top: 8px;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
+.backdrop-slider > span {
+  flex: 0 0 46px;
+}
+
+.backdrop-slider input {
+  flex: 1;
   accent-color: var(--primary);
 }
 

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -493,10 +493,14 @@ export interface BackdropState {
   glass: boolean
   style: BackdropStyle
   intensity: number
+  /** How far the glass surfaces blur what is behind them, in px. */
+  blur: number
   /** What the gradients are drawn from, whether named by the theme or derived. */
   palette: string[]
   /** True when those colours were named rather than derived from the theme. */
   custom: boolean
+  /** File name of the chosen image, or null where none has been imported. */
+  image: string | null
   /** Whether this platform can show the desktop behind the window. */
   desktopSupported: boolean
 }

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -19,10 +19,12 @@ export function applyProseSize(root: HTMLElement, size: number): void {
 export function applyTheme(root: HTMLElement, theme: Pick<HeliosTheme, 'vars'>, glass = false): void {
   for (const [name, value] of Object.entries(theme.vars)) root.style.setProperty(name, value)
   // Every other variable is emitted by every theme, so writing over them is
-  // enough. The backdrop is the one a theme may decline to set, and a stale
-  // gradient left behind is the app painting over the desktop it was just
-  // asked to show.
-  if (!theme.vars['--backdrop']) root.style.removeProperty('--backdrop')
+  // enough. These are the ones a theme may decline to set, and a stale value
+  // left behind is the app painting over the desktop it was just asked to
+  // show, or frosting a window that asked to be clear.
+  for (const name of ['--backdrop', '--glass-frost', '--glass-frost-soft']) {
+    if (!theme.vars[name]) root.style.removeProperty(name)
+  }
   // An attribute rather than more variables: glass changes which surfaces
   // paint at all, not what colour they are.
   if (glass) root.dataset.glass = 'on'

--- a/desktop/src/shared/theme/backdrop.ts
+++ b/desktop/src/shared/theme/backdrop.ts
@@ -29,7 +29,7 @@ type Layer =
  * which is what keeps it from reading as a plain vignette. The rest are the
  * quieter arrangements of the same idea.
  */
-const STYLES: Record<Exclude<BackdropStyle, 'desktop'>, Layer[]> = {
+const STYLES: Record<Exclude<BackdropStyle, 'desktop' | 'image'>, Layer[]> = {
   mesh: [
     { kind: 'radial', at: '12% 8%', size: '70% 60%', colour: 0, weight: 1 },
     { kind: 'radial', at: '88% 18%', size: '60% 55%', colour: 1, weight: 0.5 },
@@ -51,7 +51,13 @@ const STYLES: Record<Exclude<BackdropStyle, 'desktop'>, Layer[]> = {
   ],
 }
 
-export const BACKDROP_STYLES = Object.keys(STYLES) as Exclude<BackdropStyle, 'desktop'>[]
+export const BACKDROP_STYLES = Object.keys(STYLES) as Exclude<BackdropStyle, 'desktop' | 'image'>[]
+
+/** The scheme the main process serves imported images on. */
+export const MEDIA_SCHEME = 'helios-backdrop'
+
+/** A bare file name: no separators, no `..`, and an extension we serve. */
+const IMAGE_NAME = /^[\w.-]+\.(?:png|jpe?g|webp)$/i
 
 /* Below the floor the backdrop is a waste of a layer; above the ceiling it
    reaches the text, which is the one thing the surfaces above it are for. */
@@ -78,11 +84,31 @@ export function clampIntensity(value: number | undefined): number {
   return Math.max(MIN_INTENSITY, Math.min(MAX_INTENSITY, value as number))
 }
 
+/* Zero is a legitimate answer here — a theme may want its gradient sharp, and
+   on macOS the window material has already blurred the desktop. The ceiling is
+   where more radius stops changing anything a viewer can see. */
+export const MAX_BLUR = 48
+export const DEFAULT_BLUR = 24
+
+export function clampBlur(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_BLUR
+  return Math.max(0, Math.min(MAX_BLUR, Math.round(value as number)))
+}
+
 /** 'desktop' for a theme that asks for the OS material, or has asked for nothing. */
 export function styleOf(spec: BackdropSpec | undefined): BackdropStyle {
   if (!spec) return 'desktop'
   if (spec.style === 'desktop') return 'desktop'
+  // An image style with no usable image left would otherwise be a blank
+  // window; falling back to the gradient keeps something behind the glass.
+  if (spec.style === 'image') return imageName(spec) ? 'image' : 'mesh'
   return spec.style && spec.style in STYLES ? spec.style : 'mesh'
+}
+
+/** The image a spec names, or null where it names nothing we would serve. */
+export function imageName(spec: BackdropSpec | undefined): string | null {
+  const name = spec?.image?.trim()
+  return name && IMAGE_NAME.test(name) ? name : null
 }
 
 /**
@@ -125,6 +151,20 @@ export function backdropValue(spec: BackdropSpec, base: Rgb, derived: Rgb[]): st
   const style = styleOf(spec)
   if (style === 'desktop') return ''
 
+  // An image is laid under a scrim of the theme's own surface rather than shown
+  // raw. A photograph behind a transcript is a contrast problem, and intensity
+  // is how far towards the theme it is pulled — the same slider, doing the
+  // same job it does for a gradient.
+  const image = style === 'image' ? imageName(spec) : null
+  if (image) {
+    const scrim = toRgba(base, clampIntensity(spec.intensity))
+    return [
+      `linear-gradient(${scrim}, ${scrim})`,
+      `url('${MEDIA_SCHEME}://media/${encodeURIComponent(image)}') center / cover no-repeat`,
+      toRgba(base, 1),
+    ].join(', ')
+  }
+
   const intensity = clampIntensity(spec.intensity)
   const declared = spec.stops?.length ? spec.stops : null
   const palette: (Rgb | null)[] = declared
@@ -132,7 +172,7 @@ export function backdropValue(spec: BackdropSpec, base: Rgb, derived: Rgb[]): st
     : derived
 
   const layers: string[] = []
-  for (const layer of STYLES[style]) {
+  for (const layer of STYLES[style as keyof typeof STYLES]) {
     // A style may have more layers than the palette has colours, and a stop
     // whose colour does not parse is left out rather than guessed at: one
     // missing blob is a quieter failure than a grey one in the wrong place.

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -18,7 +18,15 @@ import {
   type AnsiName,
   type DeriveContext,
 } from './mapping.ts'
-import { backdropValue, clampIntensity, derivedStops, styleOf } from './backdrop.ts'
+import {
+  DEFAULT_BLUR,
+  backdropValue,
+  clampBlur,
+  clampIntensity,
+  derivedStops,
+  imageName,
+  styleOf,
+} from './backdrop.ts'
 import {
   composite,
   contrast,
@@ -67,6 +75,8 @@ export interface HeliosTheme {
     intensity: number
     /** Colours the theme named itself, or null where they are derived. */
     stops: string[] | null
+    /** File name of the image behind an 'image' style, null for the rest. */
+    image: string | null
   } | null
   /**
    * The colours a backdrop of this theme is drawn from, whether or not one is
@@ -74,6 +84,11 @@ export interface HeliosTheme {
    * able to show a style the theme is not currently using.
    */
   backdropPalette: string[]
+  /**
+   * How far the glass surfaces blur what is behind them, in px. Zero for an
+   * opaque theme, and for a glass theme that asked for none.
+   */
+  backdropBlur: number
 }
 
 const FALLBACK_BG: Record<ThemeMode, Rgb> = { dark: rgb(0x11, 0x13, 0x18), light: rgb(0xff, 0xff, 0xff) }
@@ -236,6 +251,20 @@ export function resolveTheme(
   const palette = derivedStops(resolved.get('primary') ?? bg, ansi.magenta, ansi.cyan, mode === 'dark')
   const spec = glass ? theme['helios.backdrop'] : undefined
   const style = styleOf(spec)
+
+  // The frosting, which is a property of the glass rather than of the backdrop:
+  // a window showing the desktop is blurred by the same rule as one showing a
+  // gradient. It starts at zero for the desktop only because the OS material
+  // has already blurred what is behind, and frosting it twice is just haze.
+  const blur = glass ? clampBlur(spec?.blur ?? (style === 'desktop' ? 0 : DEFAULT_BLUR)) : 0
+  if (blur > 0) {
+    // Saturation rises with the radius because blurring towards an average
+    // pulls the colour out of whatever is behind.
+    vars['--glass-frost'] = `blur(${blur}px) saturate(1.5)`
+    // Cards are a sheet on a sheet; blurring them as hard again flattens the
+    // difference between the two.
+    vars['--glass-frost-soft'] = `blur(${Math.round(blur / 2)}px)`
+  }
   let backdrop: HeliosTheme['backdrop'] = null
   if (spec && style !== 'desktop') {
     vars['--backdrop'] = backdropValue(spec, resolved.get('surface') ?? bg, palette)
@@ -246,6 +275,7 @@ export function resolveTheme(
       style,
       intensity: clampIntensity(spec.intensity),
       stops: named?.length ? named.map(toHex) : null,
+      image: style === 'image' ? imageName(spec) : null,
     }
   }
 
@@ -271,6 +301,7 @@ export function resolveTheme(
     glass,
     backdrop,
     backdropPalette: palette.map(toHex),
+    backdropBlur: blur,
   }
 }
 

--- a/desktop/src/shared/theme/vscode.ts
+++ b/desktop/src/shared/theme/vscode.ts
@@ -42,7 +42,7 @@ export interface BackdropStop {
  * How the gradients are arranged, or 'desktop' for a theme that would rather
  * show whatever is behind the window than paint anything itself.
  */
-export type BackdropStyle = 'desktop' | 'mesh' | 'corner' | 'wash' | 'aurora'
+export type BackdropStyle = 'desktop' | 'mesh' | 'corner' | 'wash' | 'aurora' | 'image'
 
 /**
  * The gradient a glass theme paints behind itself, so the look does not depend
@@ -53,8 +53,20 @@ export interface BackdropSpec {
   style?: BackdropStyle
   /** Alpha of the strongest layer; the rest are scaled from it. */
   intensity?: number
+  /**
+   * How far the glass surfaces blur what is behind them, in px. Applies to the
+   * desktop as much as to a painted gradient — it is the frosting, not the
+   * thing being frosted.
+   */
+  blur?: number
   /** Replaces the derived palette outright. */
   stops?: BackdropStop[]
+  /**
+   * File name of an imported image, for the 'image' style. A bare name inside
+   * the backdrops directory — never a path, since it is served by a scheme that
+   * refuses to leave that directory.
+   */
+  image?: string
 }
 
 export interface VSCodeTheme {

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -305,7 +305,7 @@ test('a backdrop block becomes one gradient per layer over the theme surface', (
     colors: DARK,
   })
   // Mesh is what a block with no style asked for, from the derived palette.
-  assert.deepEqual(theme.backdrop, { style: 'mesh', intensity: 0.45, stops: null })
+  assert.deepEqual(theme.backdrop, { style: 'mesh', intensity: 0.45, stops: null, image: null })
   const value = theme.vars['--backdrop'] as string
   assert.equal(value.match(/radial-gradient\(/g)?.length, 4)
   // The strongest layer is the intensity itself, and the theme's own surface is
@@ -426,6 +426,67 @@ test('a stop whose colour does not parse is left out', () => {
   assert.equal(value.match(/radial-gradient\(/g)?.length, 2)
   assert.ok(!value.includes('rebeccapurple'))
   assert.match(value, /rgb\(0 255 0/)
+})
+
+test('blur is emitted as a filter, and only when there is one to apply', () => {
+  const frosted = resolveTheme('frosted', { 'helios.glass': GLASS, 'helios.backdrop': { blur: 30 }, colors: DARK })
+  assert.equal(frosted.backdropBlur, 30)
+  assert.equal(frosted.vars['--glass-frost'], 'blur(30px) saturate(1.5)')
+  // Cards are a sheet on a sheet, so they get half.
+  assert.equal(frosted.vars['--glass-frost-soft'], 'blur(15px)')
+
+  // No variable rather than blur(0px): the reference goes unresolved and the
+  // property falls back to none, instead of promoting every glass surface to a
+  // compositing layer to blur it by nothing.
+  const sharp = resolveTheme('sharp', { 'helios.glass': GLASS, 'helios.backdrop': { blur: 0 }, colors: DARK })
+  assert.equal(sharp.vars['--glass-frost'], undefined)
+})
+
+// The OS material has already blurred what is behind the window; frosting it
+// again is haze. A painted gradient has had nothing done to it.
+test('blur defaults to none for the desktop and to a radius for a gradient', () => {
+  const desktop = resolveTheme('os', { 'helios.glass': GLASS, 'helios.backdrop': { style: 'desktop' }, colors: DARK })
+  assert.equal(desktop.backdropBlur, 0)
+
+  const painted = resolveTheme('painted', { 'helios.glass': GLASS, 'helios.backdrop': { style: 'mesh' }, colors: DARK })
+  assert.ok(painted.backdropBlur > 0)
+})
+
+test('an opaque theme frosts nothing, whatever its backdrop block says', () => {
+  const theme = resolveTheme('solid', { 'helios.backdrop': { blur: 40 }, colors: DARK })
+  assert.equal(theme.backdropBlur, 0)
+  assert.equal(theme.vars['--glass-frost'], undefined)
+})
+
+test('an image backdrop is served over the media scheme, under a scrim', () => {
+  const theme = resolveTheme('pictured', {
+    'helios.glass': GLASS,
+    'helios.backdrop': { style: 'image', image: 'liquid-glass.png', intensity: 0.3 },
+    colors: DARK,
+  })
+  assert.equal(theme.backdrop?.style, 'image')
+  assert.equal(theme.backdrop?.image, 'liquid-glass.png')
+  const value = theme.vars['--backdrop'] as string
+  assert.match(value, /url\('helios-backdrop:\/\/media\/liquid-glass\.png'\) center \/ cover no-repeat/)
+  // The scrim is the theme's own surface at the chosen strength, so a
+  // photograph cannot decide how readable the transcript on top of it is.
+  assert.match(value, /^linear-gradient\(rgb\(13 15 19 \/ 30%\), rgb\(13 15 19 \/ 30%\)\)/)
+})
+
+// The name reaches a url() in an inline style, and the scheme that serves it
+// refuses to leave one directory — so anything that is not a bare file name of
+// a type we serve is not an image at all.
+test('an image name that is a path is refused, and the style falls back', () => {
+  for (const image of ['../../secrets.png', '/etc/passwd', 'evil.png\'), url(\'http://x', 'notes.txt']) {
+    const theme = resolveTheme('sneaky', {
+      'helios.glass': GLASS,
+      'helios.backdrop': { style: 'image', image },
+      colors: DARK,
+    })
+    assert.equal(theme.backdrop?.image, null)
+    assert.equal(theme.backdrop?.style, 'mesh')
+    assert.ok(!(theme.vars['--backdrop'] as string).includes('url('))
+  }
 })
 
 test('the backdrop block survives an include chain', () => {


### PR DESCRIPTION
## Summary

Follows #74 and #75. Two more properties on `helios.backdrop`, both with controls in **Settings → Appearance → Backdrop**.

### Blur

Glass had no frosting of its own. On macOS the window material supplied it; a painted gradient showed through flat, which is what made the panels read as tinted holes rather than sheets in front of something.

- `helios.backdrop.blur`, in px, with a slider. Applied to the sidebar and the detail panel, at half strength on session cards — a card is a sheet on a sheet.
- Offered for **Desktop** as well, since frosting is a property of the glass and not of what is behind it. It defaults to `0` there, because the OS material has already blurred the desktop and doing it twice is haze; painted styles default to 24.
- Emitted as a whole filter (`--glass-frost`) rather than a radius the stylesheet builds on. A theme asking for no blur emits nothing, the `var()` goes unresolved and the property falls back to `none` — a `blur(0px)` would still promote every glass surface to its own compositing layer to blur it by nothing.
- Saturation rises with the radius, because blurring towards an average pulls the colour out of what is behind.

### Images

A new `image` style: pick a picture and it sits behind the glass.

- The renderer is a `file://` document with `img-src 'self'`, which does not cover a file in the user's home. Rather than widen that to `file:` and let the page read the disk, images are served on a `helios-backdrop:` scheme that resolves one directory and refuses anything outside it — verified with a `..%2F..%2F` request, which 404s.
- The chosen file is copied into `~/.helios/backdrops/<theme>.<ext>` rather than linked, so tidying the original folder does not silently empty the window. One image per theme, overwritten.
- The image sits under a scrim of the theme's own surface, and the intensity slider (labelled **Dim** in this mode) is how far towards the theme it is pulled. A photograph should not get to decide how readable the transcript is.
- An `image` style whose name is missing or is not a bare file name of a served type falls back to `mesh`, so the window is never blank.

Saving still writes the same `~/.helios/themes/<id>.json` include-override, and the whole block is written each time — a partial spec was how the blur would have disappeared the next time someone moved the intensity.

## Test plan

- [x] `npm run typecheck` and `npm test` — 97 pass, 5 new covering the filter variables, the desktop-versus-painted default, the media URL and the scrim, and the rejected image names
- [x] Ran the app on Liquid Glass with an image backdrop: the picture fills the window, the scrim reads at 30%, the sidebar and panel are translucent over it
- [x] `helios-backdrop://media/liquid-glass.png` loads (2400×2570); `helios-backdrop://media/..%2F..%2F.helios%2Fconfig.yaml` is refused
- [x] Blur applies — `getComputedStyle(sidebar).backdropFilter` is `blur(24px) saturate(1.5)`, and the variables clear when a theme drops them
- [ ] Blur was not verified visually: `Page.captureScreenshot` hangs on this window whenever a `backdrop-filter` is live, so the screenshots in this branch were all taken with it off
- [ ] Not checked: Windows and Linux, and the file dialog, which cannot be driven over CDP