### PR TITLE
Frost the window, not each panel

### DIFF
--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -541,11 +541,21 @@ small {
    The whole filter arrives as one variable rather than a radius this rule
    builds on: a theme that asks for no blur emits nothing, the reference goes
    unresolved, and the property falls back to `none` — where a `blur(0px)` would
-   still have promoted every glass surface to its own compositing layer. */
+   still have promoted every glass surface to its own compositing layer.
+
+   Frosted once, for the whole window, rather than per panel. The panels do not
+   cover the window: there is a drag strip above them and an 8px channel between
+   and around them, and blurring only the panels leaves those bands showing the
+   backdrop raw — barely noticeable under a gradient, and a set of sharp seams
+   under a photograph. One layer also means one filtered surface to composite
+   instead of four overlapping ones. */
+[data-glass='on'] .app {
+  backdrop-filter: var(--glass-frost);
+}
+
 [data-glass='on'] .sidebar,
 [data-glass='on'] .detail {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--on-surface) 9%, transparent);
-  backdrop-filter: var(--glass-frost);
 }
 
 [data-glass='on'] .sidebar {
@@ -554,6 +564,11 @@ small {
 
 [data-glass='on'] .detail {
   background: var(--glass-panel);
+}
+
+/* The splash screen is its own root, so it does not get the shell's frost. */
+[data-glass='on'] .boot {
+  backdrop-filter: var(--glass-frost);
 }
 
 /* The panels inside a session — transcript, terminal, git, files — sit on the


### PR DESCRIPTION
## Summary

Follow-up to #76. The blur was applied per panel, and the panels do not cover the window — there is a 32px drag strip above them and an 8px channel between and around them. Those bands showed the backdrop raw: barely visible under a gradient, and a set of sharp seams under a photograph, which is what it looks like with an image backdrop set.

- One `backdrop-filter` on `.app` instead of one each on the sidebar and the detail panel. Covers the strip, the channel and the margins, and composites one filtered surface rather than four overlapping ones.
- The panels keep their tint and their hairline; only the filter moved.
- `.boot` carries the same rule, since the splash screen is its own root and never gets the shell's.

Also fixes a comment in the same block that had been closed early, which left six lines of prose as stray tokens and made the parser drop the rule that followed them.

## Test plan

- [x] `npm test` (97) and `npm run typecheck` pass — no behaviour outside CSS
- [x] Ran the app on Liquid Glass with an image backdrop at blur 48: the title bar, the channel between sidebar and transcript, and the outer margins all frost with the panels, with no sharp band anywhere
- [x] `getComputedStyle('.app').backdropFilter` is `blur(48px) saturate(1.5)`; the sidebar no longer carries its own