### PR TITLE
Read a transcript once, then only what was added

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -151,8 +151,18 @@ export class ApiClient {
     return res.directories ?? []
   }
 
-  transcript(id: string, limit = 200, offset = 0): Promise<TranscriptPage> {
+  transcript(id: string, limit = 50, offset = 0): Promise<TranscriptPage> {
     const query = queryString({ limit: String(limit), offset: String(offset) })
+    return this.request('GET', `/api/sessions/${encodeURIComponent(id)}/transcript${query}`)
+  }
+
+  /**
+   * Asks only for what has been written since seq, under the epoch those seq
+   * numbers came from. A reply with epoch_changed set is a whole page instead:
+   * the transcript is no longer the one being followed.
+   */
+  transcriptSince(id: string, afterSeq: number, epoch: string, limit = 50): Promise<TranscriptPage> {
+    const query = queryString({ after_seq: String(afterSeq), epoch, limit: String(limit) })
     return this.request('GET', `/api/sessions/${encodeURIComponent(id)}/transcript${query}`)
   }
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -21,6 +21,7 @@ const API_METHODS = new Set<keyof ApiClient>([
   'getSession',
   'listDirectories',
   'transcript',
+  'transcriptSince',
   'subagents',
   'sendPrompt',
   'setSessionOrder',

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -179,6 +179,9 @@ export class HostApi {
   transcript(id: string, limit?: number, offset?: number): Promise<TranscriptPage> {
     return this.call('transcript', id, limit, offset)
   }
+  transcriptSince(id: string, afterSeq: number, epoch: string, limit?: number): Promise<TranscriptPage> {
+    return this.call('transcriptSince', id, afterSeq, epoch, limit)
+  }
   subagents(id: string): Promise<Subagent[]> {
     return this.call('subagents', id)
   }

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -30,7 +30,7 @@ import {
   type TranscriptMessage,
 } from '../../shared/models.ts'
 
-const PAGE = 200
+const PAGE = 50
 
 export function ChatPanel({
   hostId,
@@ -51,6 +51,9 @@ export function ChatPanel({
   const [reload, setReload] = useState(0)
   const [hasMore, setHasMore] = useState(false)
   const [total, setTotal] = useState(0)
+  // Which parse the held seq numbers count against. A delta quotes it back so
+  // the daemon can say when it no longer holds.
+  const [epoch, setEpoch] = useState('')
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
   const [attachments, setAttachments] = useState<Attachment[]>([])
@@ -63,6 +66,12 @@ export function ChatPanel({
   const scroller = useRef<HTMLDivElement | null>(null)
   const composer = useRef<HTMLTextAreaElement | null>(null)
   const pinnedToBottom = useRef(true)
+  // The messages a delta has to follow on from, without the delta effect
+  // re-running every time one arrives.
+  const messagesRef = useRef<TranscriptMessage[]>([])
+  const loadingOlder = useRef(false)
+  // Scroll height captured before older messages are prepended.
+  const anchor = useRef<number | null>(null)
   const promptDraft = useStore((s) => s.promptDraft)
   const [selection, clearSelection] = useTextSelection(scroller)
 
@@ -71,10 +80,9 @@ export function ChatPanel({
   const terminated = canResume(session)
   const cold = needsRecovery(session)
 
+  // The newest page, on arrival at a session. An unwatched transcript is not
+  // read at all: reading it again on the way back costs one request.
   useEffect(() => {
-    // last_event_at moves with every hook the agent fires, so an unwatched
-    // transcript would refetch itself all day. Reading it again on the way
-    // back costs one request instead.
     if (!active) return
     let cancelled = false
     const load = async (): Promise<void> => {
@@ -84,6 +92,7 @@ export function ChatPanel({
         setMessages(page.messages)
         setTotal(page.total)
         setHasMore(page.has_more)
+        setEpoch(page.epoch ?? '')
         setLoadedFor(session.session_id)
       } catch (err) {
         if (!cancelled) store.fail(err)
@@ -93,9 +102,39 @@ export function ChatPanel({
     return () => {
       cancelled = true
     }
-    // Reloads as the agent works: last_event_at moves on every hook, and the
-    // transcript is a file the daemon re-reads rather than a stream.
-  }, [hostId, session.session_id, session.last_event_at, status, active, reload])
+  }, [hostId, session.session_id, active, reload])
+
+  // Then only what the agent has added since. last_event_at moves on every
+  // hook it fires, which for a busy session is several times a turn — pulling
+  // the whole page each time would re-render the transcript and lose the
+  // reader's place for the sake of one new message.
+  useEffect(() => {
+    if (!active || loadedFor !== session.session_id || !epoch) return
+    const newest = messagesRef.current[messagesRef.current.length - 1]?.seq ?? -1
+    let cancelled = false
+    const load = async (): Promise<void> => {
+      try {
+        const page = await api(hostId).transcriptSince(session.session_id, newest, epoch, PAGE)
+        if (cancelled || page.messages.length === 0) return
+        if (page.epoch_changed) {
+          // The transcript is no longer the one those seq numbers counted
+          // against — forked, or replaced. What is held has to go.
+          setMessages(page.messages)
+          setEpoch(page.epoch ?? '')
+          setHasMore(page.has_more)
+        } else {
+          setMessages((current) => [...current, ...page.messages])
+        }
+        setTotal(page.total)
+      } catch (err) {
+        if (!cancelled) store.fail(err)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [hostId, session.session_id, session.last_event_at, status, active, loadedFor, epoch])
 
   // Lines picked in the Files panel arrive here rather than being sent: what to
   // ask about them is still to be typed.
@@ -110,20 +149,35 @@ export function ChatPanel({
   }, [promptDraft?.seq])
 
   useEffect(() => {
-    if (pinnedToBottom.current && scroller.current) {
-      scroller.current.scrollTop = scroller.current.scrollHeight
+    messagesRef.current = messages
+    const el = scroller.current
+    if (!el) return
+    // Older messages arriving above the reader must not move what they are
+    // reading: the view stays where it was by the height that was inserted.
+    if (anchor.current !== null) {
+      el.scrollTop += el.scrollHeight - anchor.current
+      anchor.current = null
+      return
     }
+    if (pinnedToBottom.current) el.scrollTop = el.scrollHeight
   }, [messages])
 
   useEffect(() => () => retries.current.forEach(clearTimeout), [])
 
   const loadOlder = async (): Promise<void> => {
+    if (loadingOlder.current || !hasMore) return
+    loadingOlder.current = true
+    anchor.current = scroller.current?.scrollHeight ?? null
     try {
       const page = await api(hostId).transcript(session.session_id, PAGE, messages.length)
       setMessages((current) => [...page.messages, ...current])
       setHasMore(page.has_more)
+      setTotal(page.total)
     } catch (err) {
+      anchor.current = null
       store.fail(err)
+    } finally {
+      loadingOlder.current = false
     }
   }
 
@@ -229,6 +283,8 @@ export function ChatPanel({
         onScroll={(event) => {
           const el = event.currentTarget
           pinnedToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40
+          // Near the top is a request for what came before it.
+          if (el.scrollTop < 200) void loadOlder()
         }}
       >
         {loadedFor !== session.session_id ? (

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -171,6 +171,8 @@ export interface QuestionPayload {
 
 /** internal/transcript/reader.go:22 */
 export interface TranscriptMessage {
+  /** Position in the whole transcript, not in the page. */
+  seq: number
   role: 'user' | 'assistant' | 'tool' | 'system' | string
   content?: string
   tool?: string
@@ -186,6 +188,13 @@ export interface TranscriptPage {
   returned: number
   offset: number
   has_more: boolean
+  /** Which parse the seq numbers count against. */
+  epoch?: string
+  /**
+   * Set when a delta was asked for under an epoch that no longer holds. The
+   * messages are then a fresh newest page and replace what the caller holds.
+   */
+  epoch_changed?: boolean
 }
 
 /** internal/store/sessions.go:64 */

--- a/docs/specs/38-transcript-incremental-serving.md
+++ b/docs/specs/38-transcript-incremental-serving.md
@@ -1,0 +1,290 @@
+# Transcript Serving: Parse Once, Keep It in RAM, Append the Tail
+
+## Problem
+
+`GET /api/sessions/<id>/transcript` re-reads and re-parses the entire Claude
+`.jsonl` transcript on every call, and every client re-calls it on every hook
+event. Cost scales with transcript size, not with what changed.
+
+Call chain today:
+
+- `internal/server/api.go:411` → `transcript.ParseClaudeTranscript(path, limit, offset)`
+- `internal/transcript/reader.go:86` `parseClaude` reads the whole stream into
+  `allMessages`, slices a page off the end, and **throws the rest away**.
+- `internal/provider/claude/autotitle.go:399` `readSession` does the same full
+  parse, triggered from the `Stop` hook (`internal/provider/claude/hooks.go:617`).
+- `internal/daemon/reaper.go:54` already reads *backward* in 64 KB chunks rather
+  than parsing everything — the only place that does.
+
+Event amplification:
+
+- `session_status` is broadcast from 14 sites, including **every** `PreToolUse`
+  (`hooks.go:1008`), prompt submit (`hooks.go:904`), and stop (`hooks.go:602`).
+- Mobile (`mobile/lib/screens/session_detail_screen.dart:98`) debounces 500 ms
+  then calls `_loadTranscript()` — a full `limit=200, offset=0` page.
+- Desktop (`desktop/src/renderer/components/chat.tsx:82`) keys an effect on
+  `session.last_event_at` + `status`, so it refetches `PAGE=200, offset=0` on
+  every hook too.
+
+One tool call by the agent = one full parse per attached viewer, plus another
+from autotitle at the end of the turn.
+
+## Measurements (2026-08-17, this machine)
+
+`ParseClaudeTranscript(path, 200, 0)`:
+
+| file | lines | messages | parse | alloc/parse | JSON response |
+|------|-------|----------|-------|-------------|---------------|
+| 17.6 MB | 6856 | 2660 | **205 ms** | **75.6 MB** | 0.06 MB |
+| 9.5 MB | 5440 | 2131 | 108 ms | 32.7 MB | 0.08 MB |
+| 5.7 MB | 1977 | 772 | 63 ms | 20.7 MB | 0.09 MB |
+| 0.3 MB | 200 | 66 | 3.6 ms | 0.9 MB | — |
+
+The response is 0.06 MB out of 17.6 MB read: **99.7 % of the work is discarded**,
+then redone on the next event.
+
+**Parsed messages are an order of magnitude smaller than the file.** Parsing and
+*holding* the results (`HeapAlloc` after `runtime.GC()`):
+
+| scope | raw jsonl | messages | retained heap | cold parse |
+|-------|-----------|----------|---------------|------------|
+| biggest single file | 17.6 MB | 2 660 | **1.6 MB** (9.2 %) | 198 ms |
+| 10 biggest files | 62.1 MB | 10 939 | **7.0 MB** (11.3 %) | 686 ms |
+| every transcript on disk (146) | 87.4 MB | 17 806 | **11.5 MB** (13.2 %) | 1.03 s |
+
+**~680 B per message.** The parsed form is small because the parser already
+discards what is large: `tool_result` bodies keep only a tool name and a success
+flag, and `attachment` / `file-history-snapshot` entries are dropped entirely.
+Those are the bulk of the bytes:
+
+```
+user                    67.1%   (mostly tool_result bodies — discarded)
+assistant               18.8%
+attachment              10.6%   (skipped)
+file-history-snapshot    2.2%   (skipped)
+system / pr-link / last-prompt / permission-mode / worktree-state / queue-operation  <1% each
+```
+
+Holding *every* session this machine has ever run costs 12 MB. There is no
+memory argument for re-reading anything.
+
+## Verifying the append-only assumption
+
+Everything rests on: **the prefix of a transcript file never changes**, so a
+cached parse stays valid and only the tail needs reading. Checked, not assumed:
+
+1. **Live file, sampled every 12 s for 1 min** while an agent worked: size grew
+   210 444 → 262 611 B monotonically; `md5` of the first 100 KB identical at
+   every sample.
+2. **145 files scanned**: zero duplicate `uuid` values within any file → entries
+   are never rewritten in place.
+3. **`sessionId` inside every entry equals the filename** in all 145 files → a
+   resumed session appends to its existing file rather than rewriting it.
+4. **Compaction appends.** A file carrying 2 compact entries shows the same
+   monotonic, non-duplicating structure.
+5. **Fork copies into a new file and tags what it copied.** Exactly one pair of
+   files shares a first `uuid` (`52fc5845…` / `82c4956f…`). Every copied entry
+   in the new file carries `forkedFrom: {sessionId, messageUuid}` and keeps its
+   original uuid; the source file is untouched. A fork lands on a new path and
+   inode, so it cannot alias a cached entry.
+6. **Rewind appends a branch; it does not truncate.** The transcript is a DAG:
+   entries carry `parentUuid`, and the live head is tracked by `last-prompt`
+   entries carrying `leafUuid`, appended repeatedly (261 of them in one file).
+   A rewind or an edited message starts a new branch at the rewind point; the
+   abandoned branch stays in the file. 38 of 145 files contain a `parentUuid`
+   with more than one child, i.e. an in-file branch point.
+
+Nothing observed ever shrinks or rewrites a transcript. The truncation guard
+below is therefore defensive — it covers something *outside* Claude Code editing
+the file — and is expected never to fire in normal use. It stays because it is
+one integer comparison.
+
+Also observed: ~4–5 % of entries carry timestamps out of order relative to the
+previous line (interleaved `last-prompt` / `permission-mode` writes). **File
+order is the ordering** — nothing may sort by timestamp.
+
+## Design
+
+Parse a transcript once, keep the parsed messages in RAM, and on each request
+read only the bytes appended since. Serving a page becomes a slice of a slice.
+
+### A. In-memory transcript store (`internal/transcript`)
+
+```go
+type cached struct {
+    mu          sync.Mutex
+    messages    []Message
+    parsedBytes int64  // offset of the last complete '\n' consumed
+    tailHash    uint64 // hash of the 4 KB preceding parsedBytes
+    dev, ino    uint64 // file identity from os.Stat
+    epoch       uint64 // bumped on every rebuild
+    lastUsed    time.Time
+}
+```
+
+Keyed by transcript path. On every request, `Stat` and branch:
+
+- `size == parsedBytes`, same inode → serve from RAM, no I/O beyond the stat.
+- `size > parsedBytes` → open, `Seek(parsedBytes)`, parse **only the new bytes**,
+  append to `messages`. ~10 KB per event (measured ~50 KB/min of growth on an
+  active session) → sub-millisecond.
+- `size < parsedBytes`, different inode, or `tailHash` mismatch → the prefix
+  moved (rewind, fork, external rewrite). Drop and rebuild, bump `epoch`.
+
+Note what is *not* held: the file's bytes. Only the parsed messages survive a
+refresh (~10 % of raw, 680 B/message), plus one offset and one hash.
+
+Rules:
+
+- **Never advance `parsedBytes` past the last `'\n'`.** The writer may be
+  mid-line; a partial trailing line is re-read next time rather than parsed into
+  a broken message.
+- Keep the existing over-long-line guard (`reader.go:138` `readLine`, 16 MB cap).
+  Largest line observed: 391 KB.
+- Per-entry mutex, so two viewers refreshing the same session serialise on one
+  append instead of doing the work twice.
+
+Memory: at 680 B/message, a 128 MB cap holds ~190 000 messages — an order of
+magnitude past every transcript this machine has. Bound it anyway with an LRU
+plus an idle TTL (evict after ~1 h untouched); eviction costs at most one cold
+reparse, and cold parse of the *largest* file is 198 ms.
+
+#### Keeping it in sync
+
+The read path is the sync point: every request stats the file and catches up
+before serving. Measured on the 17.6 MB transcript:
+
+```
+os.Stat            1.66 µs
+pread 10 KB         1.35 µs
+```
+
+A refresh therefore costs microseconds, and there is nothing to keep in sync
+between requests — a cache that only advances when read cannot drift, and a
+daemon restart loses nothing but a lazy rebuild.
+
+Rejected alternatives, and why they are optimisations rather than mechanisms:
+
+- **fsnotify watcher.** Adds a dependency (go.mod has none today) and an FD per
+  watched file, and a dropped event would leave a viewer stale indefinitely — so
+  the stat check has to exist regardless. Only worth it as a push trigger.
+- **Hook-driven warm.** Free, since hooks already carry `transcript_path`
+  (`hooks.go:23`, consumed at `hooks.go:1217`): the daemon can refresh the entry
+  in the hook handler so the HTTP request is a pure slice. But hooks do not fire
+  for every message (an assistant turn with no tool call only produces `Stop`),
+  so this cannot replace the stat — it front-runs it.
+- **Polling tail goroutine per session.** All the cost of a watcher, none of the
+  precision. Only justified if the SSE push in §E lands.
+
+### B. Delta responses so events do not re-ship the page
+
+With the store in place the server cost is gone, but each event still ships
+50–200 messages over the wire (over Tailscale, for mobile) and makes the client
+rebuild its list and lose scroll position.
+
+- Each message gets a **`seq`** — its index in `cached.messages`. Stable, since
+  the prefix is append-only.
+- Responses carry **`epoch`**.
+- New param `?after_seq=<n>&epoch=<e>` returns only messages past `n` —
+  typically 1–3 messages, a few KB.
+- Epoch mismatch → respond with a fresh newest page and `epoch_changed: true`;
+  the client resets. This is the rewind / fork / restart path.
+- `limit`/`offset` keep their current end-anchored meaning (`reader.go:110`) for
+  older pages, and `total` stays exact and free — the whole list is in RAM.
+
+### C. Clients: page 50 and infinite scroll
+
+Both clients pull 200 messages and rebuild the list on every event; mobile has
+no way to load older ones at all.
+
+- **Initial page 50**, newest first (down from `PAGE = 200`).
+- **Mobile** (`session_detail_screen.dart:936`): the list is already
+  `reverse: true`. The `_hasMore` branch renders a dead `"N earlier messages"`
+  label; replace it with a loader that calls `_loadOlder()` when it scrolls into
+  view, guarded by a `_loadingOlder` flag, prepending the results.
+- **Desktop** (`chat.tsx:122`): `loadOlder` exists but is manual — drive it from
+  a sentinel at the top of the scroller and drop `PAGE` to 50.
+- **On SSE `session_status`**: call `?after_seq=` with the newest held `seq` and
+  append. No list rebuild, no scroll jump; the 500 ms debounce stops being
+  load-bearing.
+- Optionally trim the in-memory list (e.g. 1000 messages) once the user is back
+  at the bottom.
+
+### D. Same store for autotitle
+
+`autotitle.readSession` (`autotitle.go:399`) full-parses only to scan the tail in
+reverse, once per `Stop` hook. Point it at the store: after this change it reads
+a slice.
+
+### E. Decided: the file stays the source of truth, read linearly
+
+A rewind appends a branch rather than truncating, so an abandoned branch stays
+in the file and the linear reader (`reader.go:86`) shows it. Measured over 145
+transcripts, 45 contain entries that are not on the current leaf path — 80fc19d3
+shows 3064 entries of which 673 are on the live path, mostly because compaction
+re-parents later turns onto the summary.
+
+**Helios keeps reading the file linearly and shows what is in it.** No walking
+`parentUuid` back from `last-prompt.leafUuid`, no reconstructing the live branch,
+no hiding pre-compaction history. The transcript file is the source of truth; if
+something is in the file, it is shown.
+
+This keeps the whole design trivial: the visible list only ever grows, `seq` is a
+plain index into it, and `epoch` is needed solely for the defensive rebuild in
+§A. Reading the entire file is fine when it is needed — the point of the store is
+that it is needed once per session, not once per event.
+
+### F. Optional, later: push deltas over SSE
+
+The daemon runs the hook that triggers the event and now already holds the
+messages, so it can broadcast `transcript_append` with the delta and remove the
+round-trip entirely. Clients keep `?after_seq=` as the reconnect path.
+
+## Ordering
+
+1. **A** — in-memory store with tail append. Invisible to clients, removes
+   nearly all the cost.
+2. **B** — `seq` + `epoch` + `after_seq`.
+3. **C + D** — page 50, infinite scroll, delta on event, autotitle rewired.
+4. **F** — SSE push, only if events still feel late.
+
+## Edge cases
+
+| case | handling |
+|------|----------|
+| rewind | appends a branch; nothing to invalidate, and the branch is shown (§E) |
+| external truncation / rewrite | `size < parsedBytes` or tail-hash mismatch → rebuild, new epoch, client resets |
+| fork (`--fork-session`) | new inode → treated as a different file |
+| `/clear` | new session file, same path as above |
+| compaction | plain appends; nothing special |
+| partial last line | never consumed; stop at the last `'\n'` |
+| line larger than a chunk | existing 16 MB `readLine` cap; observed max 391 KB |
+| out-of-order timestamps | ignore timestamps for ordering; file order wins |
+| concurrent viewers | per-entry mutex; one append, not one per viewer |
+| daemon restart | store rebuilds lazily on first request (≤ 198 ms worst case here) |
+| memory growth | LRU + idle TTL; eviction costs one reparse |
+
+## Testing
+
+- Store output equals a full parse, over every `.jsonl` in a fixture corpus.
+- Append to a fixture → the store's messages equal a fresh full parse, and only
+  the appended bytes were read.
+- `?after_seq=` delta equals the difference between two full parses.
+- Truncate a fixture mid-file → epoch bumps, result matches a fresh parse.
+- Fixture containing a rewind branch parses to the same linear list before and
+  after the branch is appended (no reset, no reorder).
+- Write a partial final line → not served; completing it serves it exactly once.
+- Fixture with a 400 KB line spanning a refresh boundary.
+- Concurrency: N goroutines refreshing one growing file, race detector on.
+- Benchmark on the 17 MB fixture: warm page **< 1 ms**, refresh after a 10 KB
+  append **< 1 ms**, cold build ~200 ms.
+- `cmd/apitest` (`main.go:384`) gains a delta-fetch assertion.
+
+## Success criteria
+
+- p95 `GET /transcript` on an active 17 MB session: **205 ms → < 1 ms** warm.
+- Allocation per event: **75.6 MB → < 100 KB**.
+- Steady-state store size for a heavy user: **~12 MB** (measured: all 146
+  transcripts on this machine).
+- Mobile can scroll back through a full transcript; neither client jumps scroll
+  position when a message arrives.

--- a/internal/provider/claude/autotitle.go
+++ b/internal/provider/claude/autotitle.go
@@ -390,13 +390,15 @@ type exchangePair struct {
 // user actually said, from one read of the transcript.
 //
 // One read, because the file is the session's whole history — a busy one runs
-// to megabytes — and both answers come out of the same scan.
+// to megabytes — and both answers come out of the same scan. It goes through
+// the store, since this runs on the Stop hook of every turn and the only new
+// part of the file is what that turn wrote.
 func readSession(transcriptPath string, n int) (pairs []exchangePair, latest string) {
 	if transcriptPath == "" {
 		return nil, ""
 	}
 
-	result, err := transcript.ParseClaudeTranscript(transcriptPath, 200, 0)
+	result, err := transcript.Page(transcriptPath, 200, 0)
 	if err != nil {
 		return nil, ""
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -399,7 +399,7 @@ func (s *PublicServer) handleSessionTranscript(w http.ResponseWriter, r *http.Re
 	}
 
 	// Parse limit/offset from query
-	limit := 200
+	limit := 50
 	offset := 0
 	if l := r.URL.Query().Get("limit"); l != "" {
 		fmt.Sscanf(l, "%d", &limit)
@@ -408,7 +408,17 @@ func (s *PublicServer) handleSessionTranscript(w http.ResponseWriter, r *http.Re
 		fmt.Sscanf(o, "%d", &offset)
 	}
 
-	result, err := transcript.ParseClaudeTranscript(*session.TranscriptPath, limit, offset)
+	// after_seq asks for what has arrived since the caller last looked, which
+	// is what a client watching a running session wants on every event. The
+	// epoch it quotes says which parse its seq numbers came from.
+	var result *transcript.TranscriptResult
+	if a := r.URL.Query().Get("after_seq"); a != "" {
+		afterSeq := -1
+		fmt.Sscanf(a, "%d", &afterSeq)
+		result, err = transcript.Delta(*session.TranscriptPath, r.URL.Query().Get("epoch"), afterSeq, limit)
+	} else {
+		result, err = transcript.Page(*session.TranscriptPath, limit, offset)
+	}
 	if err != nil {
 		jsonError(w, fmt.Sprintf("failed to read transcript: %v", err), http.StatusInternalServerError)
 		return

--- a/internal/server/transcript_test.go
+++ b/internal/server/transcript_test.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/transcript"
+)
+
+// transcriptEnv is a PublicServer over an in-memory store with one session
+// whose transcript is a file the test writes to.
+type transcriptEnv struct {
+	t    *testing.T
+	srv  *PublicServer
+	path string
+}
+
+func newTranscriptEnv(t *testing.T) *transcriptEnv {
+	t.Helper()
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
+	if err := db.UpsertSession(&store.Session{
+		SessionID:      "s1",
+		Source:         "claude",
+		CWD:            "/tmp",
+		Status:         "idle",
+		TranscriptPath: &path,
+	}); err != nil {
+		t.Fatalf("upsert session: %v", err)
+	}
+
+	shared := NewShared(db, notifications.NewManager(db), newStubBackend())
+	return &transcriptEnv{t: t, srv: &PublicServer{shared: shared}, path: path}
+}
+
+func (e *transcriptEnv) append(texts ...string) {
+	e.t.Helper()
+	f, err := os.OpenFile(e.path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		e.t.Fatalf("open transcript: %v", err)
+	}
+	defer f.Close()
+	for _, text := range texts {
+		line := fmt.Sprintf(
+			`{"type":"assistant","timestamp":"2026-08-12T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`,
+			text,
+		) + "\n"
+		if _, err := f.WriteString(line); err != nil {
+			e.t.Fatalf("append: %v", err)
+		}
+	}
+}
+
+func (e *transcriptEnv) get(query string) *transcript.TranscriptResult {
+	e.t.Helper()
+	r := httptest.NewRequest("GET", "/api/sessions/s1/transcript"+query, nil)
+	w := httptest.NewRecorder()
+	e.srv.handleSessionTranscript(w, r)
+	if w.Code != 200 {
+		e.t.Fatalf("GET %s = %d: %s", query, w.Code, w.Body.String())
+	}
+	var result transcript.TranscriptResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		e.t.Fatalf("decode %q: %v", w.Body.String(), err)
+	}
+	return &result
+}
+
+func texts(msgs []transcript.Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Content
+	}
+	return out
+}
+
+func TestTranscriptEndpointPagesFromTheEnd(t *testing.T) {
+	e := newTranscriptEnv(t)
+	e.append("one", "two", "three")
+
+	newest := e.get("?limit=2")
+	if got := texts(newest.Messages); fmt.Sprint(got) != "[two three]" {
+		t.Fatalf("newest page = %v, want [two three]", got)
+	}
+	if !newest.HasMore || newest.Total != 3 {
+		t.Fatalf("HasMore=%v Total=%d, want true and 3", newest.HasMore, newest.Total)
+	}
+
+	older := e.get("?limit=2&offset=2")
+	if got := texts(older.Messages); fmt.Sprint(got) != "[one]" {
+		t.Fatalf("older page = %v, want [one]", got)
+	}
+	if older.HasMore {
+		t.Fatal("HasMore true at the start of the transcript")
+	}
+}
+
+// A client watching a running session asks for what arrived since it last
+// looked, rather than pulling the page again on every event.
+func TestTranscriptEndpointServesDeltas(t *testing.T) {
+	e := newTranscriptEnv(t)
+	e.append("one", "two")
+
+	first := e.get("?limit=50")
+	newest := first.Messages[len(first.Messages)-1].Seq
+
+	e.append("three")
+
+	delta := e.get(fmt.Sprintf("?after_seq=%d&epoch=%s", newest, first.Epoch))
+	if got := texts(delta.Messages); fmt.Sprint(got) != "[three]" {
+		t.Fatalf("delta = %v, want [three]", got)
+	}
+	if delta.EpochChanged {
+		t.Fatal("epoch reported as changed after a plain append")
+	}
+}
+
+// A delta quoting an epoch that no longer holds has to come back as a whole
+// page, or the client would splice new messages onto a transcript that is no
+// longer the one they came from.
+func TestTranscriptEndpointResetsOnStaleEpoch(t *testing.T) {
+	e := newTranscriptEnv(t)
+	e.append("one", "two")
+	e.get("?limit=50")
+
+	if err := os.WriteFile(e.path, nil, 0o600); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	e.append("fresh")
+
+	delta := e.get("?after_seq=1&epoch=stale")
+	if !delta.EpochChanged {
+		t.Fatal("stale epoch not reported")
+	}
+	if got := texts(delta.Messages); fmt.Sprint(got) != "[fresh]" {
+		t.Fatalf("messages = %v, want the newest page [fresh]", got)
+	}
+}
+
+func TestTranscriptEndpointEmptyForSessionWithoutTranscript(t *testing.T) {
+	e := newTranscriptEnv(t)
+	if err := e.srv.shared.DB.UpsertSession(&store.Session{
+		SessionID: "s2",
+		Source:    "claude",
+		CWD:       "/tmp",
+		Status:    "idle",
+	}); err != nil {
+		t.Fatalf("upsert session: %v", err)
+	}
+
+	r := httptest.NewRequest("GET", "/api/sessions/s2/transcript", nil)
+	w := httptest.NewRecorder()
+	e.srv.handleSessionTranscript(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if total, _ := body["total"].(float64); total != 0 {
+		t.Fatalf("total = %v, want 0", body["total"])
+	}
+}

--- a/internal/transcript/reader.go
+++ b/internal/transcript/reader.go
@@ -27,6 +27,10 @@ const (
 
 // Message is a generic, provider-agnostic transcript message.
 type Message struct {
+	// Seq is the message's position in the transcript, counted from the start
+	// of the file. Transcripts are append-only, so a seq refers to the same
+	// message for as long as the epoch it was served under holds.
+	Seq       int                    `json:"seq"`
 	Role      MessageRole            `json:"role"`
 	Content   string                 `json:"content,omitempty"`
 	Tool      string                 `json:"tool,omitempty"`
@@ -43,6 +47,14 @@ type TranscriptResult struct {
 	Returned int       `json:"returned"`
 	Offset   int       `json:"offset"`
 	HasMore  bool      `json:"has_more"`
+	// Epoch identifies the parse the seq numbers belong to. It changes when a
+	// transcript stops being an extension of what was read before — a fork, a
+	// new file at the same path, a truncation.
+	Epoch string `json:"epoch,omitempty"`
+	// EpochChanged answers a delta request that named a stale epoch. The
+	// messages are then a fresh newest page rather than a delta, and the
+	// caller has to replace what it holds instead of appending.
+	EpochChanged bool `json:"epoch_changed,omitempty"`
 }
 
 // claudeEntry is the raw structure of a Claude .jsonl line.
@@ -84,30 +96,54 @@ func ParseClaudeTranscript(path string, limit, offset int) (*TranscriptResult, e
 
 // parseClaude parses the .jsonl stream, skipping any entry longer than max.
 func parseClaude(src io.Reader, max, limit, offset int) (*TranscriptResult, error) {
-	var allMessages []Message
+	allMessages, _, err := parseSegment(src, max, 0)
+	if err != nil {
+		return nil, err
+	}
+	return page(allMessages, limit, offset), nil
+}
+
+// parseSegment parses complete lines out of src, numbering messages from
+// firstSeq, and reports how many bytes it consumed.
+//
+// A transcript is read while it is being written, so the last line can be half
+// there. Only bytes up to and including the final newline are counted as
+// consumed: an unterminated tail is left for the next read rather than parsed
+// into a truncated message that would then be cached forever.
+func parseSegment(src io.Reader, max, firstSeq int) (msgs []Message, consumed int64, err error) {
 	r := bufio.NewReaderSize(src, 64*1024)
+	seq := firstSeq
 
 	for {
-		line, oversized, err := readLine(r, max)
+		line, oversized, raw, terminated, readErr := readSegmentLine(r, max)
+		if terminated {
+			consumed += raw
+		}
 		// An entry longer than the cap is a tool result carrying a whole file,
 		// and its tail is gone: parsing the head would only yield broken JSON.
-		if len(line) > 0 && !oversized {
+		if terminated && len(line) > 0 && !oversized {
 			var entry claudeEntry
 			if json.Unmarshal(line, &entry) == nil {
-				allMessages = append(allMessages, parseClaudeEntry(&entry)...)
+				for _, m := range parseClaudeEntry(&entry) {
+					m.Seq = seq
+					seq++
+					msgs = append(msgs, m)
+				}
 			}
 		}
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return msgs, consumed, nil
 			}
-			return nil, fmt.Errorf("read transcript: %w", err)
+			return nil, 0, fmt.Errorf("read transcript: %w", readErr)
 		}
 	}
+}
 
-	total := len(allMessages)
+// page slices a window off the end of msgs: offset=0 gets the last `limit`.
+func page(msgs []Message, limit, offset int) *TranscriptResult {
+	total := len(msgs)
 
-	// Paginate from the end: offset=0 gets the last `limit` messages
 	start := total - offset - limit
 	end := total - offset
 	if start < 0 {
@@ -120,27 +156,29 @@ func parseClaude(src io.Reader, max, limit, offset int) (*TranscriptResult, erro
 		end = total
 	}
 
-	page := allMessages[start:end]
-
 	return &TranscriptResult{
-		Messages: page,
+		Messages: msgs[start:end],
 		Total:    total,
-		Returned: len(page),
+		Returned: end - start,
 		Offset:   offset,
 		HasMore:  start > 0,
-	}, nil
+	}
 }
 
-// readLine returns the next line without its terminator, reporting whether it
-// was longer than max bytes — in which case the excess is read and dropped.
+// readSegmentLine returns the next line without its terminator, reporting
+// whether it was longer than max bytes — in which case the excess is read and
+// dropped — how many raw bytes it occupied, and whether it ended in a newline.
+//
 // bufio.Scanner cannot do this: one over-long line ends the scan, and a single
 // huge tool result would cost the caller the whole transcript.
-func readLine(r *bufio.Reader, max int) (line []byte, oversized bool, err error) {
+func readSegmentLine(r *bufio.Reader, max int) (line []byte, oversized bool, raw int64, terminated bool, err error) {
 	total := 0
 	for {
 		chunk, readErr := r.ReadSlice('\n')
 		more := errors.Is(readErr, bufio.ErrBufferFull)
+		raw += int64(len(chunk))
 		if !more {
+			terminated = len(chunk) > 0 && chunk[len(chunk)-1] == '\n'
 			chunk = trimEOL(chunk)
 		}
 		total += len(chunk)
@@ -153,7 +191,7 @@ func readLine(r *bufio.Reader, max int) (line []byte, oversized bool, err error)
 		if more {
 			continue
 		}
-		return line, total > max, readErr
+		return line, total > max, raw, terminated, readErr
 	}
 }
 

--- a/internal/transcript/reader_test.go
+++ b/internal/transcript/reader_test.go
@@ -7,32 +7,51 @@ import (
 	"testing"
 )
 
-func TestReadLineSplitsAndTrims(t *testing.T) {
+func TestReadSegmentLineSplitsAndTrims(t *testing.T) {
 	r := bufio.NewReaderSize(strings.NewReader("one\r\ntwo\nthree"), 16)
 
 	for _, want := range []string{"one", "two", "three"} {
-		line, oversized, err := readLine(r, 1024)
+		line, oversized, _, terminated, err := readSegmentLine(r, 1024)
 		if oversized {
-			t.Fatalf("readLine(%q) reported oversized", want)
+			t.Fatalf("readSegmentLine(%q) reported oversized", want)
 		}
 		if string(line) != want {
-			t.Fatalf("readLine = %q, want %q", line, want)
+			t.Fatalf("readSegmentLine = %q, want %q", line, want)
+		}
+		// "three" has no newline after it, which is how a line still being
+		// written looks.
+		if got := terminated; got != (want != "three") {
+			t.Fatalf("readSegmentLine(%q) terminated = %v", want, got)
 		}
 		if err != nil && want != "three" {
-			t.Fatalf("readLine(%q) error: %v", want, err)
+			t.Fatalf("readSegmentLine(%q) error: %v", want, err)
 		}
 	}
 }
 
-func TestReadLineDropsOversizedAndKeepsGoing(t *testing.T) {
+func TestReadSegmentLineCountsRawBytes(t *testing.T) {
+	r := bufio.NewReaderSize(strings.NewReader("one\r\ntwo\n"), 16)
+
+	_, _, raw, _, err := readSegmentLine(r, 1024)
+	if err != nil {
+		t.Fatalf("readSegmentLine: %v", err)
+	}
+	// The consumed count has to include the terminator, or an incremental read
+	// would re-read it and mistake it for a new line.
+	if raw != 5 {
+		t.Fatalf("raw = %d, want 5 (\"one\" plus CRLF)", raw)
+	}
+}
+
+func TestReadSegmentLineDropsOversizedAndKeepsGoing(t *testing.T) {
 	long := strings.Repeat("x", 5000)
 	// The bufio buffer is deliberately smaller than the line, so the read also
 	// spans several ErrBufferFull chunks.
 	r := bufio.NewReaderSize(strings.NewReader(long+"\nshort\n"), 16)
 
-	line, oversized, err := readLine(r, 100)
+	line, oversized, raw, _, err := readSegmentLine(r, 100)
 	if err != nil {
-		t.Fatalf("readLine: %v", err)
+		t.Fatalf("readSegmentLine: %v", err)
 	}
 	if !oversized {
 		t.Fatal("long line not reported as oversized")
@@ -40,13 +59,17 @@ func TestReadLineDropsOversizedAndKeepsGoing(t *testing.T) {
 	if len(line) != 100 {
 		t.Fatalf("kept %d bytes, want the 100-byte cap", len(line))
 	}
+	// Dropping the content must not drop the bytes from the count.
+	if raw != int64(len(long)+1) {
+		t.Fatalf("raw = %d, want %d", raw, len(long)+1)
+	}
 
-	line, oversized, err = readLine(r, 100)
+	line, oversized, _, _, err = readSegmentLine(r, 100)
 	if err != nil {
-		t.Fatalf("readLine after a dropped line: %v", err)
+		t.Fatalf("readSegmentLine after a dropped line: %v", err)
 	}
 	if oversized || string(line) != "short" {
-		t.Fatalf("readLine after a dropped line = %q (oversized=%v), want \"short\"", line, oversized)
+		t.Fatalf("readSegmentLine after a dropped line = %q (oversized=%v), want \"short\"", line, oversized)
 	}
 }
 

--- a/internal/transcript/store.go
+++ b/internal/transcript/store.go
@@ -1,0 +1,295 @@
+package transcript
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// A transcript is read once and kept. Re-reading one is what this package
+// exists to avoid: the file grows by a few KB per hook while a whole parse of a
+// large one costs ~200ms and ~75MB, and the answer is nearly always the same
+// messages as last time.
+//
+// Keeping them costs little. The parsed form is about a tenth of the file, some
+// 680 bytes a message, because the large things in a transcript — tool result
+// bodies, attachments, file snapshots — are exactly what the parser discards.
+// Every transcript one machine has ever written fits in a few tens of MB.
+const (
+	// maxEntries bounds the store by session count rather than bytes: a
+	// dropped entry costs one reparse, and a parse of the largest transcript
+	// seen in the wild is ~200ms.
+	//
+	// Set well past the number of sessions anyone watches at once, because the
+	// cost of being wrong is asymmetric: holding a transcript nobody reads
+	// costs a megabyte, while evicting one that is being read costs that parse
+	// on the next request. Every transcript on a heavily used machine — 146 of
+	// them — came to 12MB.
+	maxEntries = 256
+	// idleTTL drops sessions nobody is watching. A transcript nobody has asked
+	// about for an hour is unlikely to be asked about at all.
+	idleTTL = time.Hour
+	// tailWindow is how much of the already-read tail is re-checked to confirm
+	// the file is the same one, extended, rather than a different file that
+	// happens to be the same length or longer.
+	tailWindow = 4096
+)
+
+// Store holds parsed transcripts and brings them up to date by reading only
+// what was appended since the last read.
+type Store struct {
+	mu      sync.Mutex
+	entries map[string]*entry
+}
+
+// entry is one transcript's parsed state.
+type entry struct {
+	mu sync.Mutex
+
+	messages []Message
+	// parsedBytes is the offset just past the last complete line consumed.
+	parsedBytes int64
+	// tailHash covers the bytes just before parsedBytes, and is what tells an
+	// append apart from a rewrite that left the file the same size or longer.
+	tailHash uint64
+	// info identifies the file the messages were read from, so a new file at
+	// the same path is not mistaken for its predecessor.
+	info os.FileInfo
+	// epoch changes whenever the messages stop being an extension of what was
+	// served before, which is a caller's signal to discard what it holds.
+	epoch    string
+	lastUsed time.Time
+}
+
+// NewStore returns an empty store.
+func NewStore() *Store {
+	return &Store{entries: make(map[string]*entry)}
+}
+
+// shared is the store the daemon serves from. A transcript cache has no
+// configuration and no lifecycle — it is a memo of files on disk — so the
+// readers scattered across the daemon share one rather than being handed one.
+var shared = NewStore()
+
+// Page returns a window of a transcript, counted from the end: offset=0 is the
+// newest `limit` messages.
+func Page(path string, limit, offset int) (*TranscriptResult, error) {
+	return shared.Page(path, limit, offset)
+}
+
+// Delta returns the messages appended after seq, or a fresh newest page if the
+// epoch no longer holds.
+func Delta(path, epoch string, afterSeq, limit int) (*TranscriptResult, error) {
+	return shared.Delta(path, epoch, afterSeq, limit)
+}
+
+// Page returns a window of a transcript, counted from the end: offset=0 is the
+// newest `limit` messages.
+func (s *Store) Page(path string, limit, offset int) (*TranscriptResult, error) {
+	e, err := s.current(path)
+	if err != nil {
+		return nil, err
+	}
+	defer e.mu.Unlock()
+
+	result := page(e.messages, limit, offset)
+	result.Epoch = e.epoch
+	return result, nil
+}
+
+// Delta returns the messages appended after seq.
+//
+// A stale epoch means the transcript is no longer the one those seq numbers
+// were counted against — it was forked, replaced, or truncated. Answering with
+// a delta then would append messages to a conversation the caller no longer
+// has, so the answer is a newest page and a flag saying to start over.
+func (s *Store) Delta(path, epoch string, afterSeq, limit int) (*TranscriptResult, error) {
+	e, err := s.current(path)
+	if err != nil {
+		return nil, err
+	}
+	defer e.mu.Unlock()
+
+	if epoch != e.epoch {
+		result := page(e.messages, limit, 0)
+		result.Epoch = e.epoch
+		result.EpochChanged = true
+		return result, nil
+	}
+
+	start := afterSeq + 1
+	if start < 0 {
+		start = 0
+	}
+	if start > len(e.messages) {
+		start = len(e.messages)
+	}
+	fresh := e.messages[start:]
+	if limit > 0 && len(fresh) > limit {
+		fresh = fresh[len(fresh)-limit:]
+	}
+
+	return &TranscriptResult{
+		Messages: fresh,
+		Total:    len(e.messages),
+		Returned: len(fresh),
+		HasMore:  start > 0,
+		Epoch:    e.epoch,
+	}, nil
+}
+
+// current returns the entry for path, up to date, with its mutex held. The
+// caller unlocks.
+func (s *Store) current(path string) (*entry, error) {
+	s.mu.Lock()
+	e := s.entries[path]
+	if e == nil {
+		e = &entry{}
+		s.entries[path] = e
+	}
+	e.lastUsed = time.Now()
+	s.evictLocked()
+	s.mu.Unlock()
+
+	e.mu.Lock()
+	if err := e.refresh(path); err != nil {
+		e.mu.Unlock()
+		return nil, err
+	}
+	return e, nil
+}
+
+// evictLocked keeps the store bounded. Callers hold s.mu.
+func (s *Store) evictLocked() {
+	cutoff := time.Now().Add(-idleTTL)
+	for path, e := range s.entries {
+		if e.lastUsed.Before(cutoff) {
+			delete(s.entries, path)
+		}
+	}
+	for len(s.entries) > maxEntries {
+		var oldest string
+		var oldestAt time.Time
+		for path, e := range s.entries {
+			if oldest == "" || e.lastUsed.Before(oldestAt) {
+				oldest, oldestAt = path, e.lastUsed
+			}
+		}
+		delete(s.entries, oldest)
+	}
+}
+
+// refresh brings the entry level with the file on disk. Callers hold e.mu.
+//
+// Reading is the only thing that keeps the entry current, which is what makes
+// this safe: an entry that only ever advances when it is read cannot be stale
+// at the moment it is served. A stat is ~2µs, so checking costs nothing.
+func (e *entry) refresh(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat transcript: %w", err)
+	}
+	// Same file, same length, same moment of writing: nothing has happened
+	// since the last read. This is the common case while a session sits idle,
+	// and it costs one stat.
+	//
+	// The modification time carries the check that length alone would miss —
+	// a file rewritten to the same length is a different transcript.
+	if e.info != nil && os.SameFile(e.info, info) &&
+		info.Size() == e.parsedBytes && info.ModTime().Equal(e.info.ModTime()) {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open transcript: %w", err)
+	}
+	defer f.Close()
+
+	if e.extends(f, info) {
+		return e.appendFrom(f, info)
+	}
+	return e.rebuild(f, info)
+}
+
+// extends reports whether the file is the one already parsed, with more written
+// on the end.
+//
+// Size alone would not answer it: a file replaced by a longer one also grows.
+// Claude Code only ever appends — a rewind adds a branch rather than cutting
+// one — so a failure here means something else rewrote the file, and the safe
+// answer is to parse it again.
+func (e *entry) extends(f *os.File, info os.FileInfo) bool {
+	if e.info == nil || !os.SameFile(e.info, info) || info.Size() < e.parsedBytes {
+		return false
+	}
+	sum, err := hashTail(f, e.parsedBytes)
+	return err == nil && sum == e.tailHash
+}
+
+// rebuild parses the whole file. Callers hold e.mu.
+func (e *entry) rebuild(f *os.File, info os.FileInfo) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek transcript: %w", err)
+	}
+
+	msgs, consumed, err := parseSegment(f, maxLineBytes, 0)
+	if err != nil {
+		return err
+	}
+
+	e.messages = msgs
+	e.parsedBytes = consumed
+	e.info = info
+	e.epoch = uuid.NewString()
+	return e.rehashTail(f)
+}
+
+// appendFrom parses the bytes written since the last read. Callers hold e.mu.
+func (e *entry) appendFrom(f *os.File, info os.FileInfo) error {
+	if _, err := f.Seek(e.parsedBytes, io.SeekStart); err != nil {
+		return fmt.Errorf("seek transcript: %w", err)
+	}
+
+	msgs, consumed, err := parseSegment(f, maxLineBytes, len(e.messages))
+	if err != nil {
+		return err
+	}
+
+	e.messages = append(e.messages, msgs...)
+	e.parsedBytes += consumed
+	e.info = info
+	return e.rehashTail(f)
+}
+
+func (e *entry) rehashTail(f *os.File) error {
+	sum, err := hashTail(f, e.parsedBytes)
+	if err != nil {
+		return err
+	}
+	e.tailHash = sum
+	return nil
+}
+
+// hashTail hashes the window of bytes ending at end.
+func hashTail(f *os.File, end int64) (uint64, error) {
+	if end == 0 {
+		return 0, nil
+	}
+	start := end - tailWindow
+	if start < 0 {
+		start = 0
+	}
+	buf := make([]byte, end-start)
+	if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
+		return 0, fmt.Errorf("read transcript tail: %w", err)
+	}
+	h := fnv.New64a()
+	h.Write(buf)
+	return h.Sum64(), nil
+}

--- a/internal/transcript/store_test.go
+++ b/internal/transcript/store_test.go
@@ -1,0 +1,382 @@
+package transcript
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// entryLine is one assistant message as Claude writes it.
+func entryLine(text string) string {
+	return fmt.Sprintf(
+		`{"type":"assistant","timestamp":"2026-08-12T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`,
+		text,
+	) + "\n"
+}
+
+// writeTranscript creates a transcript holding the named messages.
+func writeTranscript(t *testing.T, texts ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	var b strings.Builder
+	for _, text := range texts {
+		b.WriteString(entryLine(text))
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func appendTo(t *testing.T, path string, texts ...string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	defer f.Close()
+	for _, text := range texts {
+		if _, err := f.WriteString(entryLine(text)); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+}
+
+func contents(msgs []Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Content
+	}
+	return out
+}
+
+func TestStoreMatchesFullParse(t *testing.T) {
+	path := writeTranscript(t, "one", "two", "three")
+
+	got, err := NewStore().Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	want, err := ParseClaudeTranscript(path, 10, 0)
+	if err != nil {
+		t.Fatalf("ParseClaudeTranscript: %v", err)
+	}
+
+	if fmt.Sprint(contents(got.Messages)) != fmt.Sprint(contents(want.Messages)) {
+		t.Fatalf("store = %v, full parse = %v", contents(got.Messages), contents(want.Messages))
+	}
+	if got.Total != want.Total {
+		t.Fatalf("Total = %d, want %d", got.Total, want.Total)
+	}
+	if got.Epoch == "" {
+		t.Fatal("no epoch on a page")
+	}
+}
+
+func TestStoreServesAppendedMessages(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	appendTo(t, path, "three")
+
+	second, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page after append: %v", err)
+	}
+	if got := contents(second.Messages); fmt.Sprint(got) != "[one two three]" {
+		t.Fatalf("messages = %v, want [one two three]", got)
+	}
+	// An append extends what was already parsed, so the caller's seq numbers
+	// stay good and it can keep what it holds.
+	if second.Epoch != first.Epoch {
+		t.Fatal("epoch changed on a plain append")
+	}
+}
+
+func TestStoreLeavesPartialLineForNextRead(t *testing.T) {
+	path := writeTranscript(t, "one")
+	s := NewStore()
+
+	if _, err := s.Page(path, 10, 0); err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	// Half an entry, as seen when a read races the agent writing.
+	half := entryLine("two")
+	half = half[:len(half)/2]
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString(half); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	f.Close()
+
+	partial, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page with a partial line: %v", err)
+	}
+	if got := contents(partial.Messages); fmt.Sprint(got) != "[one]" {
+		t.Fatalf("messages = %v, want [one]: a half-written line must not be served", got)
+	}
+
+	// Finish the line the way the writer would.
+	rest := entryLine("two")[len(half):]
+	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("reopen for append: %v", err)
+	}
+	if _, err := f.WriteString(rest); err != nil {
+		t.Fatalf("append rest: %v", err)
+	}
+	f.Close()
+
+	complete, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page after completing the line: %v", err)
+	}
+	if got := contents(complete.Messages); fmt.Sprint(got) != "[one two]" {
+		t.Fatalf("messages = %v, want [one two]: the completed line must appear exactly once", got)
+	}
+}
+
+func TestStoreRebuildsOnTruncation(t *testing.T) {
+	path := writeTranscript(t, "one", "two", "three")
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(entryLine("only")), 0o600); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	second, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page after truncation: %v", err)
+	}
+	if got := contents(second.Messages); fmt.Sprint(got) != "[only]" {
+		t.Fatalf("messages = %v, want [only]", got)
+	}
+	if second.Epoch == first.Epoch {
+		t.Fatal("epoch survived a truncation; callers would keep stale messages")
+	}
+}
+
+func TestStoreRebuildsWhenRewrittenToTheSameLength(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	// Same byte count, different content: size alone cannot catch this.
+	if err := os.WriteFile(path, []byte(entryLine("one")+entryLine("XXX")), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	second, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page after rewrite: %v", err)
+	}
+	if got := contents(second.Messages); fmt.Sprint(got) != "[one XXX]" {
+		t.Fatalf("messages = %v, want [one XXX]", got)
+	}
+	if second.Epoch == first.Epoch {
+		t.Fatal("epoch survived a same-length rewrite")
+	}
+}
+
+func TestStoreRebuildsWhenTheFileIsReplaced(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(entryLine("one")+entryLine("two")), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	// A fork lands a different file at the path, longer than the original —
+	// growth that is not an append.
+	replacement := filepath.Join(dir, "fork.jsonl")
+	if err := os.WriteFile(replacement, []byte(entryLine("one")+entryLine("two")+entryLine("forked")), 0o600); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	second, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page after replacement: %v", err)
+	}
+	if got := contents(second.Messages); fmt.Sprint(got) != "[one two forked]" {
+		t.Fatalf("messages = %v, want [one two forked]", got)
+	}
+	if second.Epoch == first.Epoch {
+		t.Fatal("epoch survived the file being replaced")
+	}
+}
+
+func TestStoreDeltaReturnsOnlyWhatIsNew(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	newest := first.Messages[len(first.Messages)-1].Seq
+
+	appendTo(t, path, "three", "four")
+
+	delta, err := s.Delta(path, first.Epoch, newest, 0)
+	if err != nil {
+		t.Fatalf("Delta: %v", err)
+	}
+	if got := contents(delta.Messages); fmt.Sprint(got) != "[three four]" {
+		t.Fatalf("delta = %v, want [three four]", got)
+	}
+	if delta.EpochChanged {
+		t.Fatal("delta reported an epoch change after a plain append")
+	}
+	if delta.Total != 4 {
+		t.Fatalf("Total = %d, want 4", delta.Total)
+	}
+}
+
+func TestStoreDeltaOnAStaleEpochResets(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	first, err := s.Page(path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(entryLine("fresh")), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	delta, err := s.Delta(path, first.Epoch, 1, 10)
+	if err != nil {
+		t.Fatalf("Delta: %v", err)
+	}
+	if !delta.EpochChanged {
+		t.Fatal("stale epoch not reported; the caller would append to a transcript it no longer has")
+	}
+	if got := contents(delta.Messages); fmt.Sprint(got) != "[fresh]" {
+		t.Fatalf("messages = %v, want the newest page [fresh]", got)
+	}
+}
+
+func TestStoreSeqSurvivesPaging(t *testing.T) {
+	path := writeTranscript(t, "one", "two", "three", "four")
+	s := NewStore()
+
+	newest, err := s.Page(path, 2, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	older, err := s.Page(path, 2, 2)
+	if err != nil {
+		t.Fatalf("Page(offset=2): %v", err)
+	}
+
+	if got := contents(newest.Messages); fmt.Sprint(got) != "[three four]" {
+		t.Fatalf("newest page = %v", got)
+	}
+	if got := contents(older.Messages); fmt.Sprint(got) != "[one two]" {
+		t.Fatalf("older page = %v", got)
+	}
+	// seq numbers the whole transcript, not the page, or a client could not
+	// stitch pages together or ask for a delta after the newest one it holds.
+	if older.Messages[0].Seq != 0 || newest.Messages[1].Seq != 3 {
+		t.Fatalf("seqs = %d…%d, want 0…3", older.Messages[0].Seq, newest.Messages[1].Seq)
+	}
+	if !newest.HasMore {
+		t.Fatal("HasMore false with two older messages on the file")
+	}
+}
+
+func TestStoreConcurrentReadersSeeOneTranscript(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if _, err := s.Page(path, 10, 0); err != nil {
+					t.Errorf("Page: %v", err)
+					return
+				}
+				if i == 0 {
+					appendTo(t, path, fmt.Sprintf("more-%d", j))
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	final, err := s.Page(path, 100, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if final.Total != 22 {
+		t.Fatalf("Total = %d, want 22", final.Total)
+	}
+	for i, m := range final.Messages {
+		if m.Seq != i {
+			t.Fatalf("message %d has seq %d: seqs must stay dense and ordered", i, m.Seq)
+		}
+	}
+}
+
+func TestStoreMissingFile(t *testing.T) {
+	if _, err := NewStore().Page(filepath.Join(t.TempDir(), "absent.jsonl"), 10, 0); err == nil {
+		t.Fatal("no error for a transcript that is not there")
+	}
+}
+
+func BenchmarkStoreWarmPage(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "transcript.jsonl")
+	var sb strings.Builder
+	for i := 0; i < 5000; i++ {
+		sb.WriteString(entryLine(fmt.Sprintf("message %d with a little padding to look real", i)))
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		b.Fatalf("write: %v", err)
+	}
+
+	s := NewStore()
+	if _, err := s.Page(path, 50, 0); err != nil {
+		b.Fatalf("warm: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.Page(path, 50, 0); err != nil {
+			b.Fatalf("Page: %v", err)
+		}
+	}
+}

--- a/mobile/lib/models/message.dart
+++ b/mobile/lib/models/message.dart
@@ -1,5 +1,8 @@
 /// Generic, provider-agnostic transcript message.
 class Message {
+  /// Position in the whole transcript, not in the page it arrived in. Asking
+  /// for what came after it is how the app follows a running session.
+  final int seq;
   final String role; // user, assistant, tool_use, tool_result
   final String? content;
   final String? tool;
@@ -9,6 +12,7 @@ class Message {
   final String timestamp;
 
   Message({
+    this.seq = 0,
     required this.role,
     this.content,
     this.tool,
@@ -20,6 +24,7 @@ class Message {
 
   factory Message.fromJson(Map<String, dynamic> json) {
     return Message(
+      seq: json['seq'] as int? ?? 0,
       role: json['role'] as String,
       content: json['content'] as String?,
       tool: json['tool'] as String?,
@@ -59,12 +64,21 @@ class TranscriptResult {
   final int offset;
   final bool hasMore;
 
+  /// Which parse the seq numbers count against.
+  final String epoch;
+
+  /// Set when a delta was asked for under an epoch that no longer holds: the
+  /// messages are a fresh newest page and replace what is held.
+  final bool epochChanged;
+
   TranscriptResult({
     required this.messages,
     required this.total,
     required this.returned,
     required this.offset,
     required this.hasMore,
+    this.epoch = '',
+    this.epochChanged = false,
   });
 
   factory TranscriptResult.fromJson(Map<String, dynamic> json) {
@@ -75,6 +89,8 @@ class TranscriptResult {
       returned: json['returned'] as int? ?? 0,
       offset: json['offset'] as int? ?? 0,
       hasMore: json['has_more'] as bool? ?? false,
+      epoch: json['epoch'] as String? ?? '',
+      epochChanged: json['epoch_changed'] as bool? ?? false,
     );
   }
 }

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -49,6 +49,15 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
   bool _sending = false;
   int _total = 0;
   bool _hasMore = false;
+  bool _loadingOlder = false;
+
+  /// Which parse the held seq numbers count against, quoted back when asking
+  /// for a delta so the daemon can say when it no longer holds.
+  String _epoch = '';
+
+  /// Messages per request. A page is what fills a screen and a little more,
+  /// not the whole conversation: the rest arrives as the reader scrolls.
+  static const int _pageSize = 50;
   StreamSubscription<SSEEvent>? _eventSub;
   String _currentVerb = randomClaudeVerb();
   Timer? _verbTimer;
@@ -95,11 +104,11 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
         if (event.type == 'session_status' &&
             data['session_id'] == widget.session.sessionId) {
           debugPrint(
-            '[Transcript][${widget.session.sessionId}] SSE session_status → reload transcript (status=${data['status']})',
+            '[Transcript][${widget.session.sessionId}] SSE session_status → read new messages (status=${data['status']})',
           );
           _transcriptDebounce?.cancel();
           _transcriptDebounce = Timer(const Duration(milliseconds: 500), () {
-            _loadTranscript();
+            _loadNewMessages();
           });
         }
         if (event.type == 'notification' ||
@@ -173,7 +182,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       debugPrint('[Transcript][$sid] no SSE service, aborting');
       return;
     }
-    final result = await sse.fetchTranscript(sid, limit: 200);
+    final result = await sse.fetchTranscript(sid, limit: _pageSize);
     debugPrint(
       '[Transcript][$sid] fetchTranscript result=${result == null ? "null" : "total=${result.total} returned=${result.messages.length} hasMore=${result.hasMore}"}',
     );
@@ -182,6 +191,7 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
         _messages = result.messages;
         _total = result.total;
         _hasMore = result.hasMore;
+        _epoch = result.epoch;
         _loading = false;
       });
     } else if (mounted) {
@@ -190,6 +200,66 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       );
       setState(() => _loading = false);
     }
+  }
+
+  /// Pulls what the agent has written since the last message held.
+  ///
+  /// A status event fires several times a turn, and the answer to it is
+  /// usually one message. Asking for the page again would rebuild the list and
+  /// throw away where the reader was.
+  Future<void> _loadNewMessages() async {
+    final sse = _sse;
+    if (sse == null) return;
+    if (_messages.isEmpty || _epoch.isEmpty) {
+      await _loadTranscript();
+      return;
+    }
+
+    final result = await sse.fetchTranscript(
+      widget.session.sessionId,
+      limit: _pageSize,
+      afterSeq: _messages.last.seq,
+      epoch: _epoch,
+    );
+    if (result == null || !mounted) return;
+
+    setState(() {
+      if (result.epochChanged) {
+        // The transcript those seq numbers counted against is gone — forked,
+        // or replaced. Start from what is there now.
+        _messages = result.messages;
+        _epoch = result.epoch;
+        _hasMore = result.hasMore;
+      } else if (result.messages.isNotEmpty) {
+        _messages = [..._messages, ...result.messages];
+      }
+      _total = result.total;
+      _loading = false;
+    });
+  }
+
+  /// Reads the page before the oldest message held, for a reader scrolling
+  /// back through the conversation.
+  Future<void> _loadOlder() async {
+    final sse = _sse;
+    if (sse == null || _loadingOlder || !_hasMore) return;
+    setState(() => _loadingOlder = true);
+
+    final result = await sse.fetchTranscript(
+      widget.session.sessionId,
+      limit: _pageSize,
+      offset: _messages.length,
+    );
+    if (!mounted) return;
+
+    setState(() {
+      if (result != null) {
+        _messages = [...result.messages, ..._messages];
+        _hasMore = result.hasMore;
+        _total = result.total;
+      }
+      _loadingOlder = false;
+    });
   }
 
   Future<void> _loadGitStatus() async {
@@ -940,17 +1010,18 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       itemCount: itemCount,
       itemBuilder: (context, index) {
-        // Last item in reversed list = "earlier messages" banner
+        // Last item in the reversed list, so the top of the screen: building
+        // it means the reader has scrolled to the start of what is held, and
+        // the page before it is what they are reaching for.
         if (_hasMore && index == itemCount - 1) {
-          return Center(
+          WidgetsBinding.instance.addPostFrameCallback((_) => _loadOlder());
+          return const Center(
             child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Text(
-                '${_total - _messages.length} earlier messages',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+              padding: EdgeInsets.all(12),
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
               ),
             ),
           );

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -570,14 +570,22 @@ class DaemonAPIService extends ChangeNotifier {
     return [];
   }
 
+  /// Reads a page of a transcript, or — given [afterSeq] and [epoch] — only
+  /// what has been written since that message. Following a running session
+  /// through deltas is what stops an event from costing a whole page.
   Future<TranscriptResult?> fetchTranscript(
     String sessionId, {
-    int limit = 200,
+    int limit = 50,
     int offset = 0,
+    int? afterSeq,
+    String? epoch,
   }) async {
     try {
+      final query = afterSeq != null
+          ? 'limit=$limit&after_seq=$afterSeq&epoch=${Uri.encodeQueryComponent(epoch ?? '')}'
+          : 'limit=$limit&offset=$offset';
       final resp = await _api.get(
-        '/api/sessions/$sessionId/transcript?limit=$limit&offset=$offset',
+        '/api/sessions/$sessionId/transcript?$query',
       );
       debugPrint(
         '[$hostId] fetchTranscript[$sessionId] status=${resp.statusCode}',


### PR DESCRIPTION
## Summary

`GET /api/sessions/<id>/transcript` re-read and re-parsed the whole `.jsonl` on
every call, and clients called it on every hook event. On a 17.6MB transcript
that is **205ms and 75.6MB allocated** to produce a **0.06MB** reply — the same
messages as last time, several times a turn, once per viewer, plus autotitle's
own full parse on every `Stop`.

Transcripts are append-only, so the store parses one once and afterwards reads
only the bytes that arrived. **Warm page: 2.7µs.** Parsed messages are ~10% of
the file (680 B/message), so all 146 transcripts on a heavily used machine come
to 12MB.

Spec: `docs/specs/38-transcript-incremental-serving.md`.

## What changed

- **`internal/transcript/store.go`** — parses once, keeps the messages, and
  brings them up to date from a stat plus the appended bytes. Bounded by an LRU
  and an idle TTL; the read path is the only thing that advances it, so it
  cannot serve something stale.
- **Contract** — messages carry `seq`, responses carry `epoch`, and
  `?after_seq=&epoch=` returns just what is new. A stale epoch answers with a
  whole page and `epoch_changed`, which is the fork / truncation / restart path.
  `limit`/`offset` keep their meaning.
- **Desktop & mobile** — 50 messages a page instead of 200, deltas on events
  rather than refetching page 0, and paging backwards as the reader scrolls.
  Mobile had no way to reach older messages at all: it rendered a count of them
  with nothing behind it.
- **Autotitle** — reads through the store instead of full-parsing per turn.

## The assumption, checked

Measured across 145 transcripts before relying on any of it:

- A live file sampled for a minute grew monotonically; the first 100KB hashed
  the same every time.
- No file rewrites an entry in place (no duplicate uuids), and `sessionId`
  always matches the filename — a resumed session appends to the file it had.
- Compaction appends. A fork copies into a **new** file, tagging entries with
  `forkedFrom`, leaving the original alone.
- A rewind appends a branch rather than truncating, so the file only grows.

The truncation guard is therefore defensive: a file that shrinks, changes inode,
or stops matching the tail it was read from is parsed again under a new epoch.

## Test plan

- [x] `go test ./...`, `-race` on the new packages, `go vet` clean
- [x] Store output compared against the old full parse across **all 146
      transcripts on disk** — identical messages, dense seq numbering
- [x] Covered: append, partial trailing line, truncation, same-length rewrite,
      file replaced under the path, delta, stale epoch, concurrent readers
- [x] Endpoint tests for paging, deltas, and the epoch reset
- [x] `tsc --noEmit` clean; `flutter analyze` clean; 57 Flutter tests pass
- [x] Benchmark: warm page 3.45µs / 400B / 3 allocs
- [ ] Mobile UI exercised against a daemon running this branch — the dev build
      is installed on device, but the daemon on this machine still predates it