### PR TITLE
Compact session list, and a rename that renames the right session

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -8,7 +8,7 @@ import type { TerminalManager } from './terminals.ts'
 import type { ThemeRegistry } from './themes.ts'
 import { DEFAULT_INTENSITY } from '../shared/theme/backdrop.ts'
 import type { BackdropSpec } from '../shared/theme/vscode.ts'
-import type { AppearancePrefs, BackdropState } from '../shared/models.ts'
+import type { AppearancePrefs, BackdropState, Density } from '../shared/models.ts'
 
 /**
  * REST calls the renderer may make. An allow-list rather than a reflective
@@ -160,10 +160,12 @@ export function registerIpc(deps: IpcDeps): void {
     glass: boolean
     glassSupported: boolean
     proseSize: number
+    density: Density
   } => ({
     theme: themes.active(),
     terminal: themes.activeTerminal(),
     proseSize: themes.getPrefs().proseSize,
+    density: themes.getPrefs().density,
     // A property of the chosen theme, not a setting of its own: picking a
     // glass theme is the whole of the request. A theme with no backdrop of its
     // own is gated on the platform, because a preference to show a backdrop

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 
 import { mergeThemes, resolveTheme, type HeliosTheme, type ThemeMode } from '../shared/theme/resolve.ts'
 import { parseJsonc, type BackdropSpec, type VSCodeTheme } from '../shared/theme/vscode.ts'
-import type { AppearancePrefs, ThemeSummary } from '../shared/models.ts'
+import type { AppearancePrefs, Density, ThemeSummary } from '../shared/models.ts'
 
 export const DEFAULT_APPEARANCE: AppearancePrefs = {
   mode: 'system',
@@ -13,6 +13,7 @@ export const DEFAULT_APPEARANCE: AppearancePrefs = {
   darkTheme: 'dark-modern',
   terminalTheme: 'match',
   proseSize: 14,
+  density: 'comfortable',
 }
 
 /* Clamped rather than trusted: the file is hand-editable, and a zero or a
@@ -22,6 +23,12 @@ const MAX_PROSE = 28
 
 /** What a backdrop image may be, and therefore what the media scheme serves. */
 const IMAGE_TYPES = new Set(['.png', '.jpg', '.jpeg', '.webp'])
+
+/* Anything else in the file — a typo, an older name — reads as the roomy
+   layout, which is the one that shows everything. */
+function density(value: unknown): Density {
+  return value === 'compact' ? 'compact' : 'comfortable'
+}
 
 function proseSize(value: unknown): number {
   const size = Math.round(Number(value))
@@ -62,6 +69,7 @@ export class ThemeRegistry {
         darkTheme: parsed.darkTheme ?? DEFAULT_APPEARANCE.darkTheme,
         terminalTheme: parsed.terminalTheme ?? DEFAULT_APPEARANCE.terminalTheme,
         proseSize: proseSize(parsed.proseSize ?? DEFAULT_APPEARANCE.proseSize),
+        density: density(parsed.density ?? DEFAULT_APPEARANCE.density),
       }
     } catch {
       this.prefs = { ...DEFAULT_APPEARANCE }
@@ -201,6 +209,7 @@ export class ThemeRegistry {
   setPrefs(next: Partial<AppearancePrefs>): AppearancePrefs {
     this.prefs = { ...this.prefs, ...next }
     this.prefs.proseSize = proseSize(this.prefs.proseSize)
+    this.prefs.density = density(this.prefs.density)
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
     fs.writeFileSync(this.file, JSON.stringify(this.prefs, null, 2))
     return this.getPrefs()

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-import { applyProseSize, applyTheme } from '../shared/theme/apply.ts'
+import type { Density } from '../shared/models.ts'
+import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
 
 interface ThemeBoot {
@@ -9,6 +10,7 @@ interface ThemeBoot {
   glass: boolean
   glassSupported: boolean
   proseSize: number
+  density: Density
 }
 
 /**
@@ -59,6 +61,7 @@ const boot = ipcRenderer.sendSync('theme:boot') as ThemeBoot
 const paint = (): void => {
   applyTheme(document.documentElement, boot.theme, boot.glass)
   applyProseSize(document.documentElement, boot.proseSize)
+  applyDensity(document.documentElement, boot.density)
 }
 
 if (document.documentElement) {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -11,11 +11,13 @@ export interface ThemePayload {
   glassSupported: boolean
   /** Reading size for rendered markdown, in px. */
   proseSize: number
+  density: Density
 }
 import type {
   AppearancePrefs,
   BackdropState,
   CommandInfo,
+  Density,
   DeviceInfo,
   DirectoryInfo,
   FileContent,
@@ -32,12 +34,12 @@ import type {
   Notification,
   NotificationPrefs,
   ProviderInfo,
-  Session,
-  ThemeSummary,
   SSEEvent,
+  Session,
   Subagent,
   TabStatus,
   TerminalInfo,
+  ThemeSummary,
   TranscriptPage,
   Worktree,
   WriteResult,

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -120,7 +120,13 @@ export function Detail(): JSX.Element {
     <div className="detail">
       {hostId && session && (
         <>
-          <SessionHeader hostId={hostId} session={session} />
+          {/* Keyed: the header holds a rename in progress, and switching
+              sessions has to end it rather than carry it across. */}
+          <SessionHeader
+            key={`${hostId}:${session.session_id}`}
+            hostId={hostId}
+            session={session}
+          />
 
           {/* One strip: the panels, the session's own terminal, then the
               shells opened beside it. Tabs within a tab would be a hierarchy
@@ -376,7 +382,18 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
             }}
           />
         ) : (
-          <h1 onDoubleClick={() => setRenaming(true)}>{sessionLabel(session)}</h1>
+          /* Seeded on open rather than kept in step with the session: the
+             draft only means anything while the field is up, and the title can
+             have moved under it since — the daemon names a session itself
+             after the first exchange. */
+          <h1
+            onDoubleClick={() => {
+              setTitle(session.title ?? '')
+              setRenaming(true)
+            }}
+          >
+            {sessionLabel(session)}
+          </h1>
         )}
         <span className="detail-cwd" title={session.cwd}>
           {session.cwd}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -7,7 +7,13 @@ import { ALERT_TYPES } from '../../shared/notifications.ts'
 import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
-import type { AppearancePrefs, BackdropState, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
+import type {
+  AppearancePrefs,
+  BackdropState,
+  Density,
+  NotificationPrefs,
+  ThemeSummary,
+} from '../../shared/models.ts'
 
 /**
  * Which types can be silenced, in the order the phone lists them. Keeping the
@@ -179,6 +185,11 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         />
 
         <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
+
+        <SessionDensity
+          density={appearance?.density}
+          onPick={(density) => void setTheme({ density })}
+        />
 
         <Backdrop />
 
@@ -729,6 +740,38 @@ function previewOf(
   const stops = palette.map(parseColor).filter((c): c is Rgb => c !== null)
   const base = parseColor(theme.vars['--surface'] ?? '') ?? (parseColor('#101014') as Rgb)
   return backdropValue({ style, intensity, ...(image ? { image } : {}) }, base, stops)
+}
+
+/** How much of each session the sidebar shows. */
+function SessionDensity({
+  density,
+  onPick,
+}: {
+  density: Density | undefined
+  onPick: (density: Density) => void
+}): JSX.Element {
+  const options: { value: Density; label: string }[] = [
+    { value: 'comfortable', label: 'Comfortable' },
+    { value: 'compact', label: 'Compact' },
+  ]
+
+  return (
+    <div className="theme-picker">
+      <span className="theme-picker-label">Session list</span>
+      <select
+        value={density ?? 'comfortable'}
+        disabled={density === undefined}
+        onChange={(event) => onPick(event.target.value as Density)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <span className="modal-note">Compact is one line a session; hover shows the rest.</span>
+    </div>
+  )
 }
 
 function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from 'react'
 
 import { api, bridge, statusOf } from './bridge.ts'
-import { applyProseSize, applyTheme } from '../shared/theme/apply.ts'
+import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
 import type { XtermTheme } from '../shared/theme/resolve.ts'
@@ -195,9 +195,10 @@ class Store {
     // The preload painted the boot theme already; this keeps up with changes
     // made afterwards, whether from the settings dialog or the OS switching
     // between light and dark underneath us.
-    bridge.theme.onChanged(({ theme, terminal, glass, proseSize }) => {
+    bridge.theme.onChanged(({ theme, terminal, glass, proseSize, density }) => {
       applyTheme(document.documentElement, theme, glass)
       applyProseSize(document.documentElement, proseSize)
+      applyDensity(document.documentElement, density)
       this.set({ terminalTheme: terminal })
     })
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -917,6 +917,93 @@ small {
   opacity: 1;
 }
 
+/* ── Compact sidebar ────────────────────────────────────────────────────────
+   One line a session: the status dot, the title, and how long ago. Text stays
+   the size it is elsewhere — the space saved is the working directory, the
+   model line and the padding around them, not the reading. */
+
+/* Square, and touching. At this height a rounded card reads as a tile, and a
+   column of tiles reads as a grid rather than a list; square rows butted
+   together read as one list, which is what compact is for. Nothing separates
+   them but the hover and the selection, so the eye follows the pointer instead
+   of counting edges. */
+[data-density='compact'] .session-card {
+  margin-bottom: 0;
+  border-radius: 0;
+}
+
+/* The selected row is the one place a border would show, and on a row with no
+   gap around it the border shifts the text by a pixel. The background says it
+   without moving anything. */
+[data-density='compact'] .session-card.selected {
+  border-color: transparent;
+}
+
+[data-density='compact'] .card-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 8px 14px;
+}
+
+/* The status row's children become the row's children, so the title can sit
+   among them rather than under them. */
+[data-density='compact'] .card-top {
+  display: contents;
+}
+
+/* The chip keeps its dot and loses its word: the colour already says it, and
+   the stripe down the card says it again. */
+[data-density='compact'] .chip {
+  order: 1;
+  height: auto;
+  padding: 0;
+  background: none;
+  font-size: 0;
+  gap: 0;
+}
+
+[data-density='compact'] .card-title {
+  order: 2;
+  flex: 1;
+  min-width: 0;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.4;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-density='compact'] .cold-mark {
+  order: 3;
+}
+
+[data-density='compact'] .pin {
+  order: 4;
+}
+
+/* Kept in the row: a session waiting on an answer should not need a hover to
+   say so. */
+[data-density='compact'] .badge {
+  order: 5;
+}
+
+[data-density='compact'] .card-top .grow {
+  display: none;
+}
+
+[data-density='compact'] .card-top .time {
+  order: 6;
+  font-size: 11px;
+}
+
+[data-density='compact'] .card-cwd,
+[data-density='compact'] .card-bottom {
+  display: none;
+}
+
 .check {
   display: flex;
   align-items: center;

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -487,7 +487,11 @@ export interface AppearancePrefs {
   terminalTheme: string
   /** Body size of rendered markdown, in px; headings and tables scale with it. */
   proseSize: number
+  /** How much of a session the sidebar shows: everything, or one line each. */
+  density: Density
 }
+
+export type Density = 'comfortable' | 'compact'
 
 /**
  * What the backdrop picker shows, for whichever theme is active.

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -1,3 +1,4 @@
+import type { Density } from '../models.ts'
 import type { HeliosTheme } from './resolve.ts'
 
 /**
@@ -14,6 +15,16 @@ import type { HeliosTheme } from './resolve.ts'
 /** The reading size for rendered markdown, which the .md rules scale from. */
 export function applyProseSize(root: HTMLElement, size: number): void {
   root.style.setProperty('--prose-size', `${size}px`)
+}
+
+/**
+ * How much of a session the sidebar shows.
+ *
+ * An attribute rather than variables, for the same reason as glass: density
+ * changes which parts of a card are drawn, not what colour or size they are.
+ */
+export function applyDensity(root: HTMLElement, density: Density): void {
+  root.dataset.density = density
 }
 
 export function applyTheme(root: HTMLElement, theme: Pick<HeliosTheme, 'vars'>, glass = false): void {


### PR DESCRIPTION
Two desktop changes: one bug that was quietly writing the wrong data, one setting.

## The rename bug (`86f935e`)

`SessionHeader` seeded its draft title with `useState(session.title ?? '')` — once,
on first mount — and the component survives switching sessions. So opening the
rename on a second session showed the first one's title.

It did not stop at showing. Blur compares the draft against the session currently
on screen and saves when they differ:

```ts
if (title !== (session.title ?? '')) {
  void run(() => api(hostId).patchSession(session.session_id, { title }))
}
```

Renaming session B after having visited A therefore wrote **A's title onto B**.
Worth a look at your session lists for titles that arrived from somewhere else.

Fixed by seeding the draft when the field opens — the only moment it means
anything, and what `ShellTab` already did — and keying the header by session so a
rename left open ends with the session it belongs to. Seeding on open also picks
up a title the daemon wrote itself after the first exchange.

## Compact list (`52656ef`)

At four lines a card, a sidebar holds eight sessions; on a machine with 150 that
is mostly scrolling. Compact draws one line — status dot, title at the usual
14px, pending badge, age — and about four times as many fit.

- The working directory and model line are not drawn, and **nothing appears on
  hover** to replace them: hovering to read is worse than scrolling to read.
- Rows are square and touching. A rounded card at 36px reads as a tile, and a
  column of tiles reads as a grid rather than a list. Separation comes from the
  status stripe, the hover, and the selection.
- Same path as text size: `AppearancePrefs.density`, stored per machine in
  `appearance.json`, validated on read so a hand-edited file cannot produce a
  broken layout, and painted onto the document by the preload before the first
  frame so the list does not start roomy and snap.
- Settings → Appearance → **Session list**.

## Test plan

- [x] `tsc --noEmit` clean, `npm run build` clean
- [x] Both densities rendered in a static harness against the built CSS —
      comfortable is unchanged, compact is one line with badge and selection intact
- [ ] Exercised in the packaged app

## Known gap

With no gaps between rows, two adjacent sessions of the same status read as one
block — the stripe is the only boundary and it is the same colour. A hairline
separator would fix it; not included here pending a decision.