### PR TITLE
Two glass fixes: the desktop backdrop, and the image that turned into a gradient

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -176,7 +176,6 @@ function applyWindowMaterial(): void {
   nativeTheme.themeSource = themes.getPrefs().mode
   if (!window || window.isDestroyed()) return
   const clear = vibrancyOn()
-  if (GLASS_SUPPORTED) window.setVibrancy(clear ? 'under-window' : null)
   // An opaque background sits in front of the material and hides it, so a
   // window showing the desktop has to stop painting one. A window painting its
   // own gradient keeps it: the renderer draws over it either way, and a clear
@@ -195,7 +194,13 @@ function createWindow(): void {
     // The frame is painted before the renderer runs, so it has to come from the
     // theme too or the window flashes the old dark grey on every open.
     backgroundColor: vibrancyOn() ? '#00000000' : (themes?.active().vars['--surface'] ?? '#101014'),
-    ...(vibrancyOn() ? { vibrancy: 'under-window' as const } : {}),
+    // Asked for at creation whatever the theme currently says, because a window
+    // born opaque cannot be made translucent afterwards: AppKit fixes that at
+    // creation, and switching to the desktop backdrop would do nothing until
+    // the app was restarted. The material is always there; what decides whether
+    // it is seen is the background painted in front of it, which
+    // applyWindowMaterial does change at runtime.
+    ...(GLASS_SUPPORTED ? { vibrancy: 'under-window' as const } : {}),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       preload: path.join(distDir, 'preload', 'preload.js'),

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -531,6 +531,10 @@ function Backdrop(): JSX.Element | null {
       style: state.style,
       intensity: state.intensity,
       blur: state.blur,
+      // Carried like everything else in the block. Left out, moving a slider
+      // writes an image style naming no image, which resolves to the mesh
+      // gradient: the picture is replaced for the crime of being blurred.
+      ...(state.image ? { image: state.image } : {}),
       ...(state.custom ? { stops: state.palette.map((color) => ({ color })) } : {}),
       ...patch,
     }


### PR DESCRIPTION
## The desktop backdrop needed a restart (`3c54ef8`)

`createWindow` passed `vibrancy: 'under-window'` only when the theme wanted it
**at creation** (`main.ts:198`). Pick "Desktop" afterwards and
`applyWindowMaterial` calls `setVibrancy` on a window born opaque — which AppKit
will not honour, since translucency is settled when the window is made. The
override was written, the picker moved, and the window stayed solid until the
next launch.

Reproduced from disk rather than guessed: `~/.helios/themes/liquid-glass.json`
held `{"style":"desktop","blur":0}` written at 16:23, while the running app had
started at 13:55.

Now the material is asked for at creation on macOS regardless, and what decides
whether it shows is the background painted in front of it — which
`applyWindowMaterial` already changes at runtime. The `setVibrancy` call is gone;
it was never the part that worked.

## An image backdrop became a gradient when a slider moved (`4e0513d`)

`save()` in the backdrop picker rewrites the whole block rather than the field
that changed — deliberate, since `setBackdrop` replaces `helios.backdrop`
outright. But the block it built named style, intensity, blur and stops, and
never the image.

So committing any slider wrote `style: 'image'` naming no image, and
`styleOf` (`backdrop.ts:104`) resolves that to `'mesh'`:

```ts
if (spec.style === 'image') return imageName(spec) ? 'image' : 'mesh'
```

Blur, Dim and the colour wells all save the same way, so all three did it. The
imported file was never lost — only its name in the spec — which is why
re-picking the same image always fixed it.

## Test plan

- [x] `tsc --noEmit` clean, `npm run build` clean
- [ ] Exercised in a running window

Not verified live: `main.ts:52` takes a single-instance lock, so a dev build only
focuses the installed app instead of opening a window to test.

## Note

Even with the desktop backdrop showing, this is the legacy `NSVisualEffectView`
blur rather than Tahoe's Liquid Glass. The bundle reports `DTSDKName =
macosx14.5` — Electron 33 against the macOS 14.5 SDK. The new material needs an
Electron built against the macOS 26 SDK, which is a bump for its own branch.