### PR TITLE
Hide finished sessions, keep the tab you were on, shape the list

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -306,11 +306,28 @@ function ShellTab({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
     >
       <span className={`dot ${tab.status.state}`} />
       {tab.title}
+      {/* Reload and end, the pair the agent's terminal carries, in the same
+          place. Its third move — detaching, and staying detached — has no
+          meaning here: the shell list re-attaches anything this client is not
+          showing the next time the session is opened, so a shell let go of
+          comes back on its own. Ending it is the cross. */}
+      <span
+        className="tab-close reload"
+        role="button"
+        aria-label="Reload"
+        title="Reload — the shell keeps running"
+        onClick={(event) => {
+          event.stopPropagation()
+          void store.reconnectTab(tab.id)
+        }}
+      >
+        ⟳
+      </span>
       <span
         className="tab-close"
         role="button"
         aria-label="Close shell"
-        title="Close this shell"
+        title="Close — ends this shell"
         onClick={(event) => {
           event.stopPropagation()
           void store.killShell(tab.id)

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -160,7 +160,15 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
 
       <label className="field">
         <span>First prompt (optional)</span>
-        <textarea rows={4} value={prompt} onChange={(event) => setPrompt(event.target.value)} />
+        {/* The box says a field; the placeholder says what the field is for.
+            Without it this reads as a note to self rather than the first thing
+            the agent will be asked. */}
+        <textarea
+          rows={4}
+          value={prompt}
+          placeholder="What should the agent start on? Left empty, the session opens at a prompt."
+          onChange={(event) => setPrompt(event.target.value)}
+        />
       </label>
 
       <div className="modal-actions">

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -7,13 +7,7 @@ import { ALERT_TYPES } from '../../shared/notifications.ts'
 import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
-import type {
-  AppearancePrefs,
-  BackdropState,
-  Density,
-  NotificationPrefs,
-  ThemeSummary,
-} from '../../shared/models.ts'
+import type { AppearancePrefs, BackdropState, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
 
 /**
  * Which types can be silenced, in the order the phone lists them. Keeping the
@@ -185,11 +179,6 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         />
 
         <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
-
-        <SessionDensity
-          density={appearance?.density}
-          onPick={(density) => void setTheme({ density })}
-        />
 
         <Backdrop />
 
@@ -744,38 +733,6 @@ function previewOf(
   const stops = palette.map(parseColor).filter((c): c is Rgb => c !== null)
   const base = parseColor(theme.vars['--surface'] ?? '') ?? (parseColor('#101014') as Rgb)
   return backdropValue({ style, intensity, ...(image ? { image } : {}) }, base, stops)
-}
-
-/** How much of each session the sidebar shows. */
-function SessionDensity({
-  density,
-  onPick,
-}: {
-  density: Density | undefined
-  onPick: (density: Density) => void
-}): JSX.Element {
-  const options: { value: Density; label: string }[] = [
-    { value: 'comfortable', label: 'Comfortable' },
-    { value: 'compact', label: 'Compact' },
-  ]
-
-  return (
-    <div className="theme-picker">
-      <span className="theme-picker-label">Session list</span>
-      <select
-        value={density ?? 'comfortable'}
-        disabled={density === undefined}
-        onChange={(event) => onPick(event.target.value as Density)}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-      <span className="modal-note">Compact is one line a session; hover shows the rest.</span>
-    </div>
-  )
 }
 
 function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -17,6 +17,30 @@ import {
 } from '../../shared/models.ts'
 import { Chevron } from './icons.tsx'
 
+/** What the sidebar may be dragged to. Narrower hides titles; wider is a
+ *  session list taking half the window from the session itself. */
+const MIN_SIDEBAR = 260
+const MAX_SIDEBAR = 560
+const SIDEBAR_KEY = 'helios.sidebarWidth'
+
+function readSidebarWidth(): number | null {
+  try {
+    const saved = Number(localStorage.getItem(SIDEBAR_KEY))
+    return saved > 0 ? Math.min(Math.max(saved, MIN_SIDEBAR), MAX_SIDEBAR) : null
+  } catch {
+    return null
+  }
+}
+
+function writeSidebarWidth(width: number | null): void {
+  try {
+    if (width === null) localStorage.removeItem(SIDEBAR_KEY)
+    else localStorage.setItem(SIDEBAR_KEY, String(width))
+  } catch {
+    // A full or unavailable store costs the width, not the sidebar.
+  }
+}
+
 interface Row {
   host: HostRecord
   session: Session
@@ -49,6 +73,7 @@ export function Sidebar({
   const query = useStore((s) => s.query)
   const showArchived = useStore((s) => s.showArchived)
   const sortMode = useStore((s) => s.sortMode)
+  const density = useStore((s) => s.density)
   // The card being dragged, so the row under the pointer can show where it
   // would land. Held per host: a drag never crosses from one daemon to another.
   const [dragging, setDragging] = useState<{ hostId: string; sessionId: string } | null>(null)
@@ -56,6 +81,33 @@ export function Sidebar({
   // Per host, not global: a machine kept for finished work and one being
   // worked in want opposite answers, and the setting is one click away.
   const [showTerminated, setShowTerminated] = useState<Record<string, boolean>>({})
+  const aside = useRef<HTMLElement | null>(null)
+
+  // The width is a CSS variable rather than state: the value is read by the
+  // stylesheet, nothing in React branches on it, and a drag that re-rendered
+  // the whole list on every pointer move would stutter against 150 sessions.
+  useEffect(() => {
+    const saved = readSidebarWidth()
+    if (saved !== null) document.documentElement.style.setProperty('--sidebar', `${saved}px`)
+  }, [])
+
+  const resize = (event: React.PointerEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    const fromX = event.clientX
+    const fromWidth = aside.current?.getBoundingClientRect().width ?? MIN_SIDEBAR
+    let latest = fromWidth
+    const move = (moved: PointerEvent): void => {
+      latest = Math.min(Math.max(fromWidth + (moved.clientX - fromX), MIN_SIDEBAR), MAX_SIDEBAR)
+      document.documentElement.style.setProperty('--sidebar', `${Math.round(latest)}px`)
+    }
+    const done = (): void => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', done)
+      writeSidebarWidth(Math.round(latest))
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', done)
+  }
 
   const grouped = useMemo<Group[]>(() => {
     const needle = query.trim().toLowerCase()
@@ -96,7 +148,7 @@ export function Sidebar({
   const manual = hosts.some((host) => sortMode[host.id] === 'manual')
 
   return (
-    <aside className="sidebar">
+    <aside className="sidebar" ref={aside}>
       <header className="sidebar-head">
         <div className="search-field">
           <span className="search-icon" aria-hidden="true">
@@ -120,6 +172,21 @@ export function Sidebar({
           onClick={() => void store.setSortModeEverywhere(manual ? 'activity' : 'manual')}
         >
           ⇅
+        </button>
+        {/* Beside the sort toggle because it is the same kind of control: not
+            a preference set once, but a way of looking at the list, changed
+            while looking at it. Shows the state it is in, as the sort does. */}
+        <button
+          className={density === 'compact' ? 'fab density-toggle on' : 'fab density-toggle'}
+          aria-label={density === 'compact' ? 'Compact list' : 'Comfortable list'}
+          title={
+            density === 'compact'
+              ? 'Compact — one line a session.\nClick for the fuller card.'
+              : 'Comfortable — status, title, directory and model.\nClick to fit more on screen.'
+          }
+          onClick={() => void store.setDensity(density === 'compact' ? 'comfortable' : 'compact')}
+        >
+          {density === 'compact' ? '▤' : '▦'}
         </button>
         <button className="fab" title="New session (⌘N)" onClick={onNewSession}>
           +
@@ -250,6 +317,20 @@ export function Sidebar({
         </button>
         <AppMenu onSettings={onSettings} />
       </footer>
+
+      {/* The panel's own edge, not a bar between the panels: the list is what
+          the pointer is already near, and a gutter belongs to neither side. */}
+      <div
+        className="sidebar-grip"
+        role="separator"
+        aria-label="Resize the session list"
+        title="Drag to resize — double-click to reset"
+        onPointerDown={resize}
+        onDoubleClick={() => {
+          document.documentElement.style.removeProperty('--sidebar')
+          writeSidebarWidth(null)
+        }}
+      />
     </aside>
   )
 }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -3,7 +3,15 @@ import { useSyncExternalStore } from 'react'
 import { api, bridge, statusOf } from './bridge.ts'
 import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
-import type { HostRecord, HostStatus, Notification, Session, SSEEvent, TabStatus } from '../shared/models.ts'
+import type {
+  Density,
+  HostRecord,
+  HostStatus,
+  Notification,
+  Session,
+  SSEEvent,
+  TabStatus,
+} from '../shared/models.ts'
 import type { XtermTheme } from '../shared/theme/resolve.ts'
 
 export interface Tab {
@@ -115,6 +123,12 @@ export interface State {
   pairingLink: string | null
   /** The palette xterm draws with; the CSS side is set on <html>, not here. */
   terminalTheme: XtermTheme
+  /**
+   * How much of a session the sidebar shows. Kept here as well as on <html>
+   * because the control that changes it lives in the sidebar and has to show
+   * which way it is set.
+   */
+  density: Density
 }
 
 const initial: State = {
@@ -134,6 +148,7 @@ const initial: State = {
   sortMode: {},
   loading: true,
   terminalTheme: bridge.theme.boot().terminal,
+  density: bridge.theme.boot().density,
   toast: null,
   pairingLink: null,
 }
@@ -199,7 +214,7 @@ class Store {
       applyTheme(document.documentElement, theme, glass)
       applyProseSize(document.documentElement, proseSize)
       applyDensity(document.documentElement, density)
-      this.set({ terminalTheme: terminal })
+      this.set({ terminalTheme: terminal, density })
     })
 
     bridge.hosts.onChanged((hosts) => {
@@ -666,10 +681,32 @@ class Store {
       await this.attachTerminal(tab.hostId, tab.sessionId, tab.termId, tab.title).catch((err: unknown) =>
         this.fail(err),
       )
+      // Closing the tab took its id out of the active list, and a strip naming
+      // nothing falls back to the agent's terminal — so reloading a shell
+      // would move the user somewhere they did not ask to go. It comes back
+      // under the same id, so it can be asked for by name.
+      this.selectTab(tab.id)
       return
     }
     const session = this.state.sessions[tab.hostId]?.find((s) => s.session_id === tab.sessionId)
     if (session) await this.openTerminal(tab.hostId, session, false)
+  }
+
+  /**
+   * Swaps the sidebar between showing a session on four lines and on one.
+   *
+   * Painted here before the main process answers: it replies with the resolved
+   * theme rather than the preference, and a toggle that waits for a round trip
+   * reads as one that missed the click.
+   */
+  async setDensity(density: Density): Promise<void> {
+    applyDensity(document.documentElement, density)
+    this.set({ density })
+    try {
+      await bridge.theme.set({ density })
+    } catch (err) {
+      this.fail(err)
+    }
   }
 
   renameTab(tabId: string, title: string): void {
@@ -713,12 +750,45 @@ class Store {
     if (hasTerminal(session)) void this.openTerminal(hostId, session, false)
   }
 
+  /**
+   * Drops a tab, handing the front to the one beside it.
+   *
+   * Naming nothing would do instead — the strip falls back to the agent's
+   * terminal when it finds no name — but closing the middle of three shells is
+   * not a request to leave the shells. The neighbour is the one before it,
+   * since a tab is usually opened after the one it belongs with; the last one
+   * closed leaves the entry empty, and the fallback is right again.
+   */
   closeTab(tabId: string): void {
     void bridge.term.close(tabId)
-    this.set((s) => ({
-      tabs: s.tabs.filter((t) => t.id !== tabId),
-      activeTabs: Object.fromEntries(Object.entries(s.activeTabs).filter(([, id]) => id !== tabId)),
-    }))
+    this.set((s) => {
+      const closing = s.tabs.find((t) => t.id === tabId)
+      const tabs = s.tabs.filter((t) => t.id !== tabId)
+      const activeTabs = { ...s.activeTabs }
+      const key = closing ? sessionKey(closing.hostId, closing.sessionId) : null
+
+      // Naming nothing would do — the strip falls back to the agent's terminal
+      // when it finds no name — but closing the middle of three shells is not
+      // a request to leave the shells. The one before it, since a shell is
+      // usually opened after the one it belongs with; the last shell closed
+      // names nothing, and the fallback is right again.
+      //
+      // Shells only. Closing the agent's terminal is a disconnect, and the
+      // panel has something to say about that which a shell would cover up.
+      if (key && closing?.kind === 'shell' && activeTabs[key] === tabId) {
+        const shells = s.tabs.filter(
+          (t) => t.kind === 'shell' && t.hostId === closing.hostId && t.sessionId === closing.sessionId,
+        )
+        const at = shells.findIndex((t) => t.id === tabId)
+        const next = shells[at - 1] ?? shells[at + 1]
+        if (next) activeTabs[key] = next.id
+        else delete activeTabs[key]
+      } else {
+        for (const [k, id] of Object.entries(activeTabs)) if (id === tabId) delete activeTabs[k]
+      }
+
+      return { tabs, activeTabs }
+    })
   }
 
   /** Brings one of a session's terminals to the front. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -72,7 +72,7 @@
   --r-md: 12px;
   --r-lg: 16px;
   --r-xl: 28px;
-  --sidebar: 320px;
+  --sidebar: 360px;
   /* Reading width for the transcript and its composer. It exists to stop a
      reply and the prompt above it drifting to opposite edges of the window,
      not to hold prose to a paragraph width — code blocks and diffs want the
@@ -251,14 +251,16 @@ button.danger:hover:not(:disabled) {
   background: color-mix(in srgb, var(--on-surface) 8%, transparent);
 }
 
-/* M3 filled fields: a tonal box, no outline until focus. */
+/* M3 filled fields: a tonal box. The outline is faint rather than absent —
+   against a glass panel a tonal box is barely a box, and a field nobody can
+   see the edge of is a field nobody types in. Focus brightens it. */
 input,
 select,
 textarea {
   font: inherit;
   color: var(--on-surface);
   background: var(--surface-high);
-  border: 1px solid transparent;
+  border: 1px solid var(--outline-variant);
   border-radius: var(--r-sm);
   padding: 9px 12px;
   user-select: text;
@@ -505,6 +507,7 @@ small {
 /* ─── Sidebar ───────────────────────────────────────────────────────────── */
 
 .sidebar {
+  position: relative;
   width: var(--sidebar);
   flex: none;
   display: flex;
@@ -512,6 +515,27 @@ small {
   background: var(--surface-low);
   border-radius: var(--r-lg);
   overflow: hidden;
+}
+
+/* Wider than it looks: a 4px edge is a target that has to be hunted, so the
+   grip reaches inside the panel where nothing else is clickable. It paints
+   nothing until the pointer is on it. */
+.sidebar-grip {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 2;
+}
+
+.sidebar-grip:hover {
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--primary) 35%, transparent)
+  );
 }
 
 /* ─── Backdrop ──────────────────────────────────────────────────────────── */
@@ -751,17 +775,20 @@ small {
 
 /* Quieter than the new-session button beside it, and filled only while it is
    the one holding the list still. */
-.sort-toggle {
+.sort-toggle,
+.density-toggle {
   background: transparent;
   color: var(--on-surface-variant);
   font-size: 16px;
 }
 
-.sort-toggle:hover:not(:disabled) {
+.sort-toggle:hover:not(:disabled),
+.density-toggle:hover:not(:disabled) {
   background: var(--surface-container);
 }
 
-.sort-toggle.on {
+.sort-toggle.on,
+.density-toggle.on {
   background: var(--primary-container);
   color: var(--on-primary-container);
 }

--- a/mobile/lib/screens/sessions_screen.dart
+++ b/mobile/lib/screens/sessions_screen.dart
@@ -28,6 +28,11 @@ class _SessionsScreenState extends State<SessionsScreen> {
   String? _cwdFilter;
   String? _cwdFilterProject;
 
+  /// Whether finished sessions are listed. Off by default: a machine that has
+  /// run a few hundred agents is mostly finished ones, and they are history
+  /// rather than work.
+  bool _showTerminated = false;
+
   @override
   void dispose() {
     _searchController.dispose();
@@ -37,6 +42,15 @@ class _SessionsScreenState extends State<SessionsScreen> {
   }
 
   String _compositeKey(Session s) => '${s.hostId}:${s.sessionId}';
+
+  /// A search or a directory filter is a request for particular sessions, and
+  /// answering it while holding some of them back would be a lie. The archive
+  /// tab is left alone too: it exists to show what was put away.
+  bool get _hidingTerminated =>
+      !_showTerminated &&
+      _cwdFilter == null &&
+      _filter != SessionFilter.archived &&
+      !(_searchExpanded && _searchController.text.trim().isNotEmpty);
 
   List<Session> _filterSessions(List<Session> sessions) {
     // When search or CWD filter is active, API already filtered — pass through.
@@ -319,13 +333,24 @@ class _SessionsScreenState extends State<SessionsScreen> {
 
         final manual = hm.manualOrder;
         final orderable = manual ? _orderableService(hm) : null;
-        final filtered = _sortSessions(_filterSessions(sessions), manual: manual);
+        final matching = _filterSessions(sessions);
+        final hiddenTerminated =
+            _hidingTerminated ? matching.where((s) => s.isTerminated).length : 0;
+        final filtered = _sortSessions(
+          _hidingTerminated ? matching.where((s) => !s.isTerminated).toList() : matching,
+          manual: manual,
+        );
 
         return Column(
           children: [
             if (_multiSelect) _buildMultiSelectBar(),
             _buildFilterRow(sessions, hm, filtered),
             if (_cwdFilter != null) _buildActiveFiltersRow(),
+            // Above the list rather than below it: revealed sessions are
+            // appended, so a control under them walks further down the screen
+            // with every use.
+            if (hiddenTerminated > 0 || (_showTerminated && _filter != SessionFilter.archived))
+              _buildTerminatedToggle(hiddenTerminated),
             Expanded(
               child: filtered.isEmpty
                   ? _buildEmptyFilterState()
@@ -356,6 +381,33 @@ class _SessionsScreenState extends State<SessionsScreen> {
           ],
         );
       },
+    );
+  }
+
+  /// The way back to the finished sessions, and the way out of them.
+  Widget _buildTerminatedToggle(int hidden) {
+    final theme = Theme.of(context);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+        child: TextButton.icon(
+          onPressed: () => setState(() => _showTerminated = !_showTerminated),
+          icon: Icon(
+            _showTerminated ? Icons.visibility_off_outlined : Icons.history,
+            size: 16,
+          ),
+          label: Text(
+            _showTerminated ? 'Hide terminated' : 'Show $hidden terminated',
+            style: const TextStyle(fontSize: 12),
+          ),
+          style: TextButton.styleFrom(
+            visualDensity: VisualDensity.compact,
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            foregroundColor: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
     );
   }
 
@@ -401,8 +453,12 @@ class _SessionsScreenState extends State<SessionsScreen> {
   }
 
   Widget _buildFilterChips(List<Session> allSessions, HostManager hm, List<Session> visible) {
-    final allCount = allSessions.where((s) => !s.archived).length;
-    final pinnedCount = allSessions.where((s) => s.pinned && !s.archived).length;
+    // Counting what the tab would show, not what exists: a chip reading 155
+    // over a list of twelve is a chip that has to be explained. The archive is
+    // its own tab and holds terminated sessions on purpose.
+    bool counted(Session s) => !s.archived && !(_hidingTerminated && s.isTerminated);
+    final allCount = allSessions.where(counted).length;
+    final pinnedCount = allSessions.where((s) => s.pinned && counted(s)).length;
     final archivedCount = allSessions.where((s) => s.archived).length;
 
     return Row(


### PR DESCRIPTION
Session-list and tab behaviour across both clients.

## Mobile: finished sessions hidden until asked for (`8dccb0a`)

A machine that has run a few hundred agents is mostly finished ones. They are
hidden now behind a count, in the same place desktop puts it — above the list,
since revealed sessions are appended and a control below them walks off screen
with every use. A search or directory filter brings them back, matching
desktop's rule that an explicit query is answered honestly. Chip counts follow
what the tab would show, because "All 155" over a list of twelve needs
explaining.

## Desktop (`a2bfad7`)

**Reload no longer jumps to the Claude tab.** `reconnectTab` closes the tab and
re-attaches; `closeTab` strips the id from `activeTabs` (`store.ts:752`) and a
strip naming nothing falls back to the agent's terminal. The tab returns under
the same id, so it is re-selected by name.

**Closing a shell picks the neighbour.** Closing the middle of three shells was
leaving the shells entirely. Now the front goes to the one before it, and to the
fallback only when the last is gone. Scoped to shells: closing the agent's
terminal is a disconnect, and the panel's message about that would be hidden by
jumping to a shell.

**Shell tabs get reload.** The same pair the agent's terminal carries — reload,
and the cross that ends it. Deliberately not the third control, detach: the
shell list re-attaches anything this client is not showing whenever the session
is reopened, so a detached shell returns on its own and the button would appear
to do nothing a moment later.

**Density switch moved to the sidebar, sidebar resizable.** Compact is a way of
looking at the list, not a preference set once, so it sits beside the sort
toggle and shows its state the same way. Removed from Settings — two homes for
one setting is how they drift. The sidebar starts at 360px and drags between 260
and 560, double-click to reset; the width goes straight to the CSS variable
rather than React state, since nothing branches on it and re-rendering 150
sessions per pointer move would stutter. Remembered in localStorage, beside the
reading width the file preview already keeps.

**The first prompt looks like a field.** Fields were outlined only on focus —
the filled-field pattern, which works on an opaque surface and disappears on a
glass one. Faint outline at rest, bright on focus, plus a placeholder saying what
the box is for and what happens if it is left empty. The outline change is
global: half a dialog with visible edges and half without looks broken.

## Test plan

- [x] `tsc --noEmit` and `npm run build` clean
- [x] `flutter analyze` clean, 60 tests pass
- [x] Field affordance checked in a harness against the built CSS — resting
      border `--outline-variant`, focused `--primary`
- [ ] Tab behaviour exercised in a running window
- [ ] Mobile build installed on device

Neither client could be exercised live: `main.ts:52` takes a single-instance
lock, so a dev build only focuses the installed app, and the phone has dropped
off wireless debugging.