### PR TITLE
refactor: drop the slash command menu from mobile

### DIFF
--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -1035,96 +1035,6 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     return ok ?? false;
   }
 
-  void _showCommandSheet() {
-    final commands = _sse?.commands ?? [];
-    if (commands.isEmpty) return;
-
-    showModalBottomSheet(
-      context: context,
-      builder: (ctx) {
-        return SafeArea(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  'Commands',
-                  style: Theme.of(ctx).textTheme.titleSmall,
-                ),
-              ),
-              Flexible(
-                child: ListView(
-                  shrinkWrap: true,
-                  children: [
-                    ...commands.map(
-                      (cmd) => ListTile(
-                        leading: Icon(_iconForCommand(cmd.icon)),
-                        title: Text(
-                          cmd.name,
-                          style: const TextStyle(
-                            fontFamily: 'monospace',
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        subtitle: Text(
-                          cmd.description,
-                          style: const TextStyle(fontSize: 12),
-                        ),
-                        onTap: () {
-                          Navigator.pop(ctx);
-                          _sendCommand(cmd.name);
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  Future<void> _sendCommand(String command) async {
-    setState(() => _sending = true);
-    final sse = _sse;
-    final error = sse == null
-        ? 'Not connected'
-        : await sse.sendSessionPrompt(widget.session.sessionId, command);
-    if (error != null && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(error), duration: const Duration(seconds: 3)),
-      );
-    }
-    if (mounted) setState(() => _sending = false);
-  }
-
-  IconData _iconForCommand(String icon) {
-    switch (icon) {
-      case 'compress':
-        return Icons.compress;
-      case 'rate_review':
-        return Icons.rate_review;
-      case 'payments':
-        return Icons.payments;
-      case 'info':
-        return Icons.info_outline;
-      case 'health_and_safety':
-        return Icons.health_and_safety;
-      case 'memory':
-        return Icons.memory;
-      case 'clear_all':
-        return Icons.clear_all;
-      case 'swap_horiz':
-        return Icons.swap_horiz;
-      default:
-        return Icons.terminal;
-    }
-  }
-
   void _openGitStatus(Session session) {
     _lastSubRoute[session.sessionId] = _SubRoute(_SubRouteType.gitStatus);
     // Use resolved git root so diffs work from any subdirectory
@@ -1309,7 +1219,6 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
     final canSend = session.canSendPrompt;
     final isQueueing = session.isQueueing;
     final theme = Theme.of(context);
-    final hasCommands = (_sse?.commands ?? []).isNotEmpty;
 
     if (session.isTerminated) {
       return Container(
@@ -1437,15 +1346,6 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
             ),
           Row(
             children: [
-              if (hasCommands)
-                IconButton(
-                  onPressed: canSend && !_sending ? _showCommandSheet : null,
-                  icon: const Text(
-                    '/',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  tooltip: 'Commands',
-                ),
               IconButton(
                 onPressed: canSend && !_sending ? _showAttachSheet : null,
                 icon: const Icon(Icons.add_photo_alternate_outlined, size: 22),

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -74,9 +74,6 @@ class DaemonAPIService extends ChangeNotifier {
   String? _lastSessionFilter;
   String? _lastSessionCwd;
 
-  List<SlashCommand> _commands = [];
-  List<SlashCommand> get commands => _commands;
-
   List<ProviderInfo> _providers = [];
   List<ProviderInfo> get providers => _providers;
   bool _providersLoaded = false;
@@ -169,7 +166,6 @@ class DaemonAPIService extends ChangeNotifier {
     fetchSessions();
     fetchNotifications();
     fetchProviders();
-    fetchCommands();
     fetchSortMode();
     if (!_connected) _startPolling();
   }
@@ -817,22 +813,6 @@ class DaemonAPIService extends ChangeNotifier {
     return false;
   }
 
-  // ==================== Commands API ====================
-
-  Future<void> fetchCommands() async {
-    try {
-      final resp = await _api.get('/api/commands');
-      if (resp.statusCode == 200) {
-        final data = jsonDecode(resp.body);
-        final list = (data['commands'] as List?) ?? [];
-        _commands = list.map((c) => SlashCommand.fromJson(c)).toList();
-        notifyListeners();
-      }
-    } catch (e) {
-      debugPrint('[$hostId] Failed to fetch commands: $e');
-    }
-  }
-
   // ==================== Settings API ====================
 
   /// Fetch all settings and personas from the backend.
@@ -1254,26 +1234,6 @@ class FileReadResult {
     if (size < 1024) return '$size B';
     if (size < 1024 * 1024) return '${(size / 1024).toStringAsFixed(1)} KB';
     return '${(size / (1024 * 1024)).toStringAsFixed(1)} MB';
-  }
-}
-
-class SlashCommand {
-  final String name;
-  final String description;
-  final String icon;
-
-  SlashCommand({
-    required this.name,
-    required this.description,
-    required this.icon,
-  });
-
-  factory SlashCommand.fromJson(Map<String, dynamic> json) {
-    return SlashCommand(
-      name: json['name'] as String,
-      description: json['description'] as String? ?? '',
-      icon: json['icon'] as String? ?? '',
-    );
   }
 }
 

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -193,7 +193,6 @@ class HostManager extends ChangeNotifier {
     if (host.id == _activeHostId) {
       service.fetchNotifications();
       service.fetchSessions();
-      service.fetchCommands();
       service.fetchProviders();
       service.fetchSortMode();
       await service.startActive();


### PR DESCRIPTION
## Summary
- Removes the `/` composer button and its bottom sheet from the session screen, along with `_sendCommand` and the icon mapping.
- Removes the `SlashCommand` model, the `commands` getter and `fetchCommands()` from `daemon_api_service.dart`, plus both call sites (`promote()` and `host_manager.dart`).
- The daemon's `/api/commands` endpoint is untouched — the TUI and desktop still use it.

## Test plan
- [x] `cd mobile && flutter analyze` (no issues)
- [x] `cd mobile && flutter test` (60 passing)