### PR TITLE
feat: report what sessions cost instead of evicting them

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -18,6 +18,7 @@ import type {
   Subagent,
   TerminalInfo,
   TranscriptPage,
+  HostStats,
   Worktree,
   WriteResult,
 } from '../shared/models.ts'
@@ -134,9 +135,12 @@ export class ApiClient {
 
   async listSessions(
     params: { q?: string; status?: string; filter?: string; cwd?: string } = {},
-  ): Promise<Session[]> {
-    const res = await this.request<{ sessions?: Session[] }>('GET', `/api/sessions${queryString(params)}`)
-    return res.sessions ?? []
+  ): Promise<{ sessions: Session[]; host?: HostStats }> {
+    const res = await this.request<{ sessions?: Session[]; host?: HostStats }>(
+      'GET',
+      `/api/sessions${queryString(params)}`,
+    )
+    return { sessions: res.sessions ?? [], host: res.host }
   }
 
   async getSession(id: string): Promise<{ session: Session; pending_permissions: number }> {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -41,6 +41,7 @@ import type {
   TerminalInfo,
   ThemeSummary,
   TranscriptPage,
+  HostStats,
   Worktree,
   WriteResult,
 } from '../shared/models.ts'
@@ -169,7 +170,9 @@ export class HostApi {
     return bridge.api.call<T>(this.hostId, method, args)
   }
 
-  listSessions(params: { q?: string; status?: string; filter?: string; cwd?: string } = {}): Promise<Session[]> {
+  listSessions(
+    params: { q?: string; status?: string; filter?: string; cwd?: string } = {},
+  ): Promise<{ sessions: Session[]; host?: HostStats }> {
     return this.call('listSessions', params)
   }
   getSession(id: string): Promise<{ session: Session; pending_permissions: number }> {

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -423,6 +423,12 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
           {statusLabel(session.status)}
         </span>
 
+        {session.memory_bytes !== undefined && (
+          <span className="card-ram" title="Memory this session's terminal holds">
+            {formatBytes(session.memory_bytes)}
+          </span>
+        )}
+
         {cold && (
           <button
             className="ghost cold"
@@ -584,4 +590,9 @@ function PermissionMode({ hostId, session }: { hostId: string; session: Session 
       ))}
     </select>
   )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  return `${Math.round(bytes / 1024 ** 2)} MB`
 }

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -39,3 +39,23 @@ export function Chevron({
     </svg>
   )
 }
+
+/** A memory module, for the row that prices a host's terminals. */
+export function Memory({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`meter-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="3" y="7" width="18" height="10" rx="1.5" />
+      <path d="M7 17v3M12 17v3M17 17v3M7 11v2M12 11v2M17 11v2" />
+    </svg>
+  )
+}
+
+/** A processor, for the load the host is under. */
+export function Cpu({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`meter-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="7" y="7" width="10" height="10" rx="1.5" />
+      <path d="M10 3v4M14 3v4M10 17v4M14 17v4M3 10h4M3 14h4M17 10h4M17 14h4" />
+    </svg>
+  )
+}

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -14,8 +14,9 @@ import {
   timeAgo,
   type HostRecord,
   type Session,
+  type HostStats,
 } from '../../shared/models.ts'
-import { Chevron } from './icons.tsx'
+import { Chevron, Cpu, Memory } from './icons.tsx'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -68,6 +69,7 @@ export function Sidebar({
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
   const sessions = useStore((s) => s.sessions)
+  const stats = useStore((s) => s.stats)
   const notifications = useStore((s) => s.notifications)
   const selection = useStore((s) => s.selection)
   const query = useStore((s) => s.query)
@@ -210,6 +212,8 @@ export function Sidebar({
                 {!loading && <span className="host-count">{rows.length}</span>}
                 <Chevron className="chevron" open={!isCollapsed} />
               </button>
+
+              {!isCollapsed && <HostMeter stats={stats[host.id]} />}
 
               {/* Above the list, not below it: revealed sessions are appended,
                   so a toggle under them walks further down the page with every
@@ -458,6 +462,11 @@ function SessionRow({
             </span>
           )}
           {pending > 0 && <span className="badge">{pending}</span>}
+          {session.memory_bytes !== undefined && (
+            <span className="card-ram" title="Memory this terminal holds">
+              {formatBytes(session.memory_bytes)}
+            </span>
+          )}
           <span className="grow" />
           <span className="time">{timeAgo(session.last_event_at ?? session.created_at)}</span>
         </div>
@@ -532,4 +541,48 @@ function shortMode(mode: string): string {
     default:
       return mode
   }
+}
+
+/**
+ * What this host is carrying: its warm terminals, then the machine behind
+ * them.
+ *
+ * The daemon reclaims nothing on its own any more, so this is the only thing
+ * that tells the user the pool has grown. It belongs to the host and not the
+ * window: memory is a machine's to run out of, and a session on the laptop
+ * says nothing about the one on the VM.
+ */
+function HostMeter({ stats }: { stats?: HostStats }): JSX.Element | null {
+  if (!stats || stats.warm === 0) return null
+  const heavy = stats.budget > 0 && stats.warm_rss > stats.budget
+  const machine = stats.memory_total > 0
+  return (
+    <div
+      className={heavy ? 'host-meter heavy' : 'host-meter'}
+      title={
+        heavy
+          ? `${stats.warm} warm terminals holding ${formatBytes(stats.warm_rss)} — terminate the ones you are done with to free memory`
+          : `${stats.warm} warm terminals holding ${formatBytes(stats.warm_rss)}`
+      }
+    >
+      <Memory />
+      <span>{formatBytes(stats.warm_rss)}</span>
+      {machine && (
+        <span className="host-machine">of {formatPair(stats.memory_used, stats.memory_total)}</span>
+      )}
+      <Cpu />
+      <span>{Math.round(stats.load * 100)}%</span>
+    </div>
+  )
+}
+
+/** Two figures sharing one unit: "21.3/34.4 GB" rather than "21.3 GB/34.4 GB". */
+function formatPair(used: number, total: number): string {
+  if (total >= 1024 ** 3) return `${(used / 1024 ** 3).toFixed(1)}/${(total / 1024 ** 3).toFixed(1)} GB`
+  return `${Math.round(used / 1024 ** 2)}/${Math.round(total / 1024 ** 2)} MB`
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  return `${Math.round(bytes / 1024 ** 2)} MB`
 }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -11,6 +11,7 @@ import type {
   Session,
   SSEEvent,
   TabStatus,
+  HostStats,
 } from '../shared/models.ts'
 import type { XtermTheme } from '../shared/theme/resolve.ts'
 
@@ -87,6 +88,8 @@ export interface State {
   hosts: HostRecord[]
   hostStatus: Record<string, HostStatus>
   sessions: Record<string, Session[]>
+  /** Each host's warm pool and machine load, from the session list envelope. */
+  stats: Record<string, HostStats>
   notifications: Record<string, Notification[]>
   /** Open terminal connections, one per session, keyed by `terminalId`. */
   tabs: Tab[]
@@ -135,6 +138,7 @@ const initial: State = {
   hosts: [],
   hostStatus: {},
   sessions: {},
+  stats: {},
   notifications: {},
   tabs: [],
   selection: null,
@@ -353,16 +357,19 @@ class Store {
 
   async refreshSessions(hostId: string): Promise<void> {
     try {
-      const sessions = await api(hostId).listSessions()
+      const { sessions, host } = await api(hostId).listSessions()
       const before = this.state.sessions[hostId]
-      this.set((s) => ({ sessions: { ...s.sessions, [hostId]: sessions } }))
+      this.set((s) => ({
+        sessions: { ...s.sessions, [hostId]: sessions },
+        stats: host ? { ...s.stats, [hostId]: host } : s.stats,
+      }))
       for (const session of sessions) {
         if (session.status !== 'terminated') continue
         const was = before?.find((s) => s.session_id === session.session_id)
         if (was && was.status !== 'terminated') this.onTerminated(hostId, session.session_id)
       }
     } catch (err) {
-      this.fail(err)
+      this.failHost(hostId, err)
     }
   }
 
@@ -371,7 +378,7 @@ class Store {
       const notifications = await api(hostId).notifications({ status: 'pending' })
       this.set((s) => ({ notifications: { ...s.notifications, [hostId]: notifications } }))
     } catch (err) {
-      this.fail(err)
+      this.failHost(hostId, err)
     }
   }
 
@@ -809,6 +816,25 @@ class Store {
 
   fail(err: unknown): void {
     this.notify(err instanceof Error ? err.message : String(err), 'error')
+  }
+
+  /**
+   * Reports a failure that belongs to one host.
+   *
+   * A host that cannot be reached already says so with its dot, and undici's
+   * bare "fetch failed" does not even name which one — so a lost connection is
+   * announced once, when the host was still believed to be up, and left to the
+   * dot after that. Anything else is a real error and is shown as it comes.
+   */
+  failHost(hostId: string, err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err)
+    if (!/fetch failed|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|network|timeout/i.test(message)) {
+      this.notify(message, 'error')
+      return
+    }
+    if (this.state.hostStatus[hostId]?.state !== 'online') return
+    const name = this.state.hosts.find((host) => host.id === hostId)?.name ?? 'The daemon'
+    this.notify(`${name} is not answering`, 'error')
   }
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -682,6 +682,51 @@ small {
   padding: 0 12px;
 }
 
+/* Under the host it belongs to: what that machine's warm terminals hold, and
+   what the machine itself has left. One line, because it is a reading and not
+   a message — the advice lives in its tooltip. */
+.host-meter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  /* Left edge on the host head's, so the reading starts under the dot rather
+     than floating in from the session cards. */
+  padding: 0 4px 6px;
+  color: var(--on-surface-variant);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.host-meter.heavy {
+  color: var(--s-waiting);
+}
+
+/* The machine's own figure is context for the pool's, not a thing to act on. */
+.host-machine {
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Sized in em like the chevron, so the glyph follows the row's font size. */
+.meter-icon {
+  flex: none;
+  width: 1.1em;
+  height: 1.1em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* The second icon in the row starts a new reading; a little air marks that. */
+.host-meter .meter-icon + span {
+  margin-right: 2px;
+}
+
 .sidebar-foot {
   display: flex;
   align-items: center;
@@ -881,6 +926,15 @@ small {
   font-size: 12px;
 }
 
+/* What the session's terminal is holding. Only warm sessions have one, so the
+   slot is simply absent the rest of the time. */
+.card-ram {
+  font-size: 11px;
+  color: var(--on-surface-variant);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 /* No live host behind the status: the card says idle, this says it will take a
    moment to prove it. */
 .cold-mark {
@@ -1015,6 +1069,12 @@ small {
    say so. */
 [data-density='compact'] .badge {
   order: 5;
+}
+
+/* The compact card is one line of status and time; the memory reading belongs
+   to the roomier layout, and to the detail header. */
+[data-density='compact'] .card-ram {
+  display: none;
 }
 
 [data-density='compact'] .card-top .grow {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -25,6 +25,8 @@ export interface Session {
   permission_mode?: string
   /** Socket path of the live terminal host, injected by the daemon. Absent means cold. */
   terminal?: string
+  /** Resident memory of the live terminal's process tree. Absent when cold. */
+  memory_bytes?: number
   created_at: string
   ended_at?: string
   supports_prompt_queue: boolean
@@ -523,4 +525,17 @@ export interface ThemeSummary {
   name: string
   mode: 'dark' | 'light'
   swatch: string[]
+}
+
+/** What a host's warm pool costs, and what the machine behind it has left.
+ *  The daemon evicts nothing, so `budget` is only the point past which it is
+ *  worth telling the user. */
+export interface HostStats {
+  warm: number
+  warm_rss: number
+  budget: number
+  /** One-minute load average over the core count: 1 means saturated. */
+  load: number
+  memory_used: number
+  memory_total: number
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -30,6 +30,8 @@ type Status struct {
 	Detail    string `json:"detail,omitempty"`
 	// Warm is the number of sessions currently holding a live terminal.
 	Warm int `json:"warm"`
+	// WarmRSS is what those terminals cost in resident memory, in bytes.
+	WarmRSS int64 `json:"warm_rss"`
 }
 
 // Backend owns the terminals behind agent sessions.
@@ -90,6 +92,13 @@ type Backend interface {
 
 	// Status reports backend health.
 	Status() Status
+}
+
+// Usager is implemented by backends that can price their terminals. Nothing
+// acts on the number: it is shown to the user, who decides what to close.
+type Usager interface {
+	// Usage reports resident bytes per warm session.
+	Usage() map[string]int64
 }
 
 // Waker is implemented by backends that can bring a cold session back

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -32,7 +32,7 @@ type Host struct {
 
 // touchInterval bounds how often screen activity reaches the registry.
 // Registry.Touch takes the pool lock and a redrawing TUI produces output many
-// times a second; the LRU does not need that resolution.
+// times a second; the ordering does not need that resolution.
 const touchInterval = 5 * time.Second
 
 // NewHost returns a Host backend over a warm-pool registry. The registry owns
@@ -42,22 +42,10 @@ func NewHost(reg *terminal.Registry) *Host {
 		reg:     reg,
 		mirrors: make(map[string]*terminal.Mirror),
 	}
-	// The registry decides what to evict but cannot see who is watching; only
-	// the mirrors know that.
-	reg.InUse = h.watched
 	return h
 }
 
-// watched reports whether a session has a viewer besides the daemon's own
-// mirror. A session with no mirror has no viewers by definition.
-func (h *Host) watched(sessionID string) bool {
-	h.mu.Lock()
-	m, ok := h.mirrors[sessionID]
-	h.mu.Unlock()
-	return ok && m.Watched()
-}
-
-// markActive pushes session activity into the registry's LRU, throttled to one
+// markActive records session activity in the registry, throttled to one
 // update per touchInterval so a busy screen does not hammer the pool lock.
 func (h *Host) markActive(sessionID string) {
 	v, _ := h.touched.LoadOrStore(sessionID, new(atomic.Int64))
@@ -377,12 +365,20 @@ func (h *Host) Sweep() []string {
 }
 
 func (h *Host) Status() Status {
+	var rss int64
+	for _, bytes := range h.reg.Usage() {
+		rss += bytes
+	}
 	return Status{
 		Name:      "host",
 		Available: true,
 		Warm:      len(h.reg.Warm()),
+		WarmRSS:   rss,
 	}
 }
+
+// Usage reports resident bytes per warm session.
+func (h *Host) Usage() map[string]int64 { return h.reg.Usage() }
 
 // Close drops every mirror. The hosts keep running: that is the point of them
 // being separate processes.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -327,6 +327,7 @@ func (s *PublicServer) handleListSessions(w http.ResponseWriter, r *http.Request
 
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
 		"sessions": sessions,
+		"host":     s.shared.hostStats(),
 	})
 }
 

--- a/internal/server/memory_test.go
+++ b/internal/server/memory_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/backend"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// usageBackend is a stub that prices its warm terminals, which is what the
+// host backend does and the tmux one never could.
+type usageBackend struct {
+	*stubBackend
+	usage map[string]int64
+}
+
+func (b *usageBackend) Usage() map[string]int64 { return b.usage }
+
+func (b *usageBackend) Status() backend.Status {
+	var total int64
+	for _, rss := range b.usage {
+		total += rss
+	}
+	return backend.Status{Name: "stub", Available: true, Warm: len(b.usage), WarmRSS: total}
+}
+
+func newMemoryTest(t *testing.T, usage map[string]int64) (*PublicServer, *Shared, *usageBackend) {
+	t.Helper()
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	be := &usageBackend{stubBackend: newStubBackend(), usage: usage}
+	shared := NewShared(db, notifications.NewManager(db), be)
+	return &PublicServer{shared: shared}, shared, be
+}
+
+func listSessions(t *testing.T, s *PublicServer) map[string]interface{} {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.handleListSessions(rec, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
+	var payload map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode %q: %v", rec.Body.String(), err)
+	}
+	return payload
+}
+
+// Nothing reclaims memory on its own any more, so the only way a user learns a
+// session is expensive is the number the list carries for it.
+func TestListSessions_PricesWarmSessions(t *testing.T) {
+	s, shared, be := newMemoryTest(t, map[string]int64{"warm": 412 * 1024 * 1024})
+	seedSessionWithStatus(t, shared.DB, "warm", "idle")
+	seedSessionWithStatus(t, shared.DB, "cold", "idle")
+	be.handles["warm"] = "/tmp/warm.sock"
+
+	sessions, ok := listSessions(t, s)["sessions"].([]interface{})
+	if !ok {
+		t.Fatal("response has no sessions array")
+	}
+
+	priced := map[string]interface{}{}
+	for _, raw := range sessions {
+		sess := raw.(map[string]interface{})
+		priced[sess["session_id"].(string)] = sess["memory_bytes"]
+	}
+	if got := priced["warm"]; got != float64(412*1024*1024) {
+		t.Errorf("warm session memory_bytes = %v, want 432013312", got)
+	}
+	// A cold session runs nothing and so costs nothing: reporting 0 would read
+	// as a measurement, when the truth is there is nothing to measure.
+	if got, ok := priced["cold"]; ok && got != nil {
+		t.Errorf("cold session carries memory_bytes = %v, want it absent", got)
+	}
+}
+
+func TestListSessions_ReportsPoolAndMachine(t *testing.T) {
+	s, shared, be := newMemoryTest(t, map[string]int64{
+		"a": 400 * 1024 * 1024,
+		"b": 200 * 1024 * 1024,
+	})
+	seedSessionWithStatus(t, shared.DB, "a", "idle")
+	be.handles["a"] = "/tmp/a.sock"
+
+	host, ok := listSessions(t, s)["host"].(map[string]interface{})
+	if !ok {
+		t.Fatal("response has no host envelope")
+	}
+	if host["warm"] != float64(2) {
+		t.Errorf("warm = %v, want 2", host["warm"])
+	}
+	if host["warm_rss"] != float64(600*1024*1024) {
+		t.Errorf("warm_rss = %v, want 629145600", host["warm_rss"])
+	}
+	// The budget is advice, not a ceiling — but a client with no number to
+	// compare against cannot tell the user the pool has grown.
+	if budget, _ := host["budget"].(float64); budget <= 0 {
+		t.Errorf("budget = %v, want the advisory threshold", host["budget"])
+	}
+	// What the pool costs means little without the machine it is costing.
+	total, _ := host["memory_total"].(float64)
+	used, _ := host["memory_used"].(float64)
+	if total <= 0 || used <= 0 || used > total {
+		t.Errorf("machine memory = %v of %v, want a usable reading", used, total)
+	}
+	if load, _ := host["load"].(float64); load < 0 {
+		t.Errorf("load = %v, want a per-core fraction", load)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/reporter"
 	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/sysinfo"
 )
 
 // Shared holds shared dependencies between internal and public servers.
@@ -56,11 +57,37 @@ type PublicServer struct {
 	shared     *Shared
 }
 
-// injectTerminal enriches a session with the handle of its live terminal, so
-// clients can tell a running session from a cold one.
+// injectTerminal enriches a session with the handle of its live terminal and
+// what that terminal costs, so clients can tell a running session from a cold
+// one and see which of them is worth closing.
 func (sh *Shared) injectTerminal(sess *store.Session) {
-	if handle, ok := sh.Backend.Handle(sess.SessionID); ok {
-		sess.Terminal = &handle
+	handle, ok := sh.Backend.Handle(sess.SessionID)
+	if !ok {
+		return
+	}
+	sess.Terminal = &handle
+	if usage, ok := sh.Backend.(backend.Usager); ok {
+		if rss, found := usage.Usage()[sess.SessionID]; found {
+			sess.MemoryBytes = &rss
+		}
+	}
+}
+
+// hostStats reports what the warm pool costs and what the machine has left,
+// so a client can show a session's price next to the room it is eating into.
+//
+// Nothing enforces the budget — the daemon evicts nobody — so it is only there
+// for a client that wants to say when the pool has grown large.
+func (sh *Shared) hostStats() map[string]interface{} {
+	status := sh.Backend.Status()
+	machine := sysinfo.Read()
+	return map[string]interface{}{
+		"warm":         status.Warm,
+		"warm_rss":     status.WarmRSS,
+		"budget":       machine.MemoryTotal / 4,
+		"load":         machine.Load,
+		"memory_used":  machine.MemoryUsed,
+		"memory_total": machine.MemoryTotal,
 	}
 }
 

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -33,7 +33,11 @@ type Session struct {
 	PermissionMode *string `json:"permission_mode,omitempty"`
 	// Terminal is the handle of the session's live terminal host, injected by
 	// the daemon rather than stored: a cold session simply has none.
-	Terminal            *string `json:"terminal,omitempty"`
+	Terminal *string `json:"terminal,omitempty"`
+	// MemoryBytes is what the live terminal's process tree costs in resident
+	// memory. Injected alongside Terminal, and absent for a cold session,
+	// which costs nothing until it is woken.
+	MemoryBytes         *int64  `json:"memory_bytes,omitempty"`
 	CreatedAt           string  `json:"created_at"`
 	EndedAt             *string `json:"ended_at,omitempty"`
 	SupportsPromptQueue bool    `json:"supports_prompt_queue"`

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -1,0 +1,170 @@
+// Package sysinfo reads what the machine as a whole is doing, so a client can
+// put a session's cost next to the room the machine has left.
+package sysinfo
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// How long a reading is trusted. Every field here comes from a shell-out or a
+// file read, and clients ask on every poll.
+const ttl = 15 * time.Second
+
+// Stats is the machine's own load, as opposed to any one session's.
+type Stats struct {
+	// Load is the one-minute load average over the core count, as a fraction:
+	// 1 means the machine is saturated. Load rather than an instantaneous CPU
+	// percentage because sampling for the latter costs a second of waiting.
+	Load float64 `json:"load"`
+	// MemoryUsed is physical memory in use, and MemoryTotal what the machine
+	// has. Both are 0 where they cannot be read.
+	MemoryUsed  int64 `json:"memory_used"`
+	MemoryTotal int64 `json:"memory_total"`
+}
+
+var (
+	mu     sync.Mutex
+	cached Stats
+	read   time.Time
+)
+
+// Read returns the machine's load and memory, cached for ttl.
+func Read() Stats {
+	mu.Lock()
+	defer mu.Unlock()
+	if !read.IsZero() && time.Since(read) < ttl {
+		return cached
+	}
+
+	total := MemoryTotal()
+	cached = Stats{
+		Load:        loadAverage() / float64(runtime.NumCPU()),
+		MemoryUsed:  total - memoryAvailable(),
+		MemoryTotal: total,
+	}
+	if cached.MemoryUsed < 0 || total == 0 {
+		cached.MemoryUsed = 0
+	}
+	read = time.Now()
+	return cached
+}
+
+// MemoryTotal returns physical memory in bytes, or 0 where it cannot be read.
+// Linux is read from /proc/meminfo rather than sysctl, which reports something
+// unrelated there.
+func MemoryTotal() int64 {
+	if runtime.GOOS == "linux" {
+		return meminfoField("MemTotal:")
+	}
+	return sysctlInt("hw.memsize")
+}
+
+// memoryAvailable returns the bytes a new process could claim without paging.
+func memoryAvailable() int64 {
+	if runtime.GOOS == "linux" {
+		return meminfoField("MemAvailable:")
+	}
+	// Free pages plus the ones the kernel would hand over on demand:
+	// speculative reads and the inactive list are both reclaimable.
+	out, err := run("vm_stat")
+	if err != nil {
+		return 0
+	}
+	pageSize := int64(4096)
+	if i := strings.Index(out, "page size of "); i >= 0 {
+		if n, err := strconv.ParseInt(strings.Fields(out[i+len("page size of "):])[0], 10, 64); err == nil {
+			pageSize = n
+		}
+	}
+	var pages int64
+	for _, line := range strings.Split(out, "\n") {
+		name, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		switch strings.TrimSpace(name) {
+		case "Pages free", "Pages inactive", "Pages speculative", "Pages purgeable":
+			n, err := strconv.ParseInt(strings.Trim(strings.TrimSpace(value), "."), 10, 64)
+			if err == nil {
+				pages += n
+			}
+		}
+	}
+	return pages * pageSize
+}
+
+// loadAverage returns the one-minute load average, or 0 if it cannot be read.
+func loadAverage() float64 {
+	if runtime.GOOS == "linux" {
+		data, err := os.ReadFile("/proc/loadavg")
+		if err != nil {
+			return 0
+		}
+		fields := strings.Fields(string(data))
+		if len(fields) == 0 {
+			return 0
+		}
+		load, _ := strconv.ParseFloat(fields[0], 64)
+		return load
+	}
+	// Darwin reports it as "{ 2.20 2.33 2.65 }".
+	out, err := run("sysctl", "-n", "vm.loadavg")
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(strings.Trim(strings.TrimSpace(out), "{}"))
+	if len(fields) == 0 {
+		return 0
+	}
+	load, _ := strconv.ParseFloat(fields[0], 64)
+	return load
+}
+
+func meminfoField(key string) int64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, key) {
+			continue
+		}
+		fields := strings.Fields(line)
+		// key, value, unit — the kernel always reports kB here.
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			return 0
+		}
+		return kb * 1024
+	}
+	return 0
+}
+
+func sysctlInt(name string) int64 {
+	out, err := run("sysctl", "-n", name)
+	if err != nil {
+		return 0
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func run(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/internal/sysinfo/sysinfo_test.go
+++ b/internal/sysinfo/sysinfo_test.go
@@ -1,0 +1,42 @@
+package sysinfo
+
+import (
+	"testing"
+	"time"
+)
+
+// The numbers are shown to a user deciding what to close, so a plausibility
+// check is the most a test can do: the real values differ every run.
+func TestReadReportsPlausibleNumbers(t *testing.T) {
+	s := Read()
+
+	if s.MemoryTotal <= 0 {
+		t.Fatalf("memory total = %d, want the machine's physical memory", s.MemoryTotal)
+	}
+	if s.MemoryUsed <= 0 || s.MemoryUsed > s.MemoryTotal {
+		t.Errorf("memory used = %d, want between 0 and %d", s.MemoryUsed, s.MemoryTotal)
+	}
+	if s.Load < 0 || s.Load > 100 {
+		t.Errorf("load = %f, want a sane per-core fraction", s.Load)
+	}
+}
+
+func TestReadIsCached(t *testing.T) {
+	first := Read()
+
+	mu.Lock()
+	cached.MemoryUsed = 1
+	mu.Unlock()
+
+	if got := Read().MemoryUsed; got != 1 {
+		t.Errorf("second read = %d, want the cached 1 — measuring costs a fork per field", got)
+	}
+
+	mu.Lock()
+	read = time.Now().Add(-2 * ttl)
+	mu.Unlock()
+
+	if got := Read().MemoryUsed; got == 1 {
+		t.Errorf("reading never went stale; want a fresh measurement near %d", first.MemoryUsed)
+	}
+}

--- a/internal/terminal/e2e_test.go
+++ b/internal/terminal/e2e_test.go
@@ -355,49 +355,6 @@ func TestE2ERegistryWakeIsIdempotent(t *testing.T) {
 	}
 }
 
-// TestE2EEvictionRespectsMaxWarm checks the warm pool ceiling, which is what
-// keeps three 380 MB Claude processes from becoming ten.
-func TestE2EEvictionRespectsMaxWarm(t *testing.T) {
-	e := newE2E(t)
-
-	reg := NewRegistry(e.heliosDir(), func(sessionID, cwd string, argv []string) error {
-		cmd := exec.Command(e.binary, "ptyhost", sessionID, "--cwd", cwd, "--cmd", "sh")
-		cmd.Env = append(os.Environ(), "HOME="+e.dir)
-		cmd.SysProcAttr = detachSysProcAttr()
-		if err := cmd.Start(); err != nil {
-			return err
-		}
-		return cmd.Process.Release()
-	})
-	reg.MaxWarm = 2
-	reg.MaxWarmRSS = 0 // isolate the count ceiling
-
-	ids := []string{"warm-a", "warm-b", "warm-c"}
-	t.Cleanup(func() {
-		for _, id := range ids {
-			reg.Evict(id)
-		}
-	})
-
-	for _, id := range ids {
-		if _, err := reg.Wake(id, e.dir); err != nil {
-			t.Fatalf("Wake %s: %v", id, err)
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-
-	if got := len(reg.Warm()); got > 2 {
-		t.Errorf("warm pool = %d, want at most 2", got)
-	}
-	// The most recent must survive; the oldest must be gone.
-	if !reg.IsWarm("warm-c") {
-		t.Error("most recently woken session was evicted")
-	}
-	if reg.IsWarm("warm-a") {
-		t.Error("least recently used session should have been evicted")
-	}
-}
-
 // hasClaude reports whether the real CLI is installed.
 func hasClaude(t *testing.T) string {
 	t.Helper()
@@ -680,5 +637,39 @@ func TestE2EArgvReachesTheChildWhole(t *testing.T) {
 
 	if !waitForFrameContaining(t, c, "["+raw+"]", 10*time.Second) {
 		t.Errorf("child never received %q intact", raw)
+	}
+}
+
+// TestE2EUsagePricesALiveHost covers the number the clients show. It replaced
+// the eviction the pool used to do on its own: nothing reclaims memory now, so
+// the reading has to be real or the user is deciding on a fiction.
+func TestE2EUsagePricesALiveHost(t *testing.T) {
+	e := newE2E(t)
+	const sid = "e2e-usage"
+
+	reg := NewRegistry(e.heliosDir(), func(sessionID, cwd string, argv []string) error {
+		cmd := exec.Command(e.binary, "ptyhost", sessionID, "--cwd", cwd, "--cmd", "sh")
+		cmd.Env = append(os.Environ(), "HOME="+e.dir)
+		cmd.SysProcAttr = detachSysProcAttr()
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		return cmd.Process.Release()
+	})
+	t.Cleanup(func() { reg.Evict(sid) })
+
+	if _, err := reg.Wake(sid, e.dir); err != nil {
+		t.Fatalf("Wake: %v", err)
+	}
+
+	usage := reg.Usage()
+	if usage[sid] <= 0 {
+		t.Fatalf("usage = %v, want resident bytes for the live host", usage)
+	}
+
+	// Cached: measuring forks ps and pgrep per process, and clients ask on
+	// every poll.
+	if again := reg.Usage(); len(again) != len(usage) || again[sid] != usage[sid] {
+		t.Errorf("second reading = %v, want the cached %v", again, usage)
 	}
 }

--- a/internal/terminal/registry.go
+++ b/internal/terminal/registry.go
@@ -2,10 +2,8 @@ package terminal
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,23 +12,9 @@ import (
 	"time"
 )
 
-// Defaults for the warm pool.
-//
-// A warm Claude Code measures ~380 MB RSS, so memory is the binding constraint
-// rather than latency: re-warming costs under 5s via `claude --resume`. That
-// makes MaxWarmRSS the ceiling that should actually bind, and MaxWarm a
-// backstop against pathological session counts rather than the everyday limit
-// — hence 20 and not 3.
-//
-// There is deliberately no idle TTL. A session goes away when the user closes
-// it, and at no other time: age is not evidence that nobody wants it, and an
-// eviction costs the host's scrollback ring, which no `claude --resume` brings
-// back. Sessions that outlive their usefulness sit idle until they are closed
-// or until the pool needs the room.
-const (
-	DefaultMaxWarm  = 20
-	DefaultMaxWarmR = 0 // 0 means "derive from system memory"
-)
+// How long a resident-set reading is trusted. Measuring shells out to ps and
+// pgrep once per process in every host's tree, and clients ask on every poll.
+const usageTTL = 30 * time.Second
 
 // SpawnFunc launches a detached ptyhost for a session. Empty argv means
 // "resume this session's agent", which is the warm-pool path; otherwise argv
@@ -47,17 +31,9 @@ type Registry struct {
 	mu      sync.Mutex
 	entries map[string]*entry
 
-	MaxWarm    int
-	MaxWarmRSS int64 // bytes; 0 disables the memory ceiling
-
-	// InUse reports whether a session is being watched right now. Sessions it
-	// returns true for are never evicted to reclaim room, however old they
-	// look: killing the terminal somebody has open on their phone is the one
-	// eviction the user is guaranteed to notice.
-	//
-	// It is called without the registry lock held, because the implementation
-	// lives in the backend and takes its own mutex before ours.
-	InUse func(sessionID string) bool
+	usageMu   sync.Mutex
+	usage     map[string]int64
+	usageRead time.Time
 }
 
 type entry struct {
@@ -71,11 +47,9 @@ type entry struct {
 // NewRegistry returns a Registry rooted at heliosDir.
 func NewRegistry(heliosDir string, spawn SpawnFunc) *Registry {
 	return &Registry{
-		heliosDir:  heliosDir,
-		spawn:      spawn,
-		entries:    make(map[string]*entry),
-		MaxWarm:    DefaultMaxWarm,
-		MaxWarmRSS: defaultMaxWarmRSS(),
+		heliosDir: heliosDir,
+		spawn:     spawn,
+		entries:   make(map[string]*entry),
 	}
 }
 
@@ -171,8 +145,6 @@ func (r *Registry) start(sessionID, cwd string, argv []string) (string, error) {
 	if r.spawn == nil {
 		return "", fmt.Errorf("terminal: no spawn function configured")
 	}
-	// Make room before adding, so the ceiling is respected at all times.
-	r.evictForRoom(1)
 
 	if err := r.spawn(sessionID, cwd, argv); err != nil {
 		return "", fmt.Errorf("spawn terminal host for %s: %w", sessionID, err)
@@ -211,8 +183,7 @@ func (r *Registry) adopt(sessionID, sock, cwd string) {
 	}
 }
 
-// Touch records that a session is active, so the LRU in evictForRoom reflects
-// use rather than adoption order.
+// Touch records that a session is active, which is what orders Warm.
 //
 // Callers should throttle: this takes the registry lock, and screen activity
 // arrives many times a second from a redrawing TUI.
@@ -290,12 +261,11 @@ func (r *Registry) Warm() []string {
 	return out
 }
 
-// Sweep forgets hosts whose socket has gone away, then enforces the count and
-// memory ceilings.
+// Sweep forgets hosts whose socket has gone away.
 //
-// It kills nothing on account of age. A session that has sat untouched for a
-// week is still a session the user did not close, and the only thing an
-// eviction would buy is memory the ceilings already govern.
+// It kills nothing of its own accord. A session that has sat untouched for a
+// week is still a session the user did not close, and only the user closes
+// one: the pool has no ceiling to enforce and no idle TTL.
 func (r *Registry) Sweep() {
 	r.mu.Lock()
 	var stale []string
@@ -312,86 +282,34 @@ func (r *Registry) Sweep() {
 		r.mu.Unlock()
 		RemoveHostFiles(r.heliosDir, id)
 	}
-	// Nothing is waiting on a slot here, unlike the call in start: a sweep that
-	// asked for headroom would evict a healthy session on every pass and hold
-	// the pool one below its ceiling forever.
-	r.evictForRoom(0)
 }
 
-// inUse consults the InUse predicate, if one is set. Never call it with the
-// registry lock held.
-func (r *Registry) inUse(sessionID string) bool {
-	return r.InUse != nil && r.InUse(sessionID)
-}
+// Usage reports resident bytes per warm session, so clients can show what a
+// session costs and the user can decide which to close. Readings are cached
+// for usageTTL because measuring is a fork per process in every host's tree.
+func (r *Registry) Usage() map[string]int64 {
+	r.usageMu.Lock()
+	defer r.usageMu.Unlock()
+	if r.usage != nil && time.Since(r.usageRead) < usageTTL {
+		return r.usage
+	}
 
-// evictForRoom enforces both ceilings: at most MaxWarm hosts, and total warm
-// RSS under MaxWarmRSS. Least-recently-active goes first, and sessions with a
-// live viewer are never chosen.
-//
-// headroom is the number of hosts the caller is about to add. start passes 1
-// so the ceiling still holds once its host comes up; a caller that is only
-// tidying passes 0. Getting this wrong is not harmless: with headroom always
-// 1, every sweep evicts a healthy session to make room nobody asked for.
-//
-// Neither the RSS measurement nor the InUse check may run under the registry
-// lock. processTreeRSS shells out to ps and pgrep once per process in the
-// tree, and InUse calls back into the backend, which takes its own mutex
-// before this one.
-func (r *Registry) evictForRoom(headroom int) {
-	for {
-		r.mu.Lock()
-		if len(r.entries) == 0 {
-			r.mu.Unlock()
-			return
-		}
-		overCount := r.MaxWarm > 0 && len(r.entries)+headroom > r.MaxWarm
-		candidates := make([]*entry, 0, len(r.entries))
-		for _, e := range r.entries {
-			candidates = append(candidates, e)
-		}
-		measure := r.MaxWarmRSS
-		r.mu.Unlock()
+	r.mu.Lock()
+	pids := make(map[string]int, len(r.entries))
+	for id, e := range r.entries {
+		pids[id] = e.pid
+	}
+	r.mu.Unlock()
 
-		var overMem bool
-		if measure > 0 {
-			var total int64
-			for _, e := range candidates {
-				total += processTreeRSS(e.pid)
-			}
-			overMem = total > measure
-		}
-		if !overCount && !overMem {
-			return
-		}
-
-		sort.Slice(candidates, func(i, j int) bool {
-			return candidates[i].lastActive.Before(candidates[j].lastActive)
-		})
-		victim := ""
-		for _, e := range candidates {
-			// Never a user's shell. An evicted agent comes back with
-			// `claude --resume`; an evicted shell is a lost scrollback and a
-			// job the user was running, with nothing to resume it from.
-			if IsShell(e.sessionID) {
-				continue
-			}
-			if !r.inUse(e.sessionID) {
-				victim = e.sessionID
-				break
-			}
-		}
-		if victim == "" {
-			// Everything warm is being watched. Going over the ceiling is the
-			// better failure: the alternative is killing a terminal somebody
-			// has open.
-			log.Printf("registry: over warm ceiling (%d hosts) but every session has a viewer", len(candidates))
-			return
-		}
-		if err := r.Evict(victim); err != nil {
-			log.Printf("registry: evict %s for room: %v", victim, err)
-			return
+	usage := make(map[string]int64, len(pids))
+	for id, pid := range pids {
+		if rss := processTreeRSS(pid); rss > 0 {
+			usage[id] = rss
 		}
 	}
+	r.usage = usage
+	r.usageRead = time.Now()
+	return usage
 }
 
 // WaitForSocket blocks until a socket accepts connections or the timeout
@@ -430,49 +348,4 @@ func processTreeRSS(pid int) int64 {
 		}
 	}
 	return total
-}
-
-// defaultMaxWarmRSS budgets a quarter of physical memory for warm sessions.
-//
-// This is the ceiling that actually binds — MaxWarm is a backstop — so a
-// platform where it returns 0 has no memory ceiling at all. Linux is read from
-// /proc/meminfo rather than sysctl, which reports something unrelated there.
-func defaultMaxWarmRSS() int64 {
-	if runtime.GOOS == "linux" {
-		return linuxMemTotal() / 4
-	}
-	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
-	if err != nil {
-		return 0
-	}
-	total, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
-	if err != nil || total <= 0 {
-		return 0
-	}
-	return total / 4
-}
-
-// linuxMemTotal returns physical memory in bytes from /proc/meminfo, or 0 if
-// it cannot be read.
-func linuxMemTotal() int64 {
-	data, err := os.ReadFile("/proc/meminfo")
-	if err != nil {
-		return 0
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if !strings.HasPrefix(line, "MemTotal:") {
-			continue
-		}
-		fields := strings.Fields(line)
-		// "MemTotal:", value, unit — the kernel always reports kB here.
-		if len(fields) < 2 {
-			return 0
-		}
-		kb, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil || kb <= 0 {
-			return 0
-		}
-		return kb * 1024
-	}
-	return 0
 }

--- a/internal/terminal/registry_test.go
+++ b/internal/terminal/registry_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"testing"
@@ -30,12 +31,11 @@ func newRegistryEnv(t *testing.T) *registryEnv {
 		t.Errorf("unexpected spawn of %s", sessionID)
 		return nil
 	})
-	reg.MaxWarmRSS = 0 // isolate the count ceiling from the memory one
 	return &registryEnv{t: t, dir: dir, reg: reg}
 }
 
 // add registers a stub host and backdates its activity by age, so tests can
-// control the LRU order directly.
+// control the activity order directly.
 func (e *registryEnv) add(sessionID string, age time.Duration) {
 	e.t.Helper()
 	if err := os.MkdirAll(RunDir(e.dir), 0o700); err != nil {
@@ -74,51 +74,12 @@ func (e *registryEnv) warm() map[string]bool {
 	return out
 }
 
-// TestSweepKeepsPoolAtMaxWarm is the regression test for the reaper evicting a
-// healthy session on every pass. evictForRoom took no headroom argument, so
-// the sweep asked for a slot nobody wanted and the pool sat one below its
-// ceiling forever: MaxWarm 3 meant 2 warm sessions.
-func TestSweepKeepsPoolAtMaxWarm(t *testing.T) {
-	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 3
-	e.add("a", 3*time.Hour)
-	e.add("b", 2*time.Hour)
-	e.add("c", time.Hour)
-
-	e.reg.Sweep()
-
-	if got := len(e.reg.Warm()); got != 3 {
-		t.Errorf("warm = %d, want 3: Sweep evicted a healthy session to make room nobody asked for", got)
-	}
-}
-
-// TestEvictForRoomMakesSpaceForOne covers the other side: the caller that is
-// about to spawn does need a free slot.
-func TestEvictForRoomMakesSpaceForOne(t *testing.T) {
-	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 3
-	e.add("a", 3*time.Hour)
-	e.add("b", 2*time.Hour)
-	e.add("c", time.Hour)
-
-	e.reg.evictForRoom(1)
-
-	warm := e.warm()
-	if len(warm) != 2 {
-		t.Fatalf("warm = %v, want 2 so a third host can start", warm)
-	}
-	if warm["a"] {
-		t.Error("least recently active session survived; the LRU picked wrong")
-	}
-}
-
 // TestSweepDoesNotEvictOnAge pins the policy decision: sessions are closed by
 // the user, never by the clock. Age alone must not cost a session its host,
 // because an eviction loses the scrollback ring and `claude --resume` does not
 // bring it back.
 func TestSweepDoesNotEvictOnAge(t *testing.T) {
 	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 10
 	e.add("ancient", 30*24*time.Hour)
 	e.add("recent", time.Minute)
 
@@ -133,56 +94,10 @@ func TestSweepDoesNotEvictOnAge(t *testing.T) {
 	}
 }
 
-// TestEvictForRoomSkipsWatchedSessions checks that a session somebody has open
-// is never the victim, however stale its LRU position looks.
-func TestEvictForRoomSkipsWatchedSessions(t *testing.T) {
-	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 2
-	e.add("watched", 5*time.Hour)
-	e.add("idle", time.Hour)
-	e.reg.InUse = func(sessionID string) bool { return sessionID == "watched" }
-
-	e.reg.evictForRoom(1)
-
-	warm := e.warm()
-	if !warm["watched"] {
-		t.Error("evicted the session with a live viewer")
-	}
-	if warm["idle"] {
-		t.Error("expected the unwatched session to be evicted instead")
-	}
-}
-
-// TestEvictForRoomStopsWhenEverythingIsWatched prefers going over the ceiling
-// to killing a terminal someone is looking at.
-func TestEvictForRoomStopsWhenEverythingIsWatched(t *testing.T) {
-	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 1
-	e.add("a", 5*time.Hour)
-	e.add("b", time.Hour)
-	e.reg.InUse = func(string) bool { return true }
-
-	done := make(chan struct{})
-	go func() {
-		e.reg.evictForRoom(0)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("evictForRoom did not return: it is looping over victims it refuses to evict")
-	}
-
-	if got := len(e.reg.Warm()); got != 2 {
-		t.Errorf("warm = %d, want 2: both sessions are watched and neither may be evicted", got)
-	}
-}
-
 // TestSweepForgetsDeadSockets keeps the half of the reaper that still earns
 // its keep: noticing that a ptyhost died.
 func TestSweepForgetsDeadSockets(t *testing.T) {
 	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 10
 	e.add("alive", time.Minute)
 	e.add("dead", time.Minute)
 
@@ -199,5 +114,21 @@ func TestSweepForgetsDeadSockets(t *testing.T) {
 	}
 	if !warm["alive"] {
 		t.Error("live session was forgotten")
+	}
+}
+
+// TestSweepHasNoCeiling pins the other half of the policy: the pool is
+// unbounded. Memory is reported to the user, who closes what they are done
+// with; nothing here reclaims it for them.
+func TestSweepHasNoCeiling(t *testing.T) {
+	e := newRegistryEnv(t)
+	for i := 0; i < 25; i++ {
+		e.add(fmt.Sprintf("sess-%d", i), time.Duration(i)*time.Hour)
+	}
+
+	e.reg.Sweep()
+
+	if got := len(e.reg.Warm()); got != 25 {
+		t.Errorf("warm = %d, want all 25 kept", got)
 	}
 }

--- a/internal/terminal/shell_test.go
+++ b/internal/terminal/shell_test.go
@@ -82,23 +82,6 @@ func TestTerminalsListsTheAgentFirst(t *testing.T) {
 	}
 }
 
-// A shell holds a scrollback and whatever the user was running. An agent
-// evicted for room comes back with --resume; a shell has nothing to come back
-// from, so the pool must take the room from somewhere else.
-func TestEvictForRoomNeverTakesAShell(t *testing.T) {
-	e := newRegistryEnv(t)
-	e.reg.MaxWarm = 2
-	e.add(ShellID("sess-1", 1), 5*time.Hour) // oldest, and the obvious victim
-	e.add("sess-1", time.Hour)
-	e.add("sess-2", 2*time.Hour)
-
-	e.reg.Sweep()
-
-	if warm := e.warm(); !warm[ShellID("sess-1", 1)] {
-		t.Errorf("warm = %v, want the shell kept", warm)
-	}
-}
-
 func TestKillShellsLeavesTheAgent(t *testing.T) {
 	e := newRegistryEnv(t)
 	e.add("sess-1", 0)

--- a/mobile/lib/models/session.dart
+++ b/mobile/lib/models/session.dart
@@ -22,6 +22,10 @@ class Session {
   /// Handle of the session's live terminal host, or null when the session is
   /// cold and has to be resumed before it can be driven.
   final String? terminal;
+
+  /// What the live terminal's process tree holds in memory. Null when cold: a
+  /// session that is not running costs nothing until it is woken.
+  final int? memoryBytes;
   final bool supportsPromptQueue;
   final String createdAt;
   final String? endedAt;
@@ -47,6 +51,7 @@ class Session {
     this.archived = false,
     this.permissionMode,
     this.terminal,
+    this.memoryBytes,
     this.supportsPromptQueue = false,
     required this.createdAt,
     this.endedAt,
@@ -71,6 +76,7 @@ class Session {
       archived: json['archived'] == true || json['archived'] == 1,
       permissionMode: json['permission_mode'] as String?,
       terminal: json['terminal'] as String?,
+      memoryBytes: (json['memory_bytes'] as num?)?.toInt(),
       supportsPromptQueue: json['supports_prompt_queue'] == true,
       createdAt: json['created_at'] as String,
       endedAt: json['ended_at'] as String?,
@@ -114,6 +120,15 @@ class Session {
   /// flight and strand any pending permission prompt.
   bool get canSwitchPermissionMode => source == 'claude' && isIdle;
 
+  /// Memory the terminal holds, as "412 MB" or "1.2 GB". Empty when cold.
+  String get memoryLabel {
+    final bytes = memoryBytes;
+    if (bytes == null || bytes <= 0) return '';
+    const gb = 1024 * 1024 * 1024;
+    if (bytes >= gb) return '${(bytes / gb).toStringAsFixed(1)} GB';
+    return '${(bytes / (1024 * 1024)).round()} MB';
+  }
+
   Session copyWith({
     String? title,
     bool? pinned,
@@ -138,6 +153,7 @@ class Session {
       archived: archived ?? this.archived,
       permissionMode: permissionMode ?? this.permissionMode,
       terminal: terminal,
+      memoryBytes: memoryBytes,
       supportsPromptQueue: supportsPromptQueue,
       createdAt: createdAt,
       endedAt: endedAt,

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -805,6 +805,26 @@ class _SessionDetailScreenState extends State<SessionDetailScreen>
       );
     }
 
+    if (session.memoryLabel.isNotEmpty) {
+      actions.add(
+        Tooltip(
+          message: 'Memory this terminal holds',
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Center(
+              child: Text(
+                session.memoryLabel,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
     if (session.needsRecovery) {
       actions.add(
         IconButton(

--- a/mobile/lib/screens/sessions_screen.dart
+++ b/mobile/lib/screens/sessions_screen.dart
@@ -722,6 +722,16 @@ class _SessionsScreenState extends State<SessionsScreen> {
                                     style: TextStyle(fontSize: 11, color: statusColor, fontWeight: FontWeight.w600),
                                   ),
                                 ),
+                                if (session.memoryLabel.isNotEmpty) ...[
+                                  const SizedBox(width: 6),
+                                  Text(
+                                    session.memoryLabel,
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ],
                                 if (session.needsRecovery) ...[
                                   const SizedBox(width: 6),
                                   Tooltip(

--- a/mobile/test/session_test.dart
+++ b/mobile/test/session_test.dart
@@ -47,4 +47,32 @@ void main() {
       expect(s.canStop, isFalse);
     });
   });
+
+  // The daemon reclaims no memory on its own, so this label is what tells the
+  // user which session is worth closing.
+  group('memoryLabel', () {
+    Session withMemory(int? bytes) => Session.fromJson({
+          'session_id': 's1',
+          'source': 'claude',
+          'cwd': '/tmp/proj',
+          'status': 'idle',
+          'created_at': '2026-01-01T00:00:00Z',
+          'memory_bytes': ?bytes,
+        });
+
+    test('megabytes below a gigabyte', () {
+      expect(withMemory(412 * 1024 * 1024).memoryLabel, '412 MB');
+    });
+
+    test('gigabytes above one', () {
+      expect(withMemory(1610612736).memoryLabel, '1.5 GB');
+    });
+
+    // A cold session runs nothing: an empty label is what keeps the chip off
+    // the card entirely, rather than showing a misleading 0 MB.
+    test('a cold session has no label', () {
+      expect(withMemory(null).memoryLabel, isEmpty);
+      expect(withMemory(0).memoryLabel, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Removes both warm-pool ceilings. `evictForRoom`, `MaxWarm`, `MaxWarmRSS` and the `InUse` predicate are gone: a terminal now lives until the user closes it, and nothing reclaims memory on a timer or a count.
- Keeps the measurement that used to drive eviction and shows it instead. `Registry.Usage()` prices each warm host (30s cache, since it forks `ps`/`pgrep` per process), surfaced through the new optional `backend.Usager` interface so the existing test fakes did not need to change.
- New `internal/sysinfo` reads the machine's load average and used/total memory — `/proc/loadavg` + `/proc/meminfo` on Linux, `sysctl vm.loadavg` + `vm_stat` on macOS, cached 15s.
- `/api/sessions` gains `memory_bytes` per warm session and a `host` envelope: `{warm, warm_rss, budget, load, memory_used, memory_total}`. `budget` is a quarter of physical memory — the old hard ceiling, now advisory only.
- Desktop: per-session figure on the card (hidden in compact density) and in the detail header; a one-line per-host reading under the host header with memory and CPU icons, amber past the budget with the terminate advice in its tooltip.
- Mobile: per-session figure on the session card and in the session detail header.
- Desktop connection errors now name the host and are announced once rather than on every poll for a host whose dot already shows it offline — undici's bare "fetch failed" said neither which host nor anything the dot did not.

## Test plan
- [x] `go test ./...`
- [x] New `internal/server/memory_test.go` — warm session priced, cold session absent, host envelope carries pool and machine figures
- [x] New `internal/terminal` e2e — spawns a real ptyhost, asserts `Usage()` measures it and caches the second read
- [x] New `internal/sysinfo` tests — plausible readings, cache expiry
- [x] `TestSweepHasNoCeiling` — 25 hosts survive a sweep
- [x] `cd mobile && flutter analyze` + `flutter test` (63)
- [x] `cd desktop && npm run typecheck && npm run build`
- [x] Sidebar reading rendered against the built CSS at sidebar width, normal and over-budget