### PR TITLE
ci: run the test suites on push and pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,11 @@ jobs:
       - run: flutter pub get
         working-directory: mobile
 
-      # Warnings are not failures here, but anything the analyzer calls an
-      # error is: the app will not build with one.
-      - run: flutter analyze
+      # Infos are not failures: CI tracks stable, which runs ahead of the
+      # SDK on a developer's machine, and its deprecation notices land as
+      # infos for APIs that machine does not have a replacement for yet.
+      # Warnings and errors still fail.
+      - run: flutter analyze --no-fatal-infos
         working-directory: mobile
 
       - run: flutter test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,90 @@
+name: Test
+
+# Every check that used to be run by hand before a merge. The three suites are
+# separate jobs so a Dart failure does not hide a Go one.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push supersedes whatever was running for the same ref.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l cmd internal)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt needed:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - run: go vet ./...
+
+      - run: go test ./...
+
+  desktop:
+    name: Desktop
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # 22, not 20: the test script strips types at runtime, which older
+          # Node refuses to do.
+          node-version: 22
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - run: npm ci
+        working-directory: desktop
+
+      - run: npm run typecheck
+        working-directory: desktop
+
+      - run: npm test
+        working-directory: desktop
+
+      - run: npm run build
+        working-directory: desktop
+
+  mobile:
+    name: Mobile
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+        working-directory: mobile
+
+      # Warnings are not failures here, but anything the analyzer calls an
+      # error is: the app will not build with one.
+      - run: flutter analyze
+        working-directory: mobile
+
+      - run: flutter test
+        working-directory: mobile


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml`. The repo had only `release.yml`, so nothing ran `go test`, `flutter test` or the desktop typecheck automatically.
- Three jobs — Go, Desktop, Mobile — so one language's failure does not mask another's. Go also gates on `gofmt` and `go vet`.
- Desktop runs on Node 22: `npm test` uses `--experimental-strip-types`, which Node 20 refuses, so that suite had quietly stopped running.
- `concurrency` cancels superseded runs for the same ref.

## Test plan
- [ ] This PR is the test: all three jobs must pass here before merge