### PR TITLE
feat: say once when a new release is out

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -6,6 +6,7 @@ import type { Notifier } from './notify.ts'
 import type { PrefsStore } from './prefs.ts'
 import type { TerminalManager } from './terminals.ts'
 import type { ThemeRegistry } from './themes.ts'
+import type { UpdateChecker } from './updates.ts'
 import { DEFAULT_INTENSITY } from '../shared/theme/backdrop.ts'
 import type { BackdropSpec } from '../shared/theme/vscode.ts'
 import type { AppearancePrefs, BackdropState, Density } from '../shared/models.ts'
@@ -66,6 +67,7 @@ export interface IpcDeps {
   notifier: Notifier
   prefs: PrefsStore
   themes: ThemeRegistry
+  updates: UpdateChecker
   quit: () => void
   /** Whether this platform can show the OS backdrop at all. */
   glassSupported: boolean
@@ -83,7 +85,8 @@ export interface IpcDeps {
  * string otherwise.
  */
 export function registerIpc(deps: IpcDeps): void {
-  const { hosts, terminals, notifier, prefs, themes, quit, glassSupported, onAppearanceChange } = deps
+  const { hosts, terminals, notifier, prefs, themes, updates, quit, glassSupported, onAppearanceChange } =
+    deps
 
   const send = (channel: string, payload: unknown): void => {
     const window = deps.window()
@@ -149,6 +152,11 @@ export function registerIpc(deps: IpcDeps): void {
   // Quitting for real, as opposed to closing the window, which leaves the app
   // on the tray waiting for approvals.
   handle('app:quit', async () => quit())
+
+  // ─── Updates ───────────────────────────────────────────────────────────
+
+  handle('updates:check', async () => updates.check())
+  handle('updates:dismiss', async (_e, version: string) => updates.dismiss(version))
 
   // ─── Appearance ────────────────────────────────────────────────────────
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -6,6 +6,7 @@ import { HostRegistry } from './hosts.ts'
 import { Hud } from './hud.ts'
 import { Notifier, type NotifyTarget } from './notify.ts'
 import { PrefsStore } from './prefs.ts'
+import { UpdateChecker } from './updates.ts'
 import { TerminalManager } from './terminals.ts'
 import { ThemeRegistry } from './themes.ts'
 import { registerIpc } from './ipc.ts'
@@ -22,6 +23,7 @@ let terminals: TerminalManager | null = null
 let notifier: Notifier | null = null
 let hud: Hud | null = null
 let prefs: PrefsStore | null = null
+let updates: UpdateChecker | null = null
 let themes: ThemeRegistry | null = null
 let quitting = false
 
@@ -78,6 +80,7 @@ async function start(): Promise<void> {
   terminals = new TerminalManager(hosts)
   prefs = new PrefsStore()
   prefs.load()
+  updates = new UpdateChecker()
   themes = new ThemeRegistry(path.join(distDir, 'themes'))
   themes.load()
   hud = new Hud(rendererDir, path.join(distDir, 'preload', 'preload.js'), activateNotification)
@@ -95,6 +98,7 @@ async function start(): Promise<void> {
     notifier,
     prefs,
     themes,
+    updates,
     quit,
     glassSupported: GLASS_SUPPORTED,
     onAppearanceChange: applyWindowMaterial,

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -1,0 +1,79 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { UpdateInfo } from '../shared/models.ts'
+import { isNewer } from '../shared/version.ts'
+
+const REPO = 'kamrul1157024/helios'
+const LATEST = `https://api.github.com/repos/${REPO}/releases/latest`
+
+/**
+ * Whether a newer release exists, and whether the user has already been told.
+ *
+ * There is no auto-updater here: the app ships as a DMG, an AppImage and a
+ * deb, and none of them update themselves. What it can do is notice, once, and
+ * point at the download — the mobile app does the same against the same
+ * releases.
+ */
+export class UpdateChecker {
+  private readonly file: string
+  private dismissed = ''
+  private checked: UpdateInfo | null = null
+
+  constructor(userDataDir = app.getPath('userData')) {
+    this.file = path.join(userDataDir, 'update-dismissed.json')
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.file, 'utf8')) as { version?: string }
+      this.dismissed = parsed.version ?? ''
+    } catch {
+      this.dismissed = ''
+    }
+  }
+
+  /**
+   * Returns the release worth mentioning, or null. Asked once per launch and
+   * remembered: this is a courtesy, not a service, and it should not cost a
+   * request every time a component mounts.
+   */
+  async check(): Promise<UpdateInfo | null> {
+    if (this.checked) return this.suppressDismissed(this.checked)
+
+    try {
+      const response = await fetch(LATEST, {
+        headers: { Accept: 'application/vnd.github+json' },
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!response.ok) return null
+
+      const body = (await response.json()) as { tag_name?: string; html_url?: string }
+      const latest = (body.tag_name ?? '').replace(/^v/, '')
+      if (!latest || !isNewer(latest, app.getVersion())) return null
+
+      this.checked = {
+        version: latest,
+        url: body.html_url ?? `https://github.com/${REPO}/releases/latest`,
+      }
+      return this.suppressDismissed(this.checked)
+    } catch {
+      // An update notice is not worth a word to the user when the network is
+      // the thing that failed.
+      return null
+    }
+  }
+
+  /** Stops this version being mentioned again, on this machine. */
+  dismiss(version: string): void {
+    this.dismissed = version
+    try {
+      fs.writeFileSync(this.file, JSON.stringify({ version }), 'utf8')
+    } catch {
+      // Losing the record costs one more banner, which is not worth failing a
+      // dismissal the user has already seen work.
+    }
+  }
+
+  private suppressDismissed(info: UpdateInfo): UpdateInfo | null {
+    return info.version === this.dismissed ? null : info
+  }
+}

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -136,6 +136,10 @@ const helios = {
     onPresent: (fn: (payload: unknown) => void) => on('hud:present', fn),
     onRetract: (fn: (payload: unknown) => void) => on('hud:retract', fn),
   },
+  updates: {
+    check: () => call<unknown>('updates:check'),
+    dismiss: (version: string) => call<void>('updates:dismiss', version),
+  },
   app: {
     quit: () => call<void>('app:quit'),
     onActivateNotification: (fn: (payload: unknown) => void) => on('app:activate-notification', fn),

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { bridge } from './bridge.ts'
+import type { UpdateInfo } from '../shared/models.ts'
 import { store, terminalId, useStore } from './store.ts'
 import { Detail } from './components/detail.tsx'
 import { HostsDialog } from './components/hosts.tsx'
@@ -65,6 +66,7 @@ export function App(): JSX.Element {
   return (
     <div className="app">
       <div className="titlebar" />
+      <UpdateBanner />
       <div className="body">
         <Sidebar
           onNewSession={() => setDialog('new')}
@@ -81,6 +83,50 @@ export function App(): JSX.Element {
       {dialog === 'settings' && <SettingsDialog onClose={() => setDialog(null)} />}
 
       {toast && <div className={`toast ${toast.kind}`}>{toast.text}</div>}
+    </div>
+  )
+}
+
+/**
+ * Says once that a newer release exists.
+ *
+ * None of the packages update themselves, so the most this can do is notice
+ * and point at the download. Dismissing is remembered per version: the next
+ * release earns one more mention, this one does not.
+ */
+function UpdateBanner(): JSX.Element | null {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null)
+
+  useEffect(() => {
+    void bridge.updates.check().then(setUpdate)
+  }, [])
+
+  if (!update) return null
+
+  return (
+    <div className="update-banner">
+      <span>helios {update.version} is out.</span>
+      {/* Worth saying outright: terminals are their own detached processes, so
+          neither the daemon restarting nor this app closing interrupts a
+          session that is running. */}
+      <span className="update-note">
+        Updating the daemon, desktop or app leaves running sessions alone.
+      </span>
+      {/* An anchor rather than a bridge call: the window open handler already
+          sends https elsewhere, and nothing in this app navigates itself. */}
+      <a className="ext-link" href={update.url} target="_blank" rel="noreferrer noopener">
+        Release notes
+      </a>
+      <span className="grow" />
+      <button
+        className="link dismiss"
+        onClick={() => {
+          void bridge.updates.dismiss(update.version)
+          setUpdate(null)
+        }}
+      >
+        Dismiss
+      </button>
     </div>
   )
 }

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -110,7 +110,7 @@ function UpdateBanner(): JSX.Element | null {
           neither the daemon restarting nor this app closing interrupts a
           session that is running. */}
       <span className="update-note">
-        Updating the daemon, desktop or app leaves running sessions alone.
+        Updating the daemon, desktop or app keeps running sessions alive.
       </span>
       {/* An anchor rather than a bridge call: the window open handler already
           sends https elsewhere, and nothing in this app navigates itself. */}

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -29,6 +29,7 @@ import type {
   GitStatus,
   GrepResult,
   HostRecord,
+  HostStats,
   HostStatus,
   ModelInfo,
   Notification,
@@ -41,7 +42,7 @@ import type {
   TerminalInfo,
   ThemeSummary,
   TranscriptPage,
-  HostStats,
+  UpdateInfo,
   Worktree,
   WriteResult,
 } from '../shared/models.ts'
@@ -132,6 +133,12 @@ interface RawBridge {
     resolved(key: string): void
     onPresent(fn: (card: { hostId: string; hostName?: string; notification: Notification }) => void): Unsubscribe
     onRetract(fn: (key: string) => void): Unsubscribe
+  }
+  updates: {
+    /** The release worth mentioning, or null when there is nothing new. */
+    check(): Promise<UpdateInfo | null>
+    /** Stops this version being mentioned again on this machine. */
+    dismiss(version: string): Promise<void>
   }
   app: {
     /** Quits for real; closing the window only hides it behind the tray. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3963,3 +3963,29 @@ hr {
   font-size: 12px;
   color: var(--on-surface-variant);
 }
+
+/* Said once, above everything, and gone for good when dismissed: a release
+   nobody has to act on today should not cost the layout permanently. */
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+  font-size: 12px;
+}
+
+.update-note {
+  opacity: 0.8;
+}
+
+.update-banner .ext-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.update-banner .dismiss {
+  color: inherit;
+  opacity: 0.8;
+}

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -539,3 +539,9 @@ export interface HostStats {
   memory_used: number
   memory_total: number
 }
+
+/** A release newer than what is running, and where to get it. */
+export interface UpdateInfo {
+  version: string
+  url: string
+}

--- a/desktop/src/shared/version.ts
+++ b/desktop/src/shared/version.ts
@@ -1,0 +1,17 @@
+/**
+ * Compares dotted numeric versions, as the release tags carry them.
+ *
+ * Here rather than beside the update checker so it can be tested without
+ * Electron: the checker imports `app` for the running version, and importing
+ * that outside a running app fails.
+ */
+export function isNewer(candidate: string, current: string): boolean {
+  const left = candidate.split('.').map((part) => parseInt(part, 10) || 0)
+  const right = current.split('.').map((part) => parseInt(part, 10) || 0)
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const a = left[i] ?? 0
+    const b = right[i] ?? 0
+    if (a !== b) return a > b
+  }
+  return false
+}

--- a/desktop/test/updates.test.ts
+++ b/desktop/test/updates.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isNewer } from '../src/shared/version.ts'
+
+// The whole feature rests on this comparison: get it wrong in one direction
+// and nobody hears about a release, wrong in the other and everyone is told
+// about the version they are already running.
+test('a later release is newer', () => {
+  assert.equal(isNewer('2.14.0', '2.13.1'), true)
+  assert.equal(isNewer('2.13.2', '2.13.1'), true)
+  assert.equal(isNewer('3.0.0', '2.99.99'), true)
+})
+
+test('the running version is not an update', () => {
+  assert.equal(isNewer('2.14.0', '2.14.0'), false)
+})
+
+test('an older release is not an update', () => {
+  assert.equal(isNewer('2.13.1', '2.14.0'), false)
+  assert.equal(isNewer('2.9.9', '2.10.0'), false)
+})
+
+// 2.9 vs 2.10 is where string comparison gets it backwards, and a build run
+// from source reports something that is not a version at all.
+test('components compare as numbers, not text', () => {
+  assert.equal(isNewer('2.10.0', '2.9.0'), true)
+})
+
+test('an unparseable version is treated as older', () => {
+  assert.equal(isNewer('', '2.14.0'), false)
+  assert.equal(isNewer('nightly', '2.14.0'), false)
+})
+
+// Electron reports 1.0.0 for an unpackaged run, so a developer would otherwise
+// be told about every release, every launch.
+test('a shorter version is padded rather than misread', () => {
+  assert.equal(isNewer('2.14', '2.14.0'), false)
+  assert.equal(isNewer('2.14.1', '2.14'), true)
+})

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import '../models/host_connection.dart';
 import '../services/host_manager.dart';
 import '../services/daemon_api_service.dart';
 import '../services/notification_service.dart';
+import '../services/update_service.dart';
 import '../providers/card_registry.dart' as registry;
 import 'setup_screen.dart';
 import 'sessions_screen.dart';
@@ -27,6 +28,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   final Map<String, StreamSubscription<SSEEvent>> _eventSubs = {};
   int _currentIndex = 0;
   bool _notifPermissionDenied = false;
+  UpdateInfo? _update;
 
   @override
   void initState() {
@@ -35,6 +37,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
     _hm = context.read<HostManager>();
     _checkNotificationPermission();
+    _checkForUpdate();
     NotificationService.instance.onAction = _handleNotificationAction;
     _subscribeToAllHosts();
   }
@@ -412,6 +415,67 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     );
   }
 
+  /// Mentions a new release once. The APK does not update itself, and the
+  /// settings screen only says so to somebody already looking; dismissing is
+  /// remembered per version, so the next release gets one mention and this one
+  /// gets none.
+  Future<void> _checkForUpdate() async {
+    final info = await UpdateService.instance.checkForUpdate();
+    if (info == null || !mounted) return;
+    if (await UpdateService.instance.isDismissed(info.latestVersion)) return;
+    if (mounted) setState(() => _update = info);
+  }
+
+  Widget _buildUpdateBanner(UpdateInfo update) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      color: theme.colorScheme.primaryContainer,
+      child: Row(
+        children: [
+          Icon(Icons.system_update, size: 18, color: theme.colorScheme.onPrimaryContainer),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'helios ${update.latestVersion} is out.',
+                  style: TextStyle(fontSize: 12, color: theme.colorScheme.onPrimaryContainer),
+                ),
+                // Worth saying outright: the terminals are their own detached
+                // processes, so nothing here or on the daemon interrupts a
+                // session that is running.
+                Text(
+                  'Updating the daemon, desktop or app leaves running sessions alone.',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.75),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              UpdateService.instance.dismiss(update.latestVersion);
+              setState(() => _update = null);
+            },
+            child: const Text('Later', style: TextStyle(fontSize: 12)),
+          ),
+          TextButton(
+            onPressed: () => UpdateService.instance.install(update),
+            child: Text(
+              update.canDirectInstall ? 'Update' : 'Get it',
+              style: const TextStyle(fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildNotifPermissionBanner() {
     final theme = Theme.of(context);
     return Container(
@@ -482,6 +546,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           ),
           body: Column(
             children: [
+              if (_update != null) _buildUpdateBanner(_update!),
               if (_notifPermissionDenied) _buildNotifPermissionBanner(),
               Expanded(
                 child: IndexedStack(

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -448,7 +448,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 // processes, so nothing here or on the daemon interrupts a
                 // session that is running.
                 Text(
-                  'Updating the daemon, desktop or app leaves running sessions alone.',
+                  'Updating the daemon, desktop or app keeps running sessions alive.',
                   style: TextStyle(
                     fontSize: 11,
                     color: theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.75),

--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -69,7 +69,7 @@ class UpdateService {
 
       final current = await currentVersion;
       debugPrint('[UpdateService] latest=$tag running=$current');
-      if (!_isNewer(tag, current)) return null;
+      if (!isNewer(tag, current)) return null;
 
       String? apkUrl;
       if (Platform.isAndroid) {
@@ -134,17 +134,25 @@ class UpdateService {
     await OpenFile.open(file.path);
   }
 
-  bool _isNewer(String latest, String current) {
-    try {
-      final l = latest.split('.').map(int.parse).toList();
-      final c = current.split('.').map(int.parse).toList();
-      for (int i = 0; i < l.length && i < c.length; i++) {
-        if (l[i] > c[i]) return true;
-        if (l[i] < c[i]) return false;
-      }
-      return l.length > c.length;
-    } catch (_) {
-      return false;
+  /// Compares dotted versions, tolerating what a build actually reports: a
+  /// debug build calls itself "0.2.0-dev", and parsing that strictly threw,
+  /// which the catch below turned into "no update" for every dev build ever
+  /// run.
+  @visibleForTesting
+  bool isNewer(String latest, String current) {
+    final l = _parts(latest);
+    final c = _parts(current);
+    for (var i = 0; i < l.length || i < c.length; i++) {
+      final a = i < l.length ? l[i] : 0;
+      final b = i < c.length ? c[i] : 0;
+      if (a != b) return a > b;
     }
+    return false;
   }
+
+  /// Leading digits of each dotted component; anything else counts as zero.
+  List<int> _parts(String version) => version
+      .split('.')
+      .map((part) => int.tryParse(RegExp(r'^\d+').firstMatch(part)?.group(0) ?? '') ?? 0)
+      .toList();
 }

--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:open_file/open_file.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 const _repo = 'kamrul1157024/helios';
@@ -29,11 +31,25 @@ class UpdateService {
   UpdateService._();
   static final instance = UpdateService._();
 
+  static const _dismissedKey = 'update.dismissed_version';
+
   String? _currentVersion;
 
   Future<String> get currentVersion async {
     _currentVersion ??= (await PackageInfo.fromPlatform()).version;
     return _currentVersion!;
+  }
+
+  /// Whether this version has already been waved away. Kept per version, so
+  /// the next release is mentioned once and this one never again.
+  Future<bool> isDismissed(String version) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_dismissedKey) == version;
+  }
+
+  Future<void> dismiss(String version) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_dismissedKey, version);
   }
 
   // Returns UpdateInfo if an update is available, null otherwise.
@@ -42,13 +58,17 @@ class UpdateService {
       final res = await http
           .get(Uri.parse(_apiUrl), headers: {'Accept': 'application/vnd.github+json'})
           .timeout(const Duration(seconds: 10));
-      if (res.statusCode != 200) return null;
+      if (res.statusCode != 200) {
+        debugPrint('[UpdateService] github said ${res.statusCode}');
+        return null;
+      }
 
       final data = jsonDecode(res.body) as Map<String, dynamic>;
       final tag = (data['tag_name'] as String?)?.replaceFirst('v', '') ?? '';
       if (tag.isEmpty) return null;
 
       final current = await currentVersion;
+      debugPrint('[UpdateService] latest=$tag running=$current');
       if (!_isNewer(tag, current)) return null;
 
       String? apkUrl;
@@ -66,7 +86,10 @@ class UpdateService {
         apkDownloadUrl: apkUrl,
         releasesPageUrl: _releasesUrl,
       );
-    } catch (_) {
+    } catch (e) {
+      // Worth a line: a check that never succeeds is indistinguishable from
+      // being up to date, and that is how a stale build goes unnoticed.
+      debugPrint('[UpdateService] check failed: $e');
       return null;
     }
   }

--- a/mobile/test/update_version_test.dart
+++ b/mobile/test/update_version_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:helios/services/update_service.dart';
+
+void main() {
+  final service = UpdateService.instance;
+
+  group('isNewer', () {
+    test('a later release is newer', () {
+      expect(service.isNewer('2.15.0', '2.14.1'), isTrue);
+      expect(service.isNewer('3.0.0', '2.99.99'), isTrue);
+    });
+
+    test('the running version is not an update', () {
+      expect(service.isNewer('2.15.0', '2.15.0'), isFalse);
+      expect(service.isNewer('2.14.0', '2.15.0'), isFalse);
+    });
+
+    test('components compare as numbers, not text', () {
+      expect(service.isNewer('2.10.0', '2.9.0'), isTrue);
+    });
+
+    // The regression this test exists for: a debug build calls itself
+    // "0.2.0-dev", int.parse threw on it, and the catch turned that into "you
+    // are up to date" — so no dev build was ever told about a release.
+    test('a suffixed build version still compares', () {
+      expect(service.isNewer('2.15.0', '0.2.0-dev'), isTrue);
+      expect(service.isNewer('2.15.0', '2.15.0-dev'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Neither client updates itself — the desktop ships as a DMG, AppImage and deb, the phone as an APK — and the only thing mentioning a release was a tile in mobile settings, which only helps someone already looking at it.

- **Desktop**: new `UpdateChecker` (`src/main/updates.ts`) asks the GitHub releases API once per launch, compares against `app.getVersion()`, and exposes it over IPC. A banner above the window body links to the release notes.
- **Mobile**: the existing `UpdateService` gains dismissal memory, and the home screen shows the same banner.
- **Dismissal is per version**, in `update-dismissed.json` on desktop and `SharedPreferences` on mobile: the next release earns one mention, the dismissed one gets none.
- Both banners say that updating does not disturb work in flight — terminals are detached processes, so a daemon restart or a closed client keeps running sessions alive. That is the question the notice would otherwise raise.
- `isNewer` lives in `src/shared/version.ts`, not beside the checker: the checker imports `electron` for the running version, which cannot be loaded from a test.

### A bug this found
The mobile check compared with `int.parse`, which throws on the `-dev` suffix a debug build carries, and the surrounding catch turned that into "up to date". Every development build had been silently ignoring every release — the banner not appearing on device is what exposed it. Components now parse leading digits, and the comparison is exposed for a regression test pinning `0.2.0-dev` against a real release.

## Test plan
- [x] Mobile banner confirmed on device: reads "helios 2.15.0 is out." with the reassurance line, Later and Update
- [x] `mobile`: `flutter analyze`, `flutter test` (80, including 4 new version-comparison tests)
- [x] `desktop`: 6 new comparison tests — later/equal/older, `2.10` vs `2.9`, unparseable, short versions padded. Full suite 103 passing on Node 22
- [x] `desktop`: `npm run typecheck`, `npm run build`
- [ ] Desktop banner not seen in a running Electron build; the logic behind it is covered by tests