### PR TITLE
fix(desktop): let the copy buttons reach the clipboard

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -252,7 +252,11 @@ function hardenSession(): void {
     })
   })
 
-  session.defaultSession.setPermissionRequestHandler((_wc, _permission, callback) => callback(false))
+  // Copy buttons go through navigator.clipboard, which asks for this before
+  // every write; everything else the renderer could ask for it has no use for.
+  session.defaultSession.setPermissionRequestHandler((_wc, permission, callback) =>
+    callback(permission === 'clipboard-sanitized-write'),
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- `hardenSession` denied every permission request, including the `clipboard-sanitized-write` that Chromium asks for before each `navigator.clipboard.writeText`. Every Copy button in the app (chat message, chat selection, file path, file contents, line range) rejected with `NotAllowedError` and no call site catches, so it failed silently.
- The handler now grants that one permission and keeps denying the rest.

## Test plan
- [x] Dev instance over CDP, before the fix: `navigator.clipboard.writeText(...)` → `NotAllowedError: Write permission denied`
- [x] Same call after the fix → resolves, and `pbpaste` returns the written text
- [x] `npm run build` clean