### PR TITLE
fix: stop viewer terminals from double-answering device queries

### DIFF
--- a/desktop/src/renderer/components/deviceReports.ts
+++ b/desktop/src/renderer/components/deviceReports.ts
@@ -25,6 +25,18 @@ export const DEVICE_REPORT_QUERIES: readonly IFunctionIdentifier[] = [
 ]
 
 /**
+ * OSC colour queries: OSC 10/11/12 (fg/bg/cursor) and OSC 4 (palette). Sent
+ * with a `?` argument, the terminal answers with the current colour — e.g.
+ * powerlevel10k probes the background with `^[]11;?^G` on every prompt. That
+ * reply leaks exactly like a DSR one (`^[]11;rgb:1f1f/1f1f/1f1f^[\`), which is
+ * the other half of the stray-line bug.
+ *
+ * Unlike the CSI reports, these OSC numbers also *set* colours, so only the
+ * `?` query is suppressed; a set (`^[]11;#1e1e1e^G`) still recolours the view.
+ */
+export const OSC_COLOUR_QUERIES: readonly number[] = [10, 11, 12, 4]
+
+/**
  * Stop a terminal from replying to device queries, so only the host answers.
  * A handler returning `true` marks the sequence handled, which suppresses
  * xterm's built-in reply. Keystrokes are produced by the key handler, not this
@@ -32,4 +44,12 @@ export const DEVICE_REPORT_QUERIES: readonly IFunctionIdentifier[] = [
  */
 export function silenceDeviceReports(parser: IParser): void {
   for (const id of DEVICE_REPORT_QUERIES) parser.registerCsiHandler(id, () => true)
+  // Swallow the colour report but let a colour *set* fall through to the
+  // built-in handler by returning false when there is no `?` to answer.
+  for (const id of OSC_COLOUR_QUERIES) parser.registerOscHandler(id, (data) => isColourQuery(data))
+}
+
+/** An OSC colour payload is a query when any of its `;`-separated parts is `?`. */
+export function isColourQuery(data: string): boolean {
+  return data.split(';').some((part) => part === '?')
 }

--- a/desktop/src/renderer/components/deviceReports.ts
+++ b/desktop/src/renderer/components/deviceReports.ts
@@ -1,0 +1,35 @@
+import type { IFunctionIdentifier, IParser } from '@xterm/xterm'
+
+/**
+ * The device queries an xterm answers on its own — cursor-position reports
+ * (DSR) and device attributes (DA). A child that wants to know about its
+ * terminal sends one of these and reads the reply.
+ *
+ * In Helios the terminal is the host, not this viewer: the host's emulator
+ * already answers these. If a viewer answered them too, its reply would arrive
+ * a network round-trip late and land on whatever is reading by then — usually
+ * the shell prompt, showing up as a stray `^[[…R`. Several viewers meant
+ * several replies, which is the doubled bytes users reported.
+ *
+ * Only the report-generating queries are listed. Finals that change the display
+ * (e.g. `q` for DECSCUSR cursor style) are deliberately absent so they still
+ * take effect, and the CPR reply's own final `R` is absent so a keyboard
+ * sequence like Shift+F3 (`^[[1;2R`) is never mistaken for a report.
+ */
+export const DEVICE_REPORT_QUERIES: readonly IFunctionIdentifier[] = [
+  { final: 'n' }, // DSR — includes the cursor-position query ^[[6n
+  { prefix: '?', final: 'n' }, // DECDSR / DECXCPR
+  { final: 'c' }, // Primary DA
+  { prefix: '>', final: 'c' }, // Secondary DA
+  { prefix: '=', final: 'c' }, // Tertiary DA
+]
+
+/**
+ * Stop a terminal from replying to device queries, so only the host answers.
+ * A handler returning `true` marks the sequence handled, which suppresses
+ * xterm's built-in reply. Keystrokes are produced by the key handler, not this
+ * parser, so they are unaffected.
+ */
+export function silenceDeviceReports(parser: IParser): void {
+  for (const id of DEVICE_REPORT_QUERIES) parser.registerCsiHandler(id, () => true)
+}

--- a/desktop/src/renderer/components/deviceReports.ts
+++ b/desktop/src/renderer/components/deviceReports.ts
@@ -1,4 +1,7 @@
-import type { IFunctionIdentifier, IParser } from '@xterm/xterm'
+import type { IDisposable, IFunctionIdentifier, IParser } from '@xterm/xterm'
+
+/** The slice of the parser this needs — narrow enough for a test to stub. */
+export type ReportParser = Pick<IParser, 'registerCsiHandler' | 'registerOscHandler'>
 
 /**
  * The device queries an xterm answers on its own — cursor-position reports
@@ -41,12 +44,24 @@ export const OSC_COLOUR_QUERIES: readonly number[] = [10, 11, 12, 4]
  * A handler returning `true` marks the sequence handled, which suppresses
  * xterm's built-in reply. Keystrokes are produced by the key handler, not this
  * parser, so they are unaffected.
+ *
+ * Returns a disposable that removes every registration. `Terminal.dispose()`
+ * tears the parser down anyway, but disposing alongside the other addons keeps
+ * the lifecycle explicit and survives a terminal that is reused rather than
+ * recreated.
  */
-export function silenceDeviceReports(parser: IParser): void {
-  for (const id of DEVICE_REPORT_QUERIES) parser.registerCsiHandler(id, () => true)
+export function silenceDeviceReports(parser: ReportParser): IDisposable {
+  const handlers: IDisposable[] = []
+  for (const id of DEVICE_REPORT_QUERIES) handlers.push(parser.registerCsiHandler(id, () => true))
   // Swallow the colour report but let a colour *set* fall through to the
   // built-in handler by returning false when there is no `?` to answer.
-  for (const id of OSC_COLOUR_QUERIES) parser.registerOscHandler(id, (data) => isColourQuery(data))
+  for (const id of OSC_COLOUR_QUERIES) handlers.push(parser.registerOscHandler(id, (data) => isColourQuery(data)))
+  return {
+    dispose() {
+      for (const h of handlers) h.dispose()
+      handlers.length = 0
+    },
+  }
 }
 
 /** An OSC colour payload is a query when any of its `;`-separated parts is `?`. */

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 
+import { silenceDeviceReports } from './deviceReports.ts'
 import { bridge } from '../bridge.ts'
 import { currentTab, store, terminalId, useStore, type Tab } from '../store.ts'
 import { canResume, hasTerminal, type Session } from '../../shared/models.ts'
@@ -123,6 +124,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
       theme,
       macOptionIsMeta: true,
     })
+    silenceDeviceReports(term.parser)
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.loadAddon(new WebLinksAddon())

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -124,7 +124,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
       theme,
       macOptionIsMeta: true,
     })
-    silenceDeviceReports(term.parser)
+    const reportSilencer = silenceDeviceReports(term.parser)
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.loadAddon(new WebLinksAddon())
@@ -149,6 +149,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
 
     return () => {
       sinks.delete(tab.id)
+      reportSilencer.dispose()
       term.dispose()
       termRef.current = null
       fitRef.current = null

--- a/desktop/test/device-reports.test.ts
+++ b/desktop/test/device-reports.test.ts
@@ -12,40 +12,41 @@ import {
   OSC_COLOUR_QUERIES,
   isColourQuery,
   silenceDeviceReports,
+  type ReportParser,
 } from '../src/renderer/components/deviceReports.ts'
 
 type CsiReg = { id: IFunctionIdentifier; cb: (params: (number | number[])[]) => boolean | Promise<boolean> }
 type OscReg = { id: number; cb: (data: string) => boolean | Promise<boolean> }
 
-function fakeParser(): {
-  parser: {
-    registerCsiHandler: (id: IFunctionIdentifier, cb: CsiReg['cb']) => { dispose(): void }
-    registerOscHandler: (id: number, cb: OscReg['cb']) => { dispose(): void }
-  }
-  csi: CsiReg[]
-  osc: OscReg[]
-} {
+// A stub of exactly the parser slice silenceDeviceReports uses — no cast needed,
+// so any drift in that surface is a compile error rather than a silent `never`.
+function fakeParser(): { parser: ReportParser; csi: CsiReg[]; osc: OscReg[]; disposed: number } {
   const csi: CsiReg[] = []
   const osc: OscReg[] = []
+  const state = { disposed: 0 }
+  const parser: ReportParser = {
+    registerCsiHandler: (id, cb) => {
+      csi.push({ id, cb })
+      return { dispose: () => void (state.disposed += 1) }
+    },
+    registerOscHandler: (id, cb) => {
+      osc.push({ id, cb })
+      return { dispose: () => void (state.disposed += 1) }
+    },
+  }
   return {
+    parser,
     csi,
     osc,
-    parser: {
-      registerCsiHandler: (id, cb) => {
-        csi.push({ id, cb })
-        return { dispose() {} }
-      },
-      registerOscHandler: (id, cb) => {
-        osc.push({ id, cb })
-        return { dispose() {} }
-      },
+    get disposed() {
+      return state.disposed
     },
   }
 }
 
 test('swallows every CSI device-report query so the built-in reply never fires', () => {
   const { parser, csi } = fakeParser()
-  silenceDeviceReports(parser as never)
+  silenceDeviceReports(parser)
 
   assert.equal(csi.length, DEVICE_REPORT_QUERIES.length)
   for (const r of csi) {
@@ -70,7 +71,7 @@ test('only touches CSI report finals — never display or keyboard sequences', (
 
 test('suppresses OSC colour queries but lets colour sets through', () => {
   const { parser, osc } = fakeParser()
-  silenceDeviceReports(parser as never)
+  silenceDeviceReports(parser)
 
   assert.deepEqual(
     osc.map((r) => r.id).sort((a, b) => a - b),
@@ -84,6 +85,18 @@ test('suppresses OSC colour queries but lets colour sets through', () => {
     assert.equal(r.cb('#1e1e1e'), false)
     assert.equal(r.cb('rgb:12/34/56'), false)
   }
+})
+
+test('disposing the return value removes every registration', () => {
+  const stub = fakeParser()
+  const silencer = silenceDeviceReports(stub.parser)
+
+  const registered = stub.csi.length + stub.osc.length
+  assert.ok(registered > 0)
+  assert.equal(stub.disposed, 0)
+
+  silencer.dispose()
+  assert.equal(stub.disposed, registered)
 })
 
 test('isColourQuery detects a `?` in any parameter position', () => {

--- a/desktop/test/device-reports.test.ts
+++ b/desktop/test/device-reports.test.ts
@@ -1,41 +1,60 @@
 // A viewer must not answer device queries itself; the host is the terminal.
 // See internal/terminal — the host's emulator is the single authoritative
-// answerer, and a viewer's late/duplicate reply is what leaked `^[[…R` onto
-// the prompt.
+// answerer, and a viewer's late/duplicate reply is what leaked `^[[…R` (CSI
+// reports) and `^[]11;rgb:…` (OSC colour reports) onto the prompt.
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import type { IFunctionIdentifier } from '@xterm/xterm'
 
-import { DEVICE_REPORT_QUERIES, silenceDeviceReports } from '../src/renderer/components/deviceReports.ts'
+import {
+  DEVICE_REPORT_QUERIES,
+  OSC_COLOUR_QUERIES,
+  isColourQuery,
+  silenceDeviceReports,
+} from '../src/renderer/components/deviceReports.ts'
 
-type Registered = { id: IFunctionIdentifier; cb: (params: (number | number[])[]) => boolean | Promise<boolean> }
+type CsiReg = { id: IFunctionIdentifier; cb: (params: (number | number[])[]) => boolean | Promise<boolean> }
+type OscReg = { id: number; cb: (data: string) => boolean | Promise<boolean> }
 
-function fakeParser(): { parser: { registerCsiHandler: (id: IFunctionIdentifier, cb: Registered['cb']) => { dispose(): void } }; registered: Registered[] } {
-  const registered: Registered[] = []
+function fakeParser(): {
+  parser: {
+    registerCsiHandler: (id: IFunctionIdentifier, cb: CsiReg['cb']) => { dispose(): void }
+    registerOscHandler: (id: number, cb: OscReg['cb']) => { dispose(): void }
+  }
+  csi: CsiReg[]
+  osc: OscReg[]
+} {
+  const csi: CsiReg[] = []
+  const osc: OscReg[] = []
   return {
-    registered,
+    csi,
+    osc,
     parser: {
       registerCsiHandler: (id, cb) => {
-        registered.push({ id, cb })
+        csi.push({ id, cb })
+        return { dispose() {} }
+      },
+      registerOscHandler: (id, cb) => {
+        osc.push({ id, cb })
         return { dispose() {} }
       },
     },
   }
 }
 
-test('swallows every device-report query so the built-in reply never fires', () => {
-  const { parser, registered } = fakeParser()
+test('swallows every CSI device-report query so the built-in reply never fires', () => {
+  const { parser, csi } = fakeParser()
   silenceDeviceReports(parser as never)
 
-  assert.equal(registered.length, DEVICE_REPORT_QUERIES.length)
-  for (const r of registered) {
+  assert.equal(csi.length, DEVICE_REPORT_QUERIES.length)
+  for (const r of csi) {
     // Returning true tells xterm the sequence was handled, suppressing its reply.
     assert.equal(r.cb([]), true)
   }
 })
 
-test('only touches report finals — never display or keyboard sequences', () => {
+test('only touches CSI report finals — never display or keyboard sequences', () => {
   const plainFinals = DEVICE_REPORT_QUERIES.filter((q) => !q.prefix).map((q) => q.final)
 
   // `R` is the CPR reply's final: leaving it alone means a Shift+F3 keystroke
@@ -47,4 +66,30 @@ test('only touches report finals — never display or keyboard sequences', () =>
 
   // Report finals are exactly DSR (n) and DA (c).
   assert.deepEqual([...new Set(DEVICE_REPORT_QUERIES.map((q) => q.final))].sort(), ['c', 'n'])
+})
+
+test('suppresses OSC colour queries but lets colour sets through', () => {
+  const { parser, osc } = fakeParser()
+  silenceDeviceReports(parser as never)
+
+  assert.deepEqual(
+    osc.map((r) => r.id).sort((a, b) => a - b),
+    [...OSC_COLOUR_QUERIES].sort((a, b) => a - b),
+  )
+
+  for (const r of osc) {
+    // A `?` query is handled here (true) so no reply is emitted…
+    assert.equal(r.cb('?'), true)
+    // …but a colour set falls through (false) so the built-in still applies it.
+    assert.equal(r.cb('#1e1e1e'), false)
+    assert.equal(r.cb('rgb:12/34/56'), false)
+  }
+})
+
+test('isColourQuery detects a `?` in any parameter position', () => {
+  assert.equal(isColourQuery('?'), true) // OSC 11;?
+  assert.equal(isColourQuery('1;?'), true) // OSC 4;1;?
+  assert.equal(isColourQuery('#1e1e1e'), false)
+  assert.equal(isColourQuery('rgb:12/34/56'), false)
+  assert.equal(isColourQuery('1;rgb:12/34/56'), false)
 })

--- a/desktop/test/device-reports.test.ts
+++ b/desktop/test/device-reports.test.ts
@@ -1,0 +1,50 @@
+// A viewer must not answer device queries itself; the host is the terminal.
+// See internal/terminal — the host's emulator is the single authoritative
+// answerer, and a viewer's late/duplicate reply is what leaked `^[[…R` onto
+// the prompt.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { IFunctionIdentifier } from '@xterm/xterm'
+
+import { DEVICE_REPORT_QUERIES, silenceDeviceReports } from '../src/renderer/components/deviceReports.ts'
+
+type Registered = { id: IFunctionIdentifier; cb: (params: (number | number[])[]) => boolean | Promise<boolean> }
+
+function fakeParser(): { parser: { registerCsiHandler: (id: IFunctionIdentifier, cb: Registered['cb']) => { dispose(): void } }; registered: Registered[] } {
+  const registered: Registered[] = []
+  return {
+    registered,
+    parser: {
+      registerCsiHandler: (id, cb) => {
+        registered.push({ id, cb })
+        return { dispose() {} }
+      },
+    },
+  }
+}
+
+test('swallows every device-report query so the built-in reply never fires', () => {
+  const { parser, registered } = fakeParser()
+  silenceDeviceReports(parser as never)
+
+  assert.equal(registered.length, DEVICE_REPORT_QUERIES.length)
+  for (const r of registered) {
+    // Returning true tells xterm the sequence was handled, suppressing its reply.
+    assert.equal(r.cb([]), true)
+  }
+})
+
+test('only touches report finals — never display or keyboard sequences', () => {
+  const plainFinals = DEVICE_REPORT_QUERIES.filter((q) => !q.prefix).map((q) => q.final)
+
+  // `R` is the CPR reply's final: leaving it alone means a Shift+F3 keystroke
+  // (`^[[1;2R`) is never mistaken for a report. `q` is DECSCUSR (cursor style),
+  // `m` is SGR, `A`–`D` are the arrow keys — all must keep working.
+  for (const untouched of ['R', 'q', 'm', 'A', 'B', 'C', 'D', 'H', 'F', '~']) {
+    assert.ok(!plainFinals.includes(untouched), `must not blanket-handle final ${untouched}`)
+  }
+
+  // Report finals are exactly DSR (n) and DA (c).
+  assert.deepEqual([...new Set(DEVICE_REPORT_QUERIES.map((q) => q.final))].sort(), ['c', 'n'])
+})

--- a/mobile/lib/screens/terminal_screen.dart
+++ b/mobile/lib/screens/terminal_screen.dart
@@ -450,7 +450,7 @@ class _TerminalTab {
     required this.getToken,
     required this.onChanged,
   }) {
-    terminal = Terminal(maxLines: 4000);
+    terminal = _MirrorTerminal(maxLines: 4000);
     // The view measures the font and reports the grid it can actually draw.
     // Computing columns here instead put the emulator's idea of the line out
     // of step with the painted one, which is what left the cursor at the far
@@ -608,6 +608,34 @@ class _TerminalTab {
     _decoder?.close();
     controller.dispose();
   }
+}
+
+/// A terminal that never answers device queries itself.
+///
+/// The session's terminal is the host; this emulator only mirrors it. The host
+/// already replies to cursor-position (DSR) and device-attribute (DA) queries
+/// the child sends, so if this mirror replied too its answer would travel back
+/// up the input channel a network round-trip late and land on whatever is
+/// reading by then — usually the shell prompt, as a stray `^[[…R`, doubled once
+/// per attached viewer. Suppressing the replies here leaves the keyboard path
+/// (onOutput for real keystrokes) untouched.
+class _MirrorTerminal extends Terminal {
+  _MirrorTerminal({super.maxLines});
+
+  @override
+  void sendCursorPosition() {}
+
+  @override
+  void sendPrimaryDeviceAttributes() {}
+
+  @override
+  void sendSecondaryDeviceAttributes() {}
+
+  @override
+  void sendTertiaryDeviceAttributes() {}
+
+  @override
+  void sendOperatingStatus() {}
 }
 
 /// Feeds decoded text straight to the emulator.


### PR DESCRIPTION
Fixes #91

## Problem

A stray line like `execute: 0d0d/0f0f/1313^[[48;1R` appeared on the shell prompt after running a command that queries the cursor (e.g. `opal-cli restart`'s docker-compose progress UI). The `^[[48;1R` tail is a **Cursor Position Report (CPR)** — the reply to a `ESC[6n` query.

## Root cause (traced end-to-end)

The host broadcasts **raw** child output — including device queries like `ESC[6n` (DSR) and `ESC[c` (DA) — to every viewer (`internal/terminal/host.go:234`). Each viewer feeds those raw bytes into its own terminal emulator, which **auto-answers** the query and sends the reply back as **input**:

- Desktop (xterm.js): `terminal.write(data)` -> `deviceStatus` handler emits CPR via `onData` -> `bridge.term.input(...)` (`desktop/src/renderer/components/terminal.tsx`).
- Mobile (xterm.dart): `terminal.write` -> `sendCursorPosition()` -> `onOutput` -> `_connection.send(...)` (`mobile/lib/screens/terminal_screen.dart`).

So a single query gets answered by the host **and** by every viewer. The viewer replies arrive a network round-trip late — after the querying program already consumed the host's authoritative answer — and land on the idle shell prompt. Multiple viewers is why the report showed *doubled* bytes.

## Fix

The host's emulator is the single authoritative answerer; viewers are mirrors and must not answer at all. Suppress the report-generating handlers on each client emulator:

- **Desktop** — `deviceReports.ts` registers no-op CSI handlers for DSR (`n`, `?n`) and DA (`c`, `>c`, `=c`); a handler returning `true` suppresses xterm.js's built-in reply.
- **Mobile** — `_MirrorTerminal` overrides `sendCursorPosition` / `send*DeviceAttributes` / `sendOperatingStatus` to no-op.

The keyboard path is separate from the CSI report path in both emulators, so keystrokes — including modified F-keys such as Shift+F3 (`^[[1;2R`, which shares the CPR final byte) — are unaffected. The host keeps answering, so apps that rely on CPR (Claude Code, etc.) still work.

## Verification

Exercised both real emulators headlessly:

| Query | xterm.js before -> after | xterm.dart before -> after |
|---|---|---|
| CPR `^[[6n` | `^[[1;1R` -> *(none)* | `^[[0;0R` -> *(none)* |
| Primary DA `^[[c` | `^[[?1;2c` -> *(none)* | `^[[?1;2c` -> *(none)* |
| Secondary DA `^[[>c` | `^[[>0;276;0c` -> *(none)* | `^[[>0;0;0c` -> *(none)* |
| Operating status `^[[5n` | *(none)* via `n` | `^[[0n` -> *(none)* |
| Arrow keys / DECSCUSR | unaffected | unaffected |

- Desktop: `npm run typecheck` clean, `npm test` 105/105 (adds `device-reports.test.ts`).
- Mobile: `flutter analyze` clean.

## Notes

A bare fire-and-forget query (`printf '\033[6n'`) can still leak the *host's own* reply if the program never reads it — that is inherent to DSR and happens on real terminals too. This PR fixes the Helios-specific defect: viewers double-answering.
