### PR TITLE
fix(desktop): open terminal links instead of a dead confirm dialog

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -225,7 +225,9 @@ function createWindow(): void {
   // Nothing in this app should navigate. Links open in the user's browser, and
   // an attempt to navigate the window itself is a bug or worse.
   window.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('https://')) void shell.openExternal(url)
+    // Web links open in the browser; anything else (file:, javascript:, …) is
+    // dropped. The renderer's terminal link handlers route here via window.open.
+    if (url.startsWith('https://') || url.startsWith('http://')) void shell.openExternal(url)
     return { action: 'deny' }
   })
   window.webContents.on('will-navigate', (event, url) => {

--- a/desktop/src/renderer/components/links.ts
+++ b/desktop/src/renderer/components/links.ts
@@ -1,0 +1,34 @@
+import type { ILinkHandler } from '@xterm/xterm'
+
+/**
+ * Open a terminal link in the user's browser.
+ *
+ * The real URL has to reach `window.open`: the main process routes
+ * `window.open(url)` to `shell.openExternal` through `setWindowOpenHandler`
+ * (see src/main/main.ts). xterm's built-in link handlers instead call
+ * `window.open()` with no argument — to null the opener before assigning
+ * `location.href` — which hands the main process an empty URL. The https guard
+ * misses it, the popup is denied so `window.open()` returns null, and the
+ * follow-up `location.href` never runs. The link just dies, behind a scary
+ * "potentially dangerous" confirm. Passing the URL up front avoids all of that.
+ *
+ * `noopener,noreferrer` keeps the (denied) child window from reaching back into
+ * this renderer, matching what the built-ins were trying to do with `opener`.
+ */
+export function openLink(uri: string): void {
+  window.open(uri, '_blank', 'noopener,noreferrer')
+}
+
+/**
+ * Handler for OSC 8 hyperlinks — the Terminal `linkHandler` option. Only
+ * `activate` is needed; hover/leave keep xterm's defaults. `allowNonHttpProtocols`
+ * stays off, so this only ever receives http(s) URLs.
+ */
+export const linkHandler: ILinkHandler = {
+  activate: (_event, uri) => openLink(uri),
+}
+
+/** Handler for plain-text URLs detected by WebLinksAddon. */
+export function webLinkActivate(_event: MouseEvent, uri: string): void {
+  openLink(uri)
+}

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -5,6 +5,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 
 import { silenceDeviceReports } from './deviceReports.ts'
+import { linkHandler, webLinkActivate } from './links.ts'
 import { bridge } from '../bridge.ts'
 import { currentTab, store, terminalId, useStore, type Tab } from '../store.ts'
 import { canResume, hasTerminal, type Session } from '../../shared/models.ts'
@@ -123,11 +124,14 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
       scrollback: 5000,
       theme,
       macOptionIsMeta: true,
+      // OSC 8 hyperlinks: open in the browser instead of xterm's default, which
+      // pops a "potentially dangerous" confirm and then fails to open at all.
+      linkHandler,
     })
     const reportSilencer = silenceDeviceReports(term.parser)
     const fit = new FitAddon()
     term.loadAddon(fit)
-    term.loadAddon(new WebLinksAddon())
+    term.loadAddon(new WebLinksAddon(webLinkActivate))
     term.open(container)
 
     try {

--- a/desktop/test/links.test.ts
+++ b/desktop/test/links.test.ts
@@ -1,0 +1,47 @@
+// Terminal links open in the browser by handing the real URL to window.open,
+// which the main process routes to shell.openExternal. Regression guard for the
+// "OK does nothing" bug where xterm called window.open() with no URL.
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, test } from 'node:test'
+
+import { linkHandler, openLink, webLinkActivate } from '../src/renderer/components/links.ts'
+
+type OpenCall = [url?: string | URL, target?: string, features?: string]
+
+let calls: OpenCall[]
+const original = (globalThis as { window?: unknown }).window
+
+beforeEach(() => {
+  calls = []
+  ;(globalThis as { window?: unknown }).window = {
+    open: (...args: OpenCall) => {
+      calls.push(args)
+      return null // Electron denies the popup; the return is unused.
+    },
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as { window?: unknown }).window = original
+})
+
+const URL_ = 'https://github.com/newscred/opal-app/pull/7053'
+
+test('openLink hands the real URL to window.open (not an empty call)', () => {
+  openLink(URL_)
+  assert.equal(calls.length, 1)
+  assert.deepEqual(calls[0], [URL_, '_blank', 'noopener,noreferrer'])
+  // The bug was calling window.open() with no URL — assert we never do that.
+  assert.notEqual(calls[0][0], undefined)
+  assert.notEqual(calls[0][0], '')
+})
+
+test('OSC 8 linkHandler.activate opens the link', () => {
+  linkHandler.activate(new Event('click') as MouseEvent, URL_, { start: { x: 1, y: 1 }, end: { x: 1, y: 1 } })
+  assert.deepEqual(calls[0], [URL_, '_blank', 'noopener,noreferrer'])
+})
+
+test('WebLinksAddon handler opens the link', () => {
+  webLinkActivate(new Event('click') as MouseEvent, URL_)
+  assert.deepEqual(calls[0], [URL_, '_blank', 'noopener,noreferrer'])
+})


### PR DESCRIPTION
Fixes #93

## Problem

Clicking a link in the terminal (e.g. a GitHub PR URL an agent prints) popped xterm's built-in confirm — *"Do you want to navigate to …? WARNING: This link could potentially be dangerous"* — and then **OK did nothing**. Every terminal link was effectively dead.

## Root cause

xterm's default link handlers — `OscLinkProvider` for OSC 8 hyperlinks (Claude Code emits PR links this way) and `WebLinksAddon` for plain-text URLs — call `window.open()` with **no URL**, then assign `location.href` (to null the opener first):

```js
let g = window.open();            // no url
if (g) { g.opener = null; g.location.href = d }
else console.warn(...)
```

The app opens external links only via `setWindowOpenHandler` (`src/main/main.ts`), which routes `window.open(url)` → `shell.openExternal(url)`. With the empty call this breaks twice:

1. `setWindowOpenHandler` receives `url = ''` → the `https://` guard misses it → `shell.openExternal` never runs.
2. The handler denies the popup → `window.open()` returns null → `location.href = d` never runs.

Net: confirm appears, OK does nothing.

## Fix

Give xterm link handlers that call `window.open(uri, '_blank', 'noopener,noreferrer')` with the **real URL**, so the existing `setWindowOpenHandler` routes it to `shell.openExternal` — no confirm, and the link actually opens.

- `desktop/src/renderer/components/links.ts` — shared `openLink(uri)`, plus a `linkHandler` (OSC 8, the Terminal option) and `webLinkActivate` (WebLinksAddon).
- `terminal.tsx` — pass `linkHandler` in the Terminal options and `webLinkActivate` to `new WebLinksAddon(...)`.
- `main.ts` — also accept `http://` (not just `https://`) so every web link opens; non-web schemes (`file:`, `javascript:`, …) are still dropped.

`allowNonHttpProtocols` stays off, so the handlers only ever receive http(s) URLs; the main-process allowlist is the second gate.

## Verification

- New `test/links.test.ts`: asserts `openLink` / `linkHandler.activate` / `webLinkActivate` all call `window.open` with the **real** URL and `noopener,noreferrer` — and specifically that we never call it empty (the bug).
- Desktop `npm run typecheck` clean, `npm test` **111/111**, build clean.

## Notes

Desktop-only (Electron). Separate from the terminal device-report leak (#91 / #92).
