### PR TITLE
feat: let an agent show you a file, a diff or a tab

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -402,6 +402,18 @@ export class ApiClient {
     return { path: res.path, entries: res.entries ?? [] }
   }
 
+  async reviewedFiles(path: string, base: string): Promise<string[]> {
+    const res = await this.request<{ files?: string[] }>(
+      'GET',
+      `/api/git/reviewed${queryString({ path, base })}`,
+    )
+    return res.files ?? []
+  }
+
+  setReviewed(path: string, base: string, file: string, reviewed: boolean): Promise<unknown> {
+    return this.request('POST', '/api/git/reviewed', { path, base, file, reviewed })
+  }
+
   readFile(path: string): Promise<FileContent> {
     return this.request('GET', `/api/file${queryString({ path })}`)
   }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -47,6 +47,8 @@ const API_METHODS = new Set<keyof ApiClient>([
   'gitLog',
   'gitChanges',
   'gitWorktrees',
+  'reviewedFiles',
+  'setReviewed',
   'listFiles',
   'readFile',
   'searchFiles',

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -279,6 +279,12 @@ export class HostApi {
   gitWorktrees(path: string): Promise<Worktree[]> {
     return this.call('gitWorktrees', path)
   }
+  reviewedFiles(path: string, base: string): Promise<string[]> {
+    return this.call('reviewedFiles', path, base)
+  }
+  setReviewed(path: string, base: string, file: string, reviewed: boolean): Promise<unknown> {
+    return this.call('setReviewed', path, base, file, reviewed)
+  }
   listFiles(path: string): Promise<{ path: string; entries: FileEntry[] }> {
     return this.call('listFiles', path)
   }

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
+import { useStore } from '../store.ts'
 import { DiffView } from './diff-view.tsx'
 import { Chevron } from './icons.tsx'
 import { PathLabel } from './path-label.tsx'
@@ -347,6 +348,7 @@ export function CommitChanges({
   const [file, setFile] = useState<string | null>(null)
   const [diff, setDiff] = useState<GitDiff | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const wanted = useStore((s) => s.diffTarget)
 
   useEffect(() => {
     let cancelled = false
@@ -358,7 +360,11 @@ export function CommitChanges({
       .then((result) => {
         if (cancelled) return
         setChanges(result)
-        setFile(result.files[0]?.path ?? null)
+        // An agent that named a file meant that file, not the first one in the
+        // commit. It says so absolutely; git lists paths from the repo root.
+        const asked = wanted?.path && relativeToRoot(root, wanted.path)
+        const match = asked && result.files.some((f) => f.path === asked) ? asked : null
+        setFile(match ?? result.files[0]?.path ?? null)
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err))
@@ -366,7 +372,7 @@ export function CommitChanges({
     return () => {
       cancelled = true
     }
-  }, [hostId, root, scope.to, scope.from])
+  }, [hostId, root, scope.to, scope.from, wanted?.seq])
 
   useEffect(() => {
     if (!file) {
@@ -449,6 +455,15 @@ export function CommitChanges({
       </div>
     </>
   )
+}
+
+/**
+ * An absolute path as git would list it, or null when it is outside the repo.
+ * An agent names files absolutely; git lists them from the repository root.
+ */
+function relativeToRoot(root: string, absolute: string): string | null {
+  const base = root.replace(/\/+$/, '')
+  return absolute.startsWith(`${base}/`) ? absolute.slice(base.length + 1) : null
 }
 
 /** Endpoints of a range are selected; what lies between them is merely in it. */

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -450,6 +450,7 @@ export function CommitChanges({
                 diff={diff.diff}
                 empty="No textual changes — binary, or a mode change."
                 layout={wanted?.layout ?? 'split'}
+                line={wanted?.line}
               />
             </>
           ) : (

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -446,7 +446,11 @@ export function CommitChanges({
                 <span>{diff.file}</span>
                 <span className="muted">{diff.stat}</span>
               </header>
-              <DiffView diff={diff.diff} empty="No textual changes — binary, or a mode change." />
+              <DiffView
+                diff={diff.diff}
+                empty="No textual changes — binary, or a mode change."
+                layout={wanted?.layout ?? 'split'}
+              />
             </>
           ) : (
             <p className="empty-note">Pick a file.</p>

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -192,6 +192,8 @@ export function Detail(): JSX.Element {
         </>
       )}
 
+      {hostId && session && <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />}
+
       <div className="panel-body">
         {!session &&
           (pendingList ? (
@@ -595,4 +597,31 @@ function PermissionMode({ hostId, session }: { hostId: string; session: Session 
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
   return `${Math.round(bytes / 1024 ** 2)} MB`
+}
+
+/**
+ * Why the agent moved the view.
+ *
+ * A panel that switches on its own is indistinguishable from a bug. This says
+ * who did it and what to look at, and it stays until dismissed rather than
+ * disappearing on a timer — the point is to be read.
+ */
+function ShowNoteStrip({ hostId, sessionId }: { hostId: string; sessionId: string }): JSX.Element | null {
+  const note = useStore((s) => s.showNote)
+  if (!note || note.hostId !== hostId || note.sessionId !== sessionId) return null
+
+  return (
+    <div className="show-note">
+      <span className="show-note-who">agent</span>
+      <span className="show-note-text">{note.text}</span>
+      <button
+        className="icon-btn"
+        aria-label="Dismiss"
+        title="Dismiss"
+        onClick={() => store.clearShowNote()}
+      >
+        ✕
+      </button>
+    </div>
+  )
 }

--- a/desktop/src/renderer/components/diff-view.tsx
+++ b/desktop/src/renderer/components/diff-view.tsx
@@ -1,16 +1,129 @@
+/** How a patch is drawn. Side by side reads better for review; unified is
+ *  narrower and is what a terminal shows. */
+export type DiffLayout = 'split' | 'unified'
+
+interface Row {
+  /** Full-width row: a file header or a hunk header. */
+  meta?: string
+  left?: { n: number | null; text: string; changed: boolean }
+  right?: { n: number | null; text: string; changed: boolean }
+}
+
 /** A unified patch, coloured. Shared by the working-tree and commit views. */
-export function DiffView({ diff, empty }: { diff: string; empty?: string }): JSX.Element {
+export function DiffView({
+  diff,
+  empty,
+  layout = 'split',
+}: {
+  diff: string
+  empty?: string
+  layout?: DiffLayout
+}): JSX.Element {
   if (!diff.trim()) return <p className="empty-note">{empty ?? 'No changes.'}</p>
+
+  if (layout === 'unified') {
+    return (
+      <pre>
+        {diff.split('\n').map((line, index) => (
+          <span key={index} className={diffClass(line)}>
+            {line || ' '}
+            {'\n'}
+          </span>
+        ))}
+      </pre>
+    )
+  }
+
   return (
-    <pre>
-      {diff.split('\n').map((line, index) => (
-        <span key={index} className={diffClass(line)}>
-          {line || ' '}
-          {'\n'}
-        </span>
-      ))}
-    </pre>
+    <div className="diff-split">
+      {toRows(diff).map((row, index) =>
+        row.meta !== undefined ? (
+          <div key={index} className={`diff-row diff-row-meta ${diffClass(row.meta)}`}>
+            {row.meta || ' '}
+          </div>
+        ) : (
+          <div key={index} className="diff-row">
+            <Side cell={row.left} kind="del" />
+            <Side cell={row.right} kind="add" />
+          </div>
+        ),
+      )}
+    </div>
   )
+}
+
+function Side({ cell, kind }: { cell: Row['left']; kind: 'del' | 'add' }): JSX.Element {
+  // An absent cell is not an empty line: one side of the pair simply has
+  // nothing here, and it is shaded so the eye skips it.
+  if (!cell) return <div className="diff-cell diff-cell-absent" />
+  return (
+    <div className={`diff-cell ${cell.changed ? (kind === 'del' ? 'd-del' : 'd-add') : ''}`}>
+      <span className="diff-gutter">{cell.n ?? ''}</span>
+      <span className="diff-text">{cell.text || ' '}</span>
+    </div>
+  )
+}
+
+/**
+ * Turns a unified patch into aligned pairs.
+ *
+ * Removals and additions arrive as consecutive runs, so a run is paired off
+ * position by position and whichever side runs out gets blanks. That is what
+ * puts a changed line opposite the line it replaced instead of below it.
+ */
+function toRows(diff: string): Row[] {
+  const rows: Row[] = []
+  let dels: Row['left'][] = []
+  let adds: Row['right'][] = []
+  let leftNo = 0
+  let rightNo = 0
+
+  const flush = (): void => {
+    for (let i = 0; i < Math.max(dels.length, adds.length); i++) {
+      rows.push({ left: dels[i], right: adds[i] })
+    }
+    dels = []
+    adds = []
+  }
+
+  for (const line of diff.split('\n')) {
+    const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line)
+    if (hunk) {
+      flush()
+      leftNo = Number(hunk[1])
+      rightNo = Number(hunk[2])
+      rows.push({ meta: line })
+      continue
+    }
+    if (
+      line.startsWith('diff --git') ||
+      line.startsWith('index ') ||
+      line.startsWith('+++') ||
+      line.startsWith('---')
+    ) {
+      flush()
+      rows.push({ meta: line })
+      continue
+    }
+
+    if (line.startsWith('-')) {
+      dels.push({ n: leftNo++, text: line.slice(1), changed: true })
+      continue
+    }
+    if (line.startsWith('+')) {
+      adds.push({ n: rightNo++, text: line.slice(1), changed: true })
+      continue
+    }
+
+    flush()
+    const text = line.startsWith(' ') ? line.slice(1) : line
+    rows.push({
+      left: { n: leftNo++, text, changed: false },
+      right: { n: rightNo++, text, changed: false },
+    })
+  }
+  flush()
+  return rows
 }
 
 export function diffClass(line: string): string {

--- a/desktop/src/renderer/components/diff-view.tsx
+++ b/desktop/src/renderer/components/diff-view.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+
 /** How a patch is drawn. Side by side reads better for review; unified is
  *  narrower and is what a terminal shows. */
 export type DiffLayout = 'split' | 'unified'
@@ -14,19 +16,30 @@ export function DiffView({
   diff,
   empty,
   layout = 'split',
+  line,
 }: {
   diff: string
   empty?: string
   layout?: DiffLayout
+  /** A line of the new file to scroll to and mark, when one was asked for. */
+  line?: number
 }): JSX.Element {
+  const marked = useRef<HTMLDivElement | null>(null)
+
+  // A patch is long and the interesting line is rarely at the top, so being
+  // pointed at one is worthless unless the pane goes there.
+  useEffect(() => {
+    marked.current?.scrollIntoView({ block: 'center' })
+  }, [line, diff])
+
   if (!diff.trim()) return <p className="empty-note">{empty ?? 'No changes.'}</p>
 
   if (layout === 'unified') {
     return (
       <pre>
-        {diff.split('\n').map((line, index) => (
-          <span key={index} className={diffClass(line)}>
-            {line || ' '}
+        {diff.split('\n').map((text, index) => (
+          <span key={index} className={diffClass(text)}>
+            {text || ' '}
             {'\n'}
           </span>
         ))}
@@ -42,7 +55,11 @@ export function DiffView({
             {row.meta || ' '}
           </div>
         ) : (
-          <div key={index} className="diff-row">
+          <div
+            key={index}
+            className={`diff-row ${line !== undefined && row.right?.n === line ? 'diff-row-marked' : ''}`}
+            ref={line !== undefined && row.right?.n === line ? marked : undefined}
+          >
             <Side cell={row.left} kind="del" />
             <Side cell={row.right} kind="add" />
           </div>

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -93,11 +93,17 @@ export function FilesPanel({
       at?: { line: number; column: number },
       /** True when the caller has another path to try if this one is missing. */
       quiet = false,
+      /**
+       * False while reopening the tabs a session had last time. Those must not
+       * take the front, or a file asked for as the panel mounts loses it to
+       * whatever was open before.
+       */
+      activate = true,
     ): Promise<boolean> => {
-      setReveal(path)
+      if (activate) setReveal(path)
       const existing = filesRef.current.find((file) => file.path === path)
       if (existing) {
-        setActivePath(path)
+        if (activate) setActivePath(path)
         if (at) {
           setFiles((current) =>
             current.map((file) =>
@@ -126,7 +132,7 @@ export function FilesPanel({
             cursor: at ? { ...at, seq: 1 } : null,
           },
         ])
-        setActivePath(path)
+        if (activate) setActivePath(path)
         return true
       } catch (err) {
         // A path from the transcript is as likely to be a directory as a file;
@@ -147,9 +153,15 @@ export function FilesPanel({
   // every time makes the panel a viewer rather than a place to work.
   const memory = `helios.files.${hostId}.${sessionId}`
   const restored = useRef<string | null>(null)
+  // Set when something asked for a specific file while the restore below was
+  // still running. Opening the panel *by* asking for a file is the common case
+  // — an agent's helios_show mounts it — and the restore finishes last, so
+  // without this it puts the previous session's file back in front.
+  const claimed = useRef(false)
 
   useEffect(() => {
     restored.current = null
+    claimed.current = false
     setFiles([])
     setActivePath(null)
     setReveal(null)
@@ -164,10 +176,10 @@ export function FilesPanel({
         if (cancelled) return
         // Quiet: the agent may have deleted a file since it was last open, and
         // a toast per missing tab is not news the user asked for.
-        await openFile(path, undefined, true)
+        await openFile(path, undefined, true, false)
       }
       if (cancelled) return
-      if (saved?.active) setActivePath(saved.active)
+      if (saved?.active && !claimed.current) setActivePath(saved.active)
       restored.current = memory
     })()
     return () => {
@@ -278,6 +290,7 @@ export function FilesPanel({
 
   useEffect(() => {
     if (!target || target.hostId !== hostId) return
+    claimed.current = true
     const path = target.path
     if (target.mode === 'find') {
       setQuickOpenQuery(basename(path))

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -286,9 +286,11 @@ export function FilesPanel({
       return
     }
     const mapped = inRoot(path, scope.current.root, scope.current.owners)
+    // An agent pointing at a file usually means one line of it.
+    const at = target.line ? { line: target.line, column: 1 } : undefined
     void (async () => {
-      if (mapped !== path && (await openFile(mapped, undefined, true))) return
-      await openFile(path)
+      if (mapped !== path && (await openFile(mapped, at, true))) return
+      await openFile(path, at)
     })()
     store.clearFileTarget()
     // seq, not path: reopening the same file has to work.

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -322,7 +322,7 @@ function ChangesView({
               <span>{diff.file}</span>
               <span className="muted">{diff.stat}</span>
             </header>
-            <DiffView diff={diff.diff} layout={target?.layout ?? 'split'} />
+            <DiffView diff={diff.diff} layout={target?.layout ?? 'split'} line={target?.line} />
           </>
         ) : (
           <p className="empty-note">{status.dirty ? 'Pick a file.' : 'Nothing to show.'}</p>

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -322,7 +322,7 @@ function ChangesView({
               <span>{diff.file}</span>
               <span className="muted">{diff.stat}</span>
             </header>
-            <DiffView diff={diff.diff} />
+            <DiffView diff={diff.diff} layout={target?.layout ?? 'split'} />
           </>
         ) : (
           <p className="empty-note">{status.dirty ? 'Pick a file.' : 'Nothing to show.'}</p>

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { api } from '../bridge.ts'
-import { store } from '../store.ts'
+import { store, useStore } from '../store.ts'
 import { CommitChanges, ScopePicker, type Scope } from './commits.tsx'
 import { DiffView } from './diff-view.tsx'
 import { PathLabel } from './path-label.tsx'
@@ -22,6 +22,16 @@ import type { GitChange, GitDiff, GitStatus } from '../../shared/models.ts'
  * Picking a worktree rescopes the whole panel to it, so a session started in
  * one checkout can still read the branch an agent is working in next door.
  */
+/**
+ * An absolute path as a path inside root, or null when it is somewhere else.
+ * A file from another checkout has no diff in this one.
+ */
+function relativeTo(root: string, absolute: string): string | null {
+  const base = root.replace(/\/+$/, '')
+  if (absolute === base) return null
+  return absolute.startsWith(`${base}/`) ? absolute.slice(base.length + 1) : null
+}
+
 export function GitPanel({
   hostId,
   cwd,
@@ -105,6 +115,14 @@ export function GitPanel({
     setScope(next)
     writeScope(scopeKey, next)
   }
+
+  // An agent naming a file means its uncommitted change, so the panel has to
+  // be showing the working tree for the selection below to land anywhere.
+  const diffTarget = useStore((s) => s.diffTarget)
+  useEffect(() => {
+    if (!diffTarget || diffTarget.hostId !== hostId) return
+    setScope({ kind: 'working' })
+  }, [diffTarget?.seq])
 
   // Status is fetched here rather than in the changes view because the header
   // shows the branch in every scope — reading a commit is no reason to lose it.
@@ -210,11 +228,21 @@ function ChangesView({
 }): JSX.Element {
   const [selected, setSelected] = useState<{ path: string; untracked: boolean } | null>(null)
   const [diff, setDiff] = useState<GitDiff | null>(null)
+  const target = useStore((s) => s.diffTarget)
 
   // A path from the previous repository would only produce a failed diff.
   useEffect(() => {
     setSelected(null)
   }, [hostId, root])
+
+  // An agent asked for one file's diff. It names the file the way its own
+  // tools do, absolutely, while git wants it relative to the repository.
+  useEffect(() => {
+    if (!target || target.hostId !== hostId || !target.path) return
+    const rel = relativeTo(root, target.path)
+    if (rel) setSelected({ path: rel, untracked: false })
+    store.clearDiffTarget()
+  }, [target?.seq])
 
   useEffect(() => {
     if (!selected) {

--- a/desktop/src/renderer/components/git.tsx
+++ b/desktop/src/renderer/components/git.tsx
@@ -116,12 +116,25 @@ export function GitPanel({
     writeScope(scopeKey, next)
   }
 
-  // An agent naming a file means its uncommitted change, so the panel has to
-  // be showing the working tree for the selection below to land anywhere.
+  // The scope an agent asked for. A branch and a single commit are different
+  // questions, and neither is the working tree — putting the panel in the wrong
+  // one is how a diff comes back empty and looks broken.
   const diffTarget = useStore((s) => s.diffTarget)
   useEffect(() => {
     if (!diffTarget || diffTarget.hostId !== hostId) return
-    setScope({ kind: 'working' })
+    if (diffTarget.base) {
+      setScope({ kind: 'review', base: diffTarget.base, span: 0, label: `${diffTarget.base}...HEAD` })
+    } else if (diffTarget.commit) {
+      setScope({
+        kind: 'commit',
+        to: diffTarget.commit,
+        from: null,
+        span: 1,
+        label: diffTarget.commit.slice(0, 7),
+      })
+    } else {
+      setScope({ kind: 'working' })
+    }
   }, [diffTarget?.seq])
 
   // Status is fetched here rather than in the changes view because the header
@@ -239,6 +252,8 @@ function ChangesView({
   // tools do, absolutely, while git wants it relative to the repository.
   useEffect(() => {
     if (!target || target.hostId !== hostId || !target.path) return
+    // A branch or commit target belongs to a history view, not this one.
+    if (target.base || target.commit) return
     const rel = relativeTo(root, target.path)
     if (rel) setSelected({ path: rel, untracked: false })
     store.clearDiffTarget()

--- a/desktop/src/renderer/components/review.tsx
+++ b/desktop/src/renderer/components/review.tsx
@@ -36,6 +36,16 @@ export function ReviewView({
     setChanges(null)
     setError(null)
     setViewed(new Set())
+    // Persisted in the daemon, not here: a review survives a restart, and an
+    // agent asks what has been read so it can skip it.
+    api(hostId)
+      .reviewedFiles(root, scope.base)
+      .then((files) => {
+        if (!cancelled) setViewed(new Set(files))
+      })
+      .catch(() => {
+        // An older daemon has no reviewed state; ticking still works locally.
+      })
     api(hostId)
       // Merge base, not the branch tip: commits landed on the base since this
       // branch was cut are not this branch's work, and a two-dot diff reports
@@ -53,12 +63,16 @@ export function ReviewView({
   }, [hostId, root, scope.base])
 
   const toggleViewed = (path: string): void => {
-    setViewed((current) => {
-      const next = new Set(current)
-      if (next.has(path)) next.delete(path)
-      else next.add(path)
-      return next
-    })
+    const next = new Set(viewed)
+    const reviewed = !next.has(path)
+    if (reviewed) next.add(path)
+    else next.delete(path)
+    setViewed(next)
+    void api(hostId)
+      .setReviewed(root, scope.base, path, reviewed)
+      .catch(() => {
+        // The tick is the user's, so it stands even if the daemon refused it.
+      })
   }
 
   if (error) return <p className="empty-note">{error}</p>

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -70,6 +70,29 @@ export interface FileTarget {
   seq: number
   /** 'find' searches the panel's root for the name instead of opening the path. */
   mode: 'open' | 'find'
+  /** Scroll here once the file is open. Absent means the top. */
+  line?: number
+}
+
+/** A diff an agent asked the human to look at. No path means the whole change. */
+export interface DiffTarget {
+  hostId: string
+  path?: string
+  base?: string
+  seq: number
+}
+
+/**
+ * Why an agent moved the view, shown above it.
+ *
+ * Without this a panel switches and nothing says who did it or what to look
+ * for, which is indistinguishable from the app misbehaving.
+ */
+export interface ShowNote {
+  hostId: string
+  sessionId: string
+  text: string
+  seq: number
 }
 
 /**
@@ -109,6 +132,8 @@ export interface State {
    */
   detached: string[]
   fileTarget: FileTarget | null
+  diffTarget: DiffTarget | null
+  showNote: ShowNote | null
   promptDraft: PromptDraft | null
   /** Sidebar filter, matched against title, project and cwd. */
   query: string
@@ -146,6 +171,8 @@ const initial: State = {
   activeTabs: {},
   detached: [],
   fileTarget: null,
+  diffTarget: null,
+  showNote: null,
   promptDraft: null,
   query: '',
   showArchived: false,
@@ -390,6 +417,10 @@ class Store {
    */
   private onServerEvent(hostId: string, event: SSEEvent): void {
     switch (event.type) {
+      case 'show': {
+        this.applyShow(hostId, event.data)
+        return
+      }
       case 'session_status': {
         const id = str(event.data.session_id)
         const status = str(event.data.status)
@@ -523,6 +554,64 @@ class Store {
    * would fire again every time the panel remounts, dragging the user back to
    * a file they looked at an hour ago.
    */
+  /**
+   * Moves a session's view because its agent asked, through helios_show.
+   *
+   * The selection is left alone on purpose. A show for a session you are not
+   * looking at prepares that session's panel and waits there — being thrown
+   * between sessions by a background agent would be worse than missing it.
+   */
+  private applyShow(hostId: string, data: Record<string, unknown>): void {
+    const sessionId = str(data.session_id)
+    const view = str(data.view)
+    if (!sessionId || !view) return
+
+    const target: Selection = { hostId, sessionId }
+    const note = str(data.note)
+    const seq = (this.state.showNote?.seq ?? 0) + 1
+
+    const panel: RightPanel | null =
+      view === 'file' ? 'files' : view === 'diff' ? 'git' : view === 'agent' ? 'chat' : null
+
+    if (view === 'terminal') {
+      const session = this.state.sessions[hostId]?.find((s) => s.session_id === sessionId)
+      if (session) void this.showTerminal(hostId, session)
+    } else if (panel) {
+      this.set((s) => ({ panels: showPanel(s, target, panel) }))
+    }
+
+    if (view === 'file') {
+      const path = str(data.path)
+      if (!path) return
+      const line = typeof data.line === 'number' ? data.line : undefined
+      this.set((s) => ({
+        fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open', line },
+      }))
+    }
+
+    if (view === 'diff') {
+      this.set((s) => ({
+        diffTarget: {
+          hostId,
+          path: str(data.path) || undefined,
+          base: str(data.base) || undefined,
+          seq: (s.diffTarget?.seq ?? 0) + 1,
+        },
+      }))
+    }
+
+    this.set({ showNote: note ? { hostId, sessionId, text: note, seq } : null })
+  }
+
+  /** Dismisses the agent's note, once the human has moved on from it. */
+  clearShowNote(): void {
+    this.set({ showNote: null })
+  }
+
+  clearDiffTarget(): void {
+    this.set({ diffTarget: null })
+  }
+
   clearFileTarget(): void {
     this.set({ fileTarget: null })
   }

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -84,6 +84,8 @@ export interface DiffTarget {
   commit?: string
   /** How to draw the patch. Side by side unless the agent asked otherwise. */
   layout?: 'split' | 'unified'
+  /** A line of the new file to scroll to and mark. */
+  line?: number
   seq: number
 }
 
@@ -602,6 +604,7 @@ class Store {
           base: str(data.base) || undefined,
           commit: str(data.commit) || undefined,
           layout: str(data.layout) === 'unified' ? 'unified' : 'split',
+          line: typeof data.line === 'number' ? data.line : undefined,
           seq: (s.diffTarget?.seq ?? 0) + 1,
         },
       }))

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -78,7 +78,10 @@ export interface FileTarget {
 export interface DiffTarget {
   hostId: string
   path?: string
+  /** Branch to diff against, for a whole-branch review. */
   base?: string
+  /** A single commit to show. Never set alongside base. */
+  commit?: string
   seq: number
 }
 
@@ -595,6 +598,7 @@ class Store {
           hostId,
           path: str(data.path) || undefined,
           base: str(data.base) || undefined,
+          commit: str(data.commit) || undefined,
           seq: (s.diffTarget?.seq ?? 0) + 1,
         },
       }))

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -82,6 +82,8 @@ export interface DiffTarget {
   base?: string
   /** A single commit to show. Never set alongside base. */
   commit?: string
+  /** How to draw the patch. Side by side unless the agent asked otherwise. */
+  layout?: 'split' | 'unified'
   seq: number
 }
 
@@ -599,6 +601,7 @@ class Store {
           path: str(data.path) || undefined,
           base: str(data.base) || undefined,
           commit: str(data.commit) || undefined,
+          layout: str(data.layout) === 'unified' ? 'unified' : 'split',
           seq: (s.diffTarget?.seq ?? 0) + 1,
         },
       }))

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4016,3 +4016,68 @@ hr {
   flex: 1;
   min-width: 0;
 }
+
+/* ─── Side-by-side diff ─────────────────────────────────────────────────── */
+
+.diff-split {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.diff-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+/* A file or hunk header belongs to both sides, so it spans them. */
+.diff-row-meta {
+  grid-template-columns: 1fr;
+  padding: 2px 10px;
+  white-space: pre;
+}
+
+.diff-cell {
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+  padding: 0 10px;
+  white-space: pre;
+  border-right: 1px solid var(--outline-variant);
+}
+
+.diff-cell:last-child {
+  border-right: none;
+}
+
+/* Nothing on this side of the pair. Shaded so the eye skips it rather than
+   reading it as a blank line that exists. */
+.diff-cell-absent {
+  background: color-mix(in srgb, var(--on-surface) 4%, transparent);
+  border-right: 1px solid var(--outline-variant);
+}
+
+.diff-gutter {
+  flex: none;
+  min-width: 4ch;
+  text-align: right;
+  color: var(--on-surface-variant);
+  opacity: 0.5;
+  user-select: none;
+}
+
+.diff-text {
+  min-width: 0;
+}
+
+/* Too narrow to read two columns: one column beats two unreadable ones. */
+@media (max-width: 900px) {
+  .diff-row {
+    grid-template-columns: 1fr;
+  }
+
+  .diff-cell-absent {
+    display: none;
+  }
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3989,3 +3989,30 @@ hr {
   color: inherit;
   opacity: 0.8;
 }
+
+/* ─── Agent note ────────────────────────────────────────────────────────── */
+
+.show-note {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--outline-variant);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  font-size: 13px;
+}
+
+.show-note-who {
+  flex: none;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+}
+
+.show-note-text {
+  flex: 1;
+  min-width: 0;
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4081,3 +4081,10 @@ hr {
     display: none;
   }
 }
+
+/* The one line an agent pointed at, inside a patch that is mostly not it. */
+.diff-row-marked {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+  border-radius: 3px;
+}

--- a/docs/specs/39-agent-driven-explain-ui.md
+++ b/docs/specs/39-agent-driven-explain-ui.md
@@ -1,0 +1,827 @@
+# Agent-Driven Explain UI: A Helios MCP Server and the Deck It Draws
+
+> **Superseded by `41-helios-mcp-tools.md`.** The deck model here — decks owned
+> by a session, content stored as references the daemon resolves at read time,
+> and a Learn tab inside the session panel — has been withdrawn. So has its
+> successor, `40-learnings.md`. Helios no longer stores an explanation at all;
+> an agent points at a view with `helios_show`.
+>
+> Still current and depended on by 41: the *Spike results* section. A stdlib MCP
+> server is sufficient, Claude Code stops a tool call at about 60 seconds and no
+> env var raises it, and the desktop is inspectable over CDP.
+
+## Problem
+
+Asking an agent to explain a large change produces a wall of prose. For
+`newscred/opal-app#6813` — 29 files, +3354/−36 — the useful answer is not text
+at all: it is *this payload, entering here, hitting this guard, which is why the
+400*. That answer needs a tree that jumps, code that scrolls to the right lines,
+a diagram, and a caption pinned beside it.
+
+Helios already renders every one of those surfaces. Nothing lets the agent point
+at them.
+
+Two consequences:
+
+1. **The agent re-types what the UI could show.** It quotes source into the
+   transcript, which costs output tokens, goes stale the moment the file
+   changes, and is less readable than the editor sitting two panes away.
+2. **The loop is open.** When the reader gets lost, wanders to another file, or
+   selects a range, the agent never learns. It keeps explaining at the wrong
+   altitude.
+
+## What already exists
+
+The transport, the panes, and the human-in-the-loop channel are all built. This
+spec mostly wires them together.
+
+| Need | Already there |
+|------|---------------|
+| Push daemon → desktop | `internal/server/sse.go:31` `Broadcast(SSEEvent{Type,Data})`, mounted at `internal/server/server.go:197` |
+| Desktop receives | `desktop/src/main/sse.ts:49` fetches `/api/events`; dispatch at `desktop/src/renderer/store.ts:391` `onServerEvent` |
+| Deliver a prompt into a session | `docs/specs/37-prompt-delivery-reliability.md` |
+| Ask the human from a cold start | `internal/provider/claude/question.go`, `docs/specs/34-askuserquestion-dual-answer.md` |
+| Session panel tab strip | `desktop/src/renderer/components/detail.tsx:20` `PANELS` |
+| Ask the human, session-scoped | `internal/hitl/hitl.go:95` `Controller.Ask(sessionID, Prompt, onAnswer)` |
+| Notify the phone | `internal/notifications/manager.go`, `internal/push` |
+| Render markdown | `desktop/src/renderer/markdown.ts` |
+| Render diff | `desktop/src/renderer/diff.ts`, `components/diff-view.tsx` |
+| Render code with decorations | `components/editor.tsx` (CodeMirror) |
+| File tree | `components/file-tree.tsx` |
+| Serve a file diff | `internal/server/git.go:104` `handleGitDiff` → `git.go:142` `fileDiff` |
+| Worktree listing | `internal/server/git.go:215` |
+
+Genuinely new: an MCP endpoint, a deck store, one desktop pane, and the git
+flags `fileDiff` does not pass today.
+
+## Spike results (2026-08-19, this machine)
+
+Three unknowns were measured before committing to the design. Two of them
+changed it.
+
+**1. Can the MCP server be dependency-free?** Yes. A 150-line stdlib-only Go
+handler — `net/http` plus `encoding/json`, no SDK — completed the full handshake
+and served a tool call to Claude Code on the first attempt.
+
+```
+POST /mcp  initialize                 id=0
+POST /mcp  notifications/initialized  id=      → 202, empty body
+GET  /mcp  Accept: text/event-stream           → 405, client continued fine
+POST /mcp  tools/list                 id=1
+POST /mcp  tools/call                 id=2     → "echo: handshake-ok"
+```
+
+Client negotiated `protocolVersion 2025-06-18` and echoed back the
+`Mcp-Session-Id` we set on every subsequent request — so per-connection binding
+is available if ever wanted. The server→client SSE stream is genuinely optional.
+
+**2. How long can a tool call block?** Not long. This is the finding that
+changed the design.
+
+| Sleep | Result |
+|-------|--------|
+| 30 s | returned normally |
+| 45 s | returned normally |
+| 120 s | `<error>The operation timed out.</error>` at ~60 s |
+| 120 s with `MCP_TOOL_TIMEOUT=300000 MCP_TIMEOUT=300000` | still timed out at ~60 s |
+
+A blocking `helios_await(300)` is therefore impossible; the ceiling is ~60 s and
+is not raisable by the documented env vars. Redesigned as a 45 s long-poll.
+
+**3. Is the desktop UI inspectable, or is frontend work blind?** Inspectable.
+Launching the renderer with `--remote-debugging-port` and an isolated
+`--user-data-dir` exposes CDP: `Page.captureScreenshot` returns the real window,
+and `Runtime.evaluate` reads the DOM. Visual iteration on `learn.tsx` does not
+require a human in the loop for every change.
+
+## Interaction flow
+
+Two directions, two different mechanisms, and they never mix. The agent writes
+to the deck over MCP. The reader writes to the agent by injecting a prompt.
+Nothing blocks, and no tool waits.
+
+```
+ READER            DESKTOP                DAEMON                    AGENT
+   │            (learn panel)      (deck store · /mcp)        (claude session)
+   │                  │                     │                        │
+   │  click           │                     │                        │
+   │  ⌁ explain PR    │                     │                        │
+   ├─────────────────▶│                     │                        │
+   │                  │  POST inject prompt │                        │
+   │                  ├────────────────────▶│  "…explain PR #6813    │
+   │                  │                     │   session=s_91cc"      │
+   │                  │                     ├───────────────────────▶│
+   │                  │                     │                        │
+   │                  │                     │      helios_deck       │  turn
+   │                  │                     │◀───────────────────────┤  starts
+   │                  │                     │      helios_deck_push  │
+   │                  │                     │◀───────────────────────┤
+   │                  │  SSE deck_updated   │  (act 1 — first paint) │
+   │                  │◀────────────────────┤                        │
+   │  ◀── act 1 ──────┤                     │                        │
+   │  starts reading  │                     │      helios_deck_push  │
+   │                  │                     │◀───────────────────────┤
+   │                  │  SSE deck_updated   │      (acts 2-4)        │
+   │                  │◀────────────────────┤                        │
+   │                  │                     │      helios_deck_end   │
+   │                  │                     │◀───────────────────────┤
+   │                  │                     │                        │ turn
+   │                  │                     │                     idle  ends
+   │                  │                     │                        │
+   ├─ ▸ next ────────▶│  client-side only. no daemon, no agent.      │
+   ├─ ◂ prev ────────▶│  the deck is already stored.                 │
+   ├─ click ssrf.go ─▶│  excursion. esc returns to the spine.        │
+   ├─ d (diff mode) ─▶│  GET /api/git/diff                           │
+   │                  ├────────────────────▶│                        │
+   │                  │◀────────────────────┤                        │
+   │                  │                     │                        │
+   │  click           │                     │                        │
+   │  ↓ deeper (3)    │                     │                        │
+   ├─────────────────▶│  POST inject prompt │                        │
+   │                  ├────────────────────▶│  "…more depth on       │
+   │                  │                     │   step 3 … after_step=3"
+   │                  │                     ├───────────────────────▶│ turn
+   │                  │                     │  helios_deck_push      │ resumes
+   │                  │                     │  (after_step:3)        │ warm
+   │                  │                     │◀───────────────────────┤
+   │                  │  SSE deck_updated   │                        │
+   │                  │◀────────────────────┤                        │
+   │  ◀── sub-deck ───┤  attached under 3. steps 1-9 untouched.      │
+   │                  │                     │                     idle
+```
+
+Three properties fall out:
+
+- **Reading costs nothing.** Between the two turns the session is idle. A deck
+  can sit on screen for an hour.
+- **The deck outlives the agent.** Navigation reads the store, so it works with
+  the session cold, after a desktop restart, and on a phone that connected late.
+- **One inbound mechanism.** Every reader action that needs the agent is a
+  prompt injection — the same path the Learn button uses. There is no second
+  protocol to keep alive.
+
+## Design
+
+### Principle: the agent supplies intent, the daemon supplies content
+
+The agent must never emit source or diff text. It emits a *reference* and the
+daemon reads the file and runs git.
+
+```jsonc
+// rejected
+{"type":"code","text":"178 func (h *Handler) Register(w, r) {\n179 …"}
+
+// accepted
+{"type":"code","ref":"internal/oauth/registration.go","symbol":"Register",
+ "mode":"annotated","base":"main"}
+```
+
+This is the load-bearing decision. It buys, in order of importance:
+
+- **Content cannot drift.** The pane shows the file as it is, not as the agent
+  remembered it.
+- **Roughly 6× fewer output tokens** for a nine-step deck (~1.5k vs ~9k),
+  which is also the difference between first paint at 3 s and at 25 s.
+- **Rendering stays the renderer's job.** Syntax highlighting, folding and
+  decorations already work; inlined text would bypass all of it.
+
+### Transport
+
+The MCP server is hosted by the daemon over streamable HTTP at `POST /mcp` on
+the **internal** listener, alongside hooks and the admin API. That listener is
+already exactly what MCP needs — `127.0.0.1` unconditionally
+(`internal/server/server.go:152`) and no auth — whereas the public listener
+binds `0.0.0.0` when the tunnel provider is `local`.
+
+Mounting it there rather than on the public server is what keeps an
+unauthenticated tool surface off the network, so it is asserted in a test rather
+than left to inspection. Within the machine it is a generic server: any local
+MCP client can use it, including agents Helios did not spawn.
+
+Verified by spike (see *Spike results*): a stdlib-only Go handler is sufficient.
+No SDK, no JSON-RPC dependency. The observed handshake is:
+
+```
+POST /mcp   initialize                  → protocolVersion 2025-06-18
+POST /mcp   notifications/initialized   → 202, no body (no id on a notification)
+GET  /mcp   Accept: text/event-stream   → 405 is fine; the client continues
+POST /mcp   tools/list
+POST /mcp   tools/call
+```
+
+Any local process can reach `/mcp` and drive any pane. Accepted: the internal
+listener already trusts loopback for hooks and admin, and the blast radius is a
+rendered panel.
+
+### Identity: the session is a parameter, stamped by the button
+
+Every tool takes a `session` argument. The agent does not infer it, and the
+daemon does not guess it. It arrives one of two ways.
+
+**Primary — the Learn button stamps it.** Helios owns prompt delivery
+(`docs/specs/37-prompt-delivery-reliability.md`), and the Learn panel lives
+inside a session's own tab strip, so the target is implied by where the user
+clicked:
+
+```
+click ⌁ explain this PR   in session s_91cc's Learn panel
+        │
+        ▼
+Helios sends into s_91cc:
+   "Walk me through PR #6813 using the Helios explain pane.
+    session=s_91cc  base=main  cwd=~/workspace/opal-app"
+```
+
+**Fallback — cold start.** The user typed a prompt instead of clicking. The
+agent calls `helios_sessions()` and asks with its *own* native AskUserQuestion,
+which Helios already renders to desktop and phone
+(`docs/specs/34-askuserquestion-dual-answer.md`,
+`internal/provider/claude/question.go`). This sidesteps a chicken-and-egg: a
+`helios_ask` about *which session to target* would itself need a session to
+render on.
+
+Deliberately rejected, in order of temptation:
+
+| Rejected | Why |
+|---|---|
+| `X-Helios-Session` header injected via `--mcp-config` | only works for sessions Helios spawned; `sessionArgs()` stays untouched instead |
+| resolve by cwd | two checkouts of one repo is a case Helios already handles (`newsession.tsx:126`) |
+| "exactly one live session" guess | silently wrong on the second session |
+| `ambiguous_session` error-as-picker | clever; unnecessary once the button stamps |
+| `helios_attach` connection binding | viable — Claude Code does honour `Mcp-Session-Id`, confirmed by spike — but a second mechanism earning nothing |
+
+Because `session` is explicit, one agent driving another session's pane is free
+by construction rather than a separate feature.
+
+### The deck model
+
+```
+deck    per session. one live at a time. replaces on re-begin.
+ ├─ step[]      ordered. append-only within a deck.
+ │   ├─ layout      single | compare | stack
+ │   ├─ slots[]     1 for single, 2 for compare/stack
+ │   │   └─ content markdown | code | diff | payload | dataflow | diagram | map
+ │   ├─ caption
+ │   └─ note        the narration shown in the explain pane
+ └─ cursor   what the agent last pushed
+```
+
+Storing a deck rather than streaming imperative commands is deliberate. Events
+like "scroll to line 40" cannot be stepped back through, are lost on reopen, and
+show a late-joining phone an empty screen. A deck with a cursor gives replay,
+back/forward and mobile parity for the same amount of code.
+
+### Where it lives: a Learn panel, not a new pane
+
+`PANELS` at `desktop/src/renderer/components/detail.tsx:20` is
+`['chat','terminal','approvals','git','files']`. Learn is a sixth entry. No
+app-wide layout change; the panel splits internally into tree | content |
+narration.
+
+```
+┌ s_91cc · opal-app ─────────────────────────────────────────────┐
+│ chat │ terminal │ approvals │ git │ files │ ⌁ learn │ zsh │ + │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**The empty state is the launcher.** No deck yet, so the panel is the buttons:
+
+```
+┌ ⌁ learn ───────────────────────────────────────────────────────┐
+│                                                                 │
+│              nothing to walk through yet                        │
+│                                                                 │
+│        ⌁ explain this PR          ⌁ explain the working diff    │
+│        ⌁ explain this file        ⌁ explain a selection         │
+│                                                                 │
+│        sends a prompt to this session                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each button templates a prompt and stamps `session=` with the session that owns
+the tab strip. The same affordance belongs in the tree context menu, the diff
+view header, and on an editor selection.
+
+```
+explain this PR         "Walk me through PR {n} using the Helios explain pane.
+                         session={id} base={base} cwd={cwd}"
+explain this file       "…explain {path} … session={id}"
+explain working diff    "…explain the uncommitted diff … session={id} base=HEAD"
+explain this selection  "…explain {path}:{a}-{b} … session={id}"
+```
+
+Open: whether the buttons are disabled when no session is targeted, or spawn one
+via `handleCreateSession` and stamp the new id. Spawning reads better but means
+a button can silently create sessions.
+
+### Storage
+
+Decks live in the existing SQLite store (`internal/store/store.go:14`), beside
+`sessions` and `notifications`. Not files: a file would lose the transactional
+write that `deck_updated` is broadcast from, and would be a second persistence
+layer next to one that already works.
+
+Size is not a concern. The agent emits no code, so twelve steps of prose plus
+refs is roughly 15 KB of JSON.
+
+```sql
+CREATE TABLE IF NOT EXISTS decks (
+    deck_id    TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    title      TEXT NOT NULL,
+    kind       TEXT NOT NULL DEFAULT 'explain',
+    base       TEXT NOT NULL DEFAULT '',    -- commit SHA, never a branch name
+    steps      TEXT NOT NULL DEFAULT '[]',  -- JSON
+    cursor     INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at   TEXT
+);
+```
+
+**`base` is resolved to a commit SHA at deck creation.** A deck stored as
+`base:"main"` is meaningful for ten minutes and misleading a month later, when
+`registration.go:190` is some other line. Cheap now, impossible to retrofit.
+
+**Retention:** decks die with their session — cascade on `session_id`, keeping
+only the most recent few per session. A deck is tied to a moment.
+
+**Non-goal, deliberately:** exporting a deck to a committable file
+(`docs/walkthroughs/6813.deck.json`) so a walkthrough becomes onboarding
+material. Genuinely worth having, entirely separate from persistence, and the
+schema above does not preclude it.
+
+### Layout × content
+
+Layout and content are independent axes. This is what makes "markdown on
+compare *and* on single" fall out instead of being two features.
+
+```
+single                    compare                   stack
+┌──────────────┐          ┌──────┬🔒┬──────┐        ┌──────────────┐
+│              │          │  A   │  │  B   │        │      A  ~40% │
+│      A       │          │      │  │      │        ├──────────────┤
+│              │          │      │  │      │        │      B       │
+└──────────────┘          └──────┴──┴──────┘        └──────────────┘
+```
+
+Only the panel's content column is affected. The tree and narration columns are
+unchanged by layout.
+
+`compare` defaults to **percentage-synced** scroll. Line-correspondence sync is
+applied only when both slots are diff-derived views of the same file, where an
+alignment pass is meaningful. The lock is user-togglable per step.
+
+Rejected: `grid` and any 3+ slot layout. Nothing reads at a third of a pane.
+
+### Content reference schema
+
+```jsonc
+{"type":"markdown", "md":"…"}                            // agent authors
+
+{"type":"code",     "ref":"path",                        // daemon reads
+                    "symbol":"Register",                 // or "lines":[178,193]
+                    "mode":"annotated|plain",
+                    "base":"main"}
+
+{"type":"diff",     "ref":"path", "base":"main",
+                    "mode":"annotated|unified|split",
+                    "whitespace":false,                  // -w
+                    "functionContext":true}              // -W
+
+{"type":"payload",  "ref":"testdata/dcr_google.json", "label":"rejected"}
+{"type":"payload",  "inline":{…}, "synthetic":true}      // must self-label
+
+{"type":"dataflow", "hops":[{"label","payload"|"ref","code":"path:line","note"}]}
+{"type":"diagram",  "mermaid":"…"}
+{"type":"map",      "base":"main", "core":["internal/verifier","…"]}
+```
+
+`ref` resolves against the session's cwd and is rejected if it escapes the repo
+root. `map` carries no data: the daemon derives clusters from `git diff --stat`
+and the agent only marks which are load-bearing.
+
+**Sample data must be real.** `payload` prefers `ref` into a fixture. Inline
+payloads require `"synthetic":true`, and the renderer labels them visibly.
+Invented data that looks like a production capture is worse than no data.
+
+### Diff rendering, from a learner's perspective
+
+Raw `git diff` is built for reviewers who already know the file. Three modes,
+chosen per step:
+
+**`annotated` — the default.** The function as it exists *now*, changed lines
+tinted, no `-` lines. The reader reads working code, not a delta.
+
+```
+┌ registration.go · Register ───────────────────────────┐
+│ 183 ▎                                                  │
+│ 184 ▎   stmt, err := h.verifier.Unwrap(ctx, req)      │
+│ 185 ▎   if err != nil {                               │
+│ 186 ▎       badRequest(w, "invalid_software_statement")│
+│ 187 ▎       return                                     │
+│ 188 ▎   }                                              │
+│ 189 ▎   req.RedirectURIs = stmt.RedirectURIs(req)     │
+│ 190                                                    │
+│ 191     if len(req.RedirectURIs) == 0 {               │
+│ 192         badRequest(w, "At least one redirect_uri…")│
+│ 193     }                                              │
+└────────────────────────────────────────────────────────┘
+```
+
+For #6813 this is decisive: the change is *where the block sits* — above line
+191. A three-line hunk hides that; the whole function shows it.
+
+**`unified`** when the delta itself is the point (a flipped condition, a
+reordered guard). **`split`** when something was replaced wholesale. Split
+manages its own two columns and therefore stays `layout:"single"` — diff is
+content, never a layout. Collapsing the two would make split-diff and
+compare-of-two-files the same shape in the schema and different code paths in
+the renderer.
+
+`fileDiff` (`internal/server/git.go:142`) must gain these flags:
+
+```
+git diff -M -w --histogram --function-context <base>...<head> -- <path>
+         │  │      │              │
+         │  │      │              └─ whole enclosing function, not 3 lines
+         │  │      └─ better hunk alignment than default myers
+         │  └─ ignore whitespace; kills reindent noise
+         └─ rename detection; else a moved file is N deletions + N additions
+```
+
+`--function-context` is the cheap win — the missing context, with no symbol
+index. `-w` is defeatable per step, because occasionally whitespace *is* the
+change.
+
+### Navigation: spine and excursions
+
+Four navigation axes would need four mental models. Two suffice.
+
+**Spine.** The deck is linear. `◂ ▸` walk it. Nothing else moves along it.
+
+**Excursion.** Anything clicked — a tree file, a dataflow hop, a code link in
+markdown, a cluster in the map — detaches, pushes one breadcrumb, and `esc`
+returns to the exact spine position *and scroll offset*. Sub-decks are
+excursions, so drilling into a cluster and clicking a stray file are the same
+gesture with the same exit.
+
+Breadcrumbs never exceed depth 2. An excursion from an excursion replaces rather
+than stacks; three-deep breadcrumbs are how readers get lost.
+
+```
+┌ TREE ──────────┐┌ CODE ─────────────────────┐┌ EXPLAIN ───────────────┐
+│ ● THE CHANGE   ││ registration.go            ││ #6813 · step 3/9       │
+│   statement.go ││ 184 ▎ stmt, err := Unwrap( ││ ⏸ detached · 4 unseen  │
+│   ssrf.go   ◂──││ 185 ▎ if err != nil {      ││ ────────────────────── │
+│ ● WIRED IN     ││ 186 ▎   badRequest(…)      ││ spine  step 3          │
+│   registration ││                            ││  └ ssrf.go     ⎋ esc   │
+│ ○ tests        ││                            ││ ────────────────────── │
+└────────────────┘└────────────────────────────┘│ Four gates. Only the   │
+                                                 │ last is not a string   │
+                                                 │ check.                 │
+                                                 │ [✓][↓ deeper][? huh]   │
+                                                 │ [ ⌁ follow agent ]     │
+                                                 └────────────────────────┘
+```
+
+Keys:
+
+```
+▸ space →   next step         j / k   next / prev changed hunk in this file
+◂ ←         prev step         ] / [   expand / collapse context lines
+esc         pop excursion     d       cycle annotated → unified → split
+⏎           enter excursion   o       open for real, leave the deck
+f           follow agent      /       find within step
+```
+
+`j/k` is not a luxury: inside a 400-line annotated function the reader needs
+hunk-to-hunk hops, and overloading `◂ ▸` for that would blur the spine.
+
+Mobile: swipe L/R is the spine, tap is an excursion, system back is `esc`,
+pull-down is follow. Same model, no keys.
+
+**Follow and detach.** The agent drives; the UI follows live. Any manual
+navigation detaches. While detached the agent keeps appending and the pane shows
+an unseen count — it never yanks the viewport. `f` snaps to the *latest* step,
+not to where the agent was when you detached: the reader asked for current, not
+for a replay.
+
+### Closing the loop
+
+**The deck is generated once per turn, and the agent then stops.** There is no
+waiting tool. The agent builds the deck, ends its turn, and the session goes
+idle costing nothing. Navigation is entirely client-side against the stored
+deck — this is what the store-a-deck-not-commands decision buys.
+
+When the reader wants more, the UI **injects a prompt**, exactly as the Learn
+button does. One mechanism for every interaction, no protocol:
+
+```
+reader clicks  ↓ deeper  on step 3
+        │
+        ▼
+Helios sends into s_91cc:
+   "Reader wants more depth on step 3 (registration.go:190).
+    Append a sub-deck under it. session=s_91cc deck=d_4f2 after_step=3"
+        │
+        ▼
+agent: helios_deck_push({session, steps:[…], after_step:3})
+```
+
+The session is warm and the transcript intact, so this is a continuation — the
+agent still remembers the deck it just built.
+
+This was originally specified as a blocking `helios_await`. That is impossible:
+Claude Code aborts a tool call at roughly 60 s and no documented env var raises
+it (see *Spike results*). Prompt injection is not a workaround for that limit —
+it is simply the better design, and it removes the tool, the poll window, the
+queued-interaction store, and the risk of the agent misreading an idle poll as
+"nobody is there".
+
+**Explicit clicks only.** Implicit telemetry — dwell time, scroll depth,
+wandering to another file — is gone, and is not missed, because the signals
+worth having were already buttons. Selecting lines does not emit anything; it
+enables the existing *explain this selection* action. Opening another file does
+not notify anyone; that file has its own *explain this file* button.
+
+| Button | Injected prompt carries |
+|--------|-------------------------|
+| `↓ deeper` | `after_step`, the step's path and lines |
+| `? huh` | `at_step`, plus "back up a level, the altitude is wrong" |
+| free-text ask | `at_step` and the question |
+| `explain this selection` | `path`, line range |
+| `explain this file` | `path` |
+
+**Consequence for the store:** `helios_deck` must not wipe an existing deck, and
+`helios_deck_push` appends. A sub-deck attaches under `after_step`. Otherwise
+clicking `↓ deeper` destroys the deck being read.
+
+Signals:
+
+| Source | Emitted |
+|--------|---------|
+| `✓ got it` / `↓ deeper` / `? huh` buttons | `{kind, step}` |
+| free-text box in the explain pane | `{kind:"ask", step, text}` |
+| editor selection | `{kind:"selected", path, lines}` |
+| excursion to an unrelated file | `{kind:"wandered", path}` |
+| ≥3 steps advanced in <2 s | `{kind:"skimmed", from, to}` |
+
+`? huh` twice consecutively is the strongest signal in the set — it means the
+altitude is wrong, not that more detail is needed.
+
+Explicitly excluded: dwell-time and scroll telemetry. Too noisy, and it makes
+the agent chase ghosts.
+
+## Tool surface
+
+Seven tools enabled by default, two gated. Deliberately excluded: `read_file`,
+`grep`, `bash`, `git_*`, `pr_fetch` — the harness does all of these better, and
+a second filesystem API only splits the agent's attention. The Helios MCP server
+exposes what **only Helios owns**: the display, the human, and other sessions.
+
+### Tier 1 — deck
+
+```
+helios_sessions(filter?)                        → id, project, cwd, title, status
+helios_deck(session, title, kind)               open or reuse; never wipes
+helios_deck_push(session, steps[], after_step?) → {cursor, warnings[], resolved{}}
+helios_deck_end(session)
+```
+
+No waiting tool: the agent builds and stops. `after_step` attaches a sub-deck
+rather than appending at the tail.
+
+`helios_sessions` is Tier 0, not a Tier 3 extra: it is how a cold-started agent
+finds a target.
+
+Batching matters. Six separate step tools would mean six round trips for Acts 1
+and 2; one batched push lands them together and halves time to first paint.
+
+`helios_deck_push` returns a useful result rather than an ack:
+
+```jsonc
+{ "cursor": 4,
+  "warnings": ["step 2 slot 1: testdata/dcr_google_unwrapped.json not found"],
+  "resolved": {"internal/oauth/registration.go#Register": [178, 193]} }
+```
+
+`resolved` lets the agent cite true line numbers in later prose without reading
+the file again. `warnings` closes the correction loop without involving the
+reader.
+
+### Tier 2 — the human
+
+| Tool | Backed by | Surfaces on |
+|------|-----------|-------------|
+| `helios_ask(question, options[], timeout_s)` | `internal/hitl/hitl.go:95`, already session-scoped | terminal overlay, desktop, phone |
+| `helios_notify(title, body, level)` | `internal/notifications`, `internal/push` | phone push |
+
+`helios_ask` is near-free wiring and is arguably the highest-value tool here —
+it is the reason Helios exists.
+
+### Tier 3 — driving other sessions (gated)
+
+```
+helios_session_send(session, text)     types into another session   default OFF
+helios_session_start(cwd, prompt, …)   spawns                       default OFF
+```
+
+Both sit behind a setting in `internal/store/settings.go`, off until turned on.
+Drawing a deck on another session's pane is *not* gated — worst case is a
+confusing panel — but typing into another agent is a different act.
+
+### Worked example — #6813, Acts 1 and 2
+
+```jsonc
+helios_deck({session:"s_91cc", title:"#6813 RFC 7591 software statements",
+             kind:"explain"})
+
+helios_deck_push({session:"s_91cc", steps:[
+  {layout:"single", caption:"the idea",
+   slots:[{type:"markdown", md:
+     "Google Gemini Enterprise tried to register on **2026-08-14** and got a
+      400 in 1.4 ms.\n\nThe redirect URI it needed was inside a signed JWT we
+      did not know how to open."}]},
+
+  {layout:"compare", caption:"same request, before and after",
+   slots:[{type:"payload", ref:"testdata/dcr_google.json",   label:"rejected"},
+          {type:"payload", ref:"testdata/dcr_unwrapped.json", label:"after"}]},
+
+  {layout:"single", caption:"where the 400 came from",
+   slots:[{type:"dataflow", hops:[
+     {label:"POST /oauth/register", ref:"testdata/dcr_google.json"},
+     {label:"decode drops the unknown field", code:"internal/oauth/registration.go:179"},
+     {label:"RedirectURIs = nil"},
+     {label:"400", code:"internal/oauth/registration.go:191",
+      note:"before the allowlist is even loaded"}]}]},
+
+  {layout:"stack", caption:"what the PR inserts",
+   slots:[{type:"diagram", mermaid:"flowchart LR\n A[decode]-->B[unwrap]-->C[SSRF gates]-->D[allowlist]"},
+          {type:"code", ref:"internal/oauth/registration.go", symbol:"Register",
+           mode:"annotated", base:"main"}]}
+]})
+```
+
+Roughly 700 output tokens for four steps that render several hundred lines of
+real, current code.
+
+Push progressively — Act 1 paints while the agent is still reading files.
+
+## The skill: a large PR is not a big small PR
+
+Ships at `.claude/skills/helios-explain/SKILL.md`. It is a decision table run
+*before* the first `helios_deck_push`, not prose.
+
+```
+measure: files changed, lines added, packages touched, test ratio
+
+  ≤5 files, ≤300 lines   LINEAR      every hunk. no map step. code-first.
+  ≤15 files              THEMED      2-4 clusters. map optional.
+                                     core file per cluster only.
+  >15 files or >1000 ln  MAP-FIRST   mandatory step 0 map.
+                                     one sentence naming the single idea.
+                                     ≤4 load-bearing files; ignore the rest.
+                                     diagram before code.
+                                     say what was skipped.
+                                     ≤12 steps, then stop.
+```
+
+Deck skeleton for MAP-FIRST and THEMED:
+
+```
+ACT 1  the idea      1-2 steps   why it exists; before/after. no code.
+ACT 2  dataflow      2-4 steps   real payload through the hops. code links only.
+ACT 3  the code      ≤4 steps    load-bearing files, each anchored to a hop.
+ACT 4  evidence      1-2 steps   tests as proof; gotchas; what was skipped.
+       ── end the turn. the reader drives from here ──
+```
+
+Rules worth encoding explicitly:
+
+- **No code until the reader can predict what the code must do.** Acts 1–2 build
+  the prediction; Act 3 confirms it. Reversed, every hunk is memorisation.
+- Lead with why the PR exists, not with what changed.
+- Tests are evidence, not a cluster to walk.
+- Name what you skipped. Otherwise "not covered" is indistinguishable from
+  "nothing there".
+- Sample data comes from fixtures, the PR body, or a live capture. Synthesised
+  payloads carry `synthetic:true`.
+
+For MAP-FIRST decks the tree pane also switches from directory order to cluster
+order, showing changed files only.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `internal/mcp/server.go` | new. streamable-HTTP MCP, stdlib only: JSON-RPC framing, tool registry, dispatch |
+| `internal/mcp/tools_deck.go` | new. Tier 1 |
+| `internal/mcp/tools_human.go` | new. Tier 2 → `hitl`, `notifications` |
+| `internal/mcp/tools_sessions.go` | new. `helios_sessions`; Tier 3 setting-gated |
+| `internal/mcp/resolve.go` | new. `ref`/`symbol` → path+lines; repo-root containment; grep-based Go symbol lookup |
+| `internal/store/decks.go` | new. deck, steps, cursor, per session; queued interactions |
+| `internal/server/decks.go` | new. `GET /api/sessions/{id}/deck`, `POST …/deck/interact`; broadcasts `deck_updated` |
+| `internal/server/server.go` | mount `/mcp` on the **internal** mux (loopback, no auth); register the deck route among the session paths |
+| `internal/server/git.go:142` | `fileDiff` gains `-M -w --histogram --function-context`, each togglable |
+| `internal/store/settings.go` | `mcp.session_write_tools` (default false) |
+| `desktop/src/renderer/components/detail.tsx:20` | add `'learn'` to `PANELS` |
+| `desktop/src/renderer/components/learn.tsx` | new. panel: empty-state launcher, spine/excursion, follow-detach, feedback controls |
+| `desktop/src/renderer/components/slots.tsx` | new. layout container + content dispatch |
+| `desktop/src/renderer/components/file-tree.tsx` | accept external reveal; cluster grouping mode |
+| `desktop/src/renderer/components/editor.tsx` | line-band decorations, scroll-to, selection → interaction |
+| `desktop/src/renderer/components/diff-view.tsx` | annotated mode |
+| `desktop/src/renderer/store.ts:391` | handle `deck_updated` |
+| `desktop/package.json` | mermaid |
+| `.claude/skills/helios-explain/SKILL.md` | new |
+
+Mobile is deliberately out of scope for the first cut; the deck model makes it
+additive later.
+
+## Risks
+
+- **Authless `/mcp` on loopback.** Any local process can drive any session's
+  pane and, if the gate is opened, send text into other sessions. Mitigation:
+  loopback bind asserted in a test; Tier 3 writes default off. Revisit the
+  moment the daemon binds wider.
+- **`helios_deck` wiping a live deck.** Clicking `↓ deeper` mid-read must not
+  destroy what is on screen. Mitigation: open-or-reuse semantics, and a test
+  that a second `helios_deck` on the same session preserves existing steps.
+- **`ref` path traversal.** `resolve.go` must reject anything outside the repo
+  root — the agent controls the string and the daemon reads the file.
+- **Mermaid bundle size.** Adds meaningfully to the renderer. Lazy-load on the
+  first diagram step.
+- **Symbol lookup by grep** is roughly 90 % right for Go and wrong for
+  overloaded or generic names. Fall back to explicit lines, and report the
+  resolution in `resolved` so the agent can see what it got.
+- **Deck replaces on re-begin.** An agent that calls `helios_deck` twice destroys
+  what the reader was mid-way through. Warn in the tool result; consider
+  refusing while an excursion is open.
+- **Injected prompts landing in a busy session.** A reader clicking `↓ deeper`
+  while the agent is mid-turn queues a prompt behind whatever it is doing.
+  Mitigation is existing behaviour (`docs/specs/37-prompt-delivery-reliability.md`);
+  the button should show that the request is queued rather than appear inert.
+
+## Testing
+
+- `internal/mcp`: handshake (`initialize`, `notifications/initialized` → 202,
+  `tools/list`, `tools/call`), unknown method → -32601, unknown `session`
+  rejected, gated tools refuse when the setting is off.
+- `internal/mcp/resolve.go`: `../` escapes rejected; symbol hit, miss, and
+  ambiguous; line ranges past EOF clamped with a warning.
+- `internal/store/decks.go`: append, cursor, per-session isolation, `after_step`
+  attachment, and a second `helios_deck` preserving an existing deck.
+- `internal/server/git.go`: golden diffs for each flag combination, including a
+  rename and a pure-reindent change, proving `-M` and `-w` do what the spec
+  claims.
+- `internal/server/decks.go`: push broadcasts exactly one `deck_updated`; a
+  feedback click injects exactly one prompt carrying `after_step`.
+- Desktop: spine advance, excursion push/pop restoring scroll offset, navigation
+  working with no agent attached at all.
+- End-to-end against a fixture repo: build a four-step deck, assert the rendered
+  panel, click `↓ deeper`, assert a sub-deck attaches under step 3 without
+  disturbing steps 1–4.
+
+## Implementation order
+
+1. `internal/store/decks.go` + `internal/server/decks.go` + `deck_updated`.
+   Verifiable with curl before any MCP exists.
+2. `internal/mcp` with Tier 1 only, mounted and reachable. The spike server is
+   the starting point.
+3. `learn.tsx` empty-state launcher + `'learn'` in `PANELS` + prompt templates —
+   the agent can now be pointed at a session for real.
+4. `slots.tsx` with `markdown` and `code` content only, `single` and `compare`.
+   This is the first end-to-end demo.
+5. `fileDiff` flags + `diff` content + annotated mode.
+6. `dataflow`, `payload`, `map`, `diagram`, `stack`.
+7. Excursions, feedback buttons and their prompt templates.
+8. Tier 2 tools.
+9. The skill.
+10. Tier 3 behind the setting.
+
+Steps 1–4 are the demo. Everything after is depth.
+
+## Success criteria
+
+- Explaining #6813 costs under 2k output tokens for the deck itself and paints
+  its first step within 5 s of the request.
+- No source or diff text appears in the agent's tool arguments.
+- A reader who clicks `↓ deeper` on any step gets a drilled sub-deck without
+  re-prompting the session.
+- `git diff --function-context` output makes the *placement* of the unwrap block
+  visible without the reader opening the file.
+- Turning the MCP server off leaves every existing surface working unchanged.
+
+## Open questions
+
+1. **Layout by role or by name?** `{"role":"before_after"}` mapped to a layout by
+   the skill yields more consistent decks; raw `layout` is more expressive and
+   one more thing for the agent to get wrong. Leaning: role for the common
+   cases, `layout` as an escape hatch.
+2. **When does `wandered` fire** — immediately on excursion, so the agent can
+   react while the reader reads, or deferred until `esc`, so the deck is not
+   rewritten mid-read? Leaning immediate, since the pane never auto-jumps while
+   detached.
+3. **Revision.** The agent learns at step 7 that step 3 was wrong. Add
+   `helios_deck_revise(step_id, patch)`, or accept the stale step? Revise is
+   correct and pushes a step-id concept through the whole schema. Leaning: ship
+   without it, add if it hurts.

--- a/docs/specs/40-learnings.md
+++ b/docs/specs/40-learnings.md
@@ -1,0 +1,356 @@
+# Learnings: A Folder an Agent Writes, a Library Helios Reads
+
+> **Withdrawn. Never implemented. See `41-helios-mcp-tools.md`.**
+>
+> This design stored an explanation as a durable artifact. The premise was
+> wrong: the value is in the moment, not in the record. An agent wants you to
+> look at one thing now, and a folder of markdown is a heavy way to say that.
+> `helios_show` says it in one tool call and stores nothing.
+>
+> Kept here for the reasoning it rules out — content as files rather than
+> references, and the point that a walkthrough of a specific change should show
+> that change frozen rather than re-read the file later.
+
+Supersedes the deck model in `docs/specs/39-agent-driven-explain-ui.md`. That
+spec's premises — decks bound to a session, content held as references the
+daemon resolves, a Learn tab inside the session panel — are all withdrawn here.
+Its measurements and spike results still stand and are not repeated.
+
+## Problem
+
+Explaining a large change produces something worth keeping. The deck model threw
+it away: a deck belonged to a session, so it died with the session that happened
+to produce it, and it lived behind a tab in that session's panel where nobody
+would look for it a week later.
+
+Three things were wrong, and they compound:
+
+1. **The wrong owner.** A walkthrough of PR #6813 is not a property of the
+   terminal that produced it.
+2. **The wrong content model.** The daemon stored references and re-read files
+   on display, so "cannot show stale code" was the goal. For a durable learning
+   that is backwards — a learning about a specific change should show that
+   change forever. Re-reading is the bug.
+3. **The wrong writer.** Helios had a launcher that injected prompts, so the UI
+   needed a session to inject into, which is what forced the binding in the
+   first place.
+
+## The model
+
+A **learning** is a folder of files an agent writes, plus a row in SQLite so it
+can be listed. Nothing else.
+
+```
+agent writes            Helios reads
+─────────────           ────────────
+markdown, diffs,   →    renders them
+learning.json           lists them
+```
+
+Helios has no write path. It never creates a learning, never edits one, never
+sends a prompt. That single constraint removes the session binding, the target
+picker, the prompt templates, and the `sendPrompt` dependency together.
+
+Because the agent authors the content, the daemon resolves nothing. Gone with
+it: the working directory, the repository root, symbol lookup, base-SHA pinning,
+and the read-time file access that made all three necessary.
+
+## Interaction
+
+Three phases, and the agent is present for only the first.
+
+```
+ ┌── PHASE 1 ─ an agent builds it ─────────────────────────────────────────┐
+ │                                                                          │
+ │  YOU              CLAUDE CODE            DAEMON              DISK        │
+ │   │                    │                    │                  │         │
+ │   │ "walk me through   │                    │                  │         │
+ │   │  PR #6813"         │                    │                  │         │
+ │   ├───────────────────▶│                    │                  │         │
+ │   │                    │ helios_learning_new│                  │         │
+ │   │                    │  (title)           │                  │         │
+ │   │                    ├───────────────────▶│  mkdir           │         │
+ │   │                    │                    ├─────────────────▶│         │
+ │   │                    │◀───────────────────┤ {path}           │         │
+ │   │                    │                    │  status=building │         │
+ │   │                    │                    │                  │         │
+ │   │                    │ Write 01-idea.md   │                  │         │
+ │   │                    ├──────────────────────────────────────▶│         │
+ │   │                    │ Write 02-gates.diff│                  │         │
+ │   │                    ├──────────────────────────────────────▶│         │
+ │   │                    │ Write learning.json│                  │         │
+ │   │                    ├──────────────────────────────────────▶│         │
+ │   │                    │                    │                  │         │
+ │   │                    │ helios_learning_done(path)            │         │
+ │   │                    ├───────────────────▶│ validate + index │         │
+ │   │                    │                    │  status=ready    │         │
+ │   │                    │◀───────────────────┤ {steps, warnings}│         │
+ │   │                    │                    │                  │         │
+ │   │                 turn ends               │ SSE learnings_changed       │
+ │   │                 session may be closed   │                  │         │
+ └──────────────────────────────────────────────────────────────────────────┘
+
+ ┌── PHASE 2 ─ you read it, whenever ──────────────────────────────────────┐
+ │                                                                          │
+ │  YOU                HELIOS                 DAEMON              DISK      │
+ │   │                    │                      │                  │       │
+ │   │ open Learnings     │ GET /api/learnings   │                  │       │
+ │   ├───────────────────▶├─────────────────────▶│ SELECT (index)   │       │
+ │   │◀───────────────────┤ title · time · status│                  │       │
+ │   │                    │                      │                  │       │
+ │   │ click one          │ GET /api/learnings/{path}               │       │
+ │   ├───────────────────▶├─────────────────────▶│ read learning.json      │
+ │   │                    │                      ├─────────────────▶│       │
+ │   │                    │                      │ + each slot file │       │
+ │   │◀───────────────────┤ steps, rendered      │◀─────────────────┤       │
+ │   │                    │                      │                  │       │
+ │   ├─ ▸ next ──────────▶│ client-side only. no daemon, no agent.  │       │
+ │   ├─ ◂ prev ──────────▶│ the files are already here.             │       │
+ │                                                                          │
+ │   no agent exists. none is needed. nothing is running.                   │
+ └──────────────────────────────────────────────────────────────────────────┘
+
+ ┌── PHASE 3 ─ extending it, possibly months later ────────────────────────┐
+ │                                                                          │
+ │  YOU                HELIOS              ANY CLAUDE CODE        DISK      │
+ │   │                    │                      │                  │       │
+ │   │ click ↓ deeper     │                      │                  │       │
+ │   ├───────────────────▶│                      │                  │       │
+ │   │◀───────────────────┤ copies a prompt to the clipboard        │       │
+ │   │                    │  "Continue Helios learning <path> —     │       │
+ │   │                    │   more depth on step 3."                │       │
+ │   │                    │                      │                  │       │
+ │   │ paste it anywhere — this repo, another, your phone           │       │
+ │   ├─────────────────────────────────────────▶│                  │       │
+ │   │                    │  helios_learning_get │                  │       │
+ │   │                    │◀─────────────────────┤ reads what exists│       │
+ │   │                    │                      │ Write 06-…md     │       │
+ │   │                    │                      ├─────────────────▶│       │
+ │   │                    │                      │ rewrite learning.json    │
+ │   │                    │                      ├─────────────────▶│       │
+ │   │                    │  helios_learning_done│                  │       │
+ │   │                    │◀─────────────────────┤                  │       │
+ │   │◀── SSE ────────────┤                      │                  │       │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+The clipboard hop in phase 3 is deliberate. Helios cannot send a prompt without
+knowing which agent to send it to, and knowing that is exactly the coupling this
+design removes. Handing you text you paste wherever you like keeps Helios
+read-only and works when the original builder is long gone.
+
+## On disk
+
+```
+~/.helios/learnings/2026-08-19-pr-6813-software-statements/
+  learning.json          the only file Helios parses
+  01-the-idea.md
+  02-constraint.md
+  03-registration.diff
+  04-gates.md
+  05-ssrf.diff
+```
+
+Folder name is dated and slugged from the title: readable, sortable, and
+something you can `git add` as a unit. The export-to-a-committable-file idea
+that spec 39 listed as a non-goal is now simply what a learning is.
+
+### learning.json
+
+```jsonc
+{
+  "title": "#6813 RFC 7591 software statements",
+  "steps": [
+    { "layout": "single", "caption": "the idea",
+      "slots": [{ "type": "markdown", "file": "01-the-idea.md" }] },
+
+    { "layout": "compare", "caption": "where it is mounted, and why",
+      "slots": [
+        { "type": "markdown", "file": "02-constraint.md", "label": "the constraint" },
+        { "type": "diff", "file": "03-registration.diff",
+          "label": "internal/oauth/registration.go" }] },
+
+    { "layout": "stack", "caption": "four gates",
+      "slots": [
+        { "type": "markdown", "file": "04-gates.md" },
+        { "type": "diff", "file": "05-ssrf.diff" }] }
+  ]
+}
+```
+
+Slots carry `file`, never inline content. Two content types:
+
+| type | file | rendered by |
+|------|------|-------------|
+| `markdown` | `.md` | `desktop/src/renderer/markdown.ts` |
+| `diff` | `.diff` | `desktop/src/renderer/components/diff-view.tsx` |
+
+There is no `code` type. A fenced block inside a `.md` covers it, and dropping
+it removes a renderer, a schema branch, and the syntax-highlight path.
+
+Three layouts: `single`, `compare`, `stack`. **An unrecognised layout is a
+validation warning, not a silent fallback.** Spec 39's renderer degraded
+`stack` to `single` without saying so, which is indistinguishable from the
+layout being ignored.
+
+## SQLite is an index, not a store
+
+```sql
+CREATE TABLE IF NOT EXISTS learnings (
+    path       TEXT PRIMARY KEY,
+    title      TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'building',
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+Four columns, and the reasoning is not brevity: **anything copied out of
+`learning.json` can drift out of sync with it.** Step count, repo name and
+layout all live in the file and are read from the file. The index holds only
+what the database uniquely provides — ordering, status, and a list without
+touching the disk.
+
+The path is the identity; there is no separate id. Renaming a folder therefore
+re-keys the learning, which is honest — it is a different artifact.
+
+Dropping the table loses the list, not the learnings. A rescan of
+`~/.helios/learnings/` rebuilds it.
+
+## Tools
+
+```
+helios_learning_new(title)        → { path }        creates the folder, status=building
+helios_learning_done(path)        → { steps, warnings[] }   validates, indexes, notifies
+helios_learnings(filter?)         → the library
+helios_learning_get(path)         → title, steps, and the file list
+```
+
+Four tools, none of which carry content. The agent writes every file with its
+own `Write` tool, which it does better than it would fill a JSON payload, and no
+markdown or diff ever passes through MCP.
+
+`helios_learning_get` exists so an agent that did not build a learning can
+extend one — phase 3 above.
+
+### Validation happens at `done`
+
+`done` is load-bearing. Until it is called, `learning.json` may reference files
+that are not written yet, so `building` keeps a half-finished learning out of
+the library and gives the UI something honest to show if an agent dies mid-write.
+
+`done` checks and reports, rather than refusing:
+
+- every `file` exists
+- every `file` resolves **inside the learning folder** — the agent writes
+  `learning.json`, so a slot naming `../../../.ssh/id_rsa` must be refused.
+  Containment did not disappear with `cwd`; its anchor moved from the repository
+  to the learning folder.
+- `layout` and `type` are recognised
+- at least one step
+
+Warnings come back in the tool result so the agent can fix them without the
+reader being involved. Only a missing or unparseable `learning.json` is a hard
+failure.
+
+## UI
+
+Learnings are a sibling of sessions in the sidebar, not a panel inside one. The
+Learn tab from spec 39 is removed and `PANELS` returns to five.
+
+```
+┌ SESSIONS ─────────────┐  ┌ #6813 · RFC 7591 software statements ─────────┐
+│ ● opal-app        2m  │  │                           ◂  3 / 9  ▸         │
+│ ● helios         14m  │  │  WHERE IT IS MOUNTED, AND WHY                 │
+│                       │  │  ┌───────────────┐┌───────────────────────────┐│
+├ LEARNINGS ────────────┤  │  │ MCP is        ││ @@ -186,6 +186,12 @@      ││
+│ #6813 software st… 2m │  │  │ unauthenticat…││ +  stmt, err := unwrap(…) ││
+│ the deck store     1h │  │  └───────────────┘└───────────────────────────┘│
+│ how auth works     3d │  │                                               │
+│ ⋯ mobile push  building│ │                          [↓ deeper]  [? huh]  │
+└───────────────────────┘  └───────────────────────────────────────────────┘
+```
+
+Selecting a learning replaces the session detail view entirely — no tab strip,
+no terminal, no approvals. A learning has none of those.
+
+The empty state teaches rather than launches, since Helios cannot create one:
+
+```
+┌ LEARNINGS ─────────────────────────────────────────────┐
+│              No learnings yet                          │
+│                                                         │
+│   Ask any Claude Code session to build one:             │
+│     "walk me through this PR as a Helios learning"      │
+│                                                         │
+│   Requires the Helios MCP server.    ✓ registered       │
+└─────────────────────────────────────────────────────────┘
+```
+
+Showing MCP registration state here matters: without it nothing will ever
+appear, and an empty list would otherwise look like a bug.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `internal/store/decks.go` | **delete**, replaced by `learnings.go` |
+| `internal/store/learnings.go` | new. four-column index: upsert, list, get, delete |
+| `internal/store/store.go` | drop the `decks` table, add `learnings` |
+| `internal/store/sessions.go` | drop the deck cleanup from `DeleteSession` — learnings outlive sessions |
+| `internal/mcp/resolve.go` | **delete** most of it. `safeJoin` survives, re-anchored to the learning folder; `findSymbol`, `resolveBase`, `readLines`, `runGit` all go |
+| `internal/mcp/tools.go` | four learning tools; `helios_sessions` no longer needed for this |
+| `internal/learning/` | new. folder creation, slug, `learning.json` parse and validate |
+| `internal/server/decks.go` | **delete**, replaced by `learnings.go` |
+| `internal/server/learnings.go` | new. `GET /api/learnings`, `GET /api/learnings/{path}`; `learnings_changed` broadcast |
+| `desktop/.../learn.tsx` | rework: reader, no launcher, no prompt injection |
+| `desktop/.../slots.tsx` | drop `code`, add `diff` via `diff-view.tsx`, add `stack` |
+| `desktop/.../detail.tsx` | remove `'learn'` from `PANELS` |
+| `desktop/.../sidebar.tsx` | Learnings section |
+| `desktop/src/shared/models.ts` | `Deck`/`DeckStep`/`DeckSlot` → `Learning`/`LearningStep`/`LearningSlot` |
+
+## Testing
+
+- `internal/learning`: `learning.json` parse; missing file reported; a slot
+  escaping the folder refused; unknown layout and unknown type warned rather
+  than dropped; slug collision.
+- `internal/store/learnings.go`: upsert by path, list ordering, `building`
+  excluded from the default list, rescan rebuilds the index.
+- `internal/mcp`: `new` creates a folder and returns its path; `done` on a
+  folder with a dangling `file` reports a warning and still indexes; `get`
+  returns enough for another agent to extend.
+- `internal/server`: list and detail endpoints; `learnings_changed` broadcast
+  once per `done`; MCP still internal-only.
+- Desktop: `compare` and `stack` render two slots; a diff slot renders through
+  `diff-view.tsx`; spine navigation works with no agent and no daemon writes.
+- End to end: create a folder by hand, call `done`, assert it appears in the
+  list and renders.
+
+## Implementation order
+
+1. `internal/learning` — folder, slug, parse, validate. Pure, testable alone.
+2. `internal/store/learnings.go` + schema; delete `decks.go`.
+3. `internal/mcp` — four tools; delete `resolve.go` down to `safeJoin`.
+4. `internal/server/learnings.go` + `learnings_changed`.
+5. Desktop: sidebar section and reader; remove the Learn tab.
+6. `slots.tsx`: `diff` and `stack`; drop `code`.
+7. The skill teaching an agent when and how to build one.
+
+Steps 1–4 are verifiable with curl and a hand-written folder before any UI
+exists.
+
+## Open
+
+**Does Helios watch the folder, or wait for `done`?** Watching gives
+progressive render as the agent writes, at the cost of flicker on partial
+writes and a lost completion signal. Waiting is simpler and was worth less once
+the agent stopped holding a session open. Leaning: wait for `done`, revisit if
+building a large learning feels dead.
+
+**Is a learning deletable from Helios?** It is a write, and the only destructive
+one. Without it the library only grows. Leaning: yes, deleting the folder, with
+a confirmation — but it is the single exception to "Helios never writes" and
+should be called out as such rather than slipped in.
+
+**Should `helios_learnings` be readable by agents at all,** or only by the UI?
+An agent that can list learnings can notice one already exists and extend it
+instead of duplicating. That seems useful and costs nothing.

--- a/docs/specs/41-helios-mcp-tools.md
+++ b/docs/specs/41-helios-mcp-tools.md
@@ -58,9 +58,10 @@ sessions, which is why they need MCP at all.
 ```jsonc
 {
   "view": "file" | "diff" | "terminal" | "agent",
-  "path": "internal/oauth/registration.go",   // file: required. diff: optional.
-  "line": 190,                                // file only
-  "base": "main",                             // diff only
+  "path": "/Users/me/src/opal-app/internal/oauth/registration.go",
+                                    // absolute. file: required, diff: optional.
+  "line": 190,                      // file only
+  "base": "main",                   // diff only
   "note": "This guard is what returned the 400."
 }
 ```
@@ -68,6 +69,15 @@ sessions, which is why they need MCP at all.
 Four views. `diff` with no `path` shows the whole change, so a separate `git`
 view is not needed. `file` already opens the Files panel, so a `files` view is
 not needed either.
+
+**Paths are absolute.** `resolveSafePath` at `internal/server/files.go:134`
+resolves a relative path with `filepath.Abs`, against the *daemon's* working
+directory, which is `/`. A repo-relative path would therefore become one that
+does not exist, and the failure would look like a missing file rather than a
+bad argument. Absolute is also the form the agent already holds: its own `Read`
+and `Edit` calls carry absolute paths, and the transcript's file chips pass
+absolute paths to the same panel. A relative path is refused with a correction.
+`~/` is accepted, because the daemon expands it.
 
 `approvals` is deliberately absent. Helios already raises a notification on the
 desktop and the phone when an agent waits for permission. An agent that can pull

--- a/docs/specs/41-helios-mcp-tools.md
+++ b/docs/specs/41-helios-mcp-tools.md
@@ -1,0 +1,282 @@
+# Helios MCP Tools: Show the Human, Reach Other Sessions
+
+Replaces the deck model in `39-agent-driven-explain-ui.md` and the learning
+model in `40-learnings.md`. Both are withdrawn. The spike results in 39 are
+still correct and this spec depends on them.
+
+## Problem
+
+An agent explains code in prose. Helios already shows code, diffs, terminals and
+transcripts. The agent cannot reach any of it.
+
+Two earlier designs tried to fix this by storing what the agent said. A deck
+belonged to a session and died with it. A learning was a folder of files an
+agent wrote. Both stored an artifact. Neither was worth keeping, because the
+value is in the moment: the agent wants you to look at one thing, now.
+
+So Helios does not store an explanation. It shows a view.
+
+## The dividing line
+
+Two mechanisms exist, and one rule separates them.
+
+**A hook covers what the agent already emits.** Helios receives every tool call
+and every question. It does not need a tool to learn about them.
+
+**An MCP tool covers what no hook can infer.** The agent must state an intent
+that its own tool calls do not carry.
+
+This rule removed three tools during design:
+
+| Rejected tool | Why |
+|---|---|
+| `helios_ask` | `handleQuestion` at `internal/provider/claude/hooks.go:283` already routes `AskUserQuestion` to the desktop and the phone. A blocking MCP call also cannot wait for a person, because Claude Code stops a tool call at about 60 seconds. |
+| a tool to report the current file | `handleToolPre` at `hooks.go:986` receives `ToolName` and `ToolInput`. Helios can read `file_path` from a `Read` call. |
+| a tool to answer another agent's prompt | It bypasses the human on the path Helios exists to protect. |
+
+The rule does **not** remove `helios_show`. Reading a file and pointing at a
+file are different intentions. The agent read `registration.go` twenty calls
+ago. It wants to point at it now. A hook fires at the wrong moment, and it
+cannot tell "I need this" from "look at this".
+
+## Tool surface
+
+Four tools.
+
+```
+helios_show(view, path?, line?, base?, note?)
+helios_sessions(filter?)
+helios_session_create(cwd, prompt, provider?, model?)
+helios_session_send(session, text)
+```
+
+`helios_show` acts on the caller's own session. The other three act on other
+sessions, which is why they need MCP at all.
+
+### helios_show
+
+```jsonc
+{
+  "view": "file" | "diff" | "terminal" | "agent",
+  "path": "internal/oauth/registration.go",   // file: required. diff: optional.
+  "line": 190,                                // file only
+  "base": "main",                             // diff only
+  "note": "This guard is what returned the 400."
+}
+```
+
+Four views. `diff` with no `path` shows the whole change, so a separate `git`
+view is not needed. `file` already opens the Files panel, so a `files` view is
+not needed either.
+
+`approvals` is deliberately absent. Helios already raises a notification on the
+desktop and the phone when an agent waits for permission. An agent that can pull
+your attention to its own approval is a small push toward being approved.
+
+`note` is one line that says why. Without it you see a file and must guess what
+you are looking at.
+
+**Validation returns a correction, not a failure.** `view=file` with no `path`
+answers `"view=file needs a path"`. The agent fixes the call itself. This is the
+one real cost of a single tool with conditional fields, and this pattern pays
+it. The deck push used the same approach and it worked.
+
+**The result reports whether anyone saw it.**
+
+```jsonc
+{ "shown": true, "clients": 2 }
+{ "shown": false, "reason": "no client attached" }
+```
+
+This matters. With no desktop and no phone attached, `helios_show` does nothing.
+The agent must learn that and write prose instead.
+
+### The other three
+
+`helios_sessions` lists sessions so an agent can address one. It omits
+terminated and archived sessions unless `all` is true. A long-lived install
+holds hundreds of dead sessions and listing them buries the live ones.
+
+`helios_session_create` and `helios_session_send` change real state. An agent
+can spawn an agent, and can type into a session you are watching. Both sit
+behind a setting in `internal/store/settings.go` and stay off until you turn
+them on.
+
+## Identity
+
+`helios_show` acts on the caller's own panel. Only a session Helios spawned has
+a panel. So Helios injects the session id when it starts the session.
+
+```
+sessionArgs() at internal/provider/claude/register.go:122 appends:
+  --mcp-config '{"mcpServers":{"helios":{"type":"http",
+      "url":"http://127.0.0.1:<internal-port>/mcp",
+      "headers":{"X-Helios-Session":"<session-id>"}}}}'
+```
+
+The spike in spec 39 proved that Claude Code sends these headers.
+
+Two properties of the flag were measured on 2026-08-24, because both could
+break a user's setup.
+
+| Test | Result |
+|---|---|
+| Inline JSON as the argument value | Works. A file path is not needed. |
+| `--mcp-config` on its own | **Merges** with the user's config. `chrome-devtools` and other user-scope servers stay available. |
+| `--mcp-config --strict-mcp-config` | **Replaces** the user's config. Only the injected server remains. |
+
+**Helios must never pass `--strict-mcp-config`.** Adding it would look tidy and
+would silently remove every other MCP server from every Helios session. The
+merge behaviour is what makes this injection safe.
+
+No tool takes a session id for the caller's own session. The agent never learns
+its own id. `helios_session_send` takes one, because it addresses another
+session on purpose.
+
+An earlier design rejected header injection. The reason was that it only works
+for sessions Helios spawns. That reason no longer applies, because `helios_show`
+is meaningless for a session that has no panel.
+
+The header is identity, not authorization. `/mcp` is unauthenticated and binds
+loopback only, on the internal listener at `internal/server/server.go:152`. Any
+local process can forge the header. The blast radius is a switched tab.
+
+## Interaction
+
+```
+ ┌── the agent points at something ────────────────────────────────────────┐
+ │                                                                          │
+ │  AGENT                    DAEMON                    DESKTOP / PHONE      │
+ │    │                         │                            │              │
+ │    │ helios_show(            │                            │              │
+ │    │   view:"file",          │                            │              │
+ │    │   path:"…registration.go",                           │              │
+ │    │   line:190,             │                            │              │
+ │    │   note:"the 400")       │                            │              │
+ │    ├────────────────────────▶│                            │              │
+ │    │   X-Helios-Session: s1  │ resolve session from header│              │
+ │    │                         │ count attached clients     │              │
+ │    │                         │                            │              │
+ │    │                         │ SSE show {session, view,   │              │
+ │    │                         │           path, line, note}│              │
+ │    │                         ├───────────────────────────▶│              │
+ │    │◀────────────────────────┤ {shown:true, clients:2}    │              │
+ │    │                         │                            │ switch panel │
+ │    │ continues working       │                            │ open file    │
+ │    │                         │                            │ show note    │
+ └──────────────────────────────────────────────────────────────────────────┘
+
+ ┌── nobody is watching ───────────────────────────────────────────────────┐
+ │    │ helios_show(…)          │                                          │
+ │    ├────────────────────────▶│ no client attached                       │
+ │    │◀────────────────────────┤ {shown:false,                            │
+ │    │                         │  reason:"no client attached"}            │
+ │    │ writes prose instead    │                                          │
+ └──────────────────────────────────────────────────────────────────────────┘
+
+ ┌── reaching another session ─────────────────────────────────────────────┐
+ │    │ helios_sessions()       │                                          │
+ │    ├────────────────────────▶│ SELECT, live sessions only               │
+ │    │◀────────────────────────┤ [{session, project, cwd, status, title}] │
+ │    │                         │                                          │
+ │    │ helios_session_send(s2, │                                          │
+ │    │   "rebase onto main")   │ setting off → refused                    │
+ │    ├────────────────────────▶│ setting on  → existing send path         │
+ │    │                         ├───────────────────────▶ session s2       │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+Helios never sends a prompt on its own. It only shows views and relays what an
+agent asked for.
+
+## Desktop
+
+Most of this exists.
+
+| Need | Already there |
+|---|---|
+| Open a file in a panel | `store.ts:515` `openFile(hostId, path)`; it switches to the Files panel |
+| Switch a panel | `store.ts:510` `setPanel(panel)` |
+| Receive daemon events | `store.ts:391` `onServerEvent` |
+| Render a diff | `components/diff-view.tsx`, `components/git.tsx` |
+
+Three additions:
+
+- `FileTarget` at `store.ts:67` gains `line`, so the panel can scroll to it.
+- A `diffTarget`, matching `fileTarget`, so the Git panel can open one file's
+  diff.
+- A note strip. It shows `note` above the view and says which agent asked. It
+  clears on the next manual navigation.
+
+The note strip is what separates a deliberate show from a normal panel switch.
+Without it the view moves and nothing says why.
+
+## What this deletes
+
+The deck code from spec 39 is built and must come out.
+
+| Delete | Reason |
+|---|---|
+| `internal/store/decks.go` and its test | no stored artifact |
+| `internal/server/decks.go` and its test | keep only `TestMCPIsInternalOnly`, moved |
+| `internal/mcp/resolve.go` | the daemon resolves nothing now |
+| `desktop/.../learn.tsx`, `slots.tsx` | no reader |
+| `decks` table; `'learn'` in `PANELS`; `Deck*` types; Learn CSS | — |
+
+`internal/mcp/server.go` stays. The protocol layer never depended on decks.
+
+## Risks
+
+- **`helios_show` moves the view under you.** That is the purpose and the
+  failure mode. No throttle at first. The tool description says to use it
+  rarely. If it becomes noise, add a per-session mute, not a rate limit.
+- **Helios must not raise its window.** Switching a tab inside the app is
+  acceptable. Taking focus from another application is not.
+- **`helios_session_send` lets an agent drive an agent.** Setting-gated, off by
+  default.
+- **A forged `X-Helios-Session` header shows a view in another session.** Local
+  processes only. Accepted.
+- **A future change adds `--strict-mcp-config`.** It would strip every other MCP
+  server from every Helios session. A test must assert that `sessionArgs` does
+  not contain the flag.
+
+## Testing
+
+- `internal/mcp`: each view validates; `view=file` with no path returns the
+  correction; an unknown view is refused; the header resolves to a session; a
+  missing header is refused.
+- `internal/mcp`: `shown:false` when no client is attached.
+- `internal/mcp`: `session_send` and `session_create` refuse while the setting
+  is off.
+- `internal/server`: one `show` broadcast per call; `/mcp` stays off the public
+  mux.
+- Desktop: a `show` event switches the panel, opens the file at the line, and
+  renders the note; the note clears on manual navigation.
+- End to end: call `helios_show` by curl against a live session and confirm the
+  desktop moves.
+
+## Implementation order
+
+1. Delete the deck code. Keep `internal/mcp/server.go` and the internal-only
+   test.
+2. Add `helios_show` to `internal/mcp`, with validation and the client count.
+3. Broadcast `show` over SSE. Handle it in `store.ts`.
+4. Add `line` to `FileTarget`. Add `diffTarget`. Add the note strip.
+5. Inject `--mcp-config` in `sessionArgs`.
+6. Add `helios_sessions`. Add the two gated session tools.
+
+Steps 1 to 4 give a working demo. Step 5 removes the manual registration step.
+
+## Open
+
+**Does a show reach every attached client, or the desktop only?** I suggest
+every client. Panel state belongs to the session, not to a client, so this needs
+no new concept.
+
+**Is follow mode still worth building?** A hook can open whatever file the agent
+reads. `helios_show` now covers the deliberate case, and the session status line
+already half answers "what is it doing". Follow may not earn its cost.
+
+**Does `helios_show` need a `view` for the transcript position?** `view=agent`
+switches to the transcript, but it cannot point at a message. Scrolling to one
+would need a message id that the agent does not have.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -119,7 +119,7 @@ func startDaemon(cfg *Config) error {
 	mgr.StartCleanup()
 
 	// Register providers
-	claude.Register()
+	claude.Register(cfg.Server.InternalPort)
 
 	// Terminal hosts are separate processes, so any that survived the last
 	// daemon are still serving; adopt them before anything else looks at

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -32,7 +32,10 @@ type Notifier interface {
 type Server struct {
 	sessions Sessions
 	notify   Notifier
-	tools    map[string]tool
+	// review is nil when the daemon cannot answer, which the tool reports
+	// rather than pretending nothing has been read.
+	review Review
+	tools  map[string]tool
 }
 
 type tool struct {
@@ -43,8 +46,8 @@ type tool struct {
 	call func(sessionID string, args map[string]interface{}) (string, error)
 }
 
-func New(sessions Sessions, notify Notifier) *Server {
-	s := &Server{sessions: sessions, notify: notify}
+func New(sessions Sessions, notify Notifier, review Review) *Server {
+	s := &Server{sessions: sessions, notify: notify, review: review}
 	s.tools = s.registry()
 	return s
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,168 @@
+// Package mcp serves Helios's Model Context Protocol tools over streamable
+// HTTP. It exposes what only Helios owns — the app's own views and its session
+// inventory — and deliberately not files, grep or git, which the agent's own
+// harness already does better.
+//
+// A hook covers whatever the agent already emits; a tool covers only what no
+// hook can infer. The transport is hand-rolled against net/http and
+// encoding/json, because the subset an agent uses is four methods.
+// See docs/specs/41-helios-mcp-tools.md.
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// protocolVersion is what Claude Code negotiated when this was verified.
+const protocolVersion = "2025-06-18"
+
+// sessionHeader carries the caller's own session id. Helios injects it when it
+// starts a session, so the agent never learns or passes its own id.
+const sessionHeader = "X-Helios-Session"
+
+// Notifier delivers a view change to attached clients and reports how many
+// received it, without this package importing the HTTP server.
+type Notifier interface {
+	Show(payload map[string]interface{}) (clients int)
+}
+
+type Server struct {
+	sessions Sessions
+	notify   Notifier
+	tools    map[string]tool
+}
+
+type tool struct {
+	description string
+	schema      map[string]interface{}
+	// call receives the caller's session id, resolved from the header. It is
+	// empty for a client Helios did not start.
+	call func(sessionID string, args map[string]interface{}) (string, error)
+}
+
+func New(sessions Sessions, notify Notifier) *Server {
+	s := &Server{sessions: sessions, notify: notify}
+	s.tools = s.registry()
+	return s
+}
+
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		// The optional server→client stream. Declining it is fine: every tool
+		// here answers in the response to its own call.
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusNoContent)
+		return
+	case http.MethodPost:
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	// A notification carries no id and expects no body.
+	if len(req.ID) == 0 {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	resp := response{JSONRPC: "2.0", ID: req.ID}
+	resp.Result = s.dispatch(req, r.Header.Get(sessionHeader), &resp)
+	if resp.Error != nil {
+		resp.Result = nil
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("mcp: write response: %v", err)
+	}
+}
+
+func (s *Server) dispatch(req request, sessionID string, resp *response) interface{} {
+	switch req.Method {
+	case "initialize":
+		return map[string]interface{}{
+			"protocolVersion": protocolVersion,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "helios", "version": "1"},
+		}
+
+	case "ping":
+		return map[string]interface{}{}
+
+	case "tools/list":
+		listed := make([]map[string]interface{}, 0, len(s.tools))
+		for _, name := range toolOrder {
+			t := s.tools[name]
+			listed = append(listed, map[string]interface{}{
+				"name":        name,
+				"description": t.description,
+				"inputSchema": t.schema,
+			})
+		}
+		return map[string]interface{}{"tools": listed}
+
+	case "tools/call":
+		var p struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			resp.Error = &rpcError{Code: -32602, Message: "invalid params"}
+			return nil
+		}
+		t, ok := s.tools[p.Name]
+		if !ok {
+			return toolError(fmt.Sprintf("unknown tool %q", p.Name))
+		}
+		out, err := t.call(sessionID, p.Arguments)
+		if err != nil {
+			// Tool failures are results, not protocol errors: the agent should
+			// read them and correct itself rather than see a transport fault.
+			return toolError(err.Error())
+		}
+		return map[string]interface{}{
+			"content": []map[string]string{{"type": "text", "text": out}},
+		}
+	}
+
+	resp.Error = &rpcError{Code: -32601, Message: "method not found: " + req.Method}
+	return nil
+}
+
+func toolError(msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"content": []map[string]string{{"type": "text", "text": msg}},
+		"isError": true,
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -193,6 +193,8 @@ func TestShow_ValidationCorrectsTheAgent(t *testing.T) {
 		{"terminal with a path", map[string]interface{}{"view": "terminal", "path": "/repo/x.go"}, "does not take a path"},
 		{"relative path", map[string]interface{}{"view": "file", "path": "internal/x.go"}, "must be absolute"},
 		{"unknown view", map[string]interface{}{"view": "sidebar"}, "unknown view"},
+		{"base on a file view", map[string]interface{}{"view": "file", "path": "/r/x.go", "base": "main"}, "for view=diff"},
+		{"base and commit together", map[string]interface{}{"view": "diff", "base": "main", "commit": "abc123"}, "not both"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -227,6 +229,28 @@ func TestShow_DiffTakesAnOptionalPath(t *testing.T) {
 	}
 	if notify.sent[1]["base"] != "main" {
 		t.Errorf("base lost: %+v", notify.sent[1])
+	}
+}
+
+// A branch range and a single commit are the two questions a review asks, and
+// neither is the working tree. Both have to survive to the client, or the panel
+// shows the wrong thing and looks broken.
+func TestShow_CarriesBranchAndCommitRanges(t *testing.T) {
+	s, notify, _ := setup(t)
+
+	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff", "base": "main"})
+	callTool(t, s, "s1", "helios_show", map[string]interface{}{
+		"view": "diff", "commit": "70f5ab0", "path": "/repo/internal/mcp/tools.go",
+	})
+
+	if notify.sent[0]["base"] != "main" {
+		t.Errorf("base lost: %+v", notify.sent[0])
+	}
+	if _, carried := notify.sent[0]["commit"]; carried {
+		t.Error("a branch diff carried a commit")
+	}
+	if notify.sent[1]["commit"] != "70f5ab0" || notify.sent[1]["path"] != "/repo/internal/mcp/tools.go" {
+		t.Errorf("commit or path lost: %+v", notify.sent[1])
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -153,7 +153,7 @@ func TestShow_BroadcastsWhatTheAgentAskedFor(t *testing.T) {
 
 	got := callTool(t, s, "s1", "helios_show", map[string]interface{}{
 		"view": "file",
-		"path": "internal/oauth/registration.go",
+		"path": "/repo/internal/oauth/registration.go",
 		"line": 190,
 		"note": "the 400 came from here",
 	})
@@ -168,7 +168,7 @@ func TestShow_BroadcastsWhatTheAgentAskedFor(t *testing.T) {
 	if sent["session_id"] != "s1" {
 		t.Errorf("session_id = %v; it must come from the header, not the agent", sent["session_id"])
 	}
-	if sent["view"] != "file" || sent["path"] != "internal/oauth/registration.go" {
+	if sent["view"] != "file" || sent["path"] != "/repo/internal/oauth/registration.go" {
 		t.Errorf("wrong payload: %+v", sent)
 	}
 	if sent["line"] != 190 {
@@ -190,7 +190,8 @@ func TestShow_ValidationCorrectsTheAgent(t *testing.T) {
 		want string
 	}{
 		{"file without path", map[string]interface{}{"view": "file"}, "needs a path"},
-		{"terminal with a path", map[string]interface{}{"view": "terminal", "path": "x.go"}, "does not take a path"},
+		{"terminal with a path", map[string]interface{}{"view": "terminal", "path": "/repo/x.go"}, "does not take a path"},
+		{"relative path", map[string]interface{}{"view": "file", "path": "internal/x.go"}, "must be absolute"},
 		{"unknown view", map[string]interface{}{"view": "sidebar"}, "unknown view"},
 	}
 	for _, tc := range cases {
@@ -216,7 +217,7 @@ func TestShow_DiffTakesAnOptionalPath(t *testing.T) {
 	s, notify, _ := setup(t)
 
 	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff"})
-	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff", "path": "a.go", "base": "main"})
+	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff", "path": "/repo/a.go", "base": "main"})
 
 	if len(notify.sent) != 2 {
 		t.Fatalf("broadcast %d times, want 2", len(notify.sent))

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -23,6 +23,19 @@ func (f *fakeNotifier) Show(payload map[string]interface{}) int {
 	return f.clients
 }
 
+type fakeReview struct {
+	root     string
+	changed  []string
+	reviewed []string
+	err      error
+}
+
+func (f fakeReview) Root(string) (string, error)              { return f.root, f.err }
+func (f fakeReview) Changed(string, string) ([]string, error) { return f.changed, nil }
+func (f fakeReview) Reviewed(string, string) ([]string, error) {
+	return f.reviewed, nil
+}
+
 func setup(t *testing.T) (*Server, *fakeNotifier, *store.Store) {
 	t.Helper()
 	db, err := store.Open(":memory:")
@@ -32,7 +45,7 @@ func setup(t *testing.T) (*Server, *fakeNotifier, *store.Store) {
 	t.Cleanup(func() { db.Close() })
 
 	notify := &fakeNotifier{clients: 1}
-	return New(db, notify), notify, db
+	return New(db, notify, fakeReview{root: "/repo"}), notify, db
 }
 
 // post sends one JSON-RPC request. session goes in the header, as Helios
@@ -262,7 +275,7 @@ func TestShow_ReportsWhenNobodyIsWatching(t *testing.T) {
 		t.Fatalf("open store: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	s := New(db, &fakeNotifier{clients: 0})
+	s := New(db, &fakeNotifier{clients: 0}, fakeReview{root: "/repo"})
 
 	got := callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "terminal"})
 	if got["shown"] != false {
@@ -314,5 +327,54 @@ func TestSessions_OmitsDeadSessionsUnlessAsked(t *testing.T) {
 	withAll := callTool(t, s, "s1", "helios_sessions", map[string]interface{}{"all": true})
 	if all, _ := withAll["sessions"].([]interface{}); len(all) != 2 {
 		t.Fatalf("all=true returned %d, want 2", len(all))
+	}
+}
+
+// The point of this tool is to let an agent skip what the human already read,
+// so the split between seen and unseen is the whole answer.
+func TestReviewState_SeparatesSeenFromUnseen(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	s := New(db, &fakeNotifier{clients: 1}, fakeReview{
+		root:     "/repo",
+		changed:  []string{"a.go", "b.go", "c.go"},
+		reviewed: []string{"b.go"},
+	})
+
+	got := callTool(t, s, "s1", "helios_review_state", map[string]interface{}{"base": "main"})
+	if got["remaining"] != float64(2) {
+		t.Fatalf("remaining = %v, want 2", got["remaining"])
+	}
+
+	files, _ := got["files"].([]interface{})
+	if len(files) != 3 {
+		t.Fatalf("got %d files, want 3", len(files))
+	}
+	seen := map[string]bool{}
+	for _, entry := range files {
+		row, _ := entry.(map[string]interface{})
+		seen[row["path"].(string)], _ = row["reviewed"].(bool)
+	}
+	if !seen["b.go"] {
+		t.Error("b.go was read but is not reported as reviewed")
+	}
+	if seen["a.go"] || seen["c.go"] {
+		t.Error("an unread file is reported as reviewed")
+	}
+}
+
+func TestReviewState_NeedsABase(t *testing.T) {
+	s, _, _ := setup(t)
+
+	text, isErr := callRaw(t, s, "s1", "helios_review_state", map[string]interface{}{})
+	if !isErr {
+		t.Fatal("accepted a review with no base")
+	}
+	if !strings.Contains(text, "base is required") {
+		t.Fatalf("unhelpful message: %s", text)
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,293 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+type fakeNotifier struct {
+	sent    []map[string]interface{}
+	clients int
+}
+
+func (f *fakeNotifier) Show(payload map[string]interface{}) int {
+	if f.clients == 0 {
+		return 0
+	}
+	f.sent = append(f.sent, payload)
+	return f.clients
+}
+
+func setup(t *testing.T) (*Server, *fakeNotifier, *store.Store) {
+	t.Helper()
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	notify := &fakeNotifier{clients: 1}
+	return New(db, notify), notify, db
+}
+
+// post sends one JSON-RPC request. session goes in the header, as Helios
+// injects it at session start.
+func post(t *testing.T, s *Server, session, method string, params interface{}) map[string]interface{} {
+	t.Helper()
+	body := map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": method}
+	if params != nil {
+		body["params"] = params
+	}
+	raw, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(raw)))
+	if session != "" {
+		req.Header.Set(sessionHeader, session)
+	}
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s: status %d", method, rec.Code)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("%s: decode: %v", method, err)
+	}
+	return out
+}
+
+func callRaw(t *testing.T, s *Server, session, name string, args map[string]interface{}) (string, bool) {
+	t.Helper()
+	resp := post(t, s, session, "tools/call",
+		map[string]interface{}{"name": name, "arguments": args})
+	result, _ := resp["result"].(map[string]interface{})
+	content, _ := result["content"].([]interface{})
+	if len(content) == 0 {
+		t.Fatalf("no content in %+v", result)
+	}
+	first, _ := content[0].(map[string]interface{})
+	text, _ := first["text"].(string)
+	isErr, _ := result["isError"].(bool)
+	return text, isErr
+}
+
+func callTool(t *testing.T, s *Server, session, name string, args map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	text, isErr := callRaw(t, s, session, name, args)
+	if isErr {
+		t.Fatalf("%s reported an error: %s", name, text)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("%s: decode %q: %v", name, text, err)
+	}
+	return payload
+}
+
+func TestHandshake(t *testing.T) {
+	s, _, _ := setup(t)
+
+	init := post(t, s, "", "initialize", map[string]interface{}{})
+	result, _ := init["result"].(map[string]interface{})
+	if result["protocolVersion"] != protocolVersion {
+		t.Fatalf("protocolVersion = %v, want %s", result["protocolVersion"], protocolVersion)
+	}
+
+	list := post(t, s, "", "tools/list", nil)
+	listResult, _ := list["result"].(map[string]interface{})
+	tools, _ := listResult["tools"].([]interface{})
+	if len(tools) != len(toolOrder) {
+		t.Fatalf("got %d tools, want %d", len(tools), len(toolOrder))
+	}
+	for i, want := range toolOrder {
+		entry, _ := tools[i].(map[string]interface{})
+		if entry["name"] != want {
+			t.Fatalf("tool %d = %v, want %s", i, entry["name"], want)
+		}
+	}
+}
+
+func TestNotificationGetsNoBody(t *testing.T) {
+	s, _, _ := setup(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("notification answered with a body: %q", rec.Body.String())
+	}
+}
+
+func TestUnknownMethodAndUnknownTool(t *testing.T) {
+	s, _, _ := setup(t)
+
+	resp := post(t, s, "", "resources/list", nil)
+	rpcErr, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected an error for an unsupported method, got %+v", resp)
+	}
+	if rpcErr["code"] != float64(-32601) {
+		t.Fatalf("code = %v, want -32601", rpcErr["code"])
+	}
+
+	// An unknown tool is a tool-level failure, not a protocol fault: the agent
+	// should read it and correct itself.
+	if _, isErr := callRaw(t, s, "s1", "helios_nope", map[string]interface{}{}); !isErr {
+		t.Fatal("unknown tool did not report isError")
+	}
+}
+
+func TestShow_BroadcastsWhatTheAgentAskedFor(t *testing.T) {
+	s, notify, _ := setup(t)
+
+	got := callTool(t, s, "s1", "helios_show", map[string]interface{}{
+		"view": "file",
+		"path": "internal/oauth/registration.go",
+		"line": 190,
+		"note": "the 400 came from here",
+	})
+	if got["shown"] != true {
+		t.Fatalf("shown = %v", got["shown"])
+	}
+
+	if len(notify.sent) != 1 {
+		t.Fatalf("broadcast %d times, want 1", len(notify.sent))
+	}
+	sent := notify.sent[0]
+	if sent["session_id"] != "s1" {
+		t.Errorf("session_id = %v; it must come from the header, not the agent", sent["session_id"])
+	}
+	if sent["view"] != "file" || sent["path"] != "internal/oauth/registration.go" {
+		t.Errorf("wrong payload: %+v", sent)
+	}
+	if sent["line"] != 190 {
+		t.Errorf("line = %v, want 190", sent["line"])
+	}
+	if sent["note"] != "the 400 came from here" {
+		t.Errorf("note lost: %+v", sent)
+	}
+}
+
+// Validation answers with the fix, so the agent corrects itself and the human
+// is never involved.
+func TestShow_ValidationCorrectsTheAgent(t *testing.T) {
+	s, notify, _ := setup(t)
+
+	cases := []struct {
+		name string
+		args map[string]interface{}
+		want string
+	}{
+		{"file without path", map[string]interface{}{"view": "file"}, "needs a path"},
+		{"terminal with a path", map[string]interface{}{"view": "terminal", "path": "x.go"}, "does not take a path"},
+		{"unknown view", map[string]interface{}{"view": "sidebar"}, "unknown view"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, isErr := callRaw(t, s, "s1", "helios_show", tc.args)
+			if !isErr {
+				t.Fatalf("accepted a bad call: %s", text)
+			}
+			if !strings.Contains(text, tc.want) {
+				t.Fatalf("message %q does not contain %q", text, tc.want)
+			}
+		})
+	}
+
+	if len(notify.sent) != 0 {
+		t.Fatalf("a rejected call still broadcast: %+v", notify.sent)
+	}
+}
+
+// diff is the one view where a path is optional: without one it shows the whole
+// change, which is why there is no separate git view.
+func TestShow_DiffTakesAnOptionalPath(t *testing.T) {
+	s, notify, _ := setup(t)
+
+	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff"})
+	callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "diff", "path": "a.go", "base": "main"})
+
+	if len(notify.sent) != 2 {
+		t.Fatalf("broadcast %d times, want 2", len(notify.sent))
+	}
+	if _, carried := notify.sent[0]["path"]; carried {
+		t.Error("a pathless diff carried a path")
+	}
+	if notify.sent[1]["base"] != "main" {
+		t.Errorf("base lost: %+v", notify.sent[1])
+	}
+}
+
+// With nobody watching, the agent should write prose instead of pointing at a
+// screen. It can only do that if the result says so.
+func TestShow_ReportsWhenNobodyIsWatching(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s := New(db, &fakeNotifier{clients: 0})
+
+	got := callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "terminal"})
+	if got["shown"] != false {
+		t.Fatalf("shown = %v, want false", got["shown"])
+	}
+	if got["reason"] != "no client attached" {
+		t.Fatalf("reason = %v", got["reason"])
+	}
+}
+
+// A client Helios did not start has no panel. Saying so is more useful than
+// silently doing nothing.
+func TestShow_RefusedWithoutASession(t *testing.T) {
+	s, _, _ := setup(t)
+
+	text, isErr := callRaw(t, s, "", "helios_show", map[string]interface{}{"view": "terminal"})
+	if !isErr {
+		t.Fatal("a session-less caller was allowed to show a view")
+	}
+	if !strings.Contains(text, "not started by Helios") {
+		t.Fatalf("unhelpful message: %s", text)
+	}
+}
+
+// A long-lived install has hundreds of dead sessions. Returning them buries the
+// ones an agent can actually address.
+func TestSessions_OmitsDeadSessionsUnlessAsked(t *testing.T) {
+	s, _, db := setup(t)
+
+	for _, sess := range []store.Session{
+		{SessionID: "live", Source: "claude", CWD: "/tmp/a", Status: "active"},
+		{SessionID: "dead", Source: "claude", CWD: "/tmp/b", Status: "terminated"},
+	} {
+		if err := db.UpsertSession(&sess); err != nil {
+			t.Fatalf("upsert %s: %v", sess.SessionID, err)
+		}
+	}
+
+	listed := callTool(t, s, "s1", "helios_sessions", map[string]interface{}{})
+	sessions, _ := listed["sessions"].([]interface{})
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want just the live one", len(sessions))
+	}
+	first, _ := sessions[0].(map[string]interface{})
+	if first["session"] != "live" {
+		t.Fatalf("listed %v, want the live session", first["session"])
+	}
+
+	withAll := callTool(t, s, "s1", "helios_sessions", map[string]interface{}{"all": true})
+	if all, _ := withAll["sessions"].([]interface{}); len(all) != 2 {
+		t.Fatalf("all=true returned %d, want 2", len(all))
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -64,6 +64,7 @@ func (s *Server) registry() map[string]tool {
 				"line":   map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
 				"base":   str("branch to diff against, e.g. main. view=diff only, and not with commit"),
 				"commit": str("one commit to show. view=diff only, and not with base"),
+				"layout": str("split (default, side by side) or unified. view=diff only"),
 				"note":   str("one line saying why the human should look at this"),
 			}, "view"),
 			call: s.callShow,
@@ -127,8 +128,12 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 	}
 
 	base, commit := argString(args, "base"), argString(args, "commit")
-	if view != "diff" && (base != "" || commit != "") {
-		return "", fmt.Errorf("base and commit are for view=diff, not view=%s", view)
+	layout := argString(args, "layout")
+	if view != "diff" && (base != "" || commit != "" || layout != "") {
+		return "", fmt.Errorf("base, commit and layout are for view=diff, not view=%s", view)
+	}
+	if layout != "" && layout != "split" && layout != "unified" {
+		return "", fmt.Errorf("layout must be split or unified, not %q", layout)
 	}
 	// A branch range and a single commit are different questions, and honouring
 	// one while ignoring the other would be worse than refusing.
@@ -144,6 +149,7 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 		"path":   path,
 		"base":   base,
 		"commit": commit,
+		"layout": layout,
 		"note":   argString(args, "note"),
 	} {
 		if value != "" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -55,13 +55,16 @@ func (s *Server) registry() map[string]tool {
 				"Paths are absolute, the same form your own file tools use. " +
 				"view=file needs path. view=diff takes an optional path; omit it " +
 				"for the whole change. view=terminal and view=agent take neither. " +
+				"A diff is the uncommitted change by default; pass base for a branch " +
+				"against it, or commit for a single commit. " +
 				"Use this rarely, when the human must actually look at something.",
 			schema: obj(map[string]interface{}{
-				"view": str("file | diff | terminal | agent"),
-				"path": str("absolute file path, for view=file and optionally view=diff"),
-				"line": map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
-				"base": str("revision to diff against, view=diff only"),
-				"note": str("one line saying why the human should look at this"),
+				"view":   str("file | diff | terminal | agent"),
+				"path":   str("absolute file path, for view=file and optionally view=diff"),
+				"line":   map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
+				"base":   str("branch to diff against, e.g. main. view=diff only, and not with commit"),
+				"commit": str("one commit to show. view=diff only, and not with base"),
+				"note":   str("one line saying why the human should look at this"),
 			}, "view"),
 			call: s.callShow,
 		},
@@ -123,14 +126,25 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 		return "", fmt.Errorf("path must be absolute, not %q", path)
 	}
 
+	base, commit := argString(args, "base"), argString(args, "commit")
+	if view != "diff" && (base != "" || commit != "") {
+		return "", fmt.Errorf("base and commit are for view=diff, not view=%s", view)
+	}
+	// A branch range and a single commit are different questions, and honouring
+	// one while ignoring the other would be worse than refusing.
+	if base != "" && commit != "" {
+		return "", fmt.Errorf("pass base or commit, not both")
+	}
+
 	payload := map[string]interface{}{
 		"session_id": sessionID,
 		"view":       view,
 	}
 	for key, value := range map[string]string{
-		"path": path,
-		"base": argString(args, "base"),
-		"note": argString(args, "note"),
+		"path":   path,
+		"base":   base,
+		"commit": commit,
+		"note":   argString(args, "note"),
 	} {
 		if value != "" {
 			payload[key] = value

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/kamrul1157024/helios/internal/store"
@@ -51,12 +52,13 @@ func (s *Server) registry() map[string]tool {
 		"helios_show": {
 			description: "Show the human something in the Helios app: open a file, " +
 				"open a diff, or switch to the terminal or the transcript. " +
+				"Paths are absolute, the same form your own file tools use. " +
 				"view=file needs path. view=diff takes an optional path; omit it " +
 				"for the whole change. view=terminal and view=agent take neither. " +
 				"Use this rarely, when the human must actually look at something.",
 			schema: obj(map[string]interface{}{
 				"view": str("file | diff | terminal | agent"),
-				"path": str("repo-relative file path, for view=file and optionally view=diff"),
+				"path": str("absolute file path, for view=file and optionally view=diff"),
 				"line": map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
 				"base": str("revision to diff against, view=diff only"),
 				"note": str("one line saying why the human should look at this"),
@@ -73,6 +75,12 @@ func (s *Server) registry() map[string]tool {
 			call: s.callSessions,
 		},
 	}
+}
+
+// isAbsolutePath accepts "~/..." as well, because the daemon expands it the
+// same way it expands an absolute path.
+func isAbsolutePath(path string) bool {
+	return filepath.IsAbs(path) || strings.HasPrefix(path, "~/")
 }
 
 func argString(args map[string]interface{}, key string) string {
@@ -107,6 +115,12 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 	}
 	if !rules.takesPath && path != "" {
 		return "", fmt.Errorf("view=%s does not take a path", view)
+	}
+	// The daemon resolves a relative path against its own working directory,
+	// which is "/" — so a repo-relative path silently becomes a path that does
+	// not exist. Absolute is also the form the agent's own file tools use.
+	if path != "" && !isAbsolutePath(path) {
+		return "", fmt.Errorf("path must be absolute, not %q", path)
 	}
 
 	payload := map[string]interface{}{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -15,10 +15,23 @@ type Sessions interface {
 	GetSession(sessionID string) (*store.Session, error)
 }
 
+// Review reports what the human has already read. It is the one thing here
+// that flows the other way: every other tool tells Helios something, and this
+// asks Helios what happened.
+type Review interface {
+	// Root is the repository the session sits in.
+	Root(sessionID string) (string, error)
+	// Changed lists the files a branch touches, against base.
+	Changed(root, base string) ([]string, error)
+	// Reviewed lists the files already read for that same range.
+	Reviewed(root, base string) ([]string, error)
+}
+
 // toolOrder fixes the order tools/list reports, so the agent meets the tool it
 // needs most first rather than in map order.
 var toolOrder = []string{
 	"helios_show",
+	"helios_review_state",
 	"helios_sessions",
 }
 
@@ -68,6 +81,16 @@ func (s *Server) registry() map[string]tool {
 				"note":   str("one line saying why the human should look at this"),
 			}, "view"),
 			call: s.callShow,
+		},
+
+		"helios_review_state": {
+			description: "What the human has already read of a branch review. " +
+				"Call this before walking someone through a diff: skip what they " +
+				"have seen and say how much is left, rather than starting again.",
+			schema: obj(map[string]interface{}{
+				"base": str("branch the review is against, e.g. main"),
+			}, "base"),
+			call: s.callReviewState,
 		},
 
 		"helios_sessions": {
@@ -175,6 +198,51 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 		})
 	}
 	return encode(map[string]interface{}{"shown": true, "clients": clients})
+}
+
+func (s *Server) callReviewState(sessionID string, args map[string]interface{}) (string, error) {
+	if sessionID == "" {
+		return "", fmt.Errorf("this session was not started by Helios, so it has no review to report")
+	}
+	if s.review == nil {
+		return "", fmt.Errorf("this daemon cannot report review state")
+	}
+	base := argString(args, "base")
+	if base == "" {
+		return "", fmt.Errorf("base is required, e.g. main")
+	}
+
+	root, err := s.review.Root(sessionID)
+	if err != nil {
+		return "", err
+	}
+	changed, err := s.review.Changed(root, base)
+	if err != nil {
+		return "", fmt.Errorf("list changed files: %w", err)
+	}
+	seen, err := s.review.Reviewed(root, base)
+	if err != nil {
+		return "", fmt.Errorf("list reviewed files: %w", err)
+	}
+
+	read := make(map[string]bool, len(seen))
+	for _, path := range seen {
+		read[path] = true
+	}
+	files := make([]map[string]interface{}, 0, len(changed))
+	remaining := 0
+	for _, path := range changed {
+		files = append(files, map[string]interface{}{"path": path, "reviewed": read[path]})
+		if !read[path] {
+			remaining++
+		}
+	}
+
+	return encode(map[string]interface{}{
+		"base":      base,
+		"files":     files,
+		"remaining": remaining,
+	})
 }
 
 func (s *Server) callSessions(_ string, args map[string]interface{}) (string, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -61,7 +61,7 @@ func (s *Server) registry() map[string]tool {
 			schema: obj(map[string]interface{}{
 				"view":   str("file | diff | terminal | agent"),
 				"path":   str("absolute file path, for view=file and optionally view=diff"),
-				"line":   map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
+				"line":   map[string]interface{}{"type": "integer", "description": "line to scroll to. view=file, or view=diff to point at one line of the patch"},
 				"base":   str("branch to diff against, e.g. main. view=diff only, and not with commit"),
 				"commit": str("one commit to show. view=diff only, and not with base"),
 				"layout": str("split (default, side by side) or unified. view=diff only"),
@@ -156,7 +156,10 @@ func (s *Server) callShow(sessionID string, args map[string]interface{}) (string
 			payload[key] = value
 		}
 	}
-	if line := argInt(args, "line"); line > 0 && view == "file" {
+	// Pointing at a line matters more in a diff than in a file: "look at this
+	// change" is the request, and a file-only line left the agent gesturing at
+	// a whole patch.
+	if line := argInt(args, "line"); line > 0 && (view == "file" || view == "diff") {
 		payload["line"] = line
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,184 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// Sessions is the slice of the store this package reads.
+type Sessions interface {
+	ListSessions() ([]store.Session, error)
+	GetSession(sessionID string) (*store.Session, error)
+}
+
+// toolOrder fixes the order tools/list reports, so the agent meets the tool it
+// needs most first rather than in map order.
+var toolOrder = []string{
+	"helios_show",
+	"helios_sessions",
+}
+
+// showViews are the views helios_show can switch to, and what each one needs.
+// "diff" takes an optional path: without one it shows the whole change, which
+// is why there is no separate "git" view.
+var showViews = map[string]struct {
+	needsPath bool
+	takesPath bool
+}{
+	"file":     {needsPath: true, takesPath: true},
+	"diff":     {needsPath: false, takesPath: true},
+	"terminal": {},
+	"agent":    {},
+}
+
+func obj(props map[string]interface{}, required ...string) map[string]interface{} {
+	schema := map[string]interface{}{"type": "object", "properties": props}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func str(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "description": desc}
+}
+
+func (s *Server) registry() map[string]tool {
+	return map[string]tool{
+		"helios_show": {
+			description: "Show the human something in the Helios app: open a file, " +
+				"open a diff, or switch to the terminal or the transcript. " +
+				"view=file needs path. view=diff takes an optional path; omit it " +
+				"for the whole change. view=terminal and view=agent take neither. " +
+				"Use this rarely, when the human must actually look at something.",
+			schema: obj(map[string]interface{}{
+				"view": str("file | diff | terminal | agent"),
+				"path": str("repo-relative file path, for view=file and optionally view=diff"),
+				"line": map[string]interface{}{"type": "integer", "description": "line to scroll to, view=file only"},
+				"base": str("revision to diff against, view=diff only"),
+				"note": str("one line saying why the human should look at this"),
+			}, "view"),
+			call: s.callShow,
+		},
+
+		"helios_sessions": {
+			description: "List Helios sessions. Dead sessions are omitted unless all=true.",
+			schema: obj(map[string]interface{}{
+				"project": str("optional substring match on project or cwd"),
+				"all":     map[string]interface{}{"type": "boolean", "description": "include terminated and archived sessions"},
+			}),
+			call: s.callSessions,
+		},
+	}
+}
+
+func argString(args map[string]interface{}, key string) string {
+	v, _ := args[key].(string)
+	return strings.TrimSpace(v)
+}
+
+func argInt(args map[string]interface{}, key string) int {
+	if f, ok := args[key].(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+// callShow validates the request and broadcasts it. Validation answers with a
+// correction rather than a bare failure, so the agent can fix the call itself
+// without the human being involved.
+func (s *Server) callShow(sessionID string, args map[string]interface{}) (string, error) {
+	if sessionID == "" {
+		return "", fmt.Errorf("this session was not started by Helios, so it has no panel to show anything in")
+	}
+
+	view := argString(args, "view")
+	rules, known := showViews[view]
+	if !known {
+		return "", fmt.Errorf("unknown view %q; use file, diff, terminal or agent", view)
+	}
+
+	path := argString(args, "path")
+	if rules.needsPath && path == "" {
+		return "", fmt.Errorf("view=%s needs a path", view)
+	}
+	if !rules.takesPath && path != "" {
+		return "", fmt.Errorf("view=%s does not take a path", view)
+	}
+
+	payload := map[string]interface{}{
+		"session_id": sessionID,
+		"view":       view,
+	}
+	for key, value := range map[string]string{
+		"path": path,
+		"base": argString(args, "base"),
+		"note": argString(args, "note"),
+	} {
+		if value != "" {
+			payload[key] = value
+		}
+	}
+	if line := argInt(args, "line"); line > 0 && view == "file" {
+		payload["line"] = line
+	}
+
+	clients := s.notify.Show(payload)
+
+	// Reported so an agent nobody is watching writes prose instead of pointing
+	// at a screen. This counts connected clients, not people looking at this
+	// particular session — the event stream has no per-session affinity.
+	if clients == 0 {
+		return encode(map[string]interface{}{
+			"shown":  false,
+			"reason": "no client attached",
+		})
+	}
+	return encode(map[string]interface{}{"shown": true, "clients": clients})
+}
+
+func (s *Server) callSessions(_ string, args map[string]interface{}) (string, error) {
+	sessions, err := s.sessions.ListSessions()
+	if err != nil {
+		return "", fmt.Errorf("list sessions: %w", err)
+	}
+
+	match := strings.ToLower(argString(args, "project"))
+	all, _ := args["all"].(bool)
+
+	out := make([]map[string]interface{}, 0, len(sessions))
+	for _, sess := range sessions {
+		// A long-lived install accumulates hundreds of dead sessions, nearly
+		// all untitled. Listing them buries the handful worth addressing.
+		if !all && (sess.Status == "terminated" || sess.Archived) {
+			continue
+		}
+		if match != "" &&
+			!strings.Contains(strings.ToLower(sess.Project), match) &&
+			!strings.Contains(strings.ToLower(sess.CWD), match) {
+			continue
+		}
+		entry := map[string]interface{}{
+			"session": sess.SessionID,
+			"project": sess.Project,
+			"cwd":     sess.CWD,
+			"status":  sess.Status,
+		}
+		if sess.Title != nil {
+			entry["title"] = *sess.Title
+		}
+		out = append(out, entry)
+	}
+	return encode(map[string]interface{}{"sessions": out})
+}
+
+func encode(v interface{}) (string, error) {
+	out, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/internal/provider/claude/register.go
+++ b/internal/provider/claude/register.go
@@ -117,12 +117,47 @@ func LaunchPermissionMode(spec provider.SessionSpec) string {
 	}
 }
 
+// mcpPort is the daemon's internal port, set once by Register. Sessions reach
+// the Helios MCP server there. Zero means no port was reported, and then no MCP
+// config is injected at all.
+var mcpPort int
+
+// mcpConfig builds the --mcp-config value that points a session at the Helios
+// MCP server and names the session it belongs to. The id travels in a header,
+// so the agent never has to know its own id or pass it to a tool.
+//
+// This must never be paired with --strict-mcp-config. Measured 2026-08-24:
+// --mcp-config on its own merges with the user's servers, while adding
+// --strict-mcp-config replaces them. That would silently remove every other
+// MCP server from every Helios session.
+func mcpConfig(sessionID string) (string, bool) {
+	if mcpPort == 0 || sessionID == "" {
+		return "", false
+	}
+	encoded, err := json.Marshal(map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"helios": map[string]interface{}{
+				"type":    "http",
+				"url":     fmt.Sprintf("http://127.0.0.1:%d/mcp", mcpPort),
+				"headers": map[string]string{"X-Helios-Session": sessionID},
+			},
+		},
+	})
+	if err != nil {
+		return "", false
+	}
+	return string(encoded), true
+}
+
 // sessionArgs builds the argv for a Claude session. Shared with the resume
 // path so a woken session gets the same flags as a fresh one.
 func sessionArgs(spec provider.SessionSpec) []string {
 	argv := []string{"claude"}
 	if spec.SessionID != "" {
 		argv = append(argv, "--session-id", spec.SessionID)
+	}
+	if config, ok := mcpConfig(spec.SessionID); ok {
+		argv = append(argv, "--mcp-config", config)
 	}
 	if spec.Model != "" {
 		argv = append(argv, "--model", spec.Model)
@@ -142,7 +177,9 @@ func sessionArgs(spec provider.SessionSpec) []string {
 }
 
 // Register registers all Claude hook and action handlers.
-func Register() {
+func Register(internalPort int) {
+	mcpPort = internalPort
+
 	// Provider registration
 	provider.RegisterProvider(
 		provider.ProviderInfo{

--- a/internal/provider/claude/register_test.go
+++ b/internal/provider/claude/register_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -176,5 +177,64 @@ func TestPermissionModesMatchCLIChoices(t *testing.T) {
 	}
 	if ValidPermissionMode("default") {
 		t.Error("ValidPermissionMode(\"default\") = true, but the CLI rejects it")
+	}
+}
+
+func TestSessionArgsInjectsSessionScopedMCPConfig(t *testing.T) {
+	mcpPort = 7654
+	t.Cleanup(func() { mcpPort = 0 })
+
+	argv := sessionArgs(provider.SessionSpec{SessionID: "s1", CWD: "/tmp"})
+
+	raw, ok := flagValue(argv, "--mcp-config")
+	if !ok {
+		t.Fatalf("argv = %v, want a --mcp-config flag", argv)
+	}
+
+	var config struct {
+		MCPServers map[string]struct {
+			Type    string            `json:"type"`
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("--mcp-config is not valid JSON: %v", err)
+	}
+
+	helios, present := config.MCPServers["helios"]
+	if !present {
+		t.Fatalf("no helios server in %s", raw)
+	}
+	if helios.URL != "http://127.0.0.1:7654/mcp" {
+		t.Errorf("url = %q", helios.URL)
+	}
+	// The agent must never need to know its own id, so it travels in a header.
+	if helios.Headers["X-Helios-Session"] != "s1" {
+		t.Errorf("session header = %q, want s1", helios.Headers["X-Helios-Session"])
+	}
+}
+
+// Measured 2026-08-24: --mcp-config alone merges with the user's own MCP
+// servers, but adding --strict-mcp-config replaces them. Passing it would
+// silently strip every other MCP server from every Helios session.
+func TestSessionArgsNeverPassesStrictMCPConfig(t *testing.T) {
+	mcpPort = 7654
+	t.Cleanup(func() { mcpPort = 0 })
+
+	argv := sessionArgs(provider.SessionSpec{SessionID: "s1", CWD: "/tmp"})
+	if slices.Contains(argv, "--strict-mcp-config") {
+		t.Fatalf("argv = %v; --strict-mcp-config would remove the user's other MCP servers", argv)
+	}
+}
+
+// A daemon that reported no port cannot describe a reachable server, and an
+// unreachable one would make every session log a failed MCP connection.
+func TestSessionArgsOmitsMCPConfigWithoutAPort(t *testing.T) {
+	mcpPort = 0
+
+	argv := sessionArgs(provider.SessionSpec{SessionID: "s1", CWD: "/tmp"})
+	if _, ok := flagValue(argv, "--mcp-config"); ok {
+		t.Fatalf("argv = %v, want no --mcp-config when no port is known", argv)
 	}
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1,5 +1,7 @@
 package server
 
+import "fmt"
+
 // Show implements mcp.Notifier. It relays a view change an agent asked for and
 // reports how many clients received it.
 //
@@ -14,4 +16,43 @@ func (sh *Shared) Show(payload map[string]interface{}) int {
 	}
 	sh.SSE.Broadcast(SSEEvent{Type: "show", Data: payload})
 	return clients
+}
+
+// Root implements mcp.Review: the repository a session sits in. Deck-free —
+// the agent names files absolutely and this only anchors the review.
+func (sh *Shared) Root(sessionID string) (string, error) {
+	sess, err := sh.DB.GetSession(sessionID)
+	if err != nil {
+		return "", fmt.Errorf("look up session %s: %w", sessionID, err)
+	}
+	if sess == nil {
+		return "", fmt.Errorf("no session %s", sessionID)
+	}
+	root, err := gitRepoRoot(sess.CWD)
+	if err != nil {
+		return "", fmt.Errorf("session %s is not in a repository", sessionID)
+	}
+	return root, nil
+}
+
+// Changed implements mcp.Review. Merge base rather than the branch tip, for the
+// same reason the review panel uses it: commits landed on the base since the
+// branch was cut are not this branch's work, and a two-dot diff reports them as
+// changes it undid.
+func (sh *Shared) Changed(root, base string) ([]string, error) {
+	from := mergeBaseFrom(root, base, "HEAD", map[string][]string{"merge_base": {"true"}})
+	files, err := changedFiles(root, from, "HEAD")
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.Path)
+	}
+	return paths, nil
+}
+
+// Reviewed implements mcp.Review.
+func (sh *Shared) Reviewed(root, base string) ([]string, error) {
+	return sh.DB.ReviewedFiles(root, base)
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1,0 +1,17 @@
+package server
+
+// Show implements mcp.Notifier. It relays a view change an agent asked for and
+// reports how many clients received it.
+//
+// The count is connected clients, not people looking at this session. The event
+// stream has one connection per host, not per session, so it cannot say who is
+// reading what. Zero is the answer that matters: it tells the agent nobody is
+// watching, so it should write prose instead of pointing at a screen.
+func (sh *Shared) Show(payload map[string]interface{}) int {
+	clients := sh.SSE.ClientCount()
+	if clients == 0 {
+		return 0
+	}
+	sh.SSE.Broadcast(SSEEvent{Type: "show", Data: payload})
+	return clients
+}

--- a/internal/server/mcp_mount_test.go
+++ b/internal/server/mcp_mount_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// MCP is unauthenticated, so where it is mounted is the only thing keeping it
+// off the network. The public listener binds 0.0.0.0 when the tunnel provider
+// is "local"; the internal one is always loopback. Moving /mcp across would
+// hand every tool on it to anyone who can reach the tunnel.
+func TestMCPIsInternalOnly(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	shared := NewShared(db, notifications.NewManager(db), newStubBackend())
+
+	initialize := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+
+	public := NewPublicServer("", 0, shared)
+	rec := httptest.NewRecorder()
+	public.httpServer.Handler.ServeHTTP(rec,
+		httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initialize)))
+	if strings.Contains(rec.Body.String(), "protocolVersion") {
+		t.Fatal("MCP answered on the public server")
+	}
+
+	internal := NewInternalServer(0, shared)
+	rec = httptest.NewRecorder()
+	internal.httpServer.Handler.ServeHTTP(rec,
+		httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initialize)))
+	if !strings.Contains(rec.Body.String(), "protocolVersion") {
+		t.Fatalf("MCP not served internally: %d %s", rec.Code, rec.Body.String())
+	}
+	if !strings.HasPrefix(internal.httpServer.Addr, "127.0.0.1:") {
+		t.Fatalf("internal listener binds %q, not loopback", internal.httpServer.Addr)
+	}
+}

--- a/internal/server/reviewed.go
+++ b/internal/server/reviewed.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleGetReviewed lists the files already read for a repository and base, so
+// the panel can show them ticked after a restart and an agent can skip them.
+func (s *PublicServer) handleGetReviewed(w http.ResponseWriter, r *http.Request) {
+	root, err := gitRepoRoot(r.URL.Query().Get("path"))
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	base := r.URL.Query().Get("base")
+	if base == "" {
+		jsonError(w, "missing base", http.StatusBadRequest)
+		return
+	}
+
+	files, err := s.shared.DB.ReviewedFiles(root, base)
+	if err != nil {
+		jsonError(w, "failed to load reviewed files", http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]interface{}{"root": root, "base": base, "files": files})
+}
+
+// handleSetReviewed records or clears one file, or clears the whole review.
+func (s *PublicServer) handleSetReviewed(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path     string `json:"path"`
+		Base     string `json:"base"`
+		File     string `json:"file"`
+		Reviewed bool   `json:"reviewed"`
+		Clear    bool   `json:"clear"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	root, err := gitRepoRoot(req.Path)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Base == "" {
+		jsonError(w, "missing base", http.StatusBadRequest)
+		return
+	}
+
+	if req.Clear {
+		if err := s.shared.DB.ClearReviewed(root, req.Base); err != nil {
+			jsonError(w, "failed to clear", http.StatusInternalServerError)
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
+		return
+	}
+
+	if req.File == "" {
+		jsonError(w, "missing file", http.StatusBadRequest)
+		return
+	}
+	if err := s.shared.DB.MarkReviewed(root, req.Base, req.File, req.Reviewed); err != nil {
+		jsonError(w, "failed to save", http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/mcp"
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/reporter"
 	"github.com/kamrul1157024/helios/internal/store"
@@ -147,6 +148,11 @@ func NewInternalServer(port int, shared *Shared) *InternalServer {
 	mux.HandleFunc("PUT /internal/settings", s.handleInternalUpdateSettings)
 	mux.Handle("GET /internal/events", shared.SSE)
 	mux.HandleFunc("GET /internal/logs", s.handleInternalLogs)
+
+	// MCP lives here rather than on the public server because this listener is
+	// already what it needs to be: loopback only, no auth. Agents reach it with
+	// a session id from their prompt; see docs/specs/39-agent-driven-explain-ui.md.
+	mux.Handle("/mcp", mcp.New(shared.DB, shared))
 
 	s.httpServer = &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", port),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,7 +152,7 @@ func NewInternalServer(port int, shared *Shared) *InternalServer {
 	// MCP lives here rather than on the public server because this listener is
 	// already what it needs to be: loopback only, no auth. Agents reach it with
 	// a session id from their prompt; see docs/specs/39-agent-driven-explain-ui.md.
-	mux.Handle("/mcp", mcp.New(shared.DB, shared))
+	mux.Handle("/mcp", mcp.New(shared.DB, shared, shared))
 
 	s.httpServer = &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
@@ -198,6 +198,8 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 	protectedMux.HandleFunc("GET /api/git/log", s.handleGitLog)
 	protectedMux.HandleFunc("GET /api/git/changes", s.handleGitChanges)
 	protectedMux.HandleFunc("GET /api/git/worktrees", s.handleGitWorktrees)
+	protectedMux.HandleFunc("GET /api/git/reviewed", s.handleGetReviewed)
+	protectedMux.HandleFunc("POST /api/git/reviewed", s.handleSetReviewed)
 	protectedMux.HandleFunc("GET /api/notifications", s.handleListNotifications)
 	protectedMux.HandleFunc("POST /api/notifications/batch", s.handleBatchNotifications)
 	protectedMux.Handle("GET /api/events", shared.SSE)

--- a/internal/server/wrap_test.go
+++ b/internal/server/wrap_test.go
@@ -249,7 +249,7 @@ func TestWrap_AdoptFailureStillRegistersSession(t *testing.T) {
 // has to be recorded even when the caller named none. Leaving the column null
 // would mean "the CLI's default" on the next wake, which is not what it ran in.
 func TestCreateSession_RecordsTheModeItLaunchedWith(t *testing.T) {
-	claude.Register()
+	claude.Register(0)
 	srv, shared, _ := newInternalTestServer(t)
 
 	// A real directory: creating a session resolves its cwd, and a path that
@@ -271,7 +271,7 @@ func TestCreateSession_RecordsTheModeItLaunchedWith(t *testing.T) {
 }
 
 func TestCreateSession_RecordsTheRequestedMode(t *testing.T) {
-	claude.Register()
+	claude.Register(0)
 	srv, shared, _ := newInternalTestServer(t)
 
 	postJSON(t, srv.URL+"/internal/sessions",

--- a/internal/store/reviewed.go
+++ b/internal/store/reviewed.go
@@ -1,0 +1,58 @@
+package store
+
+import "fmt"
+
+// Reviewed files are keyed by the branch they were reviewed against as well as
+// the repository. The same file read against main and against a release branch
+// are two different readings, and carrying one over to the other would tell a
+// reviewer they had seen a diff they have not.
+
+// MarkReviewed records that a file has been read, or clears it.
+func (s *Store) MarkReviewed(root, base, path string, reviewed bool) error {
+	var err error
+	if reviewed {
+		_, err = s.db.Exec(
+			`INSERT INTO reviewed_files (root, base, path) VALUES (?, ?, ?)
+			 ON CONFLICT(root, base, path) DO UPDATE SET reviewed_at = datetime('now')`,
+			root, base, path)
+	} else {
+		_, err = s.db.Exec(
+			`DELETE FROM reviewed_files WHERE root = ? AND base = ? AND path = ?`,
+			root, base, path)
+	}
+	if err != nil {
+		return fmt.Errorf("mark reviewed: %w", err)
+	}
+	return nil
+}
+
+// ReviewedFiles returns the paths already read for this repository and base.
+func (s *Store) ReviewedFiles(root, base string) ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT path FROM reviewed_files WHERE root = ? AND base = ? ORDER BY path`,
+		root, base)
+	if err != nil {
+		return nil, fmt.Errorf("list reviewed: %w", err)
+	}
+	defer rows.Close()
+
+	paths := []string{}
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, fmt.Errorf("scan reviewed: %w", err)
+		}
+		paths = append(paths, path)
+	}
+	return paths, rows.Err()
+}
+
+// ClearReviewed forgets a whole review. Used when a branch is re-reviewed from
+// the start rather than continued.
+func (s *Store) ClearReviewed(root, base string) error {
+	_, err := s.db.Exec(`DELETE FROM reviewed_files WHERE root = ? AND base = ?`, root, base)
+	if err != nil {
+		return fmt.Errorf("clear reviewed: %w", err)
+	}
+	return nil
+}

--- a/internal/store/reviewed_test.go
+++ b/internal/store/reviewed_test.go
@@ -1,0 +1,74 @@
+package store
+
+import "testing"
+
+func TestReviewed_RoundTripAndToggleOff(t *testing.T) {
+	s := setupTestStore(t)
+
+	if err := s.MarkReviewed("/repo", "main", "a.go", true); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := s.MarkReviewed("/repo", "main", "b.go", true); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+
+	got, err := s.ReviewedFiles("/repo", "main")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a.go" || got[1] != "b.go" {
+		t.Fatalf("got %v, want [a.go b.go]", got)
+	}
+
+	// Marking twice must not duplicate, and unmarking must actually forget.
+	if err := s.MarkReviewed("/repo", "main", "a.go", true); err != nil {
+		t.Fatalf("re-mark: %v", err)
+	}
+	if err := s.MarkReviewed("/repo", "main", "b.go", false); err != nil {
+		t.Fatalf("unmark: %v", err)
+	}
+	got, _ = s.ReviewedFiles("/repo", "main")
+	if len(got) != 1 || got[0] != "a.go" {
+		t.Fatalf("got %v, want [a.go]", got)
+	}
+}
+
+// The same file read against two bases is two different readings. Carrying one
+// over would tell a reviewer they had seen a diff they have not.
+func TestReviewed_IsPerBaseAndPerRepo(t *testing.T) {
+	s := setupTestStore(t)
+
+	if err := s.MarkReviewed("/repo", "main", "a.go", true); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+
+	for _, tc := range []struct{ root, base string }{
+		{"/repo", "release"},
+		{"/other", "main"},
+	} {
+		got, err := s.ReviewedFiles(tc.root, tc.base)
+		if err != nil {
+			t.Fatalf("list %s %s: %v", tc.root, tc.base, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s@%s leaked %v", tc.root, tc.base, got)
+		}
+	}
+}
+
+func TestReviewed_ClearForgetsTheWholeReview(t *testing.T) {
+	s := setupTestStore(t)
+
+	s.MarkReviewed("/repo", "main", "a.go", true)
+	s.MarkReviewed("/repo", "release", "a.go", true)
+	if err := s.ClearReviewed("/repo", "main"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	if got, _ := s.ReviewedFiles("/repo", "main"); len(got) != 0 {
+		t.Errorf("main not cleared: %v", got)
+	}
+	if got, _ := s.ReviewedFiles("/repo", "release"); len(got) != 1 {
+		t.Error("clearing one base cleared another")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -118,6 +118,13 @@ func (s *Store) migrate() error {
 			created_at TEXT NOT NULL DEFAULT (datetime('now'))
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_pairing_tokens_status ON pairing_tokens(status)`,
+		`CREATE TABLE IF NOT EXISTS reviewed_files (
+			root TEXT NOT NULL,
+			base TEXT NOT NULL,
+			path TEXT NOT NULL,
+			reviewed_at TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (root, base, path)
+		)`,
 	}
 
 	for _, m := range migrations {

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -28,6 +28,7 @@ const (
 	screenHooksInstall                 // prompt to install Claude hooks
 	screenHooksUpdate                  // prompt to update outdated hooks
 	screenShellSetup                   // prompt to install shell wrapper
+	screenMCPSetup                     // prompt to register the Helios MCP server
 	screenTunnelSelect                 // first time only: pick tunnel provider
 	screenBinaryMissing                // tunnel binary not found
 	screenTunnelStarting               // starting tunnel...
@@ -81,6 +82,7 @@ type statusCheckDone struct {
 	hooksOK        bool
 	hooksOutdated  bool
 	mcpRegistered  bool
+	mcpDeclined    bool
 	shellInfo      daemon.ShellInfo
 	shellInstalled bool
 	tunnelOK       bool
@@ -165,14 +167,17 @@ type StartModel struct {
 	// is one feature, and a user who does not want it should not be nagged past
 	// a single line.
 	mcpRegistered bool
-	mcpMsg        string
-	tunnelOK      bool
-	tunnelURL     string
-	tunnelProv    string
-	tunnelMode    string // tailscale exposure mode of the running tunnel; empty otherwise
-	tunnelWarn    string // daemon-reported caveat about the tunnel just started
-	deviceCount   int
-	devices       []deviceInfo
+	// mcpDeclined records that the user said no during setup. Asking again on
+	// every launch would make an optional feature feel mandatory.
+	mcpDeclined bool
+	mcpMsg      string
+	tunnelOK    bool
+	tunnelURL   string
+	tunnelProv  string
+	tunnelMode  string // tailscale exposure mode of the running tunnel; empty otherwise
+	tunnelWarn  string // daemon-reported caveat about the tunnel just started
+	deviceCount int
+	devices     []deviceInfo
 
 	// General settings screen
 	settingsCursor int
@@ -281,10 +286,18 @@ func (m StartModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case mcpRegisterDone:
 		if msg.err != nil {
 			m.mcpMsg = fmt.Sprintf("Could not register: %v", msg.err)
+			// Setup must not dead-end on a failure it cannot fix; the dashboard
+			// still offers the key.
+			if m.screen == screenMCPSetup {
+				return m.proceedAfterMCP()
+			}
 			return m, nil
 		}
 		m.mcpRegistered = true
 		m.mcpMsg = ""
+		if m.screen == screenMCPSetup {
+			return m.proceedAfterMCP()
+		}
 		return m, nil
 
 	case hooksInstallDone:
@@ -359,7 +372,7 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, tea.Quit
-		case screenHooksInstall, screenHooksUpdate, screenShellSetup, screenError:
+		case screenHooksInstall, screenHooksUpdate, screenShellSetup, screenMCPSetup, screenError:
 			return m, tea.Quit
 		case screenSettings:
 			m.screen = screenMain
@@ -436,6 +449,7 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// The summary screen is where this is usually read: a set-up install
 		// sits there waiting on enter, and never reaches the dashboard.
 		if (m.screen == screenMain || (m.screen == screenLoading && m.daemonOK)) && !m.mcpRegistered {
+			m.mcpDeclined = false
 			m.mcpMsg = "Registering..."
 			return m, registerMCPCmd(m.internalPort)
 		}
@@ -446,6 +460,8 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.proceedAfterHooks()
 		case screenShellSetup:
 			return m.proceedAfterShell()
+		case screenMCPSetup:
+			return m.declineMCP()
 		}
 	}
 
@@ -482,6 +498,10 @@ func (m StartModel) handleEnter() (tea.Model, tea.Cmd) {
 			return m.proceedAfterShell()
 		}
 		return m, installShellWrapperCmd(m.shellInfo)
+
+	case screenMCPSetup:
+		m.mcpMsg = "Registering..."
+		return m, registerMCPCmd(m.internalPort)
 
 	case screenTunnelSelect:
 		provider := tunnelProviders[m.tunnelCursor]
@@ -546,6 +566,16 @@ func (m StartModel) proceedAfterHooks() (tea.Model, tea.Cmd) {
 }
 
 func (m StartModel) proceedAfterShell() (tea.Model, tea.Cmd) {
+	// Asked once, and only once. Registering gives agents tools they did not
+	// have, which is the user's call rather than a step to get past.
+	if !m.mcpRegistered && !m.mcpDeclined {
+		m.screen = screenMCPSetup
+		return m, nil
+	}
+	return m.proceedAfterMCP()
+}
+
+func (m StartModel) proceedAfterMCP() (tea.Model, tea.Cmd) {
 	if !m.tunnelOK {
 		return m.enterTunnelSelect()
 	}
@@ -571,6 +601,7 @@ func (m StartModel) handleStatusCheck(msg statusCheckDone) (tea.Model, tea.Cmd) 
 	m.shellInfo = msg.shellInfo
 	m.shellInstalled = msg.shellInstalled
 	m.mcpRegistered = msg.mcpRegistered
+	m.mcpDeclined = msg.mcpDeclined
 	m.tunnelOK = msg.tunnelOK
 	m.tunnelURL = msg.tunnelURL
 	m.tunnelProv = msg.tunnelProv
@@ -741,6 +772,9 @@ func checkStatus(c *client, publicPort int) tea.Cmd {
 		}
 
 		result.mcpRegistered = mcpRegistered()
+		if settings, err := c.getSettings(); err == nil {
+			result.mcpDeclined = settings[mcpDeclinedSetting] == "true"
+		}
 
 		// Check shell wrapper
 		result.shellInfo = daemon.DetectShell()
@@ -876,6 +910,22 @@ func installShellWrapperCmd(info daemon.ShellInfo) tea.Cmd {
 		}
 		return shellSetupDone{installed: true}
 	}
+}
+
+// mcpDeclinedSetting remembers that the user said no during setup, so the
+// question is asked once rather than at every launch.
+const mcpDeclinedSetting = "mcp.setup_declined"
+
+// declineMCP records the refusal and moves on. Persisted through the daemon so
+// every client agrees, and so a reinstall does not start asking again.
+func (m StartModel) declineMCP() (tea.Model, tea.Cmd) {
+	m.mcpDeclined = true
+	client := m.client
+	model, cmd := m.proceedAfterMCP()
+	return model, tea.Batch(cmd, func() tea.Msg {
+		client.updateSettings(map[string]string{mcpDeclinedSetting: "true"})
+		return nil
+	})
 }
 
 // mcpRegistered reports whether Claude Code has the Helios MCP server in its

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -78,6 +80,7 @@ type statusCheckDone struct {
 	daemonOK       bool
 	hooksOK        bool
 	hooksOutdated  bool
+	mcpRegistered  bool
 	shellInfo      daemon.ShellInfo
 	shellInstalled bool
 	tunnelOK       bool
@@ -86,6 +89,10 @@ type statusCheckDone struct {
 	deviceCount    int
 	devices        []deviceInfo
 	err            error
+}
+
+type mcpRegisterDone struct {
+	err error
 }
 
 type tunnelStarted struct {
@@ -142,16 +149,23 @@ type generalSettingSaved struct {
 
 // Model
 type StartModel struct {
-	screen     screen
-	client     *client
-	spinner    spinner.Model
-	textInput  textinput.Model
-	publicPort int
+	screen       screen
+	client       *client
+	spinner      spinner.Model
+	textInput    textinput.Model
+	publicPort   int
+	internalPort int
 
 	// Status check results
 	daemonOK      bool
 	hooksOK       bool
 	hooksOutdated bool
+	// mcpRegistered reports whether Claude Code knows about the Helios MCP
+	// server. Unregistered is a suggestion, never a blocker: the explain panel
+	// is one feature, and a user who does not want it should not be nagged past
+	// a single line.
+	mcpRegistered bool
+	mcpMsg        string
 	tunnelOK      bool
 	tunnelURL     string
 	tunnelProv    string
@@ -219,11 +233,12 @@ func NewStartModel(internalPort, publicPort int) StartModel {
 	ti.Width = 50
 
 	return StartModel{
-		screen:     screenLoading,
-		client:     newClient(internalPort),
-		spinner:    s,
-		textInput:  ti,
-		publicPort: publicPort,
+		screen:       screenLoading,
+		client:       newClient(internalPort),
+		spinner:      s,
+		textInput:    ti,
+		publicPort:   publicPort,
+		internalPort: internalPort,
 	}
 }
 
@@ -262,6 +277,15 @@ func (m StartModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case devicePollResult:
 		return m.handleDevicePoll(msg)
+
+	case mcpRegisterDone:
+		if msg.err != nil {
+			m.mcpMsg = fmt.Sprintf("Could not register: %v", msg.err)
+			return m, nil
+		}
+		m.mcpRegistered = true
+		m.mcpMsg = ""
+		return m, nil
 
 	case hooksInstallDone:
 		if msg.err != nil {
@@ -408,6 +432,14 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, loadGeneralSettings(m.client)
 		}
 
+	case "m":
+		// The summary screen is where this is usually read: a set-up install
+		// sits there waiting on enter, and never reaches the dashboard.
+		if (m.screen == screenMain || (m.screen == screenLoading && m.daemonOK)) && !m.mcpRegistered {
+			m.mcpMsg = "Registering..."
+			return m, registerMCPCmd(m.internalPort)
+		}
+
 	case "tab":
 		switch m.screen {
 		case screenHooksInstall, screenHooksUpdate:
@@ -538,6 +570,7 @@ func (m StartModel) handleStatusCheck(msg statusCheckDone) (tea.Model, tea.Cmd) 
 	m.hooksOutdated = msg.hooksOutdated
 	m.shellInfo = msg.shellInfo
 	m.shellInstalled = msg.shellInstalled
+	m.mcpRegistered = msg.mcpRegistered
 	m.tunnelOK = msg.tunnelOK
 	m.tunnelURL = msg.tunnelURL
 	m.tunnelProv = msg.tunnelProv
@@ -707,6 +740,8 @@ func checkStatus(c *client, publicPort int) tea.Cmd {
 			result.hooksOutdated = daemon.HooksOutdated()
 		}
 
+		result.mcpRegistered = mcpRegistered()
+
 		// Check shell wrapper
 		result.shellInfo = daemon.DetectShell()
 		result.shellInstalled = daemon.ShellWrapperInstalled(result.shellInfo)
@@ -840,6 +875,44 @@ func installShellWrapperCmd(info daemon.ShellInfo) tea.Cmd {
 			}
 		}
 		return shellSetupDone{installed: true}
+	}
+}
+
+// mcpRegistered reports whether Claude Code has the Helios MCP server in its
+// user-scope config. `claude mcp add --scope user` writes it to the top-level
+// mcpServers map in ~/.claude.json.
+func mcpRegistered() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		return false
+	}
+	var config struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return false
+	}
+	_, ok := config.MCPServers["helios"]
+	return ok
+}
+
+// registerMCPCmd adds the Helios MCP server to Claude Code. Registration is
+// offered, never performed on the user's behalf: an agent gaining a new set of
+// tools is their call to make.
+func registerMCPCmd(internalPort int) tea.Cmd {
+	return func() tea.Msg {
+		url := fmt.Sprintf("http://127.0.0.1:%d/mcp", internalPort)
+		cmd := exec.Command("claude", "mcp", "add",
+			"--transport", "http", "--scope", "user", "helios", url)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return mcpRegisterDone{err: fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))}
+		}
+		return mcpRegisterDone{}
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -68,6 +68,8 @@ func (m StartModel) View() string {
 		return m.viewHooksUpdate()
 	case screenShellSetup:
 		return m.viewShellSetup()
+	case screenMCPSetup:
+		return m.viewMCPSetup()
 	case screenTunnelSelect:
 		return m.viewTunnelSelect()
 	case screenBinaryMissing:
@@ -112,10 +114,15 @@ func (m StartModel) viewLoading() string {
 		}
 
 		if m.mcpRegistered {
-			b.WriteString(check("Helios MCP registered with Claude Code"))
+			b.WriteString(check("Agent tools registered with Claude Code"))
+		} else if m.mcpDeclined {
+			// Opted out during setup. Still reachable, but it stops asking:
+			// a suggestion that survives being declined is a nag.
+			b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
+			b.WriteString("\n")
 		} else {
-			b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Helios MCP not registered with Claude Code"))
-			b.WriteString(dimStyle.Render("  · Lets agents build walkthroughs in the Learn panel. Press m to register, or ignore this."))
+			b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
+			b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
 			b.WriteString("\n")
 		}
 		if m.mcpMsg != "" {
@@ -154,7 +161,7 @@ func (m StartModel) viewLoading() string {
 
 		keys := "  enter continue  t change tunnel  N notifications  s settings  q quit"
 		if !m.mcpRegistered {
-			keys = "  m register MCP" + keys
+			keys = "  m agent tools" + keys
 		}
 		b.WriteString(helpStyle.Render(keys))
 	}
@@ -190,6 +197,31 @@ func (m StartModel) viewHooksUpdate() string {
 	b.WriteString(subtitleStyle.Render("  Update to ensure all hooks work correctly."))
 	b.WriteString("\n")
 	b.WriteString(helpStyle.Render("  enter update  tab skip  q quit"))
+
+	return b.String()
+}
+
+// The setup step for the MCP server. Optional and explicitly skippable: it
+// gives agents tools they did not have, which is a decision rather than a
+// formality, and skipping is remembered so it is asked once.
+func (m StartModel) viewMCPSetup() string {
+	var b strings.Builder
+
+	b.WriteString(titleStyle.Render("helios — Agent Tools"))
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Helios MCP is not registered with Claude Code"))
+	b.WriteString("\n")
+	b.WriteString(subtitleStyle.Render("  Lets an agent open a file, a diff or a tab in Helios,"))
+	b.WriteString("\n")
+	b.WriteString(subtitleStyle.Render("  so it can show you what it is talking about."))
+	b.WriteString("\n\n")
+	b.WriteString(dimStyle.Render("  Everything else in Helios works without it."))
+	b.WriteString("\n")
+	if m.mcpMsg != "" {
+		b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
+		b.WriteString("\n")
+	}
+	b.WriteString(helpStyle.Render("  enter register  tab skip  q quit"))
 
 	return b.String()
 }
@@ -398,11 +430,16 @@ func (m StartModel) viewMain() string {
 		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Claude hooks outdated"))
 	}
 	if m.mcpRegistered {
-		b.WriteString(check("Helios MCP registered with Claude Code"))
+		b.WriteString(check("Agent tools registered with Claude Code"))
+	} else if m.mcpDeclined {
+		// Opted out during setup. Still reachable, but it stops asking:
+		// a suggestion that survives being declined is a nag.
+		b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
+		b.WriteString("\n")
 	} else {
 		// A suggestion, not a fault: everything else works without it.
-		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Helios MCP not registered with Claude Code"))
-		b.WriteString(dimStyle.Render("  · Lets agents build walkthroughs in the Learn panel. Press m to register, or ignore this."))
+		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
+		b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
 		b.WriteString("\n")
 	}
 	if m.mcpMsg != "" {
@@ -516,7 +553,7 @@ func (m StartModel) viewMain() string {
 	// so the bar does not carry a permanently dead binding.
 	keys := "  t change tunnel  N notifications  s settings  q quit"
 	if !m.mcpRegistered {
-		keys = "  m register MCP" + keys
+		keys = "  m agent tools" + keys
 	}
 	b.WriteString(helpStyle.Render(keys))
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -111,6 +111,18 @@ func (m StartModel) viewLoading() string {
 			b.WriteString(cross("Claude hooks not installed"))
 		}
 
+		if m.mcpRegistered {
+			b.WriteString(check("Helios MCP registered with Claude Code"))
+		} else {
+			b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Helios MCP not registered with Claude Code"))
+			b.WriteString(dimStyle.Render("  · Lets agents build walkthroughs in the Learn panel. Press m to register, or ignore this."))
+			b.WriteString("\n")
+		}
+		if m.mcpMsg != "" {
+			b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
+			b.WriteString("\n")
+		}
+
 		if m.shellInstalled {
 			b.WriteString(check(fmt.Sprintf("Shell wrapper (%s)", m.shellInfo.Name)))
 		} else if m.shellInfo.RCPath != "" {
@@ -140,7 +152,11 @@ func (m StartModel) viewLoading() string {
 			b.WriteString("\n")
 		}
 
-		b.WriteString(helpStyle.Render("  enter continue  t change tunnel  N notifications  s settings  q quit"))
+		keys := "  enter continue  t change tunnel  N notifications  s settings  q quit"
+		if !m.mcpRegistered {
+			keys = "  m register MCP" + keys
+		}
+		b.WriteString(helpStyle.Render(keys))
 	}
 
 	return b.String()
@@ -381,6 +397,18 @@ func (m StartModel) viewMain() string {
 	} else if m.hooksOK {
 		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Claude hooks outdated"))
 	}
+	if m.mcpRegistered {
+		b.WriteString(check("Helios MCP registered with Claude Code"))
+	} else {
+		// A suggestion, not a fault: everything else works without it.
+		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Helios MCP not registered with Claude Code"))
+		b.WriteString(dimStyle.Render("  · Lets agents build walkthroughs in the Learn panel. Press m to register, or ignore this."))
+		b.WriteString("\n")
+	}
+	if m.mcpMsg != "" {
+		b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
+		b.WriteString("\n")
+	}
 	if m.shellInstalled {
 		b.WriteString(check(fmt.Sprintf("Shell wrapper (%s)", m.shellInfo.Name)))
 	} else if m.shellInfo.RCPath != "" {
@@ -484,7 +512,13 @@ func (m StartModel) viewMain() string {
 		b.WriteString(fmt.Sprintf("  Generating pairing code... %s\n", m.spinner.View()))
 	}
 
-	b.WriteString(helpStyle.Render("  t change tunnel  N notifications  s settings  q quit"))
+	// The MCP key is advertised only while there is something to do with it,
+	// so the bar does not carry a permanently dead binding.
+	keys := "  t change tunnel  N notifications  s settings  q quit"
+	if !m.mcpRegistered {
+		keys = "  m register MCP" + keys
+	}
+	b.WriteString(helpStyle.Render(keys))
 
 	return b.String()
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -83,6 +83,58 @@ func TestMainReportsMissingTunnel(t *testing.T) {
 	}
 }
 
+// The summary screen, not the dashboard, is what a fully set-up install shows:
+// it sits on "enter continue" and most people never press it. An offer only the
+// dashboard carries is an offer nobody sees.
+func TestLoadingScreenAlsoOffersMCPRegistration(t *testing.T) {
+	m := StartModel{screen: screenLoading, daemonOK: true, hooksOK: true}
+	rendered := stripANSI(m.viewLoading())
+
+	if !strings.Contains(rendered, "Helios MCP not registered") {
+		t.Fatal("summary screen says nothing about an unregistered MCP server")
+	}
+	if !strings.Contains(rendered, "m register MCP") {
+		t.Error("the m key is not advertised on the summary screen")
+	}
+
+	registered := stripANSI(StartModel{
+		screen: screenLoading, daemonOK: true, hooksOK: true, mcpRegistered: true,
+	}.viewLoading())
+	if strings.Contains(registered, "not registered") {
+		t.Error("still nagging after registration")
+	}
+}
+
+func TestMainOffersMCPRegistrationWithoutTreatingItAsAFault(t *testing.T) {
+	rendered := stripANSI(StartModel{screen: screenMain}.viewMain())
+
+	line := lineWith(rendered, "Helios MCP not registered")
+	if line == "" {
+		t.Fatal("main screen says nothing about an unregistered MCP server")
+	}
+	// Unregistered is a suggestion. Rendering it with the cross used for real
+	// problems would read as something being broken.
+	if strings.Contains(line, "✗") {
+		t.Errorf("unregistered MCP rendered as a failure: %q", line)
+	}
+	if !strings.Contains(rendered, "Press m to register") {
+		t.Error("no way offered to register")
+	}
+
+	if !strings.Contains(rendered, "m register MCP") {
+		t.Error("the m key is not advertised in the key bar")
+	}
+
+	registered := stripANSI(StartModel{screen: screenMain, mcpRegistered: true}.viewMain())
+	if strings.Contains(registered, "not registered") {
+		t.Error("still nagging after registration")
+	}
+	// A binding that does nothing should not sit in the bar.
+	if strings.Contains(registered, "m register MCP") {
+		t.Error("the m key is still advertised after registration")
+	}
+}
+
 func TestTunnelSelectShowsCurrentURL(t *testing.T) {
 	url := "http://host.tailnet.ts.net:7655"
 	m := StartModel{

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -86,14 +86,17 @@ func TestMainReportsMissingTunnel(t *testing.T) {
 // The summary screen, not the dashboard, is what a fully set-up install shows:
 // it sits on "enter continue" and most people never press it. An offer only the
 // dashboard carries is an offer nobody sees.
+// The summary screen, not the dashboard, is what a fully set-up install shows:
+// it sits on "enter continue" and most people never press it. An offer only the
+// dashboard carries is an offer nobody sees.
 func TestLoadingScreenAlsoOffersMCPRegistration(t *testing.T) {
 	m := StartModel{screen: screenLoading, daemonOK: true, hooksOK: true}
 	rendered := stripANSI(m.viewLoading())
 
-	if !strings.Contains(rendered, "Helios MCP not registered") {
-		t.Fatal("summary screen says nothing about an unregistered MCP server")
+	if !strings.Contains(rendered, "not registered") {
+		t.Fatal("summary screen says nothing about unregistered agent tools")
 	}
-	if !strings.Contains(rendered, "m register MCP") {
+	if !strings.Contains(rendered, "m agent tools") {
 		t.Error("the m key is not advertised on the summary screen")
 	}
 
@@ -105,12 +108,51 @@ func TestLoadingScreenAlsoOffersMCPRegistration(t *testing.T) {
 	}
 }
 
+// Setup asks once. It must be skippable, and skipping must be an offer rather
+// than a dead end.
+func TestMCPSetupIsSkippable(t *testing.T) {
+	rendered := stripANSI(StartModel{screen: screenMCPSetup}.viewMCPSetup())
+
+	if !strings.Contains(rendered, "tab skip") {
+		t.Error("no way offered to skip")
+	}
+	if !strings.Contains(rendered, "enter register") {
+		t.Error("no way offered to register")
+	}
+	// Skipping has to look survivable, or it reads as breaking Helios.
+	if !strings.Contains(rendered, "works without it") {
+		t.Error("does not say the rest of Helios works without it")
+	}
+}
+
+// Declining during setup must stop the nagging, and must still leave a way in.
+func TestDeclinedMCPStopsNaggingButStaysReachable(t *testing.T) {
+	for name, rendered := range map[string]string{
+		"summary": stripANSI(StartModel{
+			screen: screenLoading, daemonOK: true, hooksOK: true, mcpDeclined: true,
+		}.viewLoading()),
+		"dashboard": stripANSI(StartModel{screen: screenMain, mcpDeclined: true}.viewMain()),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(rendered, "~") && strings.Contains(rendered, "Agent tools not registered") {
+				t.Error("still warning after the user declined")
+			}
+			if !strings.Contains(rendered, "Press m to turn them on") {
+				t.Error("no way back in after declining")
+			}
+			if !strings.Contains(rendered, "m agent tools") {
+				t.Error("the key is not advertised, so opting in later is undiscoverable")
+			}
+		})
+	}
+}
+
 func TestMainOffersMCPRegistrationWithoutTreatingItAsAFault(t *testing.T) {
 	rendered := stripANSI(StartModel{screen: screenMain}.viewMain())
 
-	line := lineWith(rendered, "Helios MCP not registered")
+	line := lineWith(rendered, "Agent tools not registered")
 	if line == "" {
-		t.Fatal("main screen says nothing about an unregistered MCP server")
+		t.Fatal("main screen says nothing about unregistered agent tools")
 	}
 	// Unregistered is a suggestion. Rendering it with the cross used for real
 	// problems would read as something being broken.
@@ -121,7 +163,7 @@ func TestMainOffersMCPRegistrationWithoutTreatingItAsAFault(t *testing.T) {
 		t.Error("no way offered to register")
 	}
 
-	if !strings.Contains(rendered, "m register MCP") {
+	if !strings.Contains(rendered, "m agent tools") {
 		t.Error("the m key is not advertised in the key bar")
 	}
 
@@ -130,7 +172,7 @@ func TestMainOffersMCPRegistrationWithoutTreatingItAsAFault(t *testing.T) {
 		t.Error("still nagging after registration")
 	}
 	// A binding that does nothing should not sit in the bar.
-	if strings.Contains(registered, "m register MCP") {
+	if strings.Contains(registered, "m agent tools") {
 		t.Error("the m key is still advertised after registration")
 	}
 }


### PR DESCRIPTION
## Why

An agent explains code in prose. Helios already shows code, diffs, terminals
and transcripts, and the agent could not reach any of it.

Two earlier designs in this series tried to fix that by *storing* what the
agent said — a deck bound to a session, then a folder of markdown. Both stored
an artifact and neither was worth keeping, because the value is in the moment:
the agent wants you to look at one thing, now. This stores nothing.

## What

One tool that matters, `helios_show`:

```jsonc
{ "view": "file" | "diff" | "terminal" | "agent",
  "path": "/abs/path.go",   // absolute, as the agent's own tools name files
  "line": 190,              // file, or a line inside a diff
  "base": "main",           // diff: a whole branch
  "commit": "70f5ab0",      // diff: one commit
  "layout": "split",        // diff: side by side (default) or unified
  "note": "This guard is what returned the 400." }
```

Helios switches the panel, opens the file or the diff, scrolls to the line, and
shows the note above it — so a view that moves on its own says who moved it and
why.

And one tool that goes the other way, `helios_review_state`: which files of a
branch you have already read, and how many are left. Every other tool tells
Helios something; this asks Helios what the human did, so an agent can skip
what you have seen rather than starting from the top.

Plus `helios_sessions`, to find another session to address.

## The rule that shaped it

A hook covers whatever the agent already emits; an MCP tool covers only what no
hook can infer. That removed three tools during design:

- `helios_ask` — `handleQuestion` already routes `AskUserQuestion` to the
  desktop and phone. A blocking MCP call also cannot wait for a person, because
  Claude Code stops a tool call at about 60 seconds.
- a tool reporting the current file — `handleToolPre` already receives
  `ToolName` and `ToolInput`.
- a tool answering another agent's prompt — it bypasses the human on the path
  Helios exists to protect.

It did **not** remove `helios_show`: reading a file and pointing at a file are
different intentions, and a hook fires at the wrong moment.

## Notes for review

**Mounted on the internal listener, not the public one.** MCP is
unauthenticated. The internal listener is loopback-only by construction; the
public one binds `0.0.0.0` when the tunnel provider is `local`. A test asserts
the mounting, since that is the only thing keeping these tools off the network.

**Never passes `--strict-mcp-config`.** Measured: `--mcp-config` alone merges
with the user's own MCP servers, while the strict flag replaces them and would
silently strip every other server from every Helios session. A test asserts its
absence.

**Diffs are side by side by default.** A unified patch puts a changed line
below what it replaced rather than opposite it. Runs of removals and additions
are paired off position by position, which is what aligns a replacement with
what it replaced; the alignment is unit-tested rather than eyeballed.

**Reviewed state is keyed by base as well as path.** The same file read against
`main` and against a release branch are two different readings.

**Setup asks once and remembers a no.** These tools are a decision, not a step
to get past. A declined install shows a dim line instead of a warning while
still offering the key, so opting in later is one press.

## Testing

Go suite, `gofmt` and `tsc --noEmit` clean. Diff alignment covered by three
cases: a clean replacement, an unbalanced run, and context advancing both sides.

Verified live against a running daemon and desktop over CDP: opening a file at
a line, opening a file from a *different repository* than the session root, the
note strip, and the ten-stop walkthrough of this PR.

Bugs found by that testing rather than by review, and fixed here:

- a restored tab stealing focus from the file that caused the panel to open
- `helios_sessions` returning hundreds of dead sessions
- `path` documented as repo-relative, which could never have worked
- `base` accepted and silently dropped, so a branch diff showed the working tree
- reviewed ticks lost on unmount, independent of any agent

## Not included

`helios_session_send` and `helios_session_create`. Both need the daemon's
existing send and create paths, which live inside HTTP handlers; wiring them
needs either a refactor to extract those or duplicated logic. Left out rather
than guessed at.

## Known gap

Answering a question navigates away from the diff it was about. `detail.tsx`
already docks approvals beside the transcript for this reason; extending that
to the git panel is what would make an agent-guided review hold together.