### PR TITLE
fix: declare iOS camera and photo library usage

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -47,6 +47,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Helios uses the camera to scan the pairing QR code and to attach photos to a session.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Helios needs photo access to attach images from your library to a session.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Helios uses the microphone for voice input to send prompts.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>


### PR DESCRIPTION
## Problem

The iOS app crashed immediately on launch — before drawing a single frame — on a fresh install.

The crash report off the device is unambiguous:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an `NSCameraUsageDescription` key with a string value explaining to the user how the app uses this data.

Faulting frame was `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__` (SIGABRT). This is an iOS TCC kill, not a catchable Dart or ObjC exception — the process is terminated outright.

**Trigger:** `mobile/lib/screens/setup_screen.dart:122` mounts `MobileScanner` for QR pairing. With no paired host, that is the *first* screen, so the camera is touched on the first frame and the app is killed instantly.

Android already declared `android.permission.CAMERA` in `AndroidManifest.xml`; iOS never got the matching `Info.plist` key.

## Fix

Added two usage descriptions to `mobile/ios/Runner/Info.plist`:

- **`NSCameraUsageDescription`** — the QR pairing scanner (`mobile_scanner`) and camera attachments.
- **`NSPhotoLibraryUsageDescription`** — the attach flow calls `ImagePicker` with `ImageSource.gallery` (`session_detail_screen.dart:307`), which would have crashed the same way the first time anyone attached an existing photo. Fixing only the camera key would have left this latent.

## Verification

Built and ran a signed **release** build on a physical iPhone (iOS 26.6):

- `flutter build ios --release` — succeeds, keys confirmed baked into the built `Runner.app/Info.plist`.
- Installed via `devicectl`, launched, and confirmed the process stays alive.
- Pulled crash reports off the device again with `idevicecrashreport` — **no new crash reports** after the fix. Before the fix, every launch produced a SIGABRT `.ips`.

## Notes for reviewers

- Only `Info.plist` is touched here. Building iOS also generates CocoaPods integration files (`ios/Podfile`, `Podfile.lock`, `project.pbxproj`, `.xcconfig` includes) that are not currently tracked in this repo — those are deliberately left out of this PR so the fix stays reviewable. Worth a separate decision on whether `Podfile`/`Podfile.lock` should be committed.
- Separately, `DEVELOPMENT_TEAM` is not set in `Runner.xcodeproj/project.pbxproj`. Local signing only worked via a saved certificate choice, so device builds will fail on CI or a fresh machine. Not addressed here.
- Note that a Flutter **debug** build cannot be launched from the home screen on iOS 14+ (`Cannot create a FlutterEngine instance in debug mode without Flutter tooling or Xcode`). Verify this fix with a release or profile build, or via `flutter run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)