### PR TITLE
fix: give assistant message links visual feedback

### DIFF
--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -185,6 +185,12 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
               },
               styleSheet: MarkdownStyleSheet(
                   p: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+                  a: TextStyle(
+                    fontSize: 14,
+                    color: theme.colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                    decorationColor: theme.colorScheme.primary,
+                  ),
                   code: TextStyle(
                     fontSize: 12,
                     fontFamily: 'monospace',


### PR DESCRIPTION
## Description

Assistant message links in the Flutter app are already tappable (`onTapLink: _handleLinkTap`, added in 6934a3e), but they render as plain body text — no colour, no underline — so they don't *look* interactive. This addresses the remaining unmet part of #9: "Links should have visual feedback (e.g., underline, color)."

## Change

Add an `a:` style to the `MarkdownStyleSheet` in `mobile/lib/widgets/message_card.dart`, giving links the theme primary colour and an underline.

## Testing

- `dart analyze lib/widgets/message_card.dart` → No issues found.

Closes #9