### PR TITLE
fix(desktop): stop the side-by-side diff painting over itself

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -717,7 +717,9 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
       <>
         <KeyValues entries={entries.filter(([key]) => !coded.has(key))} />
         <div className="tool-diff">
-          <DiffView diff={diff} />
+          {/* Unified, not the default split: a tool call's diff sits inline in
+              the transcript, which is far too narrow for two columns. */}
+          <DiffView diff={diff} layout="unified" />
         </div>
       </>
     )

--- a/desktop/src/renderer/components/diff-view.tsx
+++ b/desktop/src/renderer/components/diff-view.tsx
@@ -57,7 +57,15 @@ export function DiffView({
         ) : (
           <div
             key={index}
-            className={`diff-row ${line !== undefined && row.right?.n === line ? 'diff-row-marked' : ''}`}
+            className={[
+              'diff-row',
+              // Both halves of a context row are the same text. Stacked into
+              // one column they would read as the line appearing twice.
+              !row.left?.changed && !row.right?.changed ? 'diff-row-context' : '',
+              line !== undefined && row.right?.n === line ? 'diff-row-marked' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
             ref={line !== undefined && row.right?.n === line ? marked : undefined}
           >
             <Side cell={row.left} kind="del" />

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4023,12 +4023,22 @@ hr {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   line-height: 1.5;
-  overflow-x: auto;
+  /* The cells scroll, not this: scrolling here would drag the gutters and the
+     hunk headers off screen with the code. */
+  overflow-x: hidden;
+  /* Measured against this pane, not the window. The file list and the sidebar
+     take most of a wide window, so a viewport breakpoint reports 1440px while
+     each column is 200px and every line is cut off mid-token. */
+  container-type: inline-size;
 }
 
 .diff-row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* minmax(0, 1fr), not 1fr: plain 1fr is minmax(auto, 1fr), and auto refuses
+     to shrink below the width of `white-space: pre` content — so a long line
+     pushed its column over the other one and the two painted on top of each
+     other. */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
 /* A file or hunk header belongs to both sides, so it spans them. */
@@ -4044,7 +4054,15 @@ hr {
   min-width: 0;
   padding: 0 10px;
   white-space: pre;
+  /* Each side scrolls on its own. A shared scrollbar would need both columns
+     to be the width of the longer one, which wastes half the pane. */
+  overflow-x: auto;
   border-right: 1px solid var(--outline-variant);
+}
+
+/* The per-cell scrollbars would otherwise stack up, one per line. */
+.diff-cell::-webkit-scrollbar {
+  height: 0;
 }
 
 .diff-cell:last-child {
@@ -4071,14 +4089,27 @@ hr {
   min-width: 0;
 }
 
-/* Too narrow to read two columns: one column beats two unreadable ones. */
-@media (max-width: 900px) {
+/* Two columns need roughly 60 characters each to be worth having. Below that
+   one readable column beats two unreadable ones. */
+@container (max-width: 720px) {
   .diff-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .diff-cell-absent {
     display: none;
+  }
+
+  /* Stacked, a context row would print the same line twice. Keep the new
+     side, so the numbering matches the file as it now stands. */
+  .diff-row-context .diff-cell:first-child {
+    display: none;
+  }
+
+  /* Nothing sits beside a cell any more, so the divider is a stray rule down
+     the middle of the text. */
+  .diff-cell {
+    border-right: none;
   }
 }
 


### PR DESCRIPTION
## Why

Making split the default in #95 changed **every** `DiffView` in the app, not
only the agent-driven ones. The inline diffs in the transcript broke outright —
the two columns drew on top of each other and the text was unreadable.

Reported with a screenshot. Three separate faults behind it, all introduced by
that change.

## What

**The transcript is pinned to unified.** A tool call's diff sits inline in the
message list, which is nowhere near wide enough for two columns.

**The overlap.** `grid-template-columns: 1fr 1fr` is `minmax(auto, 1fr)`, and
`auto` will not shrink below the width of `white-space: pre` content — so a
long line pushed its column over its neighbour. Now `minmax(0, 1fr)`, with each
cell scrolling on its own instead of spilling.

**The fallback never fired.** It was `@media (max-width: 900px)`, which measures
the window. The window was 1440px while the diff pane was 399px, so the app
reported "plenty of room" and rendered 200px columns with every line cut off
mid-token. It is a container query now, measured against the pane.

**Stacking duplicated context.** One column with two cells printed every
unchanged line twice, once per side. Context rows are marked and the duplicate
half is hidden, so the narrow layout reads as a unified diff rather than a
doubled one.

## Testing

Measured in the running app over CDP rather than eyeballed:

| Pane width | Columns | Context cells rendered |
|---|---|---|
| 399px | one, `389px` | 1 |
| 1000px | two, `495px 495px` | 2 |

Before the fix the same measurement showed the left cell's right edge past the
right cell's left edge — the overlap, as a number.

Diff alignment tests still pass. Go suite, `gofmt` and `tsc --noEmit` clean.