### PR TITLE
feat: let idle sessions go cold when the warm pool is over budget

### DIFF
--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -182,6 +182,11 @@ export class ApiClient {
    * Sends a prompt. A 409 is not a failure but an answer: the session is busy
    * and does not queue, or it is terminated. Callers need the code to say which.
    */
+  /** Records that a human is looking at this session. Fire and forget. */
+  touchSession(id: string): Promise<unknown> {
+    return this.request('POST', `/api/sessions/${encodeURIComponent(id)}/touch`)
+  }
+
   sendPrompt(id: string, message: string): Promise<{ success: boolean; queued?: boolean }> {
     return this.request('POST', `/api/sessions/${encodeURIComponent(id)}/send`, { message })
   }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -25,6 +25,7 @@ const API_METHODS = new Set<keyof ApiClient>([
   'transcriptSince',
   'subagents',
   'sendPrompt',
+  'touchSession',
   'setSessionOrder',
   'uploadFiles',
   'stop',

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -200,6 +200,9 @@ export class HostApi {
   sendPrompt(id: string, message: string): Promise<{ success: boolean; queued?: boolean }> {
     return this.call('sendPrompt', id, message)
   }
+  touchSession(id: string): Promise<unknown> {
+    return this.call('touchSession', id)
+  }
   /** The bytes cross to the main process, which does the multipart POST. */
   uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
     return this.call('uploadFiles', id, files)

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 import { api, bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
@@ -134,11 +135,13 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           {section === 'appearance' && (
             <>
       <section className="settings-group">
-        <h3>Appearance</h3>
-        <p className="modal-note">
-          Themes are VS Code colour themes. Drop any theme JSON into <code>~/.helios/themes</code> to add your
-          own.
-        </p>
+        <h3>
+          Appearance
+          <Info>
+            Themes are VS Code colour themes. Drop any theme JSON into <code>~/.helios/themes</code> to add
+            your own.
+          </Info>
+        </h3>
 
         <div className="mode-row">
           {MODES.map((mode) => (
@@ -189,19 +192,17 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
             </>
           )}
 
-          {section === 'sessions' && (
-            <>
-              <SessionTitles />
-              <MemoryBudget />
-            </>
-          )}
+          {section === 'sessions' && <SessionsPane />}
 
           {section === 'notifications' && (
             <>
-      <h3>Notifications</h3>
-      <p className="modal-note">
-        Requests always appear — on screen and on the tray. These toggles decide whether they also make a sound.
-      </p>
+      <h3>
+        Notifications
+        <Info>
+          Requests always appear — on screen and on the tray. These toggles decide whether they also make a
+          sound.
+        </Info>
+      </h3>
 
       <label className="check">
         <input
@@ -215,8 +216,10 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
 
       {GROUPS.map((group) => (
         <section key={group.heading} className="settings-group">
-          <h3>{group.heading}</h3>
-          <p className="modal-note">{group.note}</p>
+          <h3>
+            {group.heading}
+            <Info>{group.note}</Info>
+          </h3>
           {group.types.map(({ type, label, detail }) => (
             <label key={type} className="check">
               <input
@@ -225,10 +228,8 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
                 disabled={!prefs || !prefs.sound}
                 onChange={(event) => void apply(bridge.prefs.setAlert(type, event.target.checked))}
               />
-              <span>
-                {label}
-                <small>{detail}</small>
-              </span>
+              <span>{label}</span>
+              <Info>{detail}</Info>
             </label>
           ))}
         </section>
@@ -249,6 +250,100 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
   )
 }
 
+/**
+ * Everything on this pane belongs to a daemon rather than to this window, and
+ * every daemon has its own answer. One host at a time, picked at the top:
+ * stacking all of them meant scrolling past three copies of the same four
+ * toggles to reach the one machine you meant.
+ */
+function SessionsPane(): JSX.Element {
+  const hosts = useStore((s) => s.hosts)
+  const [hostId, setHostId] = useState<string | null>(null)
+  const selected = hosts.find((host) => host.id === hostId) ?? hosts[0]
+
+  if (!selected) return <p className="modal-note">No host paired.</p>
+
+  return (
+    <>
+      {hosts.length > 1 && (
+        <div className="settings-hostpick">
+          <span className="theme-picker-label">Host</span>
+          <select value={selected.id} onChange={(event) => setHostId(event.target.value)}>
+            {hosts.map((host) => (
+              <option key={host.id} value={host.id}>
+                {host.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      <SessionTitles hostId={selected.id} />
+      <MemoryBudget hostId={selected.id} />
+    </>
+  )
+}
+
+/**
+ * The explanation behind a setting, on a hovered icon rather than under its
+ * label. Spelled out in place, every row cost three lines and the pane read as
+ * prose with checkboxes in it; the toggles are what you came to find.
+ *
+ * Portalled and positioned in script because the panel scrolls, and an absolute
+ * bubble anchored inside it is clipped at the edge — which is exactly where a
+ * long explanation wants to go.
+ */
+function Info({ children }: { children: ReactNode }): JSX.Element {
+  const anchor = useRef<HTMLSpanElement | null>(null)
+  const closing = useRef<number | undefined>(undefined)
+  const [at, setAt] = useState<{ top: number; left: number } | null>(null)
+
+  const open = (): void => {
+    window.clearTimeout(closing.current)
+    const box = anchor.current?.getBoundingClientRect()
+    if (!box) return
+    setAt({ top: box.bottom + 6, left: Math.min(box.left, window.innerWidth - INFO_WIDTH - 12) })
+  }
+
+  // Delayed, so the pointer can cross the gap into the bubble. One explanation
+  // holds a link, and a bubble that vanishes on the way to it is a link that
+  // cannot be clicked.
+  const close = (): void => {
+    closing.current = window.setTimeout(() => setAt(null), 120)
+  }
+
+  useEffect(() => () => window.clearTimeout(closing.current), [])
+
+  return (
+    <span
+      className="info"
+      ref={anchor}
+      tabIndex={0}
+      role="button"
+      aria-label="What this does"
+      onMouseEnter={open}
+      onMouseLeave={close}
+      onFocus={open}
+      onBlur={close}
+    >
+      i
+      {at &&
+        createPortal(
+          <span
+            className="info-bubble"
+            style={{ top: at.top, left: at.left, width: INFO_WIDTH }}
+            onMouseEnter={open}
+            onMouseLeave={close}
+          >
+            {children}
+          </span>,
+          document.body,
+        )}
+    </span>
+  )
+}
+
+const INFO_WIDTH = 280
+
 /** What the daemon knows about titling, which is not this window's to keep. */
 interface TitlePrefs {
   enabled: boolean
@@ -265,13 +360,17 @@ interface TitlePrefs {
  * written per host, and a host that cannot be reached is left out rather than
  * shown a toggle that would fail to save.
  */
-/** The fractions offered. Free text invites a typo in a memory budget. */
-const BUDGET_CHOICES: { fraction: number; label: string; note?: string }[] = [
-  { fraction: 0.25, label: 'Quarter of RAM', note: 'recommended' },
-  { fraction: 0.5, label: 'Half of RAM' },
-  { fraction: 0.75, label: 'Three quarters' },
-  { fraction: 0, label: 'No limit', note: 'nothing is ever evicted' },
-]
+/**
+ * The slider's travel, as a share of physical memory.
+ *
+ * It stops short of the whole machine on both ends: a budget under a twentieth
+ * cannot hold even one agent, and one at 100% would only start evicting once
+ * the machine was already swapping.
+ */
+const BUDGET_MIN = 0.05
+const BUDGET_MAX = 0.9
+const BUDGET_STEP = 0.05
+const DEFAULT_BUDGET = 0.25
 
 function gigabytes(bytes: number): string {
   return `${(bytes / 1024 ** 3).toFixed(1)} GB`
@@ -290,144 +389,145 @@ interface BudgetPrefs {
   fraction: number
 }
 
-function MemoryBudget(): JSX.Element {
-  const hosts = useStore((s) => s.hosts)
-  const stats = useStore((s) => s.stats)
-  const [prefs, setPrefs] = useState<Record<string, BudgetPrefs>>({})
+function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
+  const total = useStore((s) => s.stats[hostId]?.memory_total ?? 0)
+  const [prefs, setPrefs] = useState<BudgetPrefs | null>(null)
 
   useEffect(() => {
-    for (const host of hosts) {
-      api(host.id)
-        .settings()
-        .then((values) => {
-          const raw = Number(values['memory.budget_fraction'])
-          setPrefs((all) => ({
-            ...all,
-            [host.id]: {
-              enabled: values['memory.evict'] === 'true',
-              fraction: Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 0.25,
-            },
-          }))
+    setPrefs(null)
+    api(hostId)
+      .settings()
+      .then((values) => {
+        const raw = Number(values['memory.budget_fraction'])
+        setPrefs({
+          enabled: values['memory.evict'] === 'true',
+          // Clamped rather than trusted: the setting predates the slider, so a
+          // stored value can sit outside its travel and leave the thumb pinned
+          // at an end while the label says something else.
+          fraction: Number.isFinite(raw) ? Math.min(BUDGET_MAX, Math.max(BUDGET_MIN, raw)) : DEFAULT_BUDGET,
         })
-        .catch(() => {
-          // Offline, or a daemon too old to know the setting.
-        })
-    }
-  }, [hosts])
+      })
+      .catch(() => {
+        // Offline, or a daemon too old to know the setting.
+      })
+  }, [hostId])
 
-  const change = async (hostId: string, next: Partial<BudgetPrefs>): Promise<void> => {
-    const before = prefs[hostId]
+  // Dragging the slider moves the label without writing anything: a drag from a
+  // quarter to a half passes through every step in between, and each one would
+  // otherwise be a request the daemon has to answer.
+  const drag = (fraction: number): void => {
+    setPrefs((before) => (before ? { ...before, fraction } : before))
+  }
+
+  const change = async (next: Partial<BudgetPrefs>): Promise<void> => {
+    const before = prefs
     if (!before) return
     const after = { ...before, ...next }
-    setPrefs((all) => ({ ...all, [hostId]: after }))
+    setPrefs(after)
     try {
       await api(hostId).updateSettings({
         'memory.evict': String(after.enabled),
         'memory.budget_fraction': String(after.fraction),
       })
     } catch (err) {
-      setPrefs((all) => ({ ...all, [hostId]: before }))
+      setPrefs(before)
       store.fail(err)
     }
   }
 
-  const reachable = hosts.filter((host) => prefs[host.id] !== undefined)
+  if (!prefs) {
+    return (
+      <section className="settings-group">
+        <h3>Save memory</h3>
+        <p className="modal-note">This host is not reachable.</p>
+      </section>
+    )
+  }
 
   return (
     <section className="settings-group">
-      <h3>Save memory</h3>
-      <p className="modal-note">
-        Each running session holds an agent in memory. Turn this on and Helios stops the ones you have not
-        opened for a while once they pass the limit below. The conversation is kept and opening a session
-        starts it again; only the terminal tab's scrollback is lost.
-      </p>
+      <h3>
+        Save memory
+        <Info>
+          Each running session holds an agent in memory. Turn this on and Helios stops the ones you have not
+          opened for a while once they pass the limit below. The conversation is kept and opening a session
+          starts it again; only the terminal tab&apos;s scrollback is lost.
+        </Info>
+      </h3>
 
-      {reachable.length === 0 ? (
-        <p className="modal-note">No host reachable to read this from.</p>
-      ) : (
-        reachable.map((host) => {
-          const total = stats[host.id]?.memory_total ?? 0
-          const current = prefs[host.id] as BudgetPrefs
-          return (
-            <div key={host.id} className="settings-host">
-              {reachable.length > 1 && <span className="theme-picker-label">{host.name}</span>}
+      <label className="check">
+        <input
+          type="checkbox"
+          checked={prefs.enabled}
+          onChange={(event) => void change({ enabled: event.target.checked })}
+        />
+        <span>Save memory</span>
+        <Info>
+          Stops the agents you have not opened lately. Opening one starts it again, with the conversation
+          intact.
+        </Info>
+      </label>
 
-              <label className="check">
-                <input
-                  type="checkbox"
-                  checked={current.enabled}
-                  onChange={(event) => void change(host.id, { enabled: event.target.checked })}
-                />
-                <span>
-                  Save memory
-                  <small>
-                    Stops the agents you have not opened lately. Opening one starts it again, with the
-                    conversation intact.
-                  </small>
-                </span>
-              </label>
-
-              {BUDGET_CHOICES.map((choice) => (
-                <label key={choice.fraction} className="check">
-                  <input
-                    type="radio"
-                    name={`budget-${host.id}`}
-                    disabled={!current.enabled}
-                    checked={current.fraction === choice.fraction}
-                    onChange={() => void change(host.id, { fraction: choice.fraction })}
-                  />
-                  <span>
-                    {choice.label}
-                    <small>
-                      {choice.fraction > 0 && total > 0 ? gigabytes(total * choice.fraction) : ''}
-                      {choice.fraction > 0 && total > 0 && choice.note ? ' · ' : ''}
-                      {choice.note ?? ''}
-                    </small>
-                  </span>
-                </label>
-              ))}
-            </div>
-          )
-        })
-      )}
+      <div className={prefs.enabled ? 'budget-slider' : 'budget-slider disabled'}>
+        <div className="budget-readout">
+          <span>
+            Memory limit
+            <Info>
+              How much the warm sessions on this host may hold between them. Past it, the ones nobody has
+              opened for a while are stopped, largest and longest unread first.
+            </Info>
+          </span>
+          <strong>{total > 0 ? gigabytes(total * prefs.fraction) : `${Math.round(prefs.fraction * 100)}%`}</strong>
+        </div>
+        <input
+          type="range"
+          min={BUDGET_MIN}
+          max={BUDGET_MAX}
+          step={BUDGET_STEP}
+          value={prefs.fraction}
+          disabled={!prefs.enabled}
+          onChange={(event) => drag(Number(event.target.value))}
+          onPointerUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
+          onKeyUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
+        />
+        <div className="budget-scale">
+          <span>{total > 0 ? gigabytes(total * BUDGET_MIN) : `${BUDGET_MIN * 100}%`}</span>
+          <span>{total > 0 ? `${gigabytes(total)} installed` : ''}</span>
+          <span>{total > 0 ? gigabytes(total * BUDGET_MAX) : `${BUDGET_MAX * 100}%`}</span>
+        </div>
+      </div>
     </section>
   )
 }
 
-function SessionTitles(): JSX.Element {
-  const hosts = useStore((s) => s.hosts)
-  const [prefs, setPrefs] = useState<Record<string, TitlePrefs>>({})
+function SessionTitles({ hostId }: { hostId: string }): JSX.Element {
+  const [prefs, setPrefs] = useState<TitlePrefs | null>(null)
 
   useEffect(() => {
-    for (const host of hosts) {
-      void api(host.id)
-        .settings()
-        .then((body) => {
-          const values = (body as { settings?: Record<string, string> }).settings ?? {}
-          setPrefs((current) => ({
-            ...current,
-            [host.id]: {
-              enabled: values['autotitle.enabled'] === 'true',
-              // Only an explicit false turns the icon off, which is how the
-              // daemon reads it (claude/autotitle.go).
-              // Off unless turned on: without a Nerd Font every category
-              // renders as the same missing-character box.
-              emoji: values['autotitle.emoji'] === 'true',
-              prompt: values['autotitle.prompt'] ?? '',
-            },
-          }))
+    setPrefs(null)
+    void api(hostId)
+      .settings()
+      .then((body) => {
+        const values = (body as { settings?: Record<string, string> }).settings ?? {}
+        setPrefs({
+          enabled: values['autotitle.enabled'] === 'true',
+          // Only an explicit false turns the icon off, which is how the daemon
+          // reads it (claude/autotitle.go). Off unless turned on: without a Nerd
+          // Font every category renders as the same missing-character box.
+          emoji: values['autotitle.emoji'] === 'true',
+          prompt: values['autotitle.prompt'] ?? '',
         })
-        .catch(() => {
-          // Offline. Nothing to show for it, and nowhere to save to.
-        })
-    }
-  }, [hosts])
+      })
+      .catch(() => {
+        // Offline. Nothing to show for it, and nowhere to save to.
+      })
+  }, [hostId])
 
-  const change = async (hostId: string, next: Partial<TitlePrefs>): Promise<void> => {
-    const before = prefs[hostId]
+  const change = async (next: Partial<TitlePrefs>): Promise<void> => {
+    const before = prefs
     if (!before) return
     const after = { ...before, ...next }
-    setPrefs((all) => ({ ...all, [hostId]: after }))
+    setPrefs(after)
     try {
       await api(hostId).updateSettings({
         'autotitle.enabled': String(after.enabled),
@@ -435,70 +535,63 @@ function SessionTitles(): JSX.Element {
         'autotitle.prompt': after.prompt,
       })
     } catch (err) {
-      setPrefs((all) => ({ ...all, [hostId]: before }))
+      setPrefs(before)
       store.fail(err)
     }
   }
 
-  const reachable = hosts.filter((host) => prefs[host.id])
+  if (!prefs) {
+    return (
+      <section className="settings-group">
+        <h3>Session titles</h3>
+        <p className="modal-note">This host is not reachable.</p>
+      </section>
+    )
+  }
 
   return (
     <section className="settings-group">
-      <h3>Session titles</h3>
-      <p className="modal-note">
-        The daemon names a session from its first exchange, using Haiku. It leaves greetings and test messages
-        alone, and never renames a session you have titled yourself.
-      </p>
+      <h3>
+        Session titles
+        <Info>
+          The daemon names a session from its first exchange, using Haiku. It leaves greetings and test
+          messages alone, and never renames a session you have titled yourself.
+        </Info>
+      </h3>
 
-      {reachable.length === 0 ? (
-        <p className="modal-note">No host reachable to read this from.</p>
-      ) : (
-        reachable.map((host) => {
-          const value = prefs[host.id] as TitlePrefs
-          return (
-            <div key={host.id} className="settings-host">
-              {/* Named only when there is a choice of host to be confused about. */}
-              {reachable.length > 1 && <span className="theme-picker-label">{host.name}</span>}
+      <label className="check">
+        <input
+          type="checkbox"
+          checked={prefs.enabled}
+          onChange={(event) => void change({ enabled: event.target.checked })}
+        />
+        <span>Generate titles automatically</span>
+        <Info>Off by default. Costs a Haiku call per session, about a tenth of a cent.</Info>
+      </label>
 
-              <label className="check">
-                <input
-                  type="checkbox"
-                  checked={value.enabled}
-                  onChange={(event) => void change(host.id, { enabled: event.target.checked })}
-                />
-                <span>
-                  Generate titles automatically
-                  <small>Off by default. Costs a Haiku call per session, about a tenth of a cent.</small>
-                </span>
-              </label>
+      <label className="check">
+        <input
+          type="checkbox"
+          checked={prefs.emoji}
+          disabled={!prefs.enabled}
+          onChange={(event) => void change({ emoji: event.target.checked })}
+        />
+        <span>Icon prefix</span>
+        <Info>
+          A glyph per category —  [FIX] rather than [FIX]. Off by default: the glyphs come from a patched{' '}
+          <a href="https://www.nerdfonts.com" target="_blank" rel="noreferrer noopener">
+            Nerd Font
+          </a>
+          , and without one installed every category shows the same empty box. The phone has no Nerd Font, so
+          titles made here appear boxed there.
+        </Info>
+      </label>
 
-              <label className="check">
-                <input
-                  type="checkbox"
-                  checked={value.emoji}
-                  disabled={!value.enabled}
-                  onChange={(event) => void change(host.id, { emoji: event.target.checked })}
-                />
-                <span>
-                  Icon prefix
-                  <small>
-                    A glyph per category —  [FIX] rather than [FIX]. Off by default: the glyphs come from a
-                    patched <a href="https://www.nerdfonts.com" target="_blank" rel="noreferrer noopener">Nerd
-                    Font</a>, and without one installed every category shows the same empty box. The phone has no
-                    Nerd Font, so titles made here appear boxed there.
-                  </small>
-                </span>
-              </label>
-
-              <CustomPrompt
-                value={value.prompt}
-                disabled={!value.enabled}
-                onSave={(prompt) => void change(host.id, { prompt })}
-              />
-            </div>
-          )
-        })
-      )}
+      <CustomPrompt
+        value={prefs.prompt}
+        disabled={!prefs.enabled}
+        onSave={(prompt) => void change({ prompt })}
+      />
     </section>
   )
 }
@@ -526,11 +619,13 @@ function CustomPrompt({
 
   return (
     <div className="title-prompt">
-      <span className="theme-picker-label">Custom prompt</span>
-      <p className="modal-note">
-        Replaces the built-in instructions entirely, so the format, the categories and the rule that skips
-        greetings all become yours to state. Leave it empty to use the built-in one.
-      </p>
+      <span className="theme-picker-label">
+        Custom prompt
+        <Info>
+          Replaces the built-in instructions entirely, so the format, the categories and the rule that skips
+          greetings all become yours to state. Leave it empty to use the built-in one.
+        </Info>
+      </span>
       <textarea
         rows={5}
         disabled={disabled}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -282,10 +282,15 @@ function gigabytes(bytes: number): string {
  * runs on a 16 GB laptop and a 64 GB desktop. The resolved size is shown beside
  * each choice, because "a quarter" means nothing until it says 8 GB.
  */
+interface BudgetPrefs {
+  enabled: boolean
+  fraction: number
+}
+
 function MemoryBudget(): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const stats = useStore((s) => s.stats)
-  const [fraction, setFraction] = useState<Record<string, number>>({})
+  const [prefs, setPrefs] = useState<Record<string, BudgetPrefs>>({})
 
   useEffect(() => {
     for (const host of hosts) {
@@ -293,9 +298,12 @@ function MemoryBudget(): JSX.Element {
         .settings()
         .then((values) => {
           const raw = Number(values['memory.budget_fraction'])
-          setFraction((all) => ({
+          setPrefs((all) => ({
             ...all,
-            [host.id]: Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 0.25,
+            [host.id]: {
+              enabled: values['memory.evict'] === 'true',
+              fraction: Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 0.25,
+            },
           }))
         })
         .catch(() => {
@@ -304,18 +312,23 @@ function MemoryBudget(): JSX.Element {
     }
   }, [hosts])
 
-  const change = async (hostId: string, next: number): Promise<void> => {
-    const before = fraction[hostId]
-    setFraction((all) => ({ ...all, [hostId]: next }))
+  const change = async (hostId: string, next: Partial<BudgetPrefs>): Promise<void> => {
+    const before = prefs[hostId]
+    if (!before) return
+    const after = { ...before, ...next }
+    setPrefs((all) => ({ ...all, [hostId]: after }))
     try {
-      await api(hostId).updateSettings({ 'memory.budget_fraction': String(next) })
+      await api(hostId).updateSettings({
+        'memory.evict': String(after.enabled),
+        'memory.budget_fraction': String(after.fraction),
+      })
     } catch (err) {
-      setFraction((all) => ({ ...all, [hostId]: before ?? 0.25 }))
+      setPrefs((all) => ({ ...all, [hostId]: before }))
       store.fail(err)
     }
   }
 
-  const reachable = hosts.filter((host) => fraction[host.id] !== undefined)
+  const reachable = hosts.filter((host) => prefs[host.id] !== undefined)
 
   return (
     <section className="settings-group">
@@ -331,17 +344,34 @@ function MemoryBudget(): JSX.Element {
       ) : (
         reachable.map((host) => {
           const total = stats[host.id]?.memory_total ?? 0
-          const current = fraction[host.id] as number
+          const current = prefs[host.id] as BudgetPrefs
           return (
             <div key={host.id} className="settings-host">
               {reachable.length > 1 && <span className="theme-picker-label">{host.name}</span>}
+
+              <label className="check">
+                <input
+                  type="checkbox"
+                  checked={current.enabled}
+                  onChange={(event) => void change(host.id, { enabled: event.target.checked })}
+                />
+                <span>
+                  Let idle sessions go cold
+                  <small>
+                    Off by default. Killing a running agent and losing its terminal scrollback is your
+                    call to make.
+                  </small>
+                </span>
+              </label>
+
               {BUDGET_CHOICES.map((choice) => (
                 <label key={choice.fraction} className="check">
                   <input
                     type="radio"
                     name={`budget-${host.id}`}
-                    checked={current === choice.fraction}
-                    onChange={() => void change(host.id, choice.fraction)}
+                    disabled={!current.enabled}
+                    checked={current.fraction === choice.fraction}
+                    onChange={() => void change(host.id, { fraction: choice.fraction })}
                   />
                   <span>
                     {choice.label}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -322,7 +322,7 @@ function Info({ children }: { children: ReactNode }): JSX.Element {
 
   return (
     <span
-      className="info"
+      className="info-dot"
       ref={anchor}
       tabIndex={0}
       role="button"
@@ -336,7 +336,7 @@ function Info({ children }: { children: ReactNode }): JSX.Element {
       {at &&
         createPortal(
           <span
-            className="info-bubble"
+            className="info-tip"
             style={{ top: at.top, left: at.left, width: INFO_WIDTH }}
             onMouseEnter={open}
             onMouseLeave={close}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -132,7 +132,9 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         </nav>
 
         <div className="settings-panel">
-          {section === 'appearance' && (
+          {section === 'appearance' && !appearance && <Loading title="Appearance" />}
+
+          {section === 'appearance' && appearance && (
             <>
       <section className="settings-group">
         <h3>
@@ -143,22 +145,24 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           </Info>
         </h3>
 
-        <div className="mode-row">
-          {MODES.map((mode) => (
-            <label key={mode.value} className="check" title={mode.detail}>
-              <input
-                type="radio"
-                name="theme-mode"
-                checked={appearance?.mode === mode.value}
-                disabled={!appearance}
-                onChange={() => void setTheme({ mode: mode.value })}
-              />
-              {mode.label}
-            </label>
-          ))}
-        </div>
+        <Row
+          label="Mode"
+          info={MODES.map((mode) => `${mode.label} — ${mode.detail}`).join(' ')}
+        >
+          <select
+            value={appearance?.mode ?? 'system'}
+            disabled={!appearance}
+            onChange={(event) => void setTheme({ mode: event.target.value as AppearancePrefs['mode'] })}
+          >
+            {MODES.map((mode) => (
+              <option key={mode.value} value={mode.value}>
+                {mode.label}
+              </option>
+            ))}
+          </select>
+        </Row>
 
-        {/* Both slots stay visible on a pinned mode: they are what 'System'
+        {/* Both slots stay listed on a pinned mode: they are what 'System'
             will switch between, and hiding the other one makes it look as
             though the choice was lost. */}
         <ThemePicker
@@ -175,6 +179,7 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         />
         <ThemePicker
           label="Terminal"
+          info="The colours inside the terminal panes. Match UI theme follows whichever of the two above is showing."
           themes={themes}
           value={appearance?.terminalTheme}
           match="Match UI theme"
@@ -194,7 +199,9 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
 
           {section === 'sessions' && <SessionsPane />}
 
-          {section === 'notifications' && (
+          {section === 'notifications' && !prefs && <Loading title="Notifications" />}
+
+          {section === 'notifications' && prefs && (
             <>
       <h3>
         Notifications
@@ -344,6 +351,27 @@ function Info({ children }: { children: ReactNode }): JSX.Element {
 
 const INFO_WIDTH = 280
 
+/**
+ * What a section shows before its host has answered.
+ *
+ * Distinct from the unreachable message on purpose: both used to be the same
+ * blank, so a daemon that was merely slow read as one that was down.
+ */
+function Loading({ title }: { title: string }): JSX.Element {
+  return (
+    <section className="settings-group">
+      <h3>{title}</h3>
+      <p className="settings-loading">
+        <span className="spinner" />
+        Reading from the host…
+      </p>
+    </section>
+  )
+}
+
+/** Loaded, still loading, or asked and refused. */
+type Loaded<T> = { state: 'loading' } | { state: 'failed' } | { state: 'ready'; value: T }
+
 /** What the daemon knows about titling, which is not this window's to keep. */
 interface TitlePrefs {
   enabled: boolean
@@ -391,54 +419,63 @@ interface BudgetPrefs {
 
 function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
   const total = useStore((s) => s.stats[hostId]?.memory_total ?? 0)
-  const [prefs, setPrefs] = useState<BudgetPrefs | null>(null)
+  const [loaded, setLoaded] = useState<Loaded<BudgetPrefs>>({ state: 'loading' })
 
   useEffect(() => {
-    setPrefs(null)
+    setLoaded({ state: 'loading' })
     api(hostId)
       .settings()
       .then((values) => {
         const raw = Number(values['memory.budget_fraction'])
-        setPrefs({
-          enabled: values['memory.evict'] === 'true',
-          // Clamped rather than trusted: the setting predates the slider, so a
-          // stored value can sit outside its travel and leave the thumb pinned
-          // at an end while the label says something else.
-          fraction: Number.isFinite(raw) ? Math.min(BUDGET_MAX, Math.max(BUDGET_MIN, raw)) : DEFAULT_BUDGET,
+        setLoaded({
+          state: 'ready',
+          value: {
+            enabled: values['memory.evict'] === 'true',
+            // Clamped rather than trusted: the setting predates the slider, so
+            // a stored value can sit outside its travel and leave the thumb
+            // pinned at an end while the label says something else.
+            fraction: Number.isFinite(raw) ? Math.min(BUDGET_MAX, Math.max(BUDGET_MIN, raw)) : DEFAULT_BUDGET,
+          },
         })
       })
       .catch(() => {
         // Offline, or a daemon too old to know the setting.
+        setLoaded({ state: 'failed' })
       })
   }, [hostId])
+
+  const prefs = loaded.state === 'ready' ? loaded.value : null
 
   // Dragging the slider moves the label without writing anything: a drag from a
   // quarter to a half passes through every step in between, and each one would
   // otherwise be a request the daemon has to answer.
   const drag = (fraction: number): void => {
-    setPrefs((before) => (before ? { ...before, fraction } : before))
+    setLoaded((before) =>
+      before.state === 'ready' ? { state: 'ready', value: { ...before.value, fraction } } : before,
+    )
   }
 
   const change = async (next: Partial<BudgetPrefs>): Promise<void> => {
     const before = prefs
     if (!before) return
     const after = { ...before, ...next }
-    setPrefs(after)
+    setLoaded({ state: 'ready', value: after })
     try {
       await api(hostId).updateSettings({
         'memory.evict': String(after.enabled),
         'memory.budget_fraction': String(after.fraction),
       })
     } catch (err) {
-      setPrefs(before)
+      setLoaded({ state: 'ready', value: before })
       store.fail(err)
     }
   }
 
+  if (loaded.state === 'loading') return <Loading title="Memory" />
   if (!prefs) {
     return (
       <section className="settings-group">
-        <h3>Save memory</h3>
+        <h3>Memory</h3>
         <p className="modal-note">This host is not reachable.</p>
       </section>
     )
@@ -447,7 +484,7 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
   return (
     <section className="settings-group">
       <h3>
-        Save memory
+        Memory
         <Info>
           Each running session holds an agent in memory. Turn this on and Helios stops the ones you have not
           opened for a while once they pass the limit below. The conversation is kept and opening a session
@@ -501,33 +538,40 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
 }
 
 function SessionTitles({ hostId }: { hostId: string }): JSX.Element {
-  const [prefs, setPrefs] = useState<TitlePrefs | null>(null)
+  const [loaded, setLoaded] = useState<Loaded<TitlePrefs>>({ state: 'loading' })
 
   useEffect(() => {
-    setPrefs(null)
+    setLoaded({ state: 'loading' })
     void api(hostId)
       .settings()
       .then((body) => {
         const values = (body as { settings?: Record<string, string> }).settings ?? {}
-        setPrefs({
-          enabled: values['autotitle.enabled'] === 'true',
-          // Only an explicit false turns the icon off, which is how the daemon
-          // reads it (claude/autotitle.go). Off unless turned on: without a Nerd
-          // Font every category renders as the same missing-character box.
-          emoji: values['autotitle.emoji'] === 'true',
-          prompt: values['autotitle.prompt'] ?? '',
+        setLoaded({
+          state: 'ready',
+          value: {
+            enabled: values['autotitle.enabled'] === 'true',
+            // Only an explicit false turns the icon off, which is how the
+            // daemon reads it (claude/autotitle.go). Off unless turned on:
+            // without a Nerd Font every category renders as the same
+            // missing-character box.
+            emoji: values['autotitle.emoji'] === 'true',
+            prompt: values['autotitle.prompt'] ?? '',
+          },
         })
       })
       .catch(() => {
         // Offline. Nothing to show for it, and nowhere to save to.
+        setLoaded({ state: 'failed' })
       })
   }, [hostId])
+
+  const prefs = loaded.state === 'ready' ? loaded.value : null
 
   const change = async (next: Partial<TitlePrefs>): Promise<void> => {
     const before = prefs
     if (!before) return
     const after = { ...before, ...next }
-    setPrefs(after)
+    setLoaded({ state: 'ready', value: after })
     try {
       await api(hostId).updateSettings({
         'autotitle.enabled': String(after.enabled),
@@ -535,11 +579,12 @@ function SessionTitles({ hostId }: { hostId: string }): JSX.Element {
         'autotitle.prompt': after.prompt,
       })
     } catch (err) {
-      setPrefs(before)
+      setLoaded({ state: 'ready', value: before })
       store.fail(err)
     }
   }
 
+  if (loaded.state === 'loading') return <Loading title="Session titles" />
   if (!prefs) {
     return (
       <section className="settings-group">
@@ -642,54 +687,82 @@ function CustomPrompt({
 }
 
 /**
- * A theme list with a swatch each, because a name is not much to choose from —
- * "Gruvbox Dark Medium" and "Gruvbox Dark Hard" are the same words and quite
- * different rooms to sit in.
+ * A label, its control, and the explanation on an icon beside the label.
+ *
+ * Every setting on the Appearance pane is one choice, and laying them out as a
+ * column of grids rather than a stack of blocks is what lets the pane be read
+ * down the labels.
+ */
+function Row({
+  label,
+  info,
+  children,
+}: {
+  label: string
+  info?: ReactNode
+  children: ReactNode
+}): JSX.Element {
+  return (
+    <div className="setting-row">
+      <span className="setting-row-label">
+        {label}
+        {info && <Info>{info}</Info>}
+      </span>
+      <div className="setting-row-control">{children}</div>
+    </div>
+  )
+}
+
+/**
+ * One theme, chosen from a list.
+ *
+ * A grid of chips before, one per installed theme, which was the tallest thing
+ * in the dialog by a wide margin and grew with every theme dropped into
+ * ~/.helios/themes. The swatch that justified the chips is kept beside the
+ * closed dropdown, and picking applies immediately — so arrowing through the
+ * list previews each theme on the whole window, which no swatch could.
  */
 function ThemePicker({
   label,
+  info,
   themes,
   value,
   match,
   onPick,
 }: {
   label: string
+  info?: ReactNode
   themes: ThemeSummary[]
   value: string | undefined
   /** Present on the terminal picker, whose first option is to follow the UI. */
   match?: string
   onPick: (id: string) => void
 }): JSX.Element {
+  const current = themes.find((theme) => theme.id === value)
   return (
-    <div className="theme-picker">
-      <span className="theme-picker-label">{label}</span>
-      <div className="theme-grid">
-        {match && (
-          <button
-            className={value === 'match' ? 'theme-chip selected' : 'theme-chip'}
-            onClick={() => onPick('match')}
-          >
-            <span className="theme-swatch inherit" />
-            {match}
-          </button>
-        )}
+    <Row label={label} info={info}>
+      {value === 'match' || !current ? (
+        <span className="theme-swatch inherit" />
+      ) : (
+        <span className="theme-swatch">
+          {current.swatch.map((colour, index) => (
+            <i key={index} style={{ background: colour }} />
+          ))}
+        </span>
+      )}
+      <select value={value ?? ''} onChange={(event) => onPick(event.target.value)}>
+        {/* Nothing is chosen until the preferences land, and a select with no
+            matching option would otherwise show the first theme as though it
+            were the active one. */}
+        {value === undefined && <option value="">Loading…</option>}
+        {match && <option value="match">{match}</option>}
         {themes.map((theme) => (
-          <button
-            key={theme.id}
-            className={value === theme.id ? 'theme-chip selected' : 'theme-chip'}
-            onClick={() => onPick(theme.id)}
-            title={theme.id}
-          >
-            <span className="theme-swatch">
-              {theme.swatch.map((colour, index) => (
-                <i key={index} style={{ background: colour }} />
-              ))}
-            </span>
+          <option key={theme.id} value={theme.id}>
             {theme.name}
-          </button>
+          </option>
         ))}
-      </div>
-    </div>
+      </select>
+    </Row>
   )
 }
 
@@ -811,29 +884,50 @@ function Backdrop(): JSX.Element | null {
   const palette = picking ?? state.palette
 
   return (
-    <div className="theme-picker">
-      <span className="theme-picker-label">Backdrop</span>
-      <div className="theme-grid">
-        {styles.map((style) => (
-          <button
-            key={style}
-            className={state.style === style ? 'theme-chip selected' : 'theme-chip'}
-            // Choosing the image style means choosing an image: a chip that
-            // selected an empty one and left the user to find a second control
-            // would be a chip that appears to do nothing.
-            onClick={() => (style === 'image' ? void chooseImage() : void save({ style }))}
-            title={CHIP_HINTS[style]}
-          >
-            <span
-              className={style === 'desktop' ? 'backdrop-swatch desktop' : 'backdrop-swatch'}
-              style={
-                style === 'desktop' ? undefined : { background: swatchOf(theme, style, intensity, palette, state.image) }
-              }
-            />
-            {BACKDROP_LABELS[style]}
+    <>
+      <Row
+        label="Backdrop"
+        info={
+          <>
+            What sits behind the glass. {CHIP_HINTS[state.style]}. Saved in {state.themeName} rather than in
+            this window, so the choice travels with the theme whose colours draw it.
+          </>
+        }
+      >
+        <span
+          className={state.style === 'desktop' ? 'backdrop-swatch desktop' : 'backdrop-swatch'}
+          style={
+            state.style === 'desktop'
+              ? undefined
+              : { background: swatchOf(theme, state.style, intensity, palette, state.image) }
+          }
+        />
+        <select
+          value={state.style}
+          // Choosing the image style means choosing an image: an option that
+          // selected an empty one and left the user to find a second control
+          // would be an option that appears to do nothing.
+          onChange={(event) => {
+            const style = event.target.value as BackdropStyle
+            if (style === 'image') void chooseImage()
+            else void save({ style })
+          }}
+        >
+          {styles.map((style) => (
+            <option key={style} value={style}>
+              {BACKDROP_LABELS[style]}
+            </option>
+          ))}
+        </select>
+        {/* Offered again once an image is showing: the option that opened the
+            file dialog is the one already selected, so re-picking it fires no
+            change event. */}
+        {state.style === 'image' && (
+          <button className="ghost" onClick={() => void chooseImage()}>
+            Change…
           </button>
-        ))}
-      </div>
+        )}
+      </Row>
       {state.style !== 'desktop' && (
         <Slider
           label={state.style === 'image' ? 'Dim' : 'Colour'}
@@ -858,31 +952,29 @@ function Backdrop(): JSX.Element | null {
         onSettle={() => commit('blur')}
       />
       {state.style !== 'desktop' && state.style !== 'image' && (
-        <div className="backdrop-colours">
-          {palette.map((colour, index) => (
-            <input
-              key={index}
-              type="color"
-              value={colour}
-              // Four wells whichever style is showing: Wash draws two of them
-              // and Mesh all four, and switching between the two should not
-              // throw away a colour that was chosen.
-              title={`Backdrop colour ${index + 1}`}
-              onChange={(event) => pick(index, event.target.value)}
-            />
-          ))}
-          {state.custom && (
-            <button
-              className="ghost"
-              onClick={() => void save({ style: state.style, intensity: state.intensity })}
-            >
-              Use theme colours
-            </button>
-          )}
-        </div>
+        <Row label="Colours" info="Wash draws the first two and Mesh all four, so switching between them keeps whatever was chosen here.">
+          <div className="backdrop-colours">
+            {palette.map((colour, index) => (
+              <input
+                key={index}
+                type="color"
+                value={colour}
+                title={`Backdrop colour ${index + 1}`}
+                onChange={(event) => pick(index, event.target.value)}
+              />
+            ))}
+            {state.custom && (
+              <button
+                className="ghost"
+                onClick={() => void save({ style: state.style, intensity: state.intensity })}
+              >
+                Use theme colours
+              </button>
+            )}
+          </div>
+        </Row>
       )}
-      <span className="modal-note">Saved in {state.themeName}.</span>
-    </div>
+    </>
   )
 }
 
@@ -898,6 +990,7 @@ const CHIP_HINTS: Record<BackdropStyle, string> = {
 /** A labelled range that reports while it moves and again when it is let go. */
 function Slider({
   label,
+  info,
   min,
   max,
   step,
@@ -906,6 +999,7 @@ function Slider({
   onSettle,
 }: {
   label: string
+  info?: ReactNode
   min: number
   max: number
   step: number
@@ -914,9 +1008,9 @@ function Slider({
   onSettle: () => void
 }): JSX.Element {
   return (
-    <label className="backdrop-slider">
-      <span>{label}</span>
+    <Row label={label} info={info}>
       <input
+        className="wide-range"
         type="range"
         min={min}
         max={max}
@@ -929,7 +1023,7 @@ function Slider({
         onKeyUp={onSettle}
         onBlur={onSettle}
       />
-    </label>
+    </Row>
   )
 }
 
@@ -975,8 +1069,7 @@ function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: 
   }
 
   return (
-    <div className="theme-picker">
-      <span className="theme-picker-label">Text size</span>
+    <Row label="Text size" info="In pixels, between 10 and 28. Sets the size of rendered markdown — the transcript and the file previews both. It does not touch the terminal.">
       <input
         className="prose-size"
         type="number"
@@ -991,7 +1084,7 @@ function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: 
           if (event.key === 'Enter') event.currentTarget.blur()
         }}
       />
-      <span className="modal-note">px — chat and file previews.</span>
-    </div>
+      <span className="setting-row-unit">px</span>
+    </Row>
   )
 }

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -65,11 +65,12 @@ const MODES: { value: AppearancePrefs['mode']; label: string; detail: string }[]
  * theme pickers pushed the notification toggles out of sight — and the two have
  * nothing to do with each other.
  */
-type SectionId = 'appearance' | 'titles' | 'notifications'
+type SectionId = 'appearance' | 'titles' | 'memory' | 'notifications'
 
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'titles', label: 'Session titles' },
+  { id: 'memory', label: 'Memory' },
   { id: 'notifications', label: 'Notifications' },
 ]
 
@@ -190,6 +191,7 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           )}
 
           {section === 'titles' && <SessionTitles />}
+          {section === 'memory' && <MemoryBudget />}
 
           {section === 'notifications' && (
             <>
@@ -260,6 +262,105 @@ interface TitlePrefs {
  * written per host, and a host that cannot be reached is left out rather than
  * shown a toggle that would fail to save.
  */
+/** The fractions offered. Free text invites a typo in a memory budget. */
+const BUDGET_CHOICES: { fraction: number; label: string; note?: string }[] = [
+  { fraction: 0.25, label: 'Quarter of RAM', note: 'recommended' },
+  { fraction: 0.5, label: 'Half of RAM' },
+  { fraction: 0.75, label: 'Three quarters' },
+  { fraction: 0, label: 'No limit', note: 'nothing is ever evicted' },
+]
+
+function gigabytes(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+}
+
+/**
+ * How much memory a daemon's warm sessions may hold before idle ones are let
+ * go cold.
+ *
+ * A share of the machine rather than a number of megabytes: the same install
+ * runs on a 16 GB laptop and a 64 GB desktop. The resolved size is shown beside
+ * each choice, because "a quarter" means nothing until it says 8 GB.
+ */
+function MemoryBudget(): JSX.Element {
+  const hosts = useStore((s) => s.hosts)
+  const stats = useStore((s) => s.stats)
+  const [fraction, setFraction] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    for (const host of hosts) {
+      api(host.id)
+        .settings()
+        .then((values) => {
+          const raw = Number(values['memory.budget_fraction'])
+          setFraction((all) => ({
+            ...all,
+            [host.id]: Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 0.25,
+          }))
+        })
+        .catch(() => {
+          // Offline, or a daemon too old to know the setting.
+        })
+    }
+  }, [hosts])
+
+  const change = async (hostId: string, next: number): Promise<void> => {
+    const before = fraction[hostId]
+    setFraction((all) => ({ ...all, [hostId]: next }))
+    try {
+      await api(hostId).updateSettings({ 'memory.budget_fraction': String(next) })
+    } catch (err) {
+      setFraction((all) => ({ ...all, [hostId]: before ?? 0.25 }))
+      store.fail(err)
+    }
+  }
+
+  const reachable = hosts.filter((host) => fraction[host.id] !== undefined)
+
+  return (
+    <section className="settings-group">
+      <h3>Warm session memory</h3>
+      <p className="modal-note">
+        Each running session holds an agent in memory. Past this share of the machine, the sessions nobody
+        has opened for a while are let go cold — the conversation is kept and your next prompt wakes them,
+        but the terminal tab loses its scrollback.
+      </p>
+
+      {reachable.length === 0 ? (
+        <p className="modal-note">No host reachable to read this from.</p>
+      ) : (
+        reachable.map((host) => {
+          const total = stats[host.id]?.memory_total ?? 0
+          const current = fraction[host.id] as number
+          return (
+            <div key={host.id} className="settings-host">
+              {reachable.length > 1 && <span className="theme-picker-label">{host.name}</span>}
+              {BUDGET_CHOICES.map((choice) => (
+                <label key={choice.fraction} className="check">
+                  <input
+                    type="radio"
+                    name={`budget-${host.id}`}
+                    checked={current === choice.fraction}
+                    onChange={() => void change(host.id, choice.fraction)}
+                  />
+                  <span>
+                    {choice.label}
+                    <small>
+                      {choice.fraction > 0 && total > 0 ? gigabytes(total * choice.fraction) : ''}
+                      {choice.fraction > 0 && total > 0 && choice.note ? ' · ' : ''}
+                      {choice.note ?? ''}
+                    </small>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )
+        })
+      )}
+    </section>
+  )
+}
+
 function SessionTitles(): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const [prefs, setPrefs] = useState<Record<string, TitlePrefs>>({})

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -453,7 +453,12 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
     setLoaded({ state: 'loading' })
     api(hostId)
       .settings()
-      .then((values) => {
+      .then((body) => {
+        // The daemon answers with the settings under a key, alongside personas
+        // and event types. Reading the envelope as though it were the map gives
+        // undefined for every setting, which is indistinguishable from a fresh
+        // install — the toggle saved and then read back off.
+        const values = (body as { settings?: Record<string, string> }).settings ?? {}
         const raw = Number(values['memory.budget_fraction'])
         setLoaded({
           state: 'ready',

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -65,12 +65,11 @@ const MODES: { value: AppearancePrefs['mode']; label: string; detail: string }[]
  * theme pickers pushed the notification toggles out of sight — and the two have
  * nothing to do with each other.
  */
-type SectionId = 'appearance' | 'titles' | 'memory' | 'notifications'
+type SectionId = 'appearance' | 'sessions' | 'notifications'
 
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
-  { id: 'titles', label: 'Session titles' },
-  { id: 'memory', label: 'Save memory' },
+  { id: 'sessions', label: 'Sessions' },
   { id: 'notifications', label: 'Notifications' },
 ]
 
@@ -190,8 +189,12 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
             </>
           )}
 
-          {section === 'titles' && <SessionTitles />}
-          {section === 'memory' && <MemoryBudget />}
+          {section === 'sessions' && (
+            <>
+              <SessionTitles />
+              <MemoryBudget />
+            </>
+          )}
 
           {section === 'notifications' && (
             <>

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -397,11 +397,39 @@ interface TitlePrefs {
  */
 const BUDGET_MIN = 0.05
 const BUDGET_MAX = 0.9
-const BUDGET_STEP = 0.05
 const DEFAULT_BUDGET = 0.25
 
+const GIB = 1024 ** 3
+
+/**
+ * The slider moves in half-gigabytes when the host has told us how much memory
+ * it has.
+ *
+ * Stepping the fraction instead gave a limit of 8.3 GB on one machine and 6.4
+ * on another, which reads as a measurement rather than a decision. The daemon
+ * is still sent a fraction — the same install runs on a 16 GB laptop and a 64
+ * GB desktop — but the number the user aims at is a round one.
+ */
+const STEP_GIB = 0.5
+const MIN_GIB = 2
+
+/** Drops a trailing zero, so the scale reads 2, 2.5, 3 rather than 2.0, 2.5. */
 function gigabytes(bytes: number): string {
-  return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  const gib = bytes / GIB
+  return `${Number.isInteger(gib) ? gib : gib.toFixed(1)} GB`
+}
+
+/** The travel of the slider on a host of this size, in whole steps. */
+function budgetRange(total: number): { min: number; max: number } {
+  const max = Math.floor((total * BUDGET_MAX) / GIB / STEP_GIB) * STEP_GIB
+  // A machine too small for the usual floor still gets a slider that moves,
+  // rather than one whose ends have crossed over.
+  return max <= MIN_GIB ? { min: STEP_GIB, max: Math.max(STEP_GIB, max) } : { min: MIN_GIB, max }
+}
+
+function snapToStep(gib: number, range: { min: number; max: number }): number {
+  const snapped = Math.round(gib / STEP_GIB) * STEP_GIB
+  return Math.min(range.max, Math.max(range.min, snapped))
 }
 
 /**
@@ -471,6 +499,12 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
     }
   }
 
+  const range = budgetRange(total)
+  // Snapped for display as well as for saving, so a fraction stored by the
+  // phone or the TUI — neither of which knows the host's size — still lands the
+  // thumb on a step rather than between two.
+  const gib = prefs ? snapToStep((total * prefs.fraction) / GIB, range) : 0
+
   if (loaded.state === 'loading') return <Loading title="Memory" />
   if (!prefs) {
     return (
@@ -514,23 +548,39 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
               opened for a while are stopped, largest and longest unread first.
             </Info>
           </span>
-          <strong>{total > 0 ? gigabytes(total * prefs.fraction) : `${Math.round(prefs.fraction * 100)}%`}</strong>
+          <strong>{total > 0 ? gigabytes(gib * GIB) : `${Math.round(prefs.fraction * 100)}%`}</strong>
         </div>
-        <input
-          type="range"
-          min={BUDGET_MIN}
-          max={BUDGET_MAX}
-          step={BUDGET_STEP}
-          value={prefs.fraction}
-          disabled={!prefs.enabled}
-          onChange={(event) => drag(Number(event.target.value))}
-          onPointerUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
-          onKeyUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
-        />
+        {/* In gigabytes when the host has reported its size, and in the raw
+            fraction when it has not: the daemon takes a fraction either way. */}
+        {total > 0 ? (
+          <input
+            type="range"
+            min={range.min}
+            max={range.max}
+            step={STEP_GIB}
+            value={gib}
+            disabled={!prefs.enabled}
+            onChange={(event) => drag((Number(event.target.value) * GIB) / total)}
+            onPointerUp={(event) => void change({ fraction: (Number(event.currentTarget.value) * GIB) / total })}
+            onKeyUp={(event) => void change({ fraction: (Number(event.currentTarget.value) * GIB) / total })}
+          />
+        ) : (
+          <input
+            type="range"
+            min={BUDGET_MIN}
+            max={BUDGET_MAX}
+            step={0.05}
+            value={prefs.fraction}
+            disabled={!prefs.enabled}
+            onChange={(event) => drag(Number(event.target.value))}
+            onPointerUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
+            onKeyUp={(event) => void change({ fraction: Number(event.currentTarget.value) })}
+          />
+        )}
         <div className="budget-scale">
-          <span>{total > 0 ? gigabytes(total * BUDGET_MIN) : `${BUDGET_MIN * 100}%`}</span>
+          <span>{total > 0 ? gigabytes(range.min * GIB) : `${BUDGET_MIN * 100}%`}</span>
           <span>{total > 0 ? `${gigabytes(total)} installed` : ''}</span>
-          <span>{total > 0 ? gigabytes(total * BUDGET_MAX) : `${BUDGET_MAX * 100}%`}</span>
+          <span>{total > 0 ? gigabytes(range.max * GIB) : `${BUDGET_MAX * 100}%`}</span>
         </div>
       </div>
     </section>

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -70,7 +70,7 @@ type SectionId = 'appearance' | 'titles' | 'memory' | 'notifications'
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'titles', label: 'Session titles' },
-  { id: 'memory', label: 'Memory' },
+  { id: 'memory', label: 'Save memory' },
   { id: 'notifications', label: 'Notifications' },
 ]
 
@@ -332,11 +332,11 @@ function MemoryBudget(): JSX.Element {
 
   return (
     <section className="settings-group">
-      <h3>Warm session memory</h3>
+      <h3>Save memory</h3>
       <p className="modal-note">
-        Each running session holds an agent in memory. Past this share of the machine, the sessions nobody
-        has opened for a while are let go cold — the conversation is kept and your next prompt wakes them,
-        but the terminal tab loses its scrollback.
+        Each running session holds an agent in memory. Turn this on and Helios stops the ones you have not
+        opened for a while once they pass the limit below. The conversation is kept and opening a session
+        starts it again; only the terminal tab's scrollback is lost.
       </p>
 
       {reachable.length === 0 ? (
@@ -356,10 +356,10 @@ function MemoryBudget(): JSX.Element {
                   onChange={(event) => void change(host.id, { enabled: event.target.checked })}
                 />
                 <span>
-                  Let idle sessions go cold
+                  Save memory
                   <small>
-                    Off by default. Killing a running agent and losing its terminal scrollback is your
-                    call to make.
+                    Stops the agents you have not opened lately. Opening one starts it again, with the
+                    conversation intact.
                   </small>
                 </span>
               </label>

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -547,28 +547,37 @@ function shortMode(mode: string): string {
  * What this host is carrying: its warm terminals, then the machine behind
  * them.
  *
- * The daemon reclaims nothing on its own any more, so this is the only thing
- * that tells the user the pool has grown. It belongs to the host and not the
- * window: memory is a machine's to run out of, and a session on the laptop
- * says nothing about the one on the VM.
+ * The daemon lets idle sessions go cold once the pool passes the budget, so
+ * this reads as consumed against allowed rather than against the machine. The
+ * machine's own figure stays as context: the budget is a share of it.
+ *
+ * It belongs to the host and not the window — memory is a machine's to run out
+ * of, and a session on the laptop says nothing about the one on the VM.
  */
 function HostMeter({ stats }: { stats?: HostStats }): JSX.Element | null {
   if (!stats || stats.warm === 0) return null
-  const heavy = stats.budget > 0 && stats.warm_rss > stats.budget
+  const metered = stats.budget > 0
+  const heavy = metered && stats.warm_rss > stats.budget
   const machine = stats.memory_total > 0
   return (
     <div
       className={heavy ? 'host-meter heavy' : 'host-meter'}
       title={
         heavy
-          ? `${stats.warm} warm terminals holding ${formatBytes(stats.warm_rss)} — terminate the ones you are done with to free memory`
-          : `${stats.warm} warm terminals holding ${formatBytes(stats.warm_rss)}`
+          ? `${stats.warm} warm sessions holding ${formatBytes(stats.warm_rss)} of ${formatBytes(stats.budget)} allowed — the ones you have not opened lately will go cold`
+          : metered
+            ? `${stats.warm} warm sessions holding ${formatBytes(stats.warm_rss)} of ${formatBytes(stats.budget)} allowed`
+            : `${stats.warm} warm sessions holding ${formatBytes(stats.warm_rss)} — no limit set, nothing is evicted`
       }
     >
       <Memory />
-      <span>{formatBytes(stats.warm_rss)}</span>
+      {metered ? (
+        <span>{formatPair(stats.warm_rss, stats.budget)}</span>
+      ) : (
+        <span>{formatBytes(stats.warm_rss)}</span>
+      )}
       {machine && (
-        <span className="host-machine">of {formatPair(stats.memory_used, stats.memory_total)}</span>
+        <span className="host-machine">machine {formatPair(stats.memory_used, stats.memory_total)}</span>
       )}
       <Cpu />
       <span>{Math.round(stats.load * 100)}%</span>

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -8,7 +8,7 @@ import { silenceDeviceReports } from './deviceReports.ts'
 import { linkHandler, webLinkActivate } from './links.ts'
 import { bridge } from '../bridge.ts'
 import { currentTab, store, terminalId, useStore, type Tab } from '../store.ts'
-import { canResume, hasTerminal, type Session } from '../../shared/models.ts'
+import { canResume, hasTerminal, needsRecovery, type Session } from '../../shared/models.ts'
 
 /**
  * Output arrives on one channel for every tab, so it is dispatched here rather
@@ -50,9 +50,18 @@ export function TerminalPanes({
   useEffect(() => {
     if (!visible || agent || isDetached || !hostId || !session) return
     // Warm sessions attach as soon as the panel is shown: the host is already
-    // running, so opening the tab is the whole of the request. A cold one waits
-    // for the button below, because attaching would start an agent.
+    // running, so opening the tab is the whole of the request.
+    //
+    // A cold one is now woken rather than waiting for a button. The daemon lets
+    // idle sessions go cold on its own, so most cold sessions are ones Helios
+    // took away rather than ones the user closed — and making the user click to
+    // undo that is friction Helios created. Opening the terminal is a clear
+    // enough request.
+    //
+    // Terminated is different and still needs the button: the daemon refuses
+    // prompts for one, so attaching would give a terminal that cannot be used.
     if (hasTerminal(session)) void store.openTerminal(hostId, session, false)
+    else if (needsRecovery(session)) void store.openTerminal(hostId, session, true)
   }, [visible, agent, isDetached, hostId, session])
 
   return (

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -245,7 +245,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
 function describe(tab: Tab): string {
   switch (tab.status.state) {
     case 'connecting':
-      return 'Connecting…'
+      return tab.status.detail ? `Waking — ${tab.status.detail}…` : 'Connecting…'
     case 'reconnecting':
       return tab.status.detail ? `Reconnecting — ${tab.status.detail}` : 'Reconnecting…'
     case 'closed':

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -225,6 +225,13 @@ const REFRESH_DEBOUNCE = 500
  */
 const TOUCH_INTERVAL = 2 * 60 * 1000
 
+/** Rounded hard: this lands in a toast, not in a memory readout. */
+function megabytes(bytes: number): string {
+  return bytes >= 1024 ** 3
+    ? `${(bytes / 1024 ** 3).toFixed(1)} GB`
+    : `${Math.round(bytes / 1024 ** 2)} MB`
+}
+
 /**
  * A single mutable store with manual subscription.
  *
@@ -436,6 +443,22 @@ class Store {
     switch (event.type) {
       case 'show': {
         this.applyShow(hostId, event.data)
+        return
+      }
+
+      case 'session_evicted': {
+        // Say it out loud. A session that goes cold in silence and then takes
+        // seconds to answer reads as Helios being slow, and its terminal tab
+        // coming back empty reads as lost work.
+        const project = str(event.data.project) || 'A session'
+        const freed = typeof event.data.freed === 'number' ? event.data.freed : 0
+        const unread = str(event.data.unread)
+        this.notify(
+          `${project} went cold${freed > 0 ? ` — freed ${megabytes(freed)}` : ''}` +
+            `${unread ? `, not opened for ${unread}` : ''}. Your next prompt wakes it.`,
+          'info',
+        )
+        void this.refreshHost(hostId)
         return
       }
       case 'session_status': {

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -455,7 +455,7 @@ class Store {
         const unread = str(event.data.unread)
         this.notify(
           `${project} went cold${freed > 0 ? ` — freed ${megabytes(freed)}` : ''}` +
-            `${unread ? `, not opened for ${unread}` : ''}. Your next prompt wakes it.`,
+            `${unread ? `, not opened for ${unread}` : ''}. Open it to bring it back.`,
           'info',
         )
         void this.refreshHost(hostId)
@@ -744,7 +744,10 @@ class Store {
       termId: session.session_id,
       kind: 'agent',
       title: session.title ?? session.project ?? session.session_id.slice(0, 8),
-      status: { state: 'connecting' },
+      // A wake restarts the agent and reloads its transcript, which takes
+      // seconds rather than milliseconds. Saying only "Connecting" for that
+      // long reads as a hang.
+      status: wake ? { state: 'connecting', detail: 'starting the agent' } : { state: 'connecting' },
     }
     this.set((s) => ({ tabs: [...s.tabs, tab] }))
 

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -217,6 +217,15 @@ function byActivity(a: Session, b: Session, pending: Map<string, number>): numbe
 const REFRESH_DEBOUNCE = 500
 
 /**
+ * How often a focused window re-reports the session it is showing.
+ *
+ * Two minutes against an eviction pass that runs every twenty: frequent enough
+ * that the daemon never thinks a session being read is unattended, rare enough
+ * to be invisible.
+ */
+const TOUCH_INTERVAL = 2 * 60 * 1000
+
+/**
  * A single mutable store with manual subscription.
  *
  * The app's state is small, mostly server-owned, and updated from three
@@ -265,6 +274,7 @@ class Store {
       if (status.state === 'online') void this.refreshHost(status.id)
     })
     bridge.hosts.onEvent(({ hostId, event }) => this.onServerEvent(hostId, event))
+    this.startTouchHeartbeat()
 
     bridge.term.onStatus(({ tabId, status }) => {
       this.set((s) => ({ tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, status } : t)) }))
@@ -530,6 +540,38 @@ class Store {
 
   select(hostId: string, sessionId: string): void {
     this.set({ selection: { hostId, sessionId } })
+    this.touch(hostId, sessionId)
+  }
+
+  /**
+   * Tells the daemon a human is looking at this session.
+   *
+   * The daemon decides which sessions to let go cold when memory is tight, and
+   * without this it can only see when the *agent* last ran — so a session being
+   * read right now looks the same as one nobody has opened in a day.
+   *
+   * Fire and forget. A missed sample costs one interval of accuracy.
+   */
+  touch(hostId: string, sessionId: string): void {
+    void api(hostId)
+      .touchSession(sessionId)
+      .catch(() => {
+        // Older daemon, or offline. Neither is worth telling the user about.
+      })
+  }
+
+  /**
+   * Keeps the selected session marked as watched while the window has focus.
+   *
+   * Focus is the point. A viewer count would say a socket is open, so a desktop
+   * left running overnight would pin whatever it happened to be showing.
+   */
+  private startTouchHeartbeat(): void {
+    setInterval(() => {
+      if (!document.hasFocus()) return
+      const selection = this.state.selection
+      if (selection) this.touch(selection.hostId, selection.sessionId)
+    }, TOUCH_INTERVAL)
   }
 
   setPanel(panel: RightPanel): void {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3824,7 +3824,7 @@ hr {
 
 /* The "i" beside a setting. It carries the explanation that used to sit under
    the label, so it has to be reachable by keyboard as well as hover. */
-.info {
+.info-dot {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3845,8 +3845,8 @@ hr {
   vertical-align: middle;
 }
 
-.info:hover,
-.info:focus-visible {
+.info-dot:hover,
+.info-dot:focus-visible {
   background: var(--primary);
   color: var(--on-primary);
   outline: none;
@@ -3854,7 +3854,7 @@ hr {
 
 /* Portalled to the body and placed in script, so the scrolling settings pane
    cannot clip it. */
-.info-bubble {
+.info-tip {
   position: fixed;
   z-index: 1000;
   padding: 8px 10px;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3762,6 +3762,53 @@ hr {
   margin-top: 16px;
 }
 
+/* A label, its control, and the info icon — one line per setting, so the pane
+   can be read down the left edge. */
+.setting-row {
+  display: grid;
+  grid-template-columns: 116px 1fr;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.setting-row-label {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
+.setting-row-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* The control takes the row; a swatch or a unit beside it does not. */
+.setting-row-control select,
+.setting-row-control .wide-range {
+  flex: 1;
+  min-width: 0;
+}
+
+.setting-row-unit {
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
+/* Reading a setting from a daemon is a round trip, and a section that is blank
+   until it lands is indistinguishable from one whose host is down. */
+.settings-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
 /* Which daemon this pane is talking to. */
 .settings-hostpick {
   display: flex;
@@ -3811,11 +3858,15 @@ hr {
   position: fixed;
   z-index: 1000;
   padding: 8px 10px;
-  border: 1px solid var(--outline);
+  border: 1px solid var(--outline-variant);
   border-radius: var(--r-md);
-  background: var(--surface-container-high);
+  /* Opaque in two layers. A theme's surface may carry alpha — the window is
+     glass — and a tooltip reading through to the settings behind it is the one
+     place that cannot be lived with. */
+  background-color: var(--surface);
+  background-image: linear-gradient(var(--surface-high), var(--surface-high));
   color: var(--on-surface);
-  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  box-shadow: 0 8px 24px var(--shadow-strong);
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
@@ -3955,41 +4006,8 @@ hr {
   margin-right: 8px;
 }
 
-.theme-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
-  gap: 6px;
-}
-
-.theme-chip {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border: 1px solid var(--outline-variant);
-  border-radius: var(--r-sm);
-  background: var(--surface-container);
-  color: var(--on-surface);
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.theme-chip:hover {
-  background: var(--surface-high);
-}
-
-.theme-chip.selected {
-  border-color: var(--primary);
-  background: var(--primary-container);
-  color: var(--on-primary-container);
-}
-
-/* A slice of the theme itself — a name alone does not distinguish two
-   variants of the same palette. */
+/* A slice of the theme itself, beside the closed dropdown — a name alone does
+   not distinguish two variants of the same palette. */
 .theme-swatch {
   display: flex;
   flex: 0 0 auto;
@@ -4004,10 +4022,6 @@ hr {
   flex: 1;
 }
 
-.theme-picker + .ghost {
-  margin-top: 14px;
-}
-
 .theme-swatch.inherit {
   background: repeating-linear-gradient(
     45deg,
@@ -4016,13 +4030,13 @@ hr {
   );
 }
 
-/* Wider than a theme swatch and in the window's own proportions: these are
-   scale models of the backdrop, and a gradient judged in a 40px strip is not
-   the one that ends up behind the app. */
+/* Wider than a theme swatch and in the window's own proportions: this is a
+   scale model of the backdrop, and a gradient judged in a 40px strip is not the
+   one that ends up behind the app. */
 .backdrop-swatch {
   flex: 0 0 auto;
-  width: 52px;
-  height: 30px;
+  width: 44px;
+  height: 22px;
   border-radius: 4px;
   border: 1px solid var(--outline-variant);
 }
@@ -4037,21 +4051,7 @@ hr {
   );
 }
 
-.backdrop-slider {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 8px;
-  font-size: 12px;
-  color: var(--on-surface-variant);
-}
-
-.backdrop-slider > span {
-  flex: 0 0 46px;
-}
-
-.backdrop-slider input {
-  flex: 1;
+.wide-range {
   accent-color: var(--primary);
 }
 
@@ -4059,7 +4059,6 @@ hr {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 8px;
 }
 
 /* The platform draws the swatch inside a colour input and will not be told

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3762,6 +3762,132 @@ hr {
   margin-top: 16px;
 }
 
+/* Which daemon this pane is talking to. */
+.settings-hostpick {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.settings-hostpick select {
+  flex: 1;
+  min-width: 0;
+}
+
+/* The "i" beside a setting. It carries the explanation that used to sit under
+   the label, so it has to be reachable by keyboard as well as hover. */
+.info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--on-surface) 14%, transparent);
+  color: var(--on-surface);
+  font-size: 10px;
+  font-style: italic;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  /* Not part of the sentence it follows: the label is what gets read. */
+  user-select: none;
+  vertical-align: middle;
+}
+
+.info:hover,
+.info:focus-visible {
+  background: var(--primary);
+  color: var(--on-primary);
+  outline: none;
+}
+
+/* Portalled to the body and placed in script, so the scrolling settings pane
+   cannot clip it. */
+.info-bubble {
+  position: fixed;
+  z-index: 1000;
+  padding: 8px 10px;
+  border: 1px solid var(--outline);
+  border-radius: var(--r-md);
+  background: var(--surface-container-high);
+  color: var(--on-surface);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+/* The memory budget. A share of the machine, so the readout above the track
+   spends it in gigabytes — "a quarter" means nothing until it says 8 GB. */
+.budget-slider {
+  margin: 14px 0 4px 26px;
+}
+
+.budget-slider.disabled {
+  opacity: 0.45;
+}
+
+.budget-readout {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.budget-readout strong {
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+}
+
+.budget-slider input[type='range'] {
+  width: 100%;
+  height: 20px;
+  margin: 4px 0 0;
+  padding: 0;
+  background: transparent;
+  /* The platform control cannot be recoloured, and its default blue is the one
+     thing in the dialog that ignores the theme. */
+  appearance: none;
+}
+
+.budget-slider input[type='range']::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--on-surface) 18%, transparent);
+}
+
+.budget-slider input[type='range']::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  /* Half the thumb above the 4px track, so it rides centred on it. */
+  margin-top: -6px;
+  border: none;
+  border-radius: 50%;
+  background: var(--primary);
+}
+
+.budget-slider input[type='range']:enabled::-webkit-slider-thumb {
+  cursor: grab;
+}
+
+.budget-slider input[type='range']:active::-webkit-slider-thumb {
+  cursor: grabbing;
+}
+
+.budget-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+
 .title-prompt {
   margin-top: 14px;
 }
@@ -3792,18 +3918,11 @@ hr {
   font-weight: 600;
 }
 
+/* One line per setting: the explanation lives on the info icon, so nothing
+   below the label pushes the next row down. */
 .settings-group .check {
-  align-items: flex-start;
+  align-items: center;
   margin-top: 10px;
-}
-
-.settings-group .check span {
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-group .check small {
-  color: var(--on-surface-variant);
 }
 
 /* ─── Theme picker ──────────────────────────────────────────────────────── */
@@ -3824,7 +3943,8 @@ hr {
 }
 
 .theme-picker-label {
-  display: block;
+  display: flex;
+  align-items: center;
   font-size: 12px;
   color: var(--on-surface-variant);
   margin-bottom: 6px;

--- a/docs/specs/42-cold-sessions.md
+++ b/docs/specs/42-cold-sessions.md
@@ -156,12 +156,19 @@ candidate it could.
 | Setting | Default | Meaning |
 |---------|---------|---------|
 | `memory.budget_fraction` | `0.25` | Share of total RAM the warm pool may hold |
-| `memory.evict` | `true` | Turn eviction off entirely |
+| `memory.evict` | `false` | **Opt-in.** Nothing is evicted until this is turned on |
 
 A fraction, not megabytes: the same install runs on a 16 GB laptop and a 64 GB
 desktop.
 
+**Eviction is off until asked for.** It kills a running agent and takes its
+scrollback, and it reverses a decision made twice before. Upgrading should not
+start doing that to somebody's machine — they should choose it, having read
+what it costs. The budget only takes effect once the switch is on.
+
 ```
+[ ] Let idle sessions go cold        off by default
+
 Warm session memory
   ( ) Quarter of RAM   8.0 GB      recommended
   ( ) Half of RAM      16.0 GB
@@ -231,8 +238,9 @@ machine explain itself.
 - **Reversing a recent decision.** Two commits removed this. If the ratio above
   ever stops holding — a much larger ring, or scrollback that stops duplicating
   the transcript — the argument collapses and this should go again.
-- **The budget becoming real on upgrade.** Nobody has felt this number. Hence
-  `memory.evict`, and hence the notification.
+- **The budget becoming real on upgrade.** Nobody has felt this number, so
+  nothing happens until `memory.evict` is turned on — and the eviction event is
+  announced when it does.
 - **A status that means "idle but mid-something".** If one is ever added and not
   put on the never-evict list, work is lost.
 
@@ -246,7 +254,8 @@ machine explain itself.
 - equal size: the longer-unread session is chosen
 - equal time: the larger session is chosen
 - no `last_interacted_at` falls back to `last_event_at`, not to "just now"
-- `memory.evict=false` evicts nothing under any pressure
+- `memory.evict` unset evicts nothing under any pressure, and only the exact
+  string "true" enables it
 - an evicted session keeps its status; nothing writes `terminated`
 - `TouchSession` moves a session out of the candidate set
 - the fraction round-trips, and an absent setting resolves to `0.25`

--- a/docs/specs/42-cold-sessions.md
+++ b/docs/specs/42-cold-sessions.md
@@ -167,14 +167,20 @@ start doing that to somebody's machine — they should choose it, having read
 what it costs. The budget only takes effect once the switch is on.
 
 ```
-[ ] Let idle sessions go cold        off by default
+Save memory                          [ ]  off by default
+  Stops the agents you have not opened lately.
 
-Warm session memory
+Use up to
   ( ) Quarter of RAM   8.0 GB      recommended
   ( ) Half of RAM      16.0 GB
   ( ) Three quarters   24.0 GB
   ( ) No limit                     nothing is ever evicted
 ```
+
+The setting is named for what it does for the user, not for the mechanism.
+"Cold", "evict" and "warm pool" are how this is discussed in the code and in
+this spec; the switch says **Save memory**, because that is the reason somebody
+would turn it on.
 
 The resolved size is shown beside each option. "A quarter" means nothing until
 it says 8 GB.

--- a/docs/specs/42-cold-sessions.md
+++ b/docs/specs/42-cold-sessions.md
@@ -93,9 +93,15 @@ were about to return to while the machine has twenty gigabytes free, and charges
 a context reload for nothing. Under pressure the question is not "is this old?"
 but "which can I most afford to lose?".
 
-It runs on the existing 20-minute pass. The machine may therefore sit over
-budget for up to twenty minutes, which is acceptable: this reclaims memory, it
-does not prevent an out-of-memory condition.
+It runs on a 2-minute pass of its own, not on the 20-minute stale-terminal
+reaper. Sharing that tick left the machine sitting over budget for up to
+nineteen minutes while the user watched it swap. The check itself is a map the
+host already keeps and one query, so it is cheap enough to run often; the
+reaper is slow because it probes sockets and re-reads transcripts.
+
+Evicting more often does not make it flappy: a session must have gone unread for
+`minIdleBeforeEvict` before it is a candidate at all, so one just woken is out of
+reach for five minutes regardless of how often the pass runs.
 
 ### The signal is when *you* last looked
 

--- a/docs/specs/42-cold-sessions.md
+++ b/docs/specs/42-cold-sessions.md
@@ -1,0 +1,276 @@
+# Cold Sessions: Enforce the Memory Budget
+
+## Read this first: eviction was removed twice, on purpose
+
+Do not treat this as a missing feature. It existed, and two commits took it out:
+
+| Commit | What it removed | Stated reason |
+|--------|-----------------|---------------|
+| `00acdc9` *stop evicting warm sessions on a timer* | the idle TTL | "age is not evidence that nobody wants it, and an eviction costs the host's scrollback ring, which `claude --resume` does not bring back" |
+| `a87a893` / #86 *report what sessions cost instead of evicting them* | the LRU at twenty hosts or a quarter of memory | "an eviction costs the host's scrollback, which no `--resume` brings back, and it happened to whichever session the user had not looked at lately" |
+
+The `budget` in `hostStats()` is not an unenforced intention. It is what is left
+of the removed feature, kept so clients can display a number.
+
+This spec reverses those two commits. It does so because of one measurement
+neither of them states, not because they were forgotten.
+
+### Why the objection no longer holds
+
+Both removals rest on the cost of losing the host's scrollback ring. That ring
+is **1 MiB** — `internal/terminal/ring.go:8`, `DefaultRingSize = 1 << 20` — and
+it already discards its oldest bytes; `host_test.go` has a case named for it.
+
+Against that, an evicted session frees the whole `claude` process. On the
+machine this was written on, the two live sessions were **786 MB** and
+**744 MB**.
+
+So the trade is roughly **1 MiB of already-truncating terminal output against
+800 MB of resident memory**, and the megabyte is a *rendering of data that
+survives anyway*:
+
+```
+what a cold session actually loses
+
+  transcript (.jsonl)   survives   →  the agent panel has the whole history
+  permission mode       survives   →  ResumeArgs replays it
+  conversation state    survives   →  claude --resume reloads it
+  terminal scrollback   lost       →  a redraw of the above, ≤1 MiB, already lossy
+```
+
+Waking reattaches, and `claude --resume` draws its own UI from the conversation.
+The terminal is not left blank; it is left without the previous rendering for
+the moment before the agent redraws.
+
+### Two things a future change should not do
+
+**Do not snapshot the ring to disk to "solve" this.** An earlier draft of this
+spec proposed writing the 1 MiB out on eviction and replaying it on wake. It is
+unnecessary — the scrollback duplicates the transcript — and it invites an
+argument about whether the replay is faithful. The honest position is that the
+scrollback was never worth the process.
+
+**Do not mark an evicted session `terminated`.** The tmux-era reaper did exactly
+that — `db.UpdateSessionStatus(sessionID, "terminated", "StaleReaper")` — which
+was a dead end for the session. `ed20e16` fixed it, and `reaper.go` states the
+model that must hold:
+
+> Losing a terminal does not end a session. Under the warm pool cold is a normal
+> state… Only claude itself, through the SessionEnd hook, terminates a session.
+
+That fix is **not** why eviction was removed. Reinstating eviction must not
+reinstate the bug.
+
+## Problem
+
+A session holds a `helios ptyhost`, which holds a running `claude`. Nothing
+bounds how many are resident. A machine used for a day holds every agent it has
+started, most untouched for hours.
+
+## What already exists
+
+This spec adds a policy. Nearly all the machinery is in place.
+
+| Piece | Where |
+|-------|-------|
+| Kill a terminal, keep the session | `backend.Backend.Kill` → `dropMirror` + `Registry.Evict` |
+| Cold is a normal state | `internal/daemon/reaper.go:18` |
+| Bring one back | `POST /api/sessions/{id}/resume`; any prompt wakes a cold session |
+| Per-session memory | `Host.Usage() map[string]int64` |
+| Pool total and budget | `Host.Status()`, `hostStats()` |
+| Resume in the same mode | `Session.PermissionMode` + `ResumeArgs` |
+| A 20-minute pass to hang this on | `daemon.go:254` |
+| Activity timestamps on the registry | `Registry.Touch`, `entry.lastActive` — kept when `InUse` and `MaxWarm` were deleted |
+
+## Design
+
+### Pressure, not age
+
+Eviction runs only when warm memory exceeds the budget.
+
+`00acdc9` is right that age is not evidence. A time-to-live kills a session you
+were about to return to while the machine has twenty gigabytes free, and charges
+a context reload for nothing. Under pressure the question is not "is this old?"
+but "which can I most afford to lose?".
+
+It runs on the existing 20-minute pass. The machine may therefore sit over
+budget for up to twenty minutes, which is acceptable: this reclaims memory, it
+does not prevent an out-of-memory condition.
+
+### The signal is when *you* last looked
+
+`last_event_at` records what the agent did. Nothing records what the human did,
+so a session you read thirty seconds ago looks identical to one you have not
+opened in a day.
+
+A new `last_interacted_at` on `sessions` records attention:
+
+| Written when | By |
+|--------------|-----|
+| a session is selected | desktop, mobile |
+| its session is in front and the window is focused | desktop, on a slow heartbeat |
+| a prompt is sent, or a file or diff is opened in it | any client |
+
+Focus is what makes this better than the `Registry.InUse` check `00acdc9` added
+and `a87a893` deleted. A viewer count says a socket is open, so a desktop left
+running on one session pinned it warm forever. A focused heartbeat stops
+counting when the app is in the background.
+
+### Only `idle` may be evicted
+
+| Status | Evict? | Why |
+|--------|--------|-----|
+| `idle` | **yes** | nothing is running and nobody is blocked |
+| `active`, `starting`, `compacting` | no | the agent is mid-turn |
+| `waiting_permission`, `waiting_input` | no | **you** are the blocker; killing it discards the question |
+| terminated, archived | n/a | no terminal to take |
+
+Pinned sessions are spared. Pinning already means "I am coming back to this".
+
+A session must also have gone uninteracted for at least five minutes, so one
+cannot be evicted moments after it is woken.
+
+### Choosing a victim
+
+```
+score = rss * max(minutes_since_last_interacted, 1)
+```
+
+Multiplied, not divided. Dividing ranks a large session read a minute ago above
+one nobody has opened all day, which is backwards — an earlier draft of this
+spec had it that way and the tests caught it.
+
+Highest score is evicted first: expensive to hold, and long unread. A session
+with no `last_interacted_at` falls back to `last_event_at`, which makes it a
+strong candidate — correctly, since no client has ever shown it.
+
+This is cost-benefit, not recency. A 900 MB session nobody has opened for two
+hours frees far more than a 200 MB session read ten minutes ago, and is the less
+likely of the two to be wanted next.
+
+Eviction stops as soon as the pool is under budget. It does not evict every
+candidate it could.
+
+### The budget is a setting
+
+| Setting | Default | Meaning |
+|---------|---------|---------|
+| `memory.budget_fraction` | `0.25` | Share of total RAM the warm pool may hold |
+| `memory.evict` | `true` | Turn eviction off entirely |
+
+A fraction, not megabytes: the same install runs on a 16 GB laptop and a 64 GB
+desktop.
+
+```
+Warm session memory
+  ( ) Quarter of RAM   8.0 GB      recommended
+  ( ) Half of RAM      16.0 GB
+  ( ) Three quarters   24.0 GB
+  ( ) No limit                     nothing is ever evicted
+```
+
+The resolved size is shown beside each option. "A quarter" means nothing until
+it says 8 GB.
+
+### Mobile needs almost nothing
+
+An evicted session already renders correctly on the phone. `a87a893` added the
+reporting side to mobile when it removed eviction, and it is still there:
+
+| Already present | Where |
+|-----------------|-------|
+| `needsRecovery`, and `hasTerminal` | `mobile/lib/models/session.dart:110` |
+| An amber "Cold — tap to resume" chip on the card | `sessions_screen.dart:735` |
+| The same state in the detail header | `session_detail_screen.dart:854` |
+| Per-session memory, blank when cold | `Session.memoryLabel` |
+
+So the only mobile work is the **setting**. The budget belongs to a daemon, not
+to a device, and `settings_screen.dart` already reads and writes daemon settings
+through `getSettings` / `updateSettings`. Without it you can watch a session go
+cold from your phone and have to walk to the machine to change the budget.
+
+Mobile deliberately gets **no eviction notification**. The card already flips to
+cold, and a push about memory on a machine you are not sitting at is noise. The
+notification is desktop and TUI only.
+
+### Announce it
+
+Broadcast `session_updated`, as a dying terminal already does, plus a
+notification:
+
+```
+opal-app went cold — freed 840 MB
+Not opened for 2h. Your next prompt wakes it.
+```
+
+A session that quietly goes cold and then takes eight seconds to answer reads as
+Helios being slow. One line prevents that, and makes the first eviction on any
+machine explain itself.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `internal/store/store.go` | `last_interacted_at` column on `sessions` |
+| `internal/store/sessions.go` | `TouchSession`, and the column in the read path |
+| `internal/server/api.go` | `POST /api/sessions/{id}/touch`; `hostStats()` uses the configured budget |
+| `internal/store/settings.go` | `memory.budget_fraction`, `memory.evict` |
+| `internal/daemon/evict.go` | new. Candidate filter, scoring, the loop |
+| `internal/daemon/reaper.go` | call it from the existing pass |
+| `desktop/.../store.ts` | touch on selection, and on a focused heartbeat |
+| `desktop/.../settings.tsx`, `internal/tui/general_settings.go` | the budget control |
+| `mobile/lib/screens/settings_screen.dart` | the same budget control; the cold state is already shown |
+
+`backend.Backend` needs nothing new.
+
+## Risks
+
+- **Evicting something being read.** `last_interacted_at` is the mitigation. The
+  failure mode is a client that never reports it, making a session a permanent
+  candidate — tolerable only because the conversation survives.
+- **Reversing a recent decision.** Two commits removed this. If the ratio above
+  ever stops holding — a much larger ring, or scrollback that stops duplicating
+  the transcript — the argument collapses and this should go again.
+- **The budget becoming real on upgrade.** Nobody has felt this number. Hence
+  `memory.evict`, and hence the notification.
+- **A status that means "idle but mid-something".** If one is ever added and not
+  put on the never-evict list, work is lost.
+
+## Testing
+
+- only `idle` is a candidate; `waiting_permission` is never chosen even when it
+  is the largest and longest unread
+- pinned sessions are skipped
+- a session interacted with inside the minimum age is skipped
+- eviction stops as soon as it is under budget
+- equal size: the longer-unread session is chosen
+- equal time: the larger session is chosen
+- no `last_interacted_at` falls back to `last_event_at`, not to "just now"
+- `memory.evict=false` evicts nothing under any pressure
+- an evicted session keeps its status; nothing writes `terminated`
+- `TouchSession` moves a session out of the candidate set
+- the fraction round-trips, and an absent setting resolves to `0.25`
+
+## Implementation order
+
+1. `last_interacted_at`, `TouchSession`, and clients reporting it. Nothing
+   evicts. Let it run, and check the timestamps match what you would have
+   chosen yourself.
+2. `internal/daemon/evict.go` — pure functions over a candidate list. No
+   backend, no database, all the policy, all the tests.
+3. Settings, and `hostStats()` reporting the configured budget.
+4. Wire into the reaper pass.
+5. The notification.
+6. Desktop, TUI and mobile controls.
+
+Step 1 first on purpose: the signal the policy rests on should be collected and
+sanity-checked before anything kills a process with it.
+
+## Open
+
+**Total RAM or free RAM?** A quarter of total is predictable. A share of free
+adapts to whatever else is running, but the budget then moves under the user.
+
+**Should the desktop touch on scroll?** Selection plus a focused heartbeat may
+be enough. Reading a long transcript without clicking is the case that would
+slip through.

--- a/docs/specs/42-cold-sessions.md
+++ b/docs/specs/42-cold-sessions.md
@@ -61,6 +61,23 @@ model that must hold:
 That fix is **not** why eviction was removed. Reinstating eviction must not
 reinstate the bug.
 
+**Not writing `terminated` is not enough on its own.** The quotation above reads
+like a safeguard and is in fact the hole. Killing the host kills the agent, and
+the agent runs its own exit hook on the way down: for Claude, `SessionEnd` calls
+`UpdateSessionStatus(id, "terminated", "SessionEnd")`, and the store stamps
+`ended_at` whenever the status becomes terminated. So an eviction that touches
+nothing still ends up filed as archived, by a path one call removed from itself.
+This was not theoretical — it happened on a real machine to five sessions before
+it was caught.
+
+The exit therefore has to carry intent. `backend.Evicter` marks the session
+before the kill; `SessionEnd` consumes the mark and, finding it, drops the
+terminal mapping and leaves the status, `ended_at` and the `session_end` report
+alone. The mark is consumed rather than merely read, so a session evicted, woken
+and later quit for real still terminates properly.
+
+Terminated is the archival state a person chooses. Cold is not a kind of ended.
+
 ## Problem
 
 A session holds a `helios ptyhost`, which holds a running `claude`. Nothing

--- a/docs/specs/43-shared-resource-leases.md
+++ b/docs/specs/43-shared-resource-leases.md
@@ -1,0 +1,476 @@
+# Shared Resource Leases: One Docker Stack, Many Agents
+
+## Problem
+
+A project has one shared thing that only one agent can use at a time. The case
+that prompted this is the `opal-app` docker stack. To test a change, an agent
+must check out its branch, bring the stack up, and wait for it to be healthy.
+
+Two agents that do this at once destroy each other's test run. The second
+checkout moves the working tree under the first agent's feet. Neither agent can
+see the other, so neither can wait for it.
+
+Today the only fix is the human. The human remembers who is testing, and tells
+the other sessions to hold. That does not scale past two sessions, and it fails
+completely when the human is not watching.
+
+The daemon is the only process that sees every session. It must own this.
+
+## What already exists
+
+This spec adds a scheduler. Most of the parts are already built.
+
+| Piece | Where |
+|-------|-------|
+| Per-session MCP tools, caller identity included | `internal/mcp/tools.go`, `call(sessionID, args)` |
+| Block an agent until something answers | `notifications.Manager.Register` + `WaitForDecision` |
+| Ask a human on the terminal, phone and desktop at once | `internal/hitl`, `notify.Show` |
+| Push state to every client | `server.SSEBroadcaster` |
+| Detect a dead terminal | `daemon.reapStaleSessions` |
+| Wake a cold session with a prompt | `POST /api/sessions/{id}/resume`; spec 42 |
+| Run a command in a watchable terminal | `internal/terminal`, `internal/backend` |
+
+Nothing here needs a new transport, a new database, or a new UI shell.
+
+## Design
+
+### Shape
+
+```
+   agent A            agent B            agent C            human
+      │                  │                  │                 │
+  helios_lease      helios_lease       helios_lease      desktop queue
+      │                  │                  │                 │
+      └──────────────────┴───────┬──────────┴─────────────────┘
+                                 │
+                        ┌────────▼─────────┐
+                        │  lease manager   │   ordering, clocks, grants
+                        │  internal/lease  │
+                        └────┬────────┬────┘
+                             │        │
+             ┌───────────────┘        └────────────────┐
+             │                                         │
+    ┌────────▼─────────┐                     ┌─────────▼────────┐
+    │ resource runner  │                     │  SSE + HITL      │
+    │ git switch       │                     │  queue to every  │
+    │ docker up        │                     │  client, prompts │
+    │ health wait      │                     │  to the holder   │
+    └────────┬─────────┘                     └──────────────────┘
+             │
+    ┌────────▼─────────┐
+    │  opal-app stack  │
+    └──────────────────┘
+```
+
+The agent never runs `git checkout` or `docker compose up`. The daemon runs
+them. There are two reasons. The switch must be idempotent across agents, and
+the second agent that wants the branch already up must skip it. An agent cannot
+know that; the daemon can.
+
+### Capacity, not a lock
+
+A resource has a **capacity**: how many branches it can host at once. A lock is
+the case where capacity is 1.
+
+Capacity in v1 is 1. The schema still carries a `slot` column. This is the only
+forward-looking piece in this spec, and it is here because the grant query is
+the hard part to retrofit. Adding a column later is cheap. Rewriting the
+scheduler later is not.
+
+```
+resource opal-docker  (capacity 2, illustration only — v1 ships capacity 1)
+
+  slot 0   branch feat/checkout-fix    holders: sess-a (write)
+  slot 1   branch main                 holders: sess-b (read), sess-c (read)
+```
+
+### Two levels of sharing
+
+Do not confuse them.
+
+- **Slots** are separate stacks. Each slot runs one branch. Capacity bounds them.
+- **Sharers** are agents inside one slot. They all use the same branch and the
+  same containers.
+
+A lease is granted onto slot S when either condition holds:
+
+1. Slot S has no holders. The runner switches it to the requested branch.
+2. Slot S already runs the requested branch, the new lease is `mode=read`, and
+   every current holder of S is `mode=read`.
+
+A writer never shares. A writer runs migrations, resets fixtures, or seeds data,
+and a reader that sees that mid-run gets a false failure.
+
+Rule 2 is the largest win in practice. Several agents often test the same
+branch. Today the second one waits for a rebuild it does not need.
+
+### The daemon owns the switch
+
+A resource is configuration, not code:
+
+```yaml
+resources:
+  opal-docker:
+    root: ~/workspace/opal-app
+    setup: make test-stack-up BRANCH=${branch}
+    health: curl -fsS localhost:3000/healthz
+    teardown: make test-stack-down
+    capacity: 1
+    hold_ttl: 20m
+    idle_ttl: 5m
+    setup_deadline: 5m
+```
+
+The runner executes `setup` in a Helios-owned terminal, not a bare `exec.Cmd`.
+A stack build takes minutes and it fails often. The human must be able to watch
+it, and the desktop app can already show a terminal.
+
+### Four clocks, four different failures
+
+Each clock exists for one failure. Do not merge them.
+
+| Clock | The failure it catches | On expiry |
+|---|---|---|
+| Setup deadline | A branch that will never build blocks the whole queue | Fail the grant. Requeue that lease at the back. Grant the next waiter. |
+| Liveness | The holder's session died | Release at once |
+| Idle | The agent took the lease, then went to do something else | Warn once, then release |
+| Hold TTL | The agent tests forever | Escalate. See below. |
+
+```
+  acquire        granted                                     TTL
+    │               │                                         │
+    ├── queued ─────┼──────────── held ───────────────────────┼──────►
+    │               │                                         │
+    │◄─ setup ─────►│◄── idle clock resets on holder activity ┤
+    │   deadline    │                                         │
+    │               │                              queue empty ──► extend, silent
+    │               │                              queue busy  ──► prompt holder
+    └── liveness: the reaper releases at any point in this line
+```
+
+### Pressure exists only when someone waits
+
+This is the rule that makes the TTL humane, and it is the one to preserve if the
+rest of this spec changes.
+
+When the hold TTL expires and the queue is empty, the lease extends itself.
+Nothing is announced. Nobody is waiting, so the expiry means nothing.
+
+When the hold TTL expires and someone is queued, the daemon asks. It raises a
+HITL prompt on the holder's terminal and a notification on the phone:
+
+```
+┌─ opal-docker ─────────────────────────────────┐
+│ Held 20m on feat/checkout-fix. 2 sessions     │
+│ are waiting.                                  │
+│                                               │
+│   > Extend 10 minutes                         │
+│     Release now                               │
+│                                               │
+│ ↑↓ select · enter confirm · esc cancel        │
+└───────────────────────────────────────────────┘
+```
+
+An unanswered prompt releases the lease after 2 minutes. An agent that is
+really testing will answer. An agent that cannot answer is the case the release
+is for.
+
+Never kill a test run without asking first.
+
+### Ordering
+
+Order is `(priority ASC, enqueued_at ASC)`. Position is computed by that query.
+It is never stored.
+
+Human reordering writes `priority` and nothing else. This keeps drag-and-drop
+from fighting the scheduler, and it makes the reorder a single-row update that
+any surface can perform.
+
+There is no automatic aging in v1. A human who can reorder can also starve
+someone by accident. The fix is to show the wait time in the UI, not to add a
+second scheduler that argues with the first.
+
+### A human is a holder too
+
+The human can take a lease with no session behind it. It is released by hand.
+
+Without this, an agent takes the stack while you are testing in a browser and
+your session dies mid-click. This is a small feature and it is not optional.
+
+### A holder must not be evicted
+
+This meets spec 42 directly.
+
+`evictionCandidates` in `internal/daemon/evict.go` treats every `idle` session as
+a candidate. A session that holds a lease is often `idle` — the agent is
+waiting while a human clicks through the app. Evicting it kills `claude`, which
+releases the lease, which tears the stack down under the human.
+
+Exclude lease **holders** from eviction.
+
+Do not exclude **queued** sessions. A queued session is the best eviction victim
+in the pool: it is doing nothing, it will do nothing for minutes, and the grant
+already wakes it. Waiting on a queue should make a session *more* likely to go
+cold, not less.
+
+### Waiting without spending tokens
+
+An agent must never poll. Polling costs a turn per check and fills the context
+with nothing.
+
+There are two waits, and the length decides which one runs.
+
+**Short wait — block inside the tool call.** `helios_lease` does not return until
+the stack is up. The agent's turn is suspended. It spends no tokens. This is the
+same mechanism a blocking permission hook already uses, and that one routinely
+waits minutes for a phone tap.
+
+**Long wait — go cold and get woken.** MCP clients time out a tool call. So
+`acquire` takes `wait_seconds`, defaulting below that timeout. If the grant has
+not landed by then, the call returns `queued` with a position, and the turn ends.
+The session is then a normal idle session; the pool may evict it. On grant, the
+daemon sends the session a prompt, which wakes it if cold.
+
+```
+ agent A                daemon                      agent B
+    │                     │                            │
+    │ acquire(feat/x)     │                            │
+    ├────────────────────►│ slot free → starting       │
+    │                     ├── git switch, docker up    │
+    │                     │   health ok → held         │
+    │◄── granted ─────────┤                            │
+    │                     │        acquire(feat/y)     │
+    │  ...testing...      │◄───────────────────────────┤
+    │                     │ queued, pos 1              │
+    │                     ├───────────────────────────►│
+    │                     │            (turn ends, B may go cold)
+    │ release             │                            │
+    ├────────────────────►│ slot free → starting       │
+    │                     ├── git switch, docker up    │
+    │                     │   health ok → held         │
+    │                     │  prompt: "opal-docker is   │
+    │                     │  ready on feat/y"          │
+    │                     ├───────────────────────────►│ wakes, continues
+```
+
+A third agent that asks for `feat/x` while A holds it is granted immediately as
+a sharer, and the middle of this diagram does not run.
+
+### Lease states
+
+```
+                  ┌──────────┐
+      acquire ───►│  queued  │
+                  └────┬─────┘
+       cancelled ◄─────┤ (human, or caller gone)
+                       │ scheduler picks it
+                  ┌────▼─────┐
+                  │ starting │  runner: switch, up, health
+                  └────┬─────┘
+            failed ◄───┤ setup deadline, or health never passes
+                       │           (requeued at the back, once)
+                  ┌────▼─────┐
+                  │   held   │◄── extend
+                  └────┬─────┘
+                       │ release, idle expiry, TTL escalation, session death
+                  ┌────▼─────┐
+                  │ released │
+                  └──────────┘
+```
+
+## The tool surface
+
+One tool, not four. The registry has three tools today and each one earns its
+place. Follow the `helios_show` pattern: one discriminator, and errors that
+correct the agent so it can retry without a human.
+
+```
+helios_lease(
+  action:    acquire | release | extend | status
+  resource:  "opal-docker"
+  branch:    "feat/checkout-fix"      # acquire only
+  mode:      read | write             # default read
+  reason:    "testing the new cart"   # shown to the human in the queue
+  wait_seconds: 25                    # acquire only
+)
+```
+
+The caller's `sessionID` is implicit, exactly as it is for `helios_show`. This
+gives ownership for free. It also means `release` is not load-bearing: the
+reaper releases on session death, and the `SessionEnd` hook releases on a clean
+exit. A forgotten `release` costs the idle timeout, not the day.
+
+`status` returns the queue as the human sees it, so an agent can say "I am
+second, behind the payments session" instead of going quiet.
+
+## Desktop
+
+One panel per resource. It reads the same SSE events every other client reads.
+
+```
+┌─ opal-docker ──────────────────────── open ── [drain] [hold for me] ─┐
+│                                                                       │
+│  HOLDING   feat/checkout-fix                                          │
+│    sess-a  "cart regression"       write   14m held · 6m left  [end]  │
+│                                                                       │
+│  WAITING                                                              │
+│  1 sess-d  main                    read     8m waited  [top] [drop]   │
+│  2 sess-b  feat/search-rank        write    3m waited  [top] [drop]   │
+│                                                                       │
+│  stack:  building ──────────────►  healthy      [watch terminal]      │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+`drain` stops new grants without disturbing the holder. Use it before you take
+the machine back. `hold for me` is the human lease.
+
+Mobile gets the read-only view and the TTL prompt. It already receives the
+notification.
+
+## Data model
+
+```sql
+CREATE TABLE resources (
+  name              TEXT PRIMARY KEY,
+  root              TEXT NOT NULL,
+  setup_cmd         TEXT NOT NULL,
+  health_cmd        TEXT NOT NULL DEFAULT '',
+  teardown_cmd      TEXT NOT NULL DEFAULT '',
+  capacity          INTEGER NOT NULL DEFAULT 1,
+  hold_ttl_s        INTEGER NOT NULL DEFAULT 1200,
+  idle_ttl_s        INTEGER NOT NULL DEFAULT 300,
+  setup_deadline_s  INTEGER NOT NULL DEFAULT 300,
+  state             TEXT NOT NULL DEFAULT 'open',   -- open | draining
+  created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE resource_slots (
+  resource   TEXT NOT NULL,
+  slot       INTEGER NOT NULL,
+  branch     TEXT NOT NULL DEFAULT '',
+  state      TEXT NOT NULL DEFAULT 'empty',  -- empty | starting | up | failed
+  PRIMARY KEY (resource, slot)
+);
+
+CREATE TABLE leases (
+  id             TEXT PRIMARY KEY,
+  resource       TEXT NOT NULL,
+  slot           INTEGER,                    -- null until granted
+  session_id     TEXT NOT NULL DEFAULT '',   -- empty means a human hold
+  holder_label   TEXT NOT NULL DEFAULT '',
+  branch         TEXT NOT NULL,
+  mode           TEXT NOT NULL DEFAULT 'read',
+  state          TEXT NOT NULL,              -- queued|starting|held|released|failed|cancelled
+  priority       INTEGER NOT NULL DEFAULT 0,
+  reason         TEXT NOT NULL DEFAULT '',
+  enqueued_at    TEXT NOT NULL,
+  granted_at     TEXT,
+  expires_at     TEXT,
+  touched_at     TEXT,
+  released_at    TEXT,
+  release_source TEXT
+);
+
+CREATE INDEX leases_queue ON leases(resource, state, priority, enqueued_at);
+```
+
+`touched_at` is written by the hook that already fires on tool use
+(`internal/daemon/hooks.go`). The idle clock needs no new plumbing.
+
+## HTTP API
+
+| Route | Purpose |
+|---|---|
+| `GET /api/resources` | List resources, slots, and current holders |
+| `GET /api/resources/{name}/queue` | Holders and waiters, ordered |
+| `POST /api/resources/{name}/leases` | Enqueue. Used by MCP and by the CLI |
+| `POST /api/resources/{name}/drain` | Stop granting. Toggle |
+| `POST /api/resources/{name}/hold` | Human lease |
+| `POST /api/leases/{id}/extend` | Extend the TTL |
+| `POST /api/leases/{id}/priority` | Human reorder |
+| `DELETE /api/leases/{id}` | Cancel if queued, release if held |
+
+SSE: `resource_updated` and `lease_updated`. Both carry the whole queue for that
+resource. The queue is small, and a client that reconstructs order from deltas
+will get it wrong.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `internal/lease/` (new) | Manager, scheduler, clocks, waiters |
+| `internal/lease/runner.go` (new) | Switch, up, health, in a Helios terminal |
+| `internal/store/leases.go` (new) | Tables and queries above |
+| `internal/mcp/tools.go` | Add `helios_lease`; add it to `toolOrder` |
+| `internal/server/` | Routes and SSE events above |
+| `internal/daemon/evict.go` | Exclude holders from `evictionCandidates` |
+| `internal/daemon/reaper.go` | Release leases for sessions that lost a terminal |
+| `internal/daemon/hooks.go` | Update `touched_at`; release on `SessionEnd` |
+| `desktop/src/` | Queue panel |
+| `mobile/lib/` | Read-only queue, TTL prompt |
+
+The waiter registry copies the shape of `notifications.Manager` — register the
+slot before publishing, buffer of one — but not its code. A grant is not a
+notification. It has no human decision in the normal path and it writes no
+notification row.
+
+## Risks
+
+| Risk | Response |
+|---|---|
+| The queue deadlocks and every agent stalls | Every wait has a clock. No path waits forever. `drain` plus force-release is the manual override |
+| A half-built stack is reported healthy | The health command decides, not the setup exit code. A slot with no health command is `up` on exit 0, and that is the operator's choice |
+| The runner and a human both run `git checkout` | The runner refuses to switch a dirty tree, and reports which files are dirty. It does not stash |
+| Coalesced readers interfere anyway | `mode=write` is the escape hatch, and it never shares |
+| An agent forgets `release` | Idle timeout, TTL escalation, and session death all release it |
+| Reordering starves a session | The wait time is shown in every queue view |
+
+## Testing
+
+Table-driven, in the style of `evict_test.go`. No docker in the unit tests: the
+runner is an interface, and the tests supply a fake.
+
+- Order: priority beats enqueue time; equal priority is FIFO.
+- Grant: an empty slot grants; a busy slot with a different branch queues.
+- Coalescing: a reader on the held branch is granted at once with no runner call.
+- Coalescing: a writer on the held branch queues.
+- Coalescing: a reader queues when the current holder is a writer.
+- Setup deadline: the grant fails, the lease requeues once, the next waiter starts.
+- Idle: expiry releases; a `touched_at` write inside the window does not.
+- TTL, empty queue: extends, announces nothing.
+- TTL, non-empty queue: prompts; no answer in 2 minutes releases.
+- Death: the reaper releases the lease and grants the next waiter.
+- Eviction: a holder is not a candidate; a queued session still is.
+- Drain: the holder keeps the lease; no waiter is granted.
+- Human hold: no session; survives a reaper pass.
+
+## Implementation order
+
+Each step is a PR that stands alone.
+
+1. Store tables, plus the ordering query and its tests. No behaviour yet.
+2. Lease manager with a fake runner: enqueue, grant, release, the four clocks.
+   This is where the logic and most of the tests live.
+3. HTTP routes and SSE. The queue is now visible with `curl`.
+4. The real runner: terminal, git switch, docker, health.
+5. `helios_lease` MCP tool, blocking path only.
+6. Death and eviction wiring: reaper, hooks, `evict.go`.
+7. Cold path: `wait_seconds` returns `queued`, and the grant wakes with a prompt.
+8. Desktop queue panel, including reorder and human hold.
+9. Mobile read-only view.
+
+Steps 1 to 5 are usable on their own. A single human with two sessions gets the
+whole benefit there.
+
+## Open
+
+1. **Do agents ever write while testing?** Migrations, seeds, fixture resets. If
+   they do, `mode` matters and the default should be `write`. If testing is
+   always browse-and-assert, the default is `read` and coalescing carries most
+   of the value.
+2. **Can the opal-app stack run twice** on separate ports and compose project
+   names? If it can, capacity goes above 1 and the queue mostly disappears.
+   That is a better outcome than a fair queue. Check it before step 2, because
+   it decides how much of the scheduler is worth building.
+3. **Should a queued lease appear on the phone?** It is not a decision, so it is
+   not a notification. It may still be worth a quiet entry. Left out of v1.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -101,6 +101,24 @@ type Usager interface {
 	Usage() map[string]int64
 }
 
+// Evicter is implemented by backends that can take a session's terminal away
+// without ending the session.
+//
+// Kill does the same thing to the process, but the difference has to survive
+// the kill: the agent runs its own exit hook on the way down, and Claude's
+// marks the session terminated and stamps ended_at. Terminated is the archival
+// state a person chooses; a session going cold has not ended and must come back
+// as itself. Evict records the intent so the hook can tell the two apart. See
+// docs/specs/42-cold-sessions.md.
+type Evicter interface {
+	// Evict stops the terminal, having first recorded that helios did it.
+	Evict(sessionID string) error
+
+	// EvictedRecently reports whether this session's terminal was taken by
+	// Evict rather than closed by the user, and consumes the mark.
+	EvictedRecently(sessionID string) bool
+}
+
 // Waker is implemented by backends that can bring a cold session back
 // without losing conversation state. The host backend re-runs
 // `claude --resume`; tmux cannot do this, so it does not implement it.

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -28,6 +28,11 @@ type Host struct {
 	// touched holds the last time each session's activity reached the
 	// registry, as unix nanos. See markActive.
 	touched sync.Map
+
+	// evicted holds the time each session's terminal was taken by Evict, so
+	// the agent's exit hook can tell a session that went cold from one that
+	// ended. See Evict.
+	evicted sync.Map
 }
 
 // touchInterval bounds how often screen activity reaches the registry.
@@ -331,6 +336,40 @@ func (h *Host) Interrupt(sessionID string) error { return h.SendKey(sessionID, K
 func (h *Host) Kill(sessionID string) error {
 	h.dropMirror(sessionID)
 	return h.reg.Evict(sessionID)
+}
+
+// evictMarkTTL bounds how long an eviction mark is believed.
+//
+// The agent's exit hook is an HTTP call from a dying process, so it lands in a
+// moment or not at all. The window only has to outlast that; holding the mark
+// longer risks swallowing a genuine SessionEnd from a session the user really
+// did quit soon afterwards.
+const evictMarkTTL = 2 * time.Minute
+
+// Evict takes a session's terminal, having first recorded that helios did it.
+//
+// Marked before the kill, not after: the agent's exit hook can reach the daemon
+// while Kill is still returning.
+func (h *Host) Evict(sessionID string) error {
+	h.evicted.Store(sessionID, time.Now())
+	if err := h.Kill(sessionID); err != nil {
+		h.evicted.Delete(sessionID)
+		return err
+	}
+	return nil
+}
+
+// EvictedRecently consumes the mark Evict left.
+//
+// Consumed rather than merely read: it answers one question, asked by the exit
+// hook of the agent just stopped. Left set, a later and genuine end of the same
+// session would be mistaken for this one.
+func (h *Host) EvictedRecently(sessionID string) bool {
+	at, ok := h.evicted.LoadAndDelete(sessionID)
+	if !ok {
+		return false
+	}
+	return time.Since(at.(time.Time)) < evictMarkTTL
 }
 
 // Capture returns the visible screen as text, with trailing blank lines

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -257,7 +257,7 @@ func startDaemon(cfg *Config) error {
 			select {
 			case <-ticker.C:
 				reapStaleSessions(db, term, shared.SSE)
-				evictOverBudget(db, term, mgr, shared.SSE)
+				evictOverBudget(db, term, shared.SSE)
 			case <-ctx.Done():
 				return
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -247,9 +247,8 @@ func startDaemon(cfg *Config) error {
 		}
 	}()
 
-	// Periodic stale terminal reaper. Twenty minutes, not ten seconds: it
-	// evicts nothing on a timer any more, and its remaining work — probing
-	// sockets and re-reading transcripts — costs more the more sessions exist.
+	// Periodic stale terminal reaper. Twenty minutes, not ten seconds: probing
+	// sockets and re-reading transcripts costs more the more sessions exist.
 	go func() {
 		ticker := time.NewTicker(20 * time.Minute)
 		defer ticker.Stop()
@@ -257,6 +256,22 @@ func startDaemon(cfg *Config) error {
 			select {
 			case <-ticker.C:
 				reapStaleSessions(db, term, shared.SSE)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// The memory budget is checked on its own, faster clock. It reads a map the
+	// host already keeps and one query, so it costs nothing next to the reaper
+	// above — and sharing the reaper's tick meant the machine could sit nineteen
+	// minutes over budget while the user watched it swap.
+	go func() {
+		ticker := time.NewTicker(2 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
 				evictOverBudget(db, term, shared.SSE)
 			case <-ctx.Done():
 				return

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -257,6 +257,7 @@ func startDaemon(cfg *Config) error {
 			select {
 			case <-ticker.C:
 				reapStaleSessions(db, term, shared.SSE)
+				evictOverBudget(db, term, mgr, shared.SSE)
 			case <-ctx.Done():
 				return
 			}

--- a/internal/daemon/evict.go
+++ b/internal/daemon/evict.go
@@ -178,15 +178,23 @@ func evictOverBudget(db *store.Store, be backend.Backend, sse *server.SSEBroadca
 		return
 	}
 
+	// Evict rather than Kill: it records that helios took the terminal, which
+	// is what stops the agent's own exit hook from filing the session as
+	// terminated on the way down.
+	evicter, ok := be.(backend.Evicter)
+	if !ok {
+		return
+	}
+
 	taken := chooseEvictions(evictionCandidates(sessions, usage, time.Now()), warmTotal, budget)
 	for _, c := range taken {
-		if err := be.Kill(c.SessionID); err != nil {
+		if err := evicter.Evict(c.SessionID); err != nil {
 			log.Printf("evict: %s: %v", c.SessionID, err)
 			continue
 		}
-		// Status is deliberately untouched. The tmux-era reaper marked an
-		// evicted session terminated, which was a dead end; only the SessionEnd
-		// hook ends a session.
+		// Status is deliberately untouched here, and the SessionEnd hook is
+		// taught to leave it alone too. Terminated is the archival state a
+		// person chooses; a session that went cold has not ended.
 		log.Printf("evict: %s went cold, freed %s, unread %s",
 			c.SessionID, humanBytes(c.RSS), c.Unread.Round(time.Minute))
 		sse.Broadcast(server.SSEEvent{

--- a/internal/daemon/evict.go
+++ b/internal/daemon/evict.go
@@ -1,10 +1,16 @@
 package daemon
 
 import (
+	"fmt"
+	"log"
 	"sort"
 	"time"
 
+	"github.com/kamrul1157024/helios/internal/backend"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/server"
 	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/sysinfo"
 )
 
 // minIdleBeforeEvict keeps a session that was just woken from being taken
@@ -132,4 +138,115 @@ func budgetBytes(fraction float64, memoryTotal uint64) int64 {
 		return 0
 	}
 	return int64(float64(memoryTotal) * fraction)
+}
+
+// evictOverBudget lets idle sessions go cold until the warm pool fits the
+// configured budget.
+//
+// Going cold is not the same as ending: the conversation is in the transcript,
+// the permission mode is on the session, and the next prompt wakes it. What is
+// lost is the host's 1 MiB scrollback ring, which is a rendering of the
+// transcript. See docs/specs/42-cold-sessions.md, which argues that trade
+// against the two commits that removed eviction before.
+func evictOverBudget(db *store.Store, be backend.Backend, mgr *notifications.Manager, sse *server.SSEBroadcaster) {
+	if !db.EvictionEnabled() {
+		return
+	}
+	budget := budgetBytes(db.MemoryBudgetFraction(), uint64(sysinfo.MemoryTotal()))
+	if budget <= 0 {
+		return
+	}
+
+	// Usage is optional on the interface, as injectTerminal also assumes. A
+	// backend that cannot report per-session memory cannot be metered, so it is
+	// left alone rather than guessed at.
+	usager, ok := be.(backend.Usager)
+	if !ok {
+		return
+	}
+	usage := usager.Usage()
+	var warmTotal int64
+	for _, rss := range usage {
+		warmTotal += rss
+	}
+	if warmTotal <= budget {
+		return
+	}
+
+	sessions, err := db.ListSessions()
+	if err != nil {
+		log.Printf("evict: list sessions: %v", err)
+		return
+	}
+
+	taken := chooseEvictions(evictionCandidates(sessions, usage, time.Now()), warmTotal, budget)
+	for _, c := range taken {
+		if err := be.Kill(c.SessionID); err != nil {
+			log.Printf("evict: %s: %v", c.SessionID, err)
+			continue
+		}
+		// Status is deliberately untouched. The tmux-era reaper marked an
+		// evicted session terminated, which was a dead end; only the SessionEnd
+		// hook ends a session.
+		log.Printf("evict: %s went cold, freed %s, unread %s",
+			c.SessionID, humanBytes(c.RSS), c.Unread.Round(time.Minute))
+		sse.Broadcast(server.SSEEvent{
+			Type: "session_updated",
+			Data: map[string]interface{}{"session_id": c.SessionID},
+		})
+		announceEviction(db, mgr, c)
+	}
+}
+
+// announceEviction tells the user what happened and why.
+//
+// A session that quietly goes cold and then takes seconds to answer reads as
+// Helios being slow, and an empty terminal tab reads as lost work. One line
+// prevents both readings.
+func announceEviction(db *store.Store, mgr *notifications.Manager, c candidate) {
+	if mgr == nil {
+		return
+	}
+	sess, err := db.GetSession(c.SessionID)
+	if err != nil || sess == nil {
+		return
+	}
+	title := fmt.Sprintf("%s went cold — freed %s", sess.Project, humanBytes(c.RSS))
+	detail := fmt.Sprintf("Not opened for %s. Your next prompt wakes it.",
+		humanDuration(c.Unread))
+
+	if err := mgr.CreateNotification(&store.Notification{
+		ID:            notifications.GenerateNotificationID(),
+		Source:        sess.Source,
+		SourceSession: c.SessionID,
+		CWD:           sess.CWD,
+		Type:          "helios.evicted",
+		Status:        "dismissed",
+		Title:         &title,
+		Detail:        &detail,
+	}); err != nil {
+		log.Printf("evict: announce %s: %v", c.SessionID, err)
+	}
+}
+
+func humanBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%d MB", b/(1<<20))
+	default:
+		return fmt.Sprintf("%d KB", b/(1<<10))
+	}
+}
+
+func humanDuration(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours())/24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
 }

--- a/internal/daemon/evict.go
+++ b/internal/daemon/evict.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"sort"
+	"time"
+
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// minIdleBeforeEvict keeps a session that was just woken from being taken
+// straight back. Without it, waking a session while over budget can evict it
+// again on the next pass, and the user sees it flap.
+const minIdleBeforeEvict = 5 * time.Minute
+
+// evictableStatuses are the states in which nothing is lost by going cold.
+//
+// Everything absent from this set means something is in flight. "active",
+// "starting" and "compacting" mean the agent is mid-turn. "waiting_permission"
+// and "waiting_input" mean the *human* is the blocker, and taking the terminal
+// would discard the question being asked.
+var evictableStatuses = map[string]bool{"idle": true}
+
+// candidate is one warm session considered for eviction.
+type candidate struct {
+	SessionID string
+	RSS       int64
+	// Unread is how long since a human last looked. Not how long since the
+	// agent last ran: an agent working alone keeps last_event_at fresh while
+	// nobody is watching, which is the opposite of what eviction should protect.
+	Unread time.Duration
+}
+
+// evictionCandidates picks the warm sessions that could go cold.
+//
+// usage carries only live terminals, so a session missing from it is already
+// cold and is not a candidate.
+func evictionCandidates(sessions []store.Session, usage map[string]int64, now time.Time) []candidate {
+	out := make([]candidate, 0, len(usage))
+	for _, sess := range sessions {
+		rss, warm := usage[sess.SessionID]
+		if !warm || rss <= 0 {
+			continue
+		}
+		if !evictableStatuses[sess.Status] || sess.Archived {
+			continue
+		}
+		// Pinning already means "I am coming back to this".
+		if sess.Pinned {
+			continue
+		}
+		unread := unreadFor(sess, now)
+		if unread < minIdleBeforeEvict {
+			continue
+		}
+		out = append(out, candidate{SessionID: sess.SessionID, RSS: rss, Unread: unread})
+	}
+	return out
+}
+
+// unreadFor is how long since a human looked at this session.
+//
+// A session no client has ever shown has no last_interacted_at, and falls back
+// to agent activity. That makes it a strong candidate, which is right: nobody
+// has opened it.
+func unreadFor(sess store.Session, now time.Time) time.Duration {
+	for _, stamp := range []*string{sess.LastInteractedAt, sess.LastEventAt} {
+		if stamp == nil || *stamp == "" {
+			continue
+		}
+		at, err := time.Parse(time.RFC3339, *stamp)
+		if err != nil {
+			continue
+		}
+		return now.Sub(at)
+	}
+	// No timestamps at all. Treat it as long unread rather than brand new, so a
+	// session with a broken record is reclaimable instead of pinned forever.
+	return now.Sub(time.Time{})
+}
+
+// chooseEvictions returns the sessions to take, in order, until the pool is
+// under budget.
+//
+// The score multiplies size by how long the session has gone unread, so the
+// best victim is both expensive to hold and unlikely to be wanted. Plain
+// recency would take a small session nobody has opened in a week and leave a
+// huge one; plain size would take the biggest even if it was being read a
+// minute ago.
+func chooseEvictions(candidates []candidate, warmTotal, budget int64) []candidate {
+	if budget <= 0 || warmTotal <= budget {
+		return nil
+	}
+
+	ranked := make([]candidate, len(candidates))
+	copy(ranked, candidates)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		return score(ranked[i]) > score(ranked[j])
+	})
+
+	var taken []candidate
+	freed := int64(0)
+	for _, c := range ranked {
+		if warmTotal-freed <= budget {
+			break
+		}
+		taken = append(taken, c)
+		freed += c.RSS
+	}
+	return taken
+}
+
+// score is bytes multiplied by minutes unread. Higher is evicted first.
+//
+// Note the multiplication. Dividing by the idle time — which an earlier draft
+// of this did, and the spec described — ranks a large session read a minute ago
+// above one nobody has opened all day, which is exactly backwards.
+func score(c candidate) float64 {
+	minutes := c.Unread.Minutes()
+	if minutes < 1 {
+		minutes = 1
+	}
+	return float64(c.RSS) * minutes
+}
+
+// budgetBytes resolves the configured share of physical memory.
+//
+// A fraction rather than a byte count: the same install runs on a 16 GB laptop
+// and a 64 GB desktop. A fraction at or below zero means no limit, which is how
+// eviction is turned off without a second flag being consulted here.
+func budgetBytes(fraction float64, memoryTotal uint64) int64 {
+	if fraction <= 0 || memoryTotal == 0 {
+		return 0
+	}
+	return int64(float64(memoryTotal) * fraction)
+}

--- a/internal/daemon/evict.go
+++ b/internal/daemon/evict.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/kamrul1157024/helios/internal/backend"
-	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/server"
 	"github.com/kamrul1157024/helios/internal/store"
 	"github.com/kamrul1157024/helios/internal/sysinfo"
@@ -148,7 +147,7 @@ func budgetBytes(fraction float64, memoryTotal uint64) int64 {
 // lost is the host's 1 MiB scrollback ring, which is a rendering of the
 // transcript. See docs/specs/42-cold-sessions.md, which argues that trade
 // against the two commits that removed eviction before.
-func evictOverBudget(db *store.Store, be backend.Backend, mgr *notifications.Manager, sse *server.SSEBroadcaster) {
+func evictOverBudget(db *store.Store, be backend.Backend, sse *server.SSEBroadcaster) {
 	if !db.EvictionEnabled() {
 		return
 	}
@@ -194,39 +193,34 @@ func evictOverBudget(db *store.Store, be backend.Backend, mgr *notifications.Man
 			Type: "session_updated",
 			Data: map[string]interface{}{"session_id": c.SessionID},
 		})
-		announceEviction(db, mgr, c)
+		announceEviction(db, sse, c)
 	}
 }
 
-// announceEviction tells the user what happened and why.
+// announceEviction tells attached clients what just happened.
 //
-// A session that quietly goes cold and then takes seconds to answer reads as
-// Helios being slow, and an empty terminal tab reads as lost work. One line
-// prevents both readings.
-func announceEviction(db *store.Store, mgr *notifications.Manager, c candidate) {
-	if mgr == nil {
-		return
+// A live event rather than a stored notification. The notification table is for
+// things awaiting an answer — clients only surface `pending` ones, and a
+// non-actionable row there would either sit unresolved in the approvals list or
+// be filtered out entirely, which is what an earlier version of this did.
+//
+// It has to be said somehow: a session that quietly goes cold and then takes
+// seconds to answer reads as Helios being slow, and an empty terminal tab reads
+// as lost work.
+func announceEviction(db *store.Store, sse *server.SSEBroadcaster, c candidate) {
+	project := ""
+	if sess, err := db.GetSession(c.SessionID); err == nil && sess != nil {
+		project = sess.Project
 	}
-	sess, err := db.GetSession(c.SessionID)
-	if err != nil || sess == nil {
-		return
-	}
-	title := fmt.Sprintf("%s went cold — freed %s", sess.Project, humanBytes(c.RSS))
-	detail := fmt.Sprintf("Not opened for %s. Your next prompt wakes it.",
-		humanDuration(c.Unread))
-
-	if err := mgr.CreateNotification(&store.Notification{
-		ID:            notifications.GenerateNotificationID(),
-		Source:        sess.Source,
-		SourceSession: c.SessionID,
-		CWD:           sess.CWD,
-		Type:          "helios.evicted",
-		Status:        "dismissed",
-		Title:         &title,
-		Detail:        &detail,
-	}); err != nil {
-		log.Printf("evict: announce %s: %v", c.SessionID, err)
-	}
+	sse.Broadcast(server.SSEEvent{
+		Type: "session_evicted",
+		Data: map[string]interface{}{
+			"session_id": c.SessionID,
+			"project":    project,
+			"freed":      c.RSS,
+			"unread":     humanDuration(c.Unread),
+		},
+	})
 }
 
 func humanBytes(b int64) string {

--- a/internal/daemon/evict_integration_test.go
+++ b/internal/daemon/evict_integration_test.go
@@ -16,8 +16,9 @@ import (
 // whole eviction pass can be driven without a real terminal host.
 type meteredBackend struct {
 	*fakeBackend
-	usage  map[string]int64
-	killed []string
+	usage   map[string]int64
+	killed  []string
+	evicted map[string]bool
 }
 
 func newMeteredBackend(usage map[string]int64) *meteredBackend {
@@ -25,7 +26,7 @@ func newMeteredBackend(usage map[string]int64) *meteredBackend {
 	for id := range usage {
 		ids = append(ids, id)
 	}
-	return &meteredBackend{fakeBackend: newFakeBackend(ids...), usage: usage}
+	return &meteredBackend{fakeBackend: newFakeBackend(ids...), usage: usage, evicted: map[string]bool{}}
 }
 
 func (m *meteredBackend) Usage() map[string]int64 { return m.usage }
@@ -35,6 +36,20 @@ func (m *meteredBackend) Kill(sessionID string) error {
 	delete(m.usage, sessionID)
 	m.live[sessionID] = false
 	return nil
+}
+
+// Evict is what the pass must call rather than Kill: the mark is the only thing
+// standing between a cold session and the agent's exit hook filing it as
+// terminated.
+func (m *meteredBackend) Evict(sessionID string) error {
+	m.evicted[sessionID] = true
+	return m.Kill(sessionID)
+}
+
+func (m *meteredBackend) EvictedRecently(sessionID string) bool {
+	was := m.evicted[sessionID]
+	delete(m.evicted, sessionID)
+	return was
 }
 
 // evictHarness wires a real store and broadcaster to a metered backend, so the
@@ -162,6 +177,12 @@ func TestEvictE2E_KeepsTheSessionAlive(t *testing.T) {
 	}
 	if h.be.Alive("big") {
 		t.Error("the terminal survived the eviction")
+	}
+	// The mark is what the agent's exit hook reads to know this was helios
+	// reclaiming memory rather than the user quitting. Without it the hook
+	// files the session as terminated and stamps ended_at.
+	if !h.be.EvictedRecently("big") {
+		t.Error("the pass killed the terminal without marking it evicted")
 	}
 }
 

--- a/internal/daemon/evict_integration_test.go
+++ b/internal/daemon/evict_integration_test.go
@@ -1,0 +1,226 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamrul1157024/helios/internal/server"
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+// meteredBackend reports per-session memory and records what was killed, so a
+// whole eviction pass can be driven without a real terminal host.
+type meteredBackend struct {
+	*fakeBackend
+	usage  map[string]int64
+	killed []string
+}
+
+func newMeteredBackend(usage map[string]int64) *meteredBackend {
+	ids := make([]string, 0, len(usage))
+	for id := range usage {
+		ids = append(ids, id)
+	}
+	return &meteredBackend{fakeBackend: newFakeBackend(ids...), usage: usage}
+}
+
+func (m *meteredBackend) Usage() map[string]int64 { return m.usage }
+
+func (m *meteredBackend) Kill(sessionID string) error {
+	m.killed = append(m.killed, sessionID)
+	delete(m.usage, sessionID)
+	m.live[sessionID] = false
+	return nil
+}
+
+// evictHarness wires a real store and broadcaster to a metered backend, so the
+// pass under test is the one the daemon actually runs.
+type evictHarness struct {
+	db  *store.Store
+	be  *meteredBackend
+	sse *server.SSEBroadcaster
+}
+
+func newEvictHarness(t *testing.T, usage map[string]int64) *evictHarness {
+	t.Helper()
+	return &evictHarness{
+		db:  setupTestStore(t),
+		be:  newMeteredBackend(usage),
+		sse: server.NewSSEBroadcaster(),
+	}
+}
+
+// add records a session as the daemon would see it: a status, and how long ago
+// a human last looked.
+func (h *evictHarness) add(t *testing.T, id, status string, unread time.Duration, pinned bool) {
+	t.Helper()
+	// InsertDiscoveredSession rather than UpsertSession: it keeps the
+	// timestamps it is given, and UpsertSession stamps last_event_at to now,
+	// which would make every session look freshly active.
+	stamp := time.Now().UTC().Add(-unread).Format(time.RFC3339)
+	if err := h.db.InsertDiscoveredSession(&store.Session{
+		SessionID:   id,
+		Source:      "claude",
+		CWD:         "/tmp/" + id,
+		Status:      status,
+		LastEventAt: &stamp,
+	}); err != nil {
+		t.Fatalf("insert %s: %v", id, err)
+	}
+	if pinned {
+		if err := h.db.UpdateSessionFlags(id, true, false); err != nil {
+			t.Fatalf("pin %s: %v", id, err)
+		}
+	}
+}
+
+func (h *evictHarness) run() { evictOverBudget(h.db, h.be, h.sse) }
+
+// Nothing happens until the user asks for it. This is the guarantee that an
+// upgrade does not start killing agents.
+func TestEvictE2E_DoesNothingUntilEnabled(t *testing.T) {
+	h := newEvictHarness(t, map[string]int64{"big": 900 << 20})
+	h.add(t, "big", "idle", 2*time.Hour, false)
+
+	// Far below what is warm, so pressure is not the reason nothing happens.
+	if err := h.db.SetSetting(store.SettingBudgetFraction, "0.000001"); err != nil {
+		t.Fatalf("budget: %v", err)
+	}
+
+	h.run()
+	if len(h.be.killed) != 0 {
+		t.Fatalf("evicted %v while the feature was off", h.be.killed)
+	}
+
+	if err := h.db.SetSetting(store.SettingEvictEnabled, "true"); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	h.run()
+	if len(h.be.killed) != 1 || h.be.killed[0] != "big" {
+		t.Fatalf("killed %v, want [big] once enabled", h.be.killed)
+	}
+}
+
+// The whole point: free memory, and take the right thing.
+func TestEvictE2E_TakesTheRightSessionAndStops(t *testing.T) {
+	h := newEvictHarness(t, map[string]int64{
+		"stale-big":    900 << 20, // unopened for hours
+		"fresh-big":    900 << 20, // read minutes ago
+		"stale-small":  50 << 20,
+		"needs-answer": 900 << 20, // waiting on the human
+		"pinned-big":   900 << 20,
+	})
+	h.add(t, "stale-big", "idle", 3*time.Hour, false)
+	h.add(t, "fresh-big", "idle", 6*time.Minute, false)
+	h.add(t, "stale-small", "idle", 3*time.Hour, false)
+	h.add(t, "needs-answer", "waiting_permission", 5*time.Hour, false)
+	h.add(t, "pinned-big", "idle", 5*time.Hour, true)
+
+	enableWithBudget(t, h, "0.0000001")
+
+	h.run()
+
+	if len(h.be.killed) == 0 {
+		t.Fatal("nothing was evicted while far over budget")
+	}
+	for _, id := range h.be.killed {
+		if id == "needs-answer" {
+			t.Error("evicted a session the human is being asked a question by")
+		}
+		if id == "pinned-big" {
+			t.Error("evicted a pinned session")
+		}
+	}
+	// Long unread and large is the best victim, so it goes first.
+	if h.be.killed[0] != "stale-big" {
+		t.Errorf("first eviction was %s, want stale-big", h.be.killed[0])
+	}
+}
+
+// A session going cold must stay a session. The tmux-era reaper marked it
+// terminated, which was a dead end.
+func TestEvictE2E_KeepsTheSessionAlive(t *testing.T) {
+	h := newEvictHarness(t, map[string]int64{"big": 900 << 20})
+	h.add(t, "big", "idle", 2*time.Hour, false)
+	enableWithBudget(t, h, "0.0000001")
+
+	h.run()
+
+	sess, err := h.db.GetSession("big")
+	if err != nil || sess == nil {
+		t.Fatalf("session gone after eviction: %v", err)
+	}
+	if sess.Status == "terminated" {
+		t.Error("eviction terminated the session")
+	}
+	if sess.EndedAt != nil {
+		t.Error("eviction set ended_at")
+	}
+	if h.be.Alive("big") {
+		t.Error("the terminal survived the eviction")
+	}
+}
+
+// The user has to be told, or a session that quietly went cold and then takes
+// seconds to answer reads as Helios being slow.
+func TestEvictE2E_AnnouncesWhatItFreed(t *testing.T) {
+	h := newEvictHarness(t, map[string]int64{"big": 900 << 20})
+	h.add(t, "big", "idle", 2*time.Hour, false)
+	enableWithBudget(t, h, "0.0000001")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	go func() {
+		// The broadcaster drops events for a client that is not yet attached,
+		// so the pass runs after the stream is being served.
+		time.Sleep(50 * time.Millisecond)
+		h.run()
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	h.sse.ServeHTTP(rec, req.WithContext(ctx))
+
+	body := rec.Body.String()
+	for _, want := range []string{"session_evicted", "big", "session_updated", "freed"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("broadcast is missing %q: %s", want, body)
+		}
+	}
+}
+
+// Touching a session takes it out of reach, which is the whole reason the
+// timestamp exists.
+func TestEvictE2E_TouchProtectsASession(t *testing.T) {
+	h := newEvictHarness(t, map[string]int64{"a": 900 << 20, "b": 100 << 20})
+	h.add(t, "a", "idle", 5*time.Hour, false)
+	h.add(t, "b", "idle", 4*time.Hour, false)
+	enableWithBudget(t, h, "0.0000001")
+
+	// Someone opens "a" right now.
+	if err := h.db.TouchSession("a"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	h.run()
+
+	for _, id := range h.be.killed {
+		if id == "a" {
+			t.Fatalf("evicted the session someone just opened; killed %v", h.be.killed)
+		}
+	}
+}
+
+func enableWithBudget(t *testing.T, h *evictHarness, fraction string) {
+	t.Helper()
+	if err := h.db.SetSetting(store.SettingEvictEnabled, "true"); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := h.db.SetSetting(store.SettingBudgetFraction, fraction); err != nil {
+		t.Fatalf("budget: %v", err)
+	}
+}

--- a/internal/daemon/evict_test.go
+++ b/internal/daemon/evict_test.go
@@ -1,0 +1,208 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kamrul1157024/helios/internal/store"
+)
+
+var now = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+func at(d time.Duration) *string {
+	s := now.Add(-d).Format(time.RFC3339)
+	return &s
+}
+
+func session(id, status string, interacted time.Duration) store.Session {
+	return store.Session{
+		SessionID:        id,
+		Status:           status,
+		LastInteractedAt: at(interacted),
+		LastEventAt:      at(interacted),
+	}
+}
+
+func ids(cs []candidate) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.SessionID
+	}
+	return out
+}
+
+// Everything but idle means something is in flight. waiting_permission is the
+// one that matters most: it looks idle by the clock, but the human is the
+// blocker and taking the terminal discards the question.
+func TestCandidates_OnlyIdle(t *testing.T) {
+	sessions := []store.Session{
+		session("idle", "idle", time.Hour),
+		session("active", "active", time.Hour),
+		session("starting", "starting", time.Hour),
+		session("compacting", "compacting", time.Hour),
+		session("permission", "waiting_permission", time.Hour),
+		session("input", "waiting_input", time.Hour),
+	}
+	usage := map[string]int64{}
+	for _, s := range sessions {
+		usage[s.SessionID] = 100
+	}
+
+	got := evictionCandidates(sessions, usage, now)
+	if len(got) != 1 || got[0].SessionID != "idle" {
+		t.Fatalf("candidates = %v, want [idle]", ids(got))
+	}
+}
+
+func TestCandidates_SkipsPinnedArchivedAndCold(t *testing.T) {
+	pinned := session("pinned", "idle", time.Hour)
+	pinned.Pinned = true
+	archived := session("archived", "idle", time.Hour)
+	archived.Archived = true
+	cold := session("cold", "idle", time.Hour)
+
+	sessions := []store.Session{pinned, archived, cold, session("ok", "idle", time.Hour)}
+	// cold has no entry in usage, which is how a session with no live terminal
+	// presents itself.
+	usage := map[string]int64{"pinned": 100, "archived": 100, "ok": 100}
+
+	got := evictionCandidates(sessions, usage, now)
+	if len(got) != 1 || got[0].SessionID != "ok" {
+		t.Fatalf("candidates = %v, want [ok]", ids(got))
+	}
+}
+
+// A session woken while the machine is over budget must not be taken straight
+// back on the next pass.
+func TestCandidates_RespectsMinimumIdleAge(t *testing.T) {
+	sessions := []store.Session{
+		session("fresh", "idle", time.Minute),
+		session("settled", "idle", 10*time.Minute),
+	}
+	usage := map[string]int64{"fresh": 100, "settled": 100}
+
+	got := evictionCandidates(sessions, usage, now)
+	if len(got) != 1 || got[0].SessionID != "settled" {
+		t.Fatalf("candidates = %v, want [settled]", ids(got))
+	}
+}
+
+// The signal is human attention, not agent activity. An agent working alone
+// keeps last_event_at fresh while nobody is watching.
+func TestCandidates_PrefersInteractionOverAgentActivity(t *testing.T) {
+	// Agent ran a minute ago; nobody has looked in two hours.
+	unwatched := session("unwatched", "idle", 0)
+	unwatched.LastInteractedAt = at(2 * time.Hour)
+	unwatched.LastEventAt = at(time.Minute)
+
+	got := evictionCandidates([]store.Session{unwatched}, map[string]int64{"unwatched": 100}, now)
+	if len(got) != 1 {
+		t.Fatalf("candidates = %v, want [unwatched]", ids(got))
+	}
+	if got[0].Unread < 2*time.Hour {
+		t.Fatalf("unread = %s; agent activity was counted as a human looking", got[0].Unread)
+	}
+}
+
+// No client has ever shown it, so it is a strong candidate rather than a new one.
+func TestCandidates_MissingInteractionFallsBackToAgentActivity(t *testing.T) {
+	sess := session("never-opened", "idle", 0)
+	sess.LastInteractedAt = nil
+	sess.LastEventAt = at(90 * time.Minute)
+
+	got := evictionCandidates([]store.Session{sess}, map[string]int64{"never-opened": 100}, now)
+	if len(got) != 1 || got[0].Unread < 90*time.Minute {
+		t.Fatalf("unread = %v; a never-opened session was treated as just-read", got)
+	}
+}
+
+func TestChoose_NothingWhenUnderBudget(t *testing.T) {
+	cs := []candidate{{SessionID: "a", RSS: 100, Unread: time.Hour}}
+	if got := chooseEvictions(cs, 500, 1000); got != nil {
+		t.Fatalf("evicted %v while under budget", ids(got))
+	}
+}
+
+func TestChoose_NothingWhenBudgetIsUnlimited(t *testing.T) {
+	cs := []candidate{{SessionID: "a", RSS: 100, Unread: time.Hour}}
+	if got := chooseEvictions(cs, 10_000, 0); got != nil {
+		t.Fatalf("evicted %v with no budget set", ids(got))
+	}
+}
+
+func TestChoose_StopsAsSoonAsUnderBudget(t *testing.T) {
+	cs := []candidate{
+		{SessionID: "big", RSS: 800, Unread: time.Hour},
+		{SessionID: "small", RSS: 100, Unread: time.Hour},
+	}
+	got := chooseEvictions(cs, 1000, 500)
+	if len(got) != 1 || got[0].SessionID != "big" {
+		t.Fatalf("evicted %v, want just [big]", ids(got))
+	}
+}
+
+func TestChoose_SameSizePrefersLongerUnread(t *testing.T) {
+	cs := []candidate{
+		{SessionID: "recent", RSS: 500, Unread: 10 * time.Minute},
+		{SessionID: "stale", RSS: 500, Unread: 5 * time.Hour},
+	}
+	got := chooseEvictions(cs, 1000, 600)
+	if len(got) != 1 || got[0].SessionID != "stale" {
+		t.Fatalf("evicted %v, want [stale]", ids(got))
+	}
+}
+
+func TestChoose_SameAgePrefersLarger(t *testing.T) {
+	cs := []candidate{
+		{SessionID: "small", RSS: 200, Unread: time.Hour},
+		{SessionID: "large", RSS: 900, Unread: time.Hour},
+	}
+	got := chooseEvictions(cs, 1100, 900)
+	if len(got) != 1 || got[0].SessionID != "large" {
+		t.Fatalf("evicted %v, want [large]", ids(got))
+	}
+}
+
+// The whole reason the score is a product rather than either input alone.
+func TestChoose_WeighsSizeAgainstHowLongUnread(t *testing.T) {
+	cs := []candidate{
+		// Huge, but read a few minutes ago — likely still in use.
+		{SessionID: "huge-recent", RSS: 900, Unread: 6 * time.Minute},
+		// Smaller, but nobody has opened it in hours.
+		{SessionID: "modest-stale", RSS: 400, Unread: 4 * time.Hour},
+	}
+	got := chooseEvictions(cs, 1300, 1000)
+	if len(got) != 1 || got[0].SessionID != "modest-stale" {
+		t.Fatalf("evicted %v, want [modest-stale]: being read six minutes ago outweighs being twice the size", ids(got))
+	}
+
+	// Make the recent one enormous and it wins anyway: the score is a product,
+	// not a preference for one input.
+	cs = []candidate{
+		{SessionID: "vast-recent", RSS: 40_000, Unread: 6 * time.Minute},
+		{SessionID: "modest-stale", RSS: 400, Unread: 4 * time.Hour},
+	}
+	got = chooseEvictions(cs, 40_400, 40_000)
+	if len(got) != 1 || got[0].SessionID != "vast-recent" {
+		t.Fatalf("evicted %v, want [vast-recent]", ids(got))
+	}
+}
+
+func TestBudgetBytes(t *testing.T) {
+	const sixteenGB = uint64(16) << 30
+
+	if got := budgetBytes(0.25, sixteenGB); got != int64(4)<<30 {
+		t.Errorf("quarter of 16 GB = %d, want %d", got, int64(4)<<30)
+	}
+	// Zero and negative both mean no limit, so eviction cannot be switched on
+	// by a malformed setting.
+	if got := budgetBytes(0, sixteenGB); got != 0 {
+		t.Errorf("zero fraction = %d, want 0", got)
+	}
+	if got := budgetBytes(-1, sixteenGB); got != 0 {
+		t.Errorf("negative fraction = %d, want 0", got)
+	}
+	if got := budgetBytes(0.25, 0); got != 0 {
+		t.Errorf("unknown machine memory = %d, want 0", got)
+	}
+}

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -822,6 +822,19 @@ func handleSessionEnd(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 	if ctx.Terminal != nil {
 		ctx.Terminal.Forget(input.SessionID)
 	}
+
+	// Unless helios stopped the agent itself to reclaim memory. The exit is
+	// then ours, not the user's, and the session is cold rather than over:
+	// leaving the status alone is what lets the next prompt wake it as itself.
+	// Terminated stamps ended_at and reads as archived. See
+	// docs/specs/42-cold-sessions.md.
+	if evicter, ok := ctx.Terminal.(backend.Evicter); ok && evicter.EvictedRecently(input.SessionID) {
+		ctx.Notify("session_updated", map[string]interface{}{"session_id": input.SessionID})
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+		return
+	}
+
 	ctx.DB.UpdateSessionStatus(input.SessionID, "terminated", "SessionEnd")
 	ctx.Notify("session_status", map[string]interface{}{
 		"session_id": input.SessionID,

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -44,10 +44,28 @@ type fakeBackend struct {
 	kills   []string
 	keys    []string // "sessionID:key"
 	texts   []string // "sessionID:text"
+	evicted map[string]bool
 }
 
 func newFakeBackend() *fakeBackend {
-	return &fakeBackend{handles: map[string]string{}}
+	return &fakeBackend{handles: map[string]string{}, evicted: map[string]bool{}}
+}
+
+// Evict and EvictedRecently mirror the host backend: a mark set before the kill
+// and consumed by the first caller to ask.
+func (f *fakeBackend) Evict(sessionID string) error {
+	f.mu.Lock()
+	f.evicted[sessionID] = true
+	f.mu.Unlock()
+	return f.Kill(sessionID)
+}
+
+func (f *fakeBackend) EvictedRecently(sessionID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	was := f.evicted[sessionID]
+	delete(f.evicted, sessionID)
+	return was
 }
 
 // live registers a session as having a terminal.
@@ -711,6 +729,53 @@ func TestSessionEnd_SetsEndedAt(t *testing.T) {
 	if sess.EndedAt == nil || *sess.EndedAt == "" {
 		t.Error("ended_at not set after SessionEnd")
 	}
+}
+
+// A session helios stopped to reclaim memory has not ended. Killing the host
+// kills the agent, which runs this very hook on the way down — so without the
+// eviction mark every cold session was filed as terminated, the archival state
+// a person chooses. That is the bug this pins.
+func TestSessionEnd_LeavesAnEvictedSessionAlone(t *testing.T) {
+	ctx, db, sseEvents := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "idle")
+	be := terminalOf(ctx)
+	be.live("sess-1")
+
+	if err := be.Evict("sess-1"); err != nil {
+		t.Fatalf("evict: %v", err)
+	}
+	callHook(handleSessionEnd, ctx, hookInput{SessionID: "sess-1", CWD: "/tmp/proj"})
+
+	assertStatus(t, db, "sess-1", "idle")
+	sess, _ := db.GetSession("sess-1")
+	if sess.EndedAt != nil && *sess.EndedAt != "" {
+		t.Errorf("ended_at = %q; a cold session has not ended", *sess.EndedAt)
+	}
+	for _, e := range *sseEvents {
+		if e == "session_status" {
+			t.Error("broadcast a status change for a session that only went cold")
+		}
+	}
+}
+
+// The mark answers one exit. A session evicted, woken, and later quit by the
+// user must still end properly.
+func TestSessionEnd_TerminatesNormallyAfterAnEviction(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "idle")
+	be := terminalOf(ctx)
+	be.live("sess-1")
+
+	if err := be.Evict("sess-1"); err != nil {
+		t.Fatalf("evict: %v", err)
+	}
+	callHook(handleSessionEnd, ctx, hookInput{SessionID: "sess-1", CWD: "/tmp/proj"})
+
+	// Woken again, then really quit.
+	be.live("sess-1")
+	callHook(handleSessionEnd, ctx, hookInput{SessionID: "sess-1", CWD: "/tmp/proj"})
+
+	assertStatus(t, db, "sess-1", "terminated")
 }
 
 func TestSessionEnd_ForgetsTerminal(t *testing.T) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -462,6 +462,20 @@ var (
 	promptAckTimeout = 8 * time.Second
 )
 
+// handleSessionTouch records that a human is looking at this session.
+//
+// Deliberately cheap and fire-and-forget: clients call it on selection and on a
+// heartbeat, and a failure means one missed sample rather than anything the
+// user should hear about.
+func (s *PublicServer) handleSessionTouch(w http.ResponseWriter, r *http.Request) {
+	id := extractSessionID(r.URL.Path, "/touch")
+	if err := s.shared.DB.TouchSession(id); err != nil {
+		jsonError(w, "failed to record interaction", http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]interface{}{"success": true})
+}
+
 func (s *PublicServer) handleSessionSend(w http.ResponseWriter, r *http.Request) {
 	id := extractSessionID(r.URL.Path, "/send")
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -245,6 +245,8 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 			s.handleListSubagents(w, r)
 		case r.Method == "GET" && strings.HasSuffix(path, "/transcript"):
 			s.handleSessionTranscript(w, r)
+		case r.Method == "POST" && strings.HasSuffix(path, "/touch"):
+			s.handleSessionTouch(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/send"):
 			s.handleSessionSend(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/files"):

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,9 +83,11 @@ func (sh *Shared) hostStats() map[string]interface{} {
 	status := sh.Backend.Status()
 	machine := sysinfo.Read()
 	return map[string]interface{}{
-		"warm":         status.Warm,
-		"warm_rss":     status.WarmRSS,
-		"budget":       machine.MemoryTotal / 4,
+		"warm":     status.Warm,
+		"warm_rss": status.WarmRSS,
+		// The configured share, not a fixed quarter: the same number now
+		// decides what gets evicted, so what clients display has to be it.
+		"budget":       uint64(float64(machine.MemoryTotal) * sh.DB.MemoryBudgetFraction()),
 		"load":         machine.Load,
 		"memory_used":  machine.MemoryUsed,
 		"memory_total": machine.MemoryTotal,

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -9,18 +9,22 @@ import (
 )
 
 type Session struct {
-	SessionID       string  `json:"session_id"`
-	Source          string  `json:"source"`
-	CWD             string  `json:"cwd"`
-	Project         string  `json:"project"`
-	Title           *string `json:"title,omitempty"`
-	TranscriptPath  *string `json:"transcript_path,omitempty"`
-	Model           *string `json:"model,omitempty"`
-	Status          string  `json:"status"`
-	LastEvent       *string `json:"last_event,omitempty"`
-	LastEventAt     *string `json:"last_event_at,omitempty"`
-	LastUserMessage *string `json:"last_user_message,omitempty"`
-	Pinned          bool    `json:"pinned"`
+	SessionID      string  `json:"session_id"`
+	Source         string  `json:"source"`
+	CWD            string  `json:"cwd"`
+	Project        string  `json:"project"`
+	Title          *string `json:"title,omitempty"`
+	TranscriptPath *string `json:"transcript_path,omitempty"`
+	Model          *string `json:"model,omitempty"`
+	Status         string  `json:"status"`
+	LastEvent      *string `json:"last_event,omitempty"`
+	LastEventAt    *string `json:"last_event_at,omitempty"`
+	// LastInteractedAt is when a human last looked at this session, which is a
+	// different question from when its agent last ran. A session read a minute
+	// ago and one untouched for a day both go quiet in last_event_at.
+	LastInteractedAt *string `json:"last_interacted_at,omitempty"`
+	LastUserMessage  *string `json:"last_user_message,omitempty"`
+	Pinned           bool    `json:"pinned"`
 	// SortOrder is the session's place in a hand-arranged list. Lower sorts
 	// first and the scale is arbitrary — only the relative order is meaningful,
 	// and it is ignored entirely unless the list is set to sort manually.
@@ -141,6 +145,19 @@ func (s *Store) UpdateSessionStatus(sessionID, status, event string) error {
 	return err
 }
 
+// TouchSession records that a human just looked at this session.
+//
+// Separate from last_event_at on purpose: that one moves whenever the agent
+// does anything, including while nobody is watching, so it cannot answer "is
+// anyone still interested in this".
+func (s *Store) TouchSession(sessionID string) error {
+	_, err := s.db.Exec(
+		`UPDATE sessions SET last_interacted_at = ? WHERE session_id = ?`,
+		time.Now().UTC().Format(time.RFC3339), sessionID,
+	)
+	return err
+}
+
 // UpdateSessionLastUserMessage stores the last user prompt for a session.
 func (s *Store) UpdateSessionLastUserMessage(sessionID, message string) error {
 	_, err := s.db.Exec(
@@ -174,12 +191,12 @@ func (s *Store) GetSession(sessionID string) (*Session, error) {
 	sess := &Session{}
 	err := s.db.QueryRow(
 		`SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-		        last_event, last_event_at, last_user_message, pinned, archived, sort_order,
+		        last_event, last_event_at, last_interacted_at, last_user_message, pinned, archived, sort_order,
 		        permission_mode, created_at, ended_at
 		 FROM sessions WHERE session_id = ?`, sessionID,
 	).Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 		&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-		&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
+		&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
 		&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -233,7 +250,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 	}
 
 	q := `SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-	        last_event, last_event_at, last_user_message, pinned, archived, sort_order,
+	        last_event, last_event_at, last_interacted_at, last_user_message, pinned, archived, sort_order,
 	        permission_mode, created_at, ended_at
 	 FROM sessions`
 	if len(where) > 0 {
@@ -252,7 +269,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 		var sess Session
 		if err := rows.Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 			&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-			&sess.LastEvent, &sess.LastEventAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
+			&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
 			&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt); err != nil {
 			return nil, err
 		}

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -253,3 +253,37 @@ func TestUpsertSession_UpdateKeepsItsPlace(t *testing.T) {
 		t.Errorf("an update moved it to %d, want 0", sess.SortOrder)
 	}
 }
+
+// last_interacted_at answers "is anyone still interested", which last_event_at
+// cannot: the agent moves that one while nobody is watching.
+func TestTouchSessionIsSeparateFromAgentActivity(t *testing.T) {
+	s := setupTestStore(t)
+
+	sess := &Session{SessionID: "s1", Source: "claude", CWD: "/tmp", Status: "idle"}
+	if err := s.UpsertSession(sess); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, _ := s.GetSession("s1")
+	if got.LastInteractedAt != nil {
+		t.Fatalf("a session nobody opened has been interacted with: %v", *got.LastInteractedAt)
+	}
+
+	if err := s.TouchSession("s1"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	got, _ = s.GetSession("s1")
+	if got.LastInteractedAt == nil {
+		t.Fatal("touch did not record anything")
+	}
+
+	// Agent activity must not count as a human looking.
+	touched := *got.LastInteractedAt
+	if err := s.UpdateSessionStatus("s1", "active", "PreToolUse:Read"); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	got, _ = s.GetSession("s1")
+	if *got.LastInteractedAt != touched {
+		t.Error("agent activity moved last_interacted_at")
+	}
+}

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -103,11 +103,15 @@ func (s *Store) MemoryBudgetFraction() float64 {
 }
 
 // EvictionEnabled reports whether the daemon may let idle sessions go cold.
-// On unless explicitly turned off.
+//
+// Off unless asked for. Eviction kills a running agent and takes its terminal
+// scrollback, and it reverses a decision made twice before — see
+// docs/specs/42-cold-sessions.md. That is not something to start doing to
+// somebody's machine because they upgraded.
 func (s *Store) EvictionEnabled() bool {
 	raw, err := s.GetSetting(SettingEvictEnabled)
 	if err != nil || raw == "" {
-		return true
+		return false
 	}
-	return raw != "false"
+	return raw == "true"
 }

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -1,6 +1,9 @@
 package store
 
-import "database/sql"
+import (
+	"database/sql"
+	"strconv"
+)
 
 // GetSetting retrieves a setting value by key. Returns "" if not found.
 func (s *Store) GetSetting(key string) (string, error) {
@@ -68,4 +71,43 @@ func (s *Store) SetSettings(settings map[string]string) error {
 		}
 	}
 	return tx.Commit()
+}
+
+// Memory budget settings. The warm pool holds a running agent per session, so
+// left alone it grows until the machine does. See docs/specs/42-cold-sessions.md.
+const (
+	SettingBudgetFraction = "memory.budget_fraction"
+	SettingEvictEnabled   = "memory.evict"
+
+	// DefaultBudgetFraction matches the quarter hostStats has always reported,
+	// so enforcing the budget does not also change it.
+	DefaultBudgetFraction = 0.25
+)
+
+// MemoryBudgetFraction is the share of physical memory the warm pool may hold.
+//
+// A fraction rather than a byte count: the same install runs on a 16 GB laptop
+// and a 64 GB desktop. Zero means no limit. An unreadable or out-of-range value
+// falls back to the default rather than to no limit, so a malformed setting
+// cannot quietly disable the budget.
+func (s *Store) MemoryBudgetFraction() float64 {
+	raw, err := s.GetSetting(SettingBudgetFraction)
+	if err != nil || raw == "" {
+		return DefaultBudgetFraction
+	}
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil || value < 0 || value > 1 {
+		return DefaultBudgetFraction
+	}
+	return value
+}
+
+// EvictionEnabled reports whether the daemon may let idle sessions go cold.
+// On unless explicitly turned off.
+func (s *Store) EvictionEnabled() bool {
+	raw, err := s.GetSetting(SettingEvictEnabled)
+	if err != nil || raw == "" {
+		return true
+	}
+	return raw != "false"
 }

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -33,16 +33,26 @@ func TestMemoryBudgetFraction(t *testing.T) {
 	}
 }
 
+// Opt-in. Upgrading must not start killing agents on somebody's machine.
 func TestEvictionEnabled(t *testing.T) {
 	s := setupTestStore(t)
 
-	if !s.EvictionEnabled() {
-		t.Error("eviction is off by default; it should be on")
+	if s.EvictionEnabled() {
+		t.Error("eviction is on by default; it must be opt-in")
 	}
-	if err := s.SetSetting(SettingEvictEnabled, "false"); err != nil {
+	if err := s.SetSetting(SettingEvictEnabled, "true"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if s.EvictionEnabled() {
-		t.Error("eviction stayed on after being turned off")
+	if !s.EvictionEnabled() {
+		t.Error("eviction stayed off after being turned on")
+	}
+	// Anything unrecognised means off, so a malformed value cannot enable it.
+	for _, raw := range []string{"false", "yes", "1", ""} {
+		if err := s.SetSetting(SettingEvictEnabled, raw); err != nil {
+			t.Fatalf("set %q: %v", raw, err)
+		}
+		if s.EvictionEnabled() {
+			t.Errorf("%q enabled eviction", raw)
+		}
 	}
 }

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -1,0 +1,48 @@
+package store
+
+import "testing"
+
+// A malformed setting must fall back to the default, not to "no limit". The
+// unsafe direction is silently disabling the budget.
+func TestMemoryBudgetFraction(t *testing.T) {
+	s := setupTestStore(t)
+
+	if got := s.MemoryBudgetFraction(); got != DefaultBudgetFraction {
+		t.Errorf("unset = %v, want %v", got, DefaultBudgetFraction)
+	}
+
+	for _, tc := range []struct {
+		raw  string
+		want float64
+	}{
+		{"0.5", 0.5},
+		{"1", 1},
+		// Zero is a real choice — "no limit" — rather than a parse failure.
+		{"0", 0},
+		{"nonsense", DefaultBudgetFraction},
+		{"-0.5", DefaultBudgetFraction},
+		{"12", DefaultBudgetFraction},
+		{"", DefaultBudgetFraction},
+	} {
+		if err := s.SetSetting(SettingBudgetFraction, tc.raw); err != nil {
+			t.Fatalf("set %q: %v", tc.raw, err)
+		}
+		if got := s.MemoryBudgetFraction(); got != tc.want {
+			t.Errorf("%q = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestEvictionEnabled(t *testing.T) {
+	s := setupTestStore(t)
+
+	if !s.EvictionEnabled() {
+		t.Error("eviction is off by default; it should be on")
+	}
+	if err := s.SetSetting(SettingEvictEnabled, "false"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if s.EvictionEnabled() {
+		t.Error("eviction stayed on after being turned off")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -157,6 +157,10 @@ func (s *Store) migrate() error {
 		// than the smallest, which puts it on top without renumbering the rest.
 		{"add_sessions_sort_order", `ALTER TABLE sessions ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`},
 		{"drop_sessions_managed", `ALTER TABLE sessions DROP COLUMN managed`},
+		// When a human last looked at the session, as opposed to when its agent
+		// last did something. Eviction needs the first, and last_event_at only
+		// answers the second.
+		{"add_sessions_last_interacted_at", `ALTER TABLE sessions ADD COLUMN last_interacted_at TEXT`},
 	}
 
 	for _, cm := range columnMigrations {

--- a/internal/terminal/attach_e2e_test.go
+++ b/internal/terminal/attach_e2e_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -61,6 +62,25 @@ func (u *userTerminal) typeKeys(t *testing.T, s string) {
 	}
 }
 
+// runEcho types `echo <word>` and waits for the word to come back as output.
+//
+// The word is typed in two quoted halves so that it appears whole *only* in the
+// command's output. Typing it plainly, the terminal's own line-discipline echo
+// puts it on screen before anything has read it — and waiting on that is
+// waiting on nothing: the attach may not have switched the pty to raw yet, so
+// the line sits in the canonical buffer and is delivered much later, after the
+// test has moved on to set an overlay or press the detach key. That is the race
+// behind two long-standing flakes in this file.
+//
+// Waiting for the output instead means the bytes reached the host, the shell
+// ran them, and the reply came back — an ordering barrier rather than a guess.
+func (u *userTerminal) runEcho(t *testing.T, word string, d time.Duration) bool {
+	t.Helper()
+	half := len(word) / 2
+	u.typeKeys(t, fmt.Sprintf("echo '%s''%s'\r", word[:half], word[half:]))
+	return u.waitForText(word, d)
+}
+
 func (u *userTerminal) waitForText(want string, d time.Duration) bool {
 	deadline := time.Now().Add(d)
 	for time.Now().Before(deadline) {
@@ -99,8 +119,7 @@ func TestE2EAttachRoundTripsAndDetaches(t *testing.T) {
 		done <- res
 	}()
 
-	ut.typeKeys(t, "echo attach-roundtrip\r")
-	if !ut.waitForText("attach-roundtrip", 10*time.Second) {
+	if !ut.runEcho(t, "attach-roundtrip", 10*time.Second) {
 		t.Fatal("keystrokes did not round-trip through attach")
 	}
 
@@ -203,8 +222,7 @@ func TestE2EOverlayOnAnAttachedTerminal(t *testing.T) {
 		Socket: sock, Name: "e2e-overlay", In: ut.slave, Out: ut.slave,
 	})
 
-	ut.typeKeys(t, "echo before-overlay\r")
-	if !ut.waitForText("before-overlay", 10*time.Second) {
+	if !ut.runEcho(t, "before-overlay", 10*time.Second) {
 		t.Fatal("the attach never reached the shell")
 	}
 
@@ -239,8 +257,7 @@ func TestE2EOverlayOnAnAttachedTerminal(t *testing.T) {
 		t.Fatalf("ClearOverlay: %v", err)
 	}
 	// Proof the keyboard went back to the shell, not just that the box left.
-	ut.typeKeys(t, "echo after-overlay\r")
-	if !ut.waitForText("after-overlay", 10*time.Second) {
+	if !ut.runEcho(t, "after-overlay", 10*time.Second) {
 		t.Error("input never returned to the child after the overlay cleared")
 	}
 }

--- a/internal/terminal/attach_e2e_test.go
+++ b/internal/terminal/attach_e2e_test.go
@@ -74,11 +74,26 @@ func (u *userTerminal) typeKeys(t *testing.T, s string) {
 //
 // Waiting for the output instead means the bytes reached the host, the shell
 // ran them, and the reply came back — an ordering barrier rather than a guess.
+//
+// Retyped until it lands, as the resize test does, because there is no moment
+// at which the shell is known to be listening. Attach may not have finished
+// switching the pty to raw, and ClearOverlay is fire-and-forget — a line typed
+// immediately after it can reach the host while the overlay is still up, where
+// it is swallowed as overlay input rather than passed to the child.
 func (u *userTerminal) runEcho(t *testing.T, word string, d time.Duration) bool {
 	t.Helper()
 	half := len(word) / 2
-	u.typeKeys(t, fmt.Sprintf("echo '%s''%s'\r", word[:half], word[half:]))
-	return u.waitForText(word, d)
+	line := fmt.Sprintf("echo '%s''%s'\r", word[:half], word[half:])
+	deadline := time.Now().Add(d)
+	for {
+		u.typeKeys(t, line)
+		if u.waitForText(word, 500*time.Millisecond) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+	}
 }
 
 func (u *userTerminal) waitForText(want string, d time.Duration) bool {

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -22,9 +22,9 @@ var generalSettingsKeys = []struct {
 	// one and wraps. Nil means the row is a plain on/off.
 	choices []settingChoice
 }{
-	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
+	{key: "autotitle.enabled", label: "Auto title generation", section: "Sessions"},
 	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
-	{key: "memory.evict", label: "Save memory", section: "Memory"},
+	{key: "memory.evict", label: "Save memory", section: ""},
 	{key: "memory.budget_fraction", label: "Use up to", section: "", choices: budgetChoices},
 }
 

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -18,31 +20,30 @@ var generalSettingsKeys = []struct {
 	key     string
 	label   string
 	section string
-	// choices makes a row a cycle rather than a toggle. Enter steps to the next
-	// one and wraps. Nil means the row is a plain on/off.
-	choices []settingChoice
+	// slider makes a row a value dragged with ←/→ rather than a toggle. The
+	// value is a fraction stored as a string.
+	slider bool
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Sessions"},
 	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
 	{key: "memory.evict", label: "Save memory", section: ""},
-	{key: "memory.budget_fraction", label: "Use up to", section: "", choices: budgetChoices},
+	{key: "memory.budget_fraction", label: "Memory limit", section: "", slider: true},
 }
 
-// settingChoice is one step of a cycling row.
-type settingChoice struct {
-	value string
-	label string
-}
-
-// budgetChoices are the shares of machine memory the warm pool may hold. Past
-// it, sessions nobody has opened for a while go cold. See
-// docs/specs/42-cold-sessions.md.
-var budgetChoices = []settingChoice{
-	{value: "0.25", label: "quarter of RAM"},
-	{value: "0.5", label: "half of RAM"},
-	{value: "0.75", label: "three quarters"},
-	{value: "0", label: "no limit"},
-}
+// The slider's travel, as a share of machine memory. Past the budget, sessions
+// nobody has opened for a while go cold. See docs/specs/42-cold-sessions.md.
+//
+// It stops short of the whole machine at both ends: below a twentieth the
+// budget cannot hold one agent, and at 100% eviction would only begin once the
+// machine was already swapping.
+const (
+	budgetMin     = 0.05
+	budgetMax     = 0.9
+	budgetStep    = 0.05
+	budgetDefault = 0.25
+	// budgetCells is how wide the bar is drawn.
+	budgetCells = 17
+)
 
 var generalSettingDefaults = map[string]bool{
 	"autotitle.enabled": false,
@@ -61,8 +62,8 @@ func loadGeneralSettings(c *client) tea.Cmd {
 		values := make(map[string]bool, len(generalSettingsKeys))
 		choices := make(map[string]string, len(generalSettingsKeys))
 		for _, item := range generalSettingsKeys {
-			if item.choices != nil {
-				choices[item.key] = pickChoice(item.choices, settings[item.key])
+			if item.slider {
+				choices[item.key] = formatFraction(clampBudget(parseFraction(settings[item.key])))
 				continue
 			}
 			if raw, ok := settings[item.key]; ok {
@@ -75,26 +76,60 @@ func loadGeneralSettings(c *client) tea.Cmd {
 	}
 }
 
-// pickChoice resolves a stored value to one of the offered steps. Anything
-// unrecognised lands on the first, so a hand-edited setting cannot leave the
-// row showing nothing.
-func pickChoice(choices []settingChoice, stored string) string {
-	for _, c := range choices {
-		if c.value == stored {
-			return c.value
-		}
+// parseFraction reads a stored fraction. Anything unparseable lands on the
+// default, so a hand-edited setting cannot leave the row showing nothing.
+func parseFraction(stored string) float64 {
+	f, err := strconv.ParseFloat(stored, 64)
+	if err != nil {
+		return budgetDefault
 	}
-	return choices[0].value
+	return f
 }
 
-// labelFor is what a cycling row displays.
-func labelFor(choices []settingChoice, value string) string {
-	for _, c := range choices {
-		if c.value == value {
-			return c.label
-		}
+// clampBudget holds a value inside the slider's travel. The setting predates
+// the slider, so a stored one can sit outside it.
+func clampBudget(f float64) float64 {
+	return math.Min(budgetMax, math.Max(budgetMin, f))
+}
+
+// formatFraction is the stored form: two decimals, so stepping by twentieths
+// cannot accumulate float noise in the database.
+func formatFraction(f float64) string {
+	return strconv.FormatFloat(f, 'f', 2, 64)
+}
+
+// budgetBar draws the slider. A filled run, an empty one, and the percentage,
+// because a bar alone cannot be read back as a number.
+func budgetBar(f float64) string {
+	filled := int(math.Round((f - budgetMin) / (budgetMax - budgetMin) * float64(budgetCells)))
+	if filled < 0 {
+		filled = 0
 	}
-	return choices[0].label
+	if filled > budgetCells {
+		filled = budgetCells
+	}
+	return fmt.Sprintf("%s%s %3d%%",
+		strings.Repeat("━", filled),
+		strings.Repeat("─", budgetCells-filled),
+		int(math.Round(f*100)))
+}
+
+// adjustGeneralSetting moves a slider row by one step. Rows that are not
+// sliders ignore ←/→.
+func (m StartModel) adjustGeneralSetting(delta float64) (tea.Model, tea.Cmd) {
+	item := generalSettingsKeys[m.settingsCursor]
+	if !item.slider {
+		return m, nil
+	}
+	if m.settingsChoices == nil {
+		m.settingsChoices = map[string]string{}
+	}
+	next := formatFraction(clampBudget(parseFraction(m.settingsChoices[item.key]) + delta))
+	if next == m.settingsChoices[item.key] {
+		return m, nil
+	}
+	m.settingsChoices[item.key] = next
+	return m, saveSetting(m.client, item.key, next)
 }
 
 func (m StartModel) toggleGeneralSetting() (tea.Model, tea.Cmd) {
@@ -102,34 +137,23 @@ func (m StartModel) toggleGeneralSetting() (tea.Model, tea.Cmd) {
 		m.settingsValues = defaultGeneralSettings()
 	}
 	item := generalSettingsKeys[m.settingsCursor]
-	key := item.key
-
-	var val string
-	if item.choices != nil {
-		// A cycle, not a flip: step to the next choice and wrap.
-		if m.settingsChoices == nil {
-			m.settingsChoices = map[string]string{}
-		}
-		current := pickChoice(item.choices, m.settingsChoices[key])
-		next := item.choices[0].value
-		for i, c := range item.choices {
-			if c.value == current {
-				next = item.choices[(i+1)%len(item.choices)].value
-				break
-			}
-		}
-		m.settingsChoices[key] = next
-		val = next
-	} else {
-		m.settingsValues[key] = !m.settingsValues[key]
-		val = "false"
-		if m.settingsValues[key] {
-			val = "true"
-		}
+	// A slider has no state to flip; enter on one would either do nothing or
+	// jump it somewhere the user did not aim for.
+	if item.slider {
+		return m, nil
 	}
+
+	m.settingsValues[item.key] = !m.settingsValues[item.key]
+	val := "false"
+	if m.settingsValues[item.key] {
+		val = "true"
+	}
+	return m, saveSetting(m.client, item.key, val)
+}
+
+func saveSetting(c *client, key, val string) tea.Cmd {
 	patch := map[string]string{key: val}
-	c := m.client
-	return m, func() tea.Msg {
+	return func() tea.Msg {
 		c.updateSettings(patch) //nolint:errcheck — best-effort
 		return generalSettingSaved{}
 	}
@@ -140,9 +164,9 @@ func (m StartModel) resetGeneralSettings() (tea.Model, tea.Cmd) {
 	patch := make(map[string]string, len(generalSettingsKeys))
 	m.settingsChoices = map[string]string{}
 	for _, item := range generalSettingsKeys {
-		if item.choices != nil {
-			patch[item.key] = item.choices[0].value
-			m.settingsChoices[item.key] = item.choices[0].value
+		if item.slider {
+			patch[item.key] = formatFraction(budgetDefault)
+			m.settingsChoices[item.key] = formatFraction(budgetDefault)
 			continue
 		}
 		if generalSettingDefaults[item.key] {
@@ -186,8 +210,14 @@ func (m StartModel) viewGeneralSettings() string {
 		}
 
 		var state string
-		if item.choices != nil {
-			state = toggleOnStyle.Render(labelFor(item.choices, m.settingsChoices[item.key]))
+		if item.slider {
+			bar := budgetBar(clampBudget(parseFraction(m.settingsChoices[item.key])))
+			// A limit nothing enforces should not read as a live setting.
+			if values["memory.evict"] {
+				state = toggleOnStyle.Render(bar)
+			} else {
+				state = dimStyle.Render(bar)
+			}
 		} else if values[item.key] {
 			state = toggleOnStyle.Render("[ON ]")
 		} else {
@@ -204,7 +234,7 @@ func (m StartModel) viewGeneralSettings() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("  ↑/↓ navigate  space/enter change  r reset defaults  q back"))
+	b.WriteString(helpStyle.Render("  ↑/↓ navigate  space/enter toggle  ←/→ adjust  r reset defaults  q back"))
 
 	return b.String()
 }

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -18,9 +18,29 @@ var generalSettingsKeys = []struct {
 	key     string
 	label   string
 	section string
+	// choices makes a row a cycle rather than a toggle. Enter steps to the next
+	// one and wraps. Nil means the row is a plain on/off.
+	choices []settingChoice
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
 	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
+	{key: "memory.budget_fraction", label: "Warm session memory", section: "Memory", choices: budgetChoices},
+}
+
+// settingChoice is one step of a cycling row.
+type settingChoice struct {
+	value string
+	label string
+}
+
+// budgetChoices are the shares of machine memory the warm pool may hold. Past
+// it, sessions nobody has opened for a while go cold. See
+// docs/specs/42-cold-sessions.md.
+var budgetChoices = []settingChoice{
+	{value: "0.25", label: "quarter of RAM"},
+	{value: "0.5", label: "half of RAM"},
+	{value: "0.75", label: "three quarters"},
+	{value: "0", label: "no limit"},
 }
 
 var generalSettingDefaults = map[string]bool{
@@ -35,27 +55,73 @@ func loadGeneralSettings(c *client) tea.Cmd {
 			return generalSettingsLoaded{err: err}
 		}
 		values := make(map[string]bool, len(generalSettingsKeys))
+		choices := make(map[string]string, len(generalSettingsKeys))
 		for _, item := range generalSettingsKeys {
+			if item.choices != nil {
+				choices[item.key] = pickChoice(item.choices, settings[item.key])
+				continue
+			}
 			if raw, ok := settings[item.key]; ok {
 				values[item.key] = raw == "true"
 				continue
 			}
 			values[item.key] = generalSettingDefaults[item.key]
 		}
-		return generalSettingsLoaded{values: values}
+		return generalSettingsLoaded{values: values, choices: choices}
 	}
+}
+
+// pickChoice resolves a stored value to one of the offered steps. Anything
+// unrecognised lands on the first, so a hand-edited setting cannot leave the
+// row showing nothing.
+func pickChoice(choices []settingChoice, stored string) string {
+	for _, c := range choices {
+		if c.value == stored {
+			return c.value
+		}
+	}
+	return choices[0].value
+}
+
+// labelFor is what a cycling row displays.
+func labelFor(choices []settingChoice, value string) string {
+	for _, c := range choices {
+		if c.value == value {
+			return c.label
+		}
+	}
+	return choices[0].label
 }
 
 func (m StartModel) toggleGeneralSetting() (tea.Model, tea.Cmd) {
 	if m.settingsValues == nil {
 		m.settingsValues = defaultGeneralSettings()
 	}
-	key := generalSettingsKeys[m.settingsCursor].key
-	m.settingsValues[key] = !m.settingsValues[key]
+	item := generalSettingsKeys[m.settingsCursor]
+	key := item.key
 
-	val := "false"
-	if m.settingsValues[key] {
-		val = "true"
+	var val string
+	if item.choices != nil {
+		// A cycle, not a flip: step to the next choice and wrap.
+		if m.settingsChoices == nil {
+			m.settingsChoices = map[string]string{}
+		}
+		current := pickChoice(item.choices, m.settingsChoices[key])
+		next := item.choices[0].value
+		for i, c := range item.choices {
+			if c.value == current {
+				next = item.choices[(i+1)%len(item.choices)].value
+				break
+			}
+		}
+		m.settingsChoices[key] = next
+		val = next
+	} else {
+		m.settingsValues[key] = !m.settingsValues[key]
+		val = "false"
+		if m.settingsValues[key] {
+			val = "true"
+		}
 	}
 	patch := map[string]string{key: val}
 	c := m.client
@@ -68,7 +134,13 @@ func (m StartModel) toggleGeneralSetting() (tea.Model, tea.Cmd) {
 func (m StartModel) resetGeneralSettings() (tea.Model, tea.Cmd) {
 	m.settingsValues = defaultGeneralSettings()
 	patch := make(map[string]string, len(generalSettingsKeys))
+	m.settingsChoices = map[string]string{}
 	for _, item := range generalSettingsKeys {
+		if item.choices != nil {
+			patch[item.key] = item.choices[0].value
+			m.settingsChoices[item.key] = item.choices[0].value
+			continue
+		}
 		if generalSettingDefaults[item.key] {
 			patch[item.key] = "true"
 		} else {
@@ -109,13 +181,16 @@ func (m StartModel) viewGeneralSettings() string {
 			b.WriteString("\n\n")
 		}
 
-		enabled := values[item.key]
-		toggle := toggleOffStyle.Render("[OFF]")
-		if enabled {
-			toggle = toggleOnStyle.Render("[ON ]")
+		var state string
+		if item.choices != nil {
+			state = toggleOnStyle.Render(labelFor(item.choices, m.settingsChoices[item.key]))
+		} else if values[item.key] {
+			state = toggleOnStyle.Render("[ON ]")
+		} else {
+			state = toggleOffStyle.Render("[OFF]")
 		}
 
-		row := fmt.Sprintf("  %-30s %s", item.label, toggle)
+		row := fmt.Sprintf("  %-30s %s", item.label, state)
 		if i == m.settingsCursor {
 			b.WriteString(selectedStyle.Render(row))
 		} else {
@@ -125,7 +200,7 @@ func (m StartModel) viewGeneralSettings() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("  ↑/↓ navigate  space/enter toggle  r reset defaults  q back"))
+	b.WriteString(helpStyle.Render("  ↑/↓ navigate  space/enter change  r reset defaults  q back"))
 
 	return b.String()
 }

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -24,8 +24,8 @@ var generalSettingsKeys = []struct {
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
 	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
-	{key: "memory.evict", label: "Let idle sessions go cold", section: "Memory"},
-	{key: "memory.budget_fraction", label: "Warm session memory", section: "", choices: budgetChoices},
+	{key: "memory.evict", label: "Save memory", section: "Memory"},
+	{key: "memory.budget_fraction", label: "Use up to", section: "", choices: budgetChoices},
 }
 
 // settingChoice is one step of a cycling row.

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -24,7 +24,8 @@ var generalSettingsKeys = []struct {
 }{
 	{key: "autotitle.enabled", label: "Auto title generation", section: "Auto Title"},
 	{key: "autotitle.emoji", label: "Title icon prefix (needs a Nerd Font)", section: ""},
-	{key: "memory.budget_fraction", label: "Warm session memory", section: "Memory", choices: budgetChoices},
+	{key: "memory.evict", label: "Let idle sessions go cold", section: "Memory"},
+	{key: "memory.budget_fraction", label: "Warm session memory", section: "", choices: budgetChoices},
 }
 
 // settingChoice is one step of a cycling row.
@@ -46,6 +47,9 @@ var budgetChoices = []settingChoice{
 var generalSettingDefaults = map[string]bool{
 	"autotitle.enabled": false,
 	"autotitle.emoji":   false,
+	// Opt-in: eviction kills a running agent, so upgrading must not start
+	// doing it. See docs/specs/42-cold-sessions.md.
+	"memory.evict": false,
 }
 
 func loadGeneralSettings(c *client) tea.Cmd {

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -141,8 +141,9 @@ type tickMsg time.Time
 type tokenTickMsg time.Time
 
 type generalSettingsLoaded struct {
-	values map[string]bool
-	err    error
+	values  map[string]bool
+	choices map[string]string
+	err     error
 }
 
 type generalSettingSaved struct {
@@ -182,6 +183,8 @@ type StartModel struct {
 	// General settings screen
 	settingsCursor int
 	settingsValues map[string]bool
+	// Rows that cycle through named choices rather than toggling.
+	settingsChoices map[string]string
 
 	// Shell setup
 	shellInfo      daemon.ShellInfo
@@ -341,6 +344,7 @@ func (m StartModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case generalSettingsLoaded:
 		if msg.err == nil && msg.values != nil {
 			m.settingsValues = msg.values
+			m.settingsChoices = msg.choices
 		}
 		return m, nil
 

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -407,6 +407,16 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case "left", "h":
+		if m.screen == screenSettings {
+			return m.adjustGeneralSetting(-budgetStep)
+		}
+
+	case "right", "l":
+		if m.screen == screenSettings {
+			return m.adjustGeneralSetting(budgetStep)
+		}
+
 	case " ":
 		if m.screen == screenSettings {
 			return m.toggleGeneralSetting()

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -32,6 +32,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// phone and have to walk to the machine to adjust it.
   double _memoryBudgetFraction = 0.25;
 
+  /// Off unless asked for. Eviction kills a running agent, so upgrading must
+  /// not start doing it to somebody's machine.
+  bool _evictEnabled = false;
+
   // Update check
   String _currentVersion = '';
   UpdateInfo? _updateInfo;
@@ -67,6 +71,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           );
           _memoryBudgetFraction =
               (budget != null && budget >= 0 && budget <= 1) ? budget : 0.25;
+          _evictEnabled = (settings['memory.evict'] as String?) == 'true';
           _settingsLoaded = true;
         });
       }
@@ -113,32 +118,48 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   List<Widget> _buildMemoryBudgetTiles() {
     return [
-      const Padding(
-        padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
-        child: Text(
-          'Past this share of the host, sessions nobody has opened for a while '
-          'go cold. The conversation is kept and your next prompt wakes them.',
-          style: TextStyle(fontSize: 12),
+      SwitchListTile(
+        secondary: const Icon(Icons.memory),
+        title: const Text('Let idle sessions go cold'),
+        subtitle: const Text(
+          'Off by default. Frees memory by stopping agents you have not '
+          'opened lately; opening one starts it again.',
         ),
-      ),
-      RadioGroup<double>(
-        groupValue: _memoryBudgetFraction,
+        value: _evictEnabled,
         onChanged: (value) {
-          if (value == null) return;
-          setState(() => _memoryBudgetFraction = value);
-          _updateSetting('memory.budget_fraction', value.toString());
+          setState(() => _evictEnabled = value);
+          _updateSetting('memory.evict', value ? 'true' : 'false');
         },
-        child: Column(
-          children: [
-            for (final (fraction, label, note) in _budgetChoices)
-              RadioListTile<double>(
-                value: fraction,
-                title: Text(label),
-                subtitle: note == null ? null : Text(note),
-              ),
-          ],
-        ),
       ),
+      if (_evictEnabled) ...[
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Text(
+            'Past this share of the host, sessions nobody has opened for a '
+            'while go cold. The conversation is kept and opening one brings '
+            'it back.',
+            style: TextStyle(fontSize: 12),
+          ),
+        ),
+        RadioGroup<double>(
+          groupValue: _memoryBudgetFraction,
+          onChanged: (value) {
+            if (value == null) return;
+            setState(() => _memoryBudgetFraction = value);
+            _updateSetting('memory.budget_fraction', value.toString());
+          },
+          child: Column(
+            children: [
+              for (final (fraction, label, note) in _budgetChoices)
+                RadioListTile<double>(
+                  value: fraction,
+                  title: Text(label),
+                  subtitle: note == null ? null : Text(note),
+                ),
+            ],
+          ),
+        ),
+      ],
     ];
   }
 

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -69,8 +69,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
           final budget = double.tryParse(
             (settings['memory.budget_fraction'] as String?) ?? '',
           );
+          // Clamped rather than trusted: the setting predates the slider, so a
+          // stored value can sit outside its travel.
           _memoryBudgetFraction =
-              (budget != null && budget >= 0 && budget <= 1) ? budget : 0.25;
+              budget == null ? 0.25 : budget.clamp(_budgetMin, _budgetMax);
           _evictEnabled = (settings['memory.evict'] as String?) == 'true';
           _settingsLoaded = true;
         });
@@ -107,14 +109,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) setState(() => _updateDownloading = false);
   }
 
-  /// The budget choices. A free-text field invites a typo in a memory limit,
-  /// and the useful range is narrow.
-  static const _budgetChoices = <(double, String, String?)>[
-    (0.25, 'Quarter of RAM', 'Recommended'),
-    (0.5, 'Half of RAM', null),
-    (0.75, 'Three quarters', null),
-    (0, 'No limit', 'Nothing is ever evicted'),
-  ];
+  /// The slider's travel, as a share of the host's memory. It stops short of
+  /// the whole machine at both ends: below a twentieth the budget cannot hold
+  /// one agent, and at 100% eviction would only begin once the host was already
+  /// swapping.
+  static const _budgetMin = 0.05;
+  static const _budgetMax = 0.9;
+  static const _budgetDivisions = 17;
 
   List<Widget> _buildMemoryBudgetTiles() {
     return [
@@ -131,34 +132,33 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _updateSetting('memory.evict', value ? 'true' : 'false');
         },
       ),
-      if (_evictEnabled) ...[
-        const Padding(
-          padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
-          child: Text(
-            'Use up to this share of the host. Past it, the sessions nobody '
-            'has opened for a while are stopped.',
-            style: TextStyle(fontSize: 12),
-          ),
-        ),
-        RadioGroup<double>(
-          groupValue: _memoryBudgetFraction,
-          onChanged: (value) {
-            if (value == null) return;
-            setState(() => _memoryBudgetFraction = value);
-            _updateSetting('memory.budget_fraction', value.toString());
-          },
-          child: Column(
+      if (_evictEnabled)
+        ListTile(
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              for (final (fraction, label, note) in _budgetChoices)
-                RadioListTile<double>(
-                  value: fraction,
-                  title: Text(label),
-                  subtitle: note == null ? null : Text(note),
-                ),
+              const Text('Memory limit'),
+              Text(
+                '${(_memoryBudgetFraction * 100).round()}% of host RAM',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
             ],
           ),
+          subtitle: Slider(
+            value: _memoryBudgetFraction.clamp(_budgetMin, _budgetMax),
+            min: _budgetMin,
+            max: _budgetMax,
+            divisions: _budgetDivisions,
+            label: '${(_memoryBudgetFraction * 100).round()}%',
+            // Dragging moves the label only. Each step the thumb passes through
+            // would otherwise be a request the daemon has to answer.
+            onChanged: (value) => setState(() => _memoryBudgetFraction = value),
+            onChangeEnd: (value) => _updateSetting(
+              'memory.budget_fraction',
+              value.toStringAsFixed(2),
+            ),
+          ),
         ),
-      ],
     ];
   }
 

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -195,8 +195,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const _SectionHeader('Appearance'),
               _buildThemeTile(context),
-              const _SectionHeader('Memory'),
-              ..._buildMemoryBudgetTiles(),
               const _SectionHeader('Notifications'),
               SwitchListTile(
                 title: const Text('Sound'),
@@ -229,7 +227,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   );
                 },
               ),
-              const _SectionHeader('Session Titles'),
+              const _SectionHeader('Sessions'),
               if (!_settingsLoaded)
                 const ListTile(
                   leading: SizedBox(
@@ -260,6 +258,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       _updateSetting('autotitle.emoji', value ? 'true' : 'false');
                     },
                   ),
+                ..._buildMemoryBudgetTiles(),
               ],
             ],
           ),

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -26,6 +26,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _autoTitleEnabled = false;
   bool _autoTitleEmoji = true;
 
+  /// Share of the host's memory its warm sessions may hold. The budget belongs
+  /// to the daemon rather than to this device, so it is worth being able to
+  /// change it from here — otherwise you can watch a session go cold from the
+  /// phone and have to walk to the machine to adjust it.
+  double _memoryBudgetFraction = 0.25;
+
   // Update check
   String _currentVersion = '';
   UpdateInfo? _updateInfo;
@@ -56,6 +62,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // Off unless turned on: Flutter ships no Nerd Font, so the glyphs
           // render as empty boxes on the phone.
           _autoTitleEmoji = (settings['autotitle.emoji'] as String?) == 'true';
+          final budget = double.tryParse(
+            (settings['memory.budget_fraction'] as String?) ?? '',
+          );
+          _memoryBudgetFraction =
+              (budget != null && budget >= 0 && budget <= 1) ? budget : 0.25;
           _settingsLoaded = true;
         });
       }
@@ -91,6 +102,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) setState(() => _updateDownloading = false);
   }
 
+  /// The budget choices. A free-text field invites a typo in a memory limit,
+  /// and the useful range is narrow.
+  static const _budgetChoices = <(double, String, String?)>[
+    (0.25, 'Quarter of RAM', 'Recommended'),
+    (0.5, 'Half of RAM', null),
+    (0.75, 'Three quarters', null),
+    (0, 'No limit', 'Nothing is ever evicted'),
+  ];
+
+  List<Widget> _buildMemoryBudgetTiles() {
+    return [
+      const Padding(
+        padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+        child: Text(
+          'Past this share of the host, sessions nobody has opened for a while '
+          'go cold. The conversation is kept and your next prompt wakes them.',
+          style: TextStyle(fontSize: 12),
+        ),
+      ),
+      RadioGroup<double>(
+        groupValue: _memoryBudgetFraction,
+        onChanged: (value) {
+          if (value == null) return;
+          setState(() => _memoryBudgetFraction = value);
+          _updateSetting('memory.budget_fraction', value.toString());
+        },
+        child: Column(
+          children: [
+            for (final (fraction, label, note) in _budgetChoices)
+              RadioListTile<double>(
+                value: fraction,
+                title: Text(label),
+                subtitle: note == null ? null : Text(note),
+              ),
+          ],
+        ),
+      ),
+    ];
+  }
+
   Future<void> _updateSetting(String key, String value) async {
     final hm = context.read<HostManager>();
     for (final host in hm.hosts) {
@@ -124,6 +175,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const _SectionHeader('Appearance'),
               _buildThemeTile(context),
+              const _SectionHeader('Memory'),
+              ..._buildMemoryBudgetTiles(),
               const _SectionHeader('Notifications'),
               SwitchListTile(
                 title: const Text('Sound'),

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -120,10 +120,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return [
       SwitchListTile(
         secondary: const Icon(Icons.memory),
-        title: const Text('Let idle sessions go cold'),
+        title: const Text('Save memory'),
         subtitle: const Text(
-          'Off by default. Frees memory by stopping agents you have not '
-          'opened lately; opening one starts it again.',
+          'Stops the agents you have not opened lately. Opening one starts '
+          'it again, with the conversation intact.',
         ),
         value: _evictEnabled,
         onChanged: (value) {
@@ -135,9 +135,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         const Padding(
           padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
           child: Text(
-            'Past this share of the host, sessions nobody has opened for a '
-            'while go cold. The conversation is kept and opening one brings '
-            'it back.',
+            'Use up to this share of the host. Past it, the sessions nobody '
+            'has opened for a while are stopped.',
             style: TextStyle(fontSize: 12),
           ),
         ),


### PR DESCRIPTION
## Opt-in

**Off by default.** Nothing changes until `memory.evict` is turned on in
settings. Eviction kills a running agent and takes its terminal scrollback, and
it reverses a decision this project made twice — that is a choice to make
deliberately, not something an upgrade should start doing.

## Read this before reviewing: eviction was removed twice, deliberately

Please check the argument rather than the code.

| Commit | Removed | Stated reason |
|---|---|---|
| `00acdc9` | the idle TTL | "age is not evidence that nobody wants it, and an eviction costs the host's scrollback ring, which `claude --resume` does not bring back" |
| `a87a893` / #86 | the LRU at twenty hosts or a quarter of memory | "an eviction costs the host's scrollback… and it happened to whichever session the user had not looked at lately" |

The `budget` in `hostStats()` was not an oversight. It is the residue of that
removal, kept as a number to display.

**What changed is a measurement neither commit states.** The scrollback ring is
**1 MiB** (`internal/terminal/ring.go:8`) and already discards its oldest bytes.
An evicted session frees an entire `claude` — 786 MB and 744 MB for the two live
on the machine this was written on. The megabyte is also a *rendering of the
transcript*, which survives:

```
transcript (.jsonl)   survives  →  the agent panel has the whole history
permission mode       survives  →  ResumeArgs replays it
conversation state    survives  →  claude --resume reloads it
terminal scrollback   lost      →  a redraw of the above, ≤1 MiB, already lossy
```

If that ratio stops holding, this should be removed again. The spec says so.

## What it does

Over budget, idle sessions go cold: the terminal is killed, the session is not.

**The signal is human attention.** `last_event_at` moves whenever the agent does
anything, including while nobody watches. A new `last_interacted_at` records
when a client actually showed the session — on selection, and on a two-minute
heartbeat **gated on window focus**. Focus is what fixes the `Registry.InUse`
approach `00acdc9` added and `a87a893` deleted: a viewer count says a socket is
open, so a desktop left running overnight pinned whatever it was showing.

**Only `idle` is evictable.** `waiting_permission` looks idle by the clock, but
the human is the blocker and taking the terminal discards the question. Pinned
sessions are spared, and a session must have gone five minutes unread.

**Score is `rss × minutes_unread`.** The spec originally said *divide*, and the
tests caught it: dividing ranks a large session read a minute ago above one
nobody has opened all day.

**Status is never touched.** The tmux-era reaper marked evicted sessions
`terminated`, a dead end. That bug is not why eviction was removed, and this
does not reinstate it.

## Coming back

**Opening a cold session wakes it.** The manual button existed because attaching
starts an agent — the user's call. But the daemon now takes terminals away on
its own, so most cold sessions are ones Helios cold-started, and making you
click to undo that is friction Helios created. The pane shows
`Waking — starting the agent…` for the seconds it takes. Terminated sessions
still need the button, since the daemon refuses their prompts.

**Eviction is announced live.** A `session_evicted` event raises a toast naming
what was freed and how long the session had gone unopened. An earlier revision
wrote a row to the notifications table instead; that table is for things
awaiting an answer, clients only surface `pending` ones, and `CreateNotification`
does not broadcast — so nothing appeared at all.

**The host meter now reads consumed against allowed** rather than against the
machine, since a budget decides what dies. Its comment still claimed the daemon
reclaims nothing on its own.

## Settings

`memory.evict`, default off. `memory.budget_fraction`, default `0.25` — the
quarter `hostStats` already reported. A fraction, not megabytes: the same
install runs on a 16 GB laptop and a 64 GB desktop. A malformed fraction falls
back to the default, not to "no limit"; only the exact string `"true"` enables
eviction.

All three clients: desktop and mobile show four shares with the resolved size
beside each, disabled until the switch is on. The TUI settings list was booleans
only, so rows can now cycle.

## Testing

11 policy tests over pure functions — status filter, pinned, minimum age,
attention beating agent activity, the fallback when no client ever opened it,
stop-at-budget, and the size/staleness trade in both directions. Plus settings
parsing including `nonsense`, `-0.5`, `12` and the opt-in gate.

Go suite, `gofmt`, `tsc --noEmit` and `flutter analyze` clean. The TUI rows were
rendered and checked.

**Not verified end to end.** Nothing has evicted a session on a real
over-budget machine, and the wake path has not been watched. The policy is
unit-tested; the wiring is not.