### PR TITLE
fix: follow a session's transcript when it moves into a worktree

### DIFF
--- a/docs/specs/44-transcript-path-relocation.md
+++ b/docs/specs/44-transcript-path-relocation.md
@@ -1,0 +1,209 @@
+# Transcript Path Relocation: Follow a Session Into Its Worktree
+
+## Problem
+
+A session that enters a git worktree loses its transcript. The messages view
+goes empty and stays empty for the rest of the session's life, while the
+terminal keeps working normally — the agent is fine, only Helios' view of it is
+broken.
+
+Observed on session `c7e3af80-96a6-4157-9583-21b739bab1b3` ("SA warning
+removal"), 2026-08-27. Its cwd, read out of the transcript itself:
+
+| time | cwd |
+|------|-----|
+| 05:32:53 | `/workspace/opal-app` ← `SessionStart` registered the session here |
+| 05:34:23 | `/workspace/opal-app/frontend` |
+| **05:35:25** | `/workspace/opal-app/.claude/worktrees/remove-workspace-tools-warning` |
+
+Claude Code names a transcript's directory after the session's cwd, so at 05:35
+the file moved:
+
+- recorded in `sessions.transcript_path`:
+  `~/.claude/projects/-home-md-kamrul-hassan-workspace-opal-app/c7e3af80….jsonl`
+  — **gone**
+- actually on disk:
+  `~/.claude/projects/-home-md-kamrul-hassan-workspace-opal-app--claude-worktrees-remove-workspace-tools-warning/c7e3af80….jsonl`
+  — 1.3 MB, 146 messages, still being appended to
+
+Reading each path directly:
+
+```
+stale  → ERR: stat transcript: … no such file or directory
+actual → total=146 returned=5
+```
+
+`GET /api/sessions/<id>/transcript` (`internal/server/api.go:421`) hands the
+stale path to `transcript.Page`, gets that error, and answers **500
+`failed to read transcript`** on every poll. Mobile and desktop both render
+that as an empty conversation.
+
+**Blast radius:** 54 of 237 sessions in `helios.db` point at a transcript file
+that is not there. Most are terminated sessions whose files aged out, but every
+worktree-entering session joins them, and several `-worktree-` paths in that
+list are this same failure.
+
+## Root cause
+
+Two writers own `transcript_path`, and neither can correct it after the fact.
+
+`internal/store/sessions.go:163` is write-once:
+
+```sql
+UPDATE sessions SET transcript_path = ?
+WHERE session_id = ? AND transcript_path IS NULL
+```
+
+Every hook calls `updateSessionTranscript`
+(`internal/provider/claude/hooks.go:1214`) carrying the *current* path, so the
+CLI was telling us the new location roughly 200 times after the move. The
+`IS NULL` guard made all of it a no-op. The guard dates to the initial commit
+`f6cc4a3`, with no rationale beyond its comment, "sets the transcript path if
+not already set".
+
+`UpsertSession` (`internal/store/sessions.go:84`) *can* overwrite the path, but
+its only hook caller is `SessionStart` (`hooks.go:783`), which does not fire
+again for a cwd change. That is also why `sessions.cwd` still reads
+`/workspace/opal-app` for this session.
+
+## Design
+
+Three changes, one per layer:
+
+```text
+ hook event    GET /transcript
+      |               |
+      v               v
+ +---------+     +---------+
+ | A store |<----| C serve |
+ | last    | save| resolve |
+ | one     |     | + repair|
+ | wins    |     +----+----+
+ +---------+          | miss
+                      v
+                 +---------+
+                 | B find  |
+                 | by id   |
+                 +---------+
+```
+
+What one request does:
+
+```text
+GET /transcript
+      |
+      v
+stat(recorded)  --ok--> serve
+      |
+   missing
+      |
+      v
+scan projects/
+  */<id>.jsonl  --hit--> save,
+      |                  serve
+   nothing
+      |
+      v
+200 + empty page
+  (never a 500)
+```
+
+A live session never reaches the scan: A re-records the path on the first hook
+after the move, so C's `stat` hits on the next poll.
+
+### A. The recorded path follows the file (`internal/store`)
+
+Drop the `IS NULL` guard, and skip the write when nothing changed so the common
+case stays a no-op:
+
+```sql
+UPDATE sessions SET transcript_path = ?
+WHERE session_id = ? AND (transcript_path IS NULL OR transcript_path != ?)
+```
+
+The last hook to speak wins. This is the whole fix for sessions running under
+current hooks: any hook event after the move re-records the path.
+
+### B. Find a transcript by session ID (`internal/discovery`)
+
+Sessions that moved *before* this change have a stale row and may never fire
+another hook — a terminated session never will. `FindClaudeTranscript(sessionID)`
+walks `~/.claude/projects/*/` for `<sessionID>.jsonl` and returns the match:
+
+```go
+func FindClaudeTranscript(sessionID string) string
+```
+
+Returns `""` when nothing matches. When several directories hold a file for the
+same session, the newest by mtime wins — that being the one still being written
+to. The lookup is exact-name, so subagent transcripts (`agent-*.jsonl`) cannot
+be mistaken for a session's own.
+
+This belongs in `discovery` because that package already owns knowledge of the
+`~/.claude/projects` layout.
+
+### C. The API resolves and repairs (`internal/server`)
+
+```go
+func (s *PublicServer) resolveTranscriptPath(session *store.Session) string
+```
+
+- recorded path exists → return it (one `stat`, the normal case)
+- recorded path missing, source is `claude` → `FindClaudeTranscript`, write the
+  result back with `UpdateSessionTranscriptPath`, return it
+- nothing found → `""`
+
+Used by `handleSessionTranscript` and by `handleGenerateSessionTitle`, which
+reads the same field. Writing the result back means the directory walk happens
+once per relocation, not once per poll.
+
+A `""` result takes the existing "session has no transcript" branch: **200 with
+an empty page, not a 500**. A transcript that is genuinely gone is an empty
+transcript — the client polls this endpoint and has nothing to retry, so an
+error status only produces noise and an error banner over an empty list.
+
+### D. Not in scope
+
+- **`sessions.cwd` staleness.** The same move leaves cwd pointing at the
+  pre-worktree directory, which misdirects the diff and file-browser views.
+  Hooks carry cwd on every event, but the agent also `cd`s into subdirectories
+  (`/opal-app/frontend` above), so blindly following it would flip the session's
+  displayed project name back and forth. Fixing it needs a rule for which cwd is
+  the session's own — separate change, separate spec.
+- **`internal/daemon/reaper.go:39`** reads `TranscriptPath` to backfill the last
+  user message. It runs on live sessions, which self-heal via A.
+- **Backfilling the 54 stale rows in a batch.** C repairs each row the first
+  time anything asks for it, which is enough; a migration would walk every
+  project directory at startup for rows nobody will ever open.
+
+## Edge cases
+
+| case | behaviour |
+|------|-----------|
+| transcript deleted outright | 200, empty page; the row keeps its stale path |
+| two copies of the same session ID | newest mtime wins |
+| non-`claude` session with a bad path | no lookup, empty page |
+| `~/.claude/projects` unreadable or absent | `""`, empty page |
+| session with no path at all | unchanged — the existing empty branch |
+| relocation mid-poll | the delta's epoch changes, so the client resets to a full page (spec 38) rather than splicing onto the old file |
+
+## Testing
+
+Three tests, each verified to fail against the current code with the same
+`500 … no such file or directory` seen in production:
+
+- `internal/store` — `UpdateSessionTranscriptPath` overwrites an existing path.
+- `internal/discovery` — `FindClaudeTranscript` picks the newest of two copies;
+  returns `""` for an unknown ID. Uses `t.Setenv("HOME", t.TempDir())`.
+- `internal/server` — a session whose recorded transcript has moved to another
+  project directory serves its messages *and* has the new path recorded
+  afterwards; a session whose transcript was deleted returns an empty page
+  rather than a 500.
+
+## Success criteria
+
+1. Entering a worktree does not interrupt the messages view.
+2. Sessions already holding a stale path recover the first time they are opened,
+   including terminated ones.
+3. `GET /api/sessions/<id>/transcript` never returns 500 for a missing file.
+4. Steady state costs one extra `stat` per request and no extra writes.

--- a/internal/discovery/claude.go
+++ b/internal/discovery/claude.go
@@ -94,6 +94,46 @@ func DiscoverClaudeSessions(db *store.Store) {
 	}
 }
 
+// FindClaudeTranscript looks a session's transcript up by ID, wherever Claude
+// Code keeps it now. The project directory is named after the session's cwd, so
+// a session that enters a git worktree leaves its old directory behind; callers
+// use this when the path they recorded no longer resolves.
+//
+// Returns "" when nothing matches. When several directories hold a file for the
+// same session the newest wins, that being the one still being written to.
+func FindClaudeTranscript(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	projectsDir := filepath.Join(home, ".claude", "projects")
+	projectDirs, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+
+	best := ""
+	var newest int64
+	for _, pd := range projectDirs {
+		if !pd.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(projectsDir, pd.Name(), sessionID+".jsonl")
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if best == "" || info.ModTime().UnixNano() > newest {
+			best, newest = candidate, info.ModTime().UnixNano()
+		}
+	}
+	return best
+}
+
 // parseSessionFromJSONL reads the first few lines of a .jsonl file to extract
 // session metadata: sessionId, cwd, timestamp, model.
 func parseSessionFromJSONL(path, sessionID string) *store.Session {

--- a/internal/discovery/claude_test.go
+++ b/internal/discovery/claude_test.go
@@ -1,0 +1,51 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTranscript puts a session's .jsonl in the project directory Claude Code
+// would name for the given cwd, and returns its path.
+func writeTranscript(t *testing.T, home, projectDir, sessionID string, modTime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "projects", projectDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+	return path
+}
+
+// A session that enters a git worktree leaves a transcript behind in the
+// directory named after the cwd it started in.
+func TestFindClaudeTranscriptPrefersTheNewestCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	old := time.Date(2026, 8, 27, 5, 30, 0, 0, time.UTC)
+	writeTranscript(t, home, "-tmp-repo", "s1", old)
+	moved := writeTranscript(t, home, "-tmp-repo--claude-worktrees-feature", "s1", old.Add(time.Hour))
+
+	if got := FindClaudeTranscript("s1"); got != moved {
+		t.Errorf("FindClaudeTranscript = %q, want %q", got, moved)
+	}
+}
+
+func TestFindClaudeTranscriptEmptyWhenAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTranscript(t, home, "-tmp-repo", "s1", time.Now())
+
+	if got := FindClaudeTranscript("s2"); got != "" {
+		t.Errorf("FindClaudeTranscript = %q, want \"\"", got)
+	}
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kamrul1157024/helios/internal/auth"
 	"github.com/kamrul1157024/helios/internal/backend"
+	"github.com/kamrul1157024/helios/internal/discovery"
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/provider"
 	claudeprovider "github.com/kamrul1157024/helios/internal/provider/claude"
@@ -373,6 +374,38 @@ func (s *PublicServer) handleGetSession(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// resolveTranscriptPath returns a transcript path that exists, or "" when the
+// session has none to read.
+//
+// The recorded path can go stale: Claude Code keeps a transcript in a directory
+// named after the session's cwd, so entering a git worktree moves the file out
+// from under whatever was recorded when the session started. Sessions running
+// under current hooks re-record the path themselves; this catches the ones that
+// moved before, and writes the new path back so the walk happens once.
+func (s *PublicServer) resolveTranscriptPath(session *store.Session) string {
+	recorded := ""
+	if session.TranscriptPath != nil {
+		recorded = *session.TranscriptPath
+	}
+	if recorded != "" {
+		if _, err := os.Stat(recorded); err == nil {
+			return recorded
+		}
+	}
+	if session.Source != "claude" {
+		return ""
+	}
+
+	found := discovery.FindClaudeTranscript(session.SessionID)
+	if found == "" {
+		return ""
+	}
+	if err := s.shared.DB.UpdateSessionTranscriptPath(session.SessionID, found); err != nil {
+		log.Printf("api: record relocated transcript for %s: %v", session.SessionID, err)
+	}
+	return found
+}
+
 func (s *PublicServer) handleSessionTranscript(w http.ResponseWriter, r *http.Request) {
 	// Path: /api/sessions/<id>/transcript
 	path := strings.TrimPrefix(r.URL.Path, "/api/sessions/")
@@ -388,7 +421,8 @@ func (s *PublicServer) handleSessionTranscript(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if session.TranscriptPath == nil || *session.TranscriptPath == "" {
+	transcriptPath := s.resolveTranscriptPath(session)
+	if transcriptPath == "" {
 		jsonResponse(w, http.StatusOK, map[string]interface{}{
 			"messages": []interface{}{},
 			"total":    0,
@@ -416,9 +450,9 @@ func (s *PublicServer) handleSessionTranscript(w http.ResponseWriter, r *http.Re
 	if a := r.URL.Query().Get("after_seq"); a != "" {
 		afterSeq := -1
 		fmt.Sscanf(a, "%d", &afterSeq)
-		result, err = transcript.Delta(*session.TranscriptPath, r.URL.Query().Get("epoch"), afterSeq, limit)
+		result, err = transcript.Delta(transcriptPath, r.URL.Query().Get("epoch"), afterSeq, limit)
 	} else {
-		result, err = transcript.Page(*session.TranscriptPath, limit, offset)
+		result, err = transcript.Page(transcriptPath, limit, offset)
 	}
 	if err != nil {
 		jsonError(w, fmt.Sprintf("failed to read transcript: %v", err), http.StatusInternalServerError)
@@ -989,10 +1023,7 @@ func (s *PublicServer) handleGenerateSessionTitle(w http.ResponseWriter, r *http
 		return
 	}
 
-	transcriptPath := ""
-	if session.TranscriptPath != nil {
-		transcriptPath = *session.TranscriptPath
-	}
+	transcriptPath := s.resolveTranscriptPath(session)
 
 	notify := func(eventType string, data interface{}) {
 		s.shared.SSE.Broadcast(SSEEvent{Type: eventType, Data: data})

--- a/internal/server/transcript_test.go
+++ b/internal/server/transcript_test.go
@@ -151,6 +151,62 @@ func TestTranscriptEndpointResetsOnStaleEpoch(t *testing.T) {
 	}
 }
 
+// Entering a git worktree moves a session's cwd, and Claude Code moves the
+// transcript with it. The path recorded at SessionStart then points at nothing,
+// and the session's messages have to be found where they actually are.
+func TestTranscriptEndpointFollowsAMovedTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	e := newTranscriptEnv(t)
+	e.append("one", "two")
+
+	moved := filepath.Join(home, ".claude", "projects", "-tmp--claude-worktrees-feature")
+	if err := os.MkdirAll(moved, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body, err := os.ReadFile(e.path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	movedPath := filepath.Join(moved, "s1.jsonl")
+	if err := os.WriteFile(movedPath, body, 0o600); err != nil {
+		t.Fatalf("write moved transcript: %v", err)
+	}
+	if err := os.Remove(e.path); err != nil {
+		t.Fatalf("remove old transcript: %v", err)
+	}
+
+	if got := texts(e.get("?limit=50").Messages); fmt.Sprint(got) != "[one two]" {
+		t.Fatalf("messages = %v, want [one two]", got)
+	}
+
+	// And the new path is recorded, so the next read does not go looking again.
+	sess, err := e.srv.shared.DB.GetSession("s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.TranscriptPath == nil || *sess.TranscriptPath != movedPath {
+		t.Errorf("recorded path = %v, want %q", sess.TranscriptPath, movedPath)
+	}
+}
+
+// A transcript that is simply gone is an empty one, not a failed request: the
+// client polls this endpoint, and there is nothing for it to retry.
+func TestTranscriptEndpointEmptyWhenTheFileIsGone(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	e := newTranscriptEnv(t)
+	e.append("one")
+	if err := os.Remove(e.path); err != nil {
+		t.Fatalf("remove transcript: %v", err)
+	}
+
+	if got := e.get("?limit=50"); got.Total != 0 {
+		t.Errorf("total = %d, want 0", got.Total)
+	}
+}
+
 func TestTranscriptEndpointEmptyForSessionWithoutTranscript(t *testing.T) {
 	e := newTranscriptEnv(t)
 	if err := e.srv.shared.DB.UpsertSession(&store.Session{

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -177,11 +177,17 @@ func (s *Store) UpdateSessionPermissionMode(sessionID, mode string) error {
 	return err
 }
 
-// UpdateSessionTranscriptPath sets the transcript path if not already set.
+// UpdateSessionTranscriptPath records where a session's transcript lives now.
+//
+// Deliberately not write-once. Claude Code names a transcript's directory after
+// the session's cwd, so moving into a git worktree moves the file, and the path
+// recorded at SessionStart is left pointing at nothing. Every hook carries the
+// current path, so the last one to speak wins.
 func (s *Store) UpdateSessionTranscriptPath(sessionID, path string) error {
 	_, err := s.db.Exec(
-		`UPDATE sessions SET transcript_path = ? WHERE session_id = ? AND transcript_path IS NULL`,
-		path, sessionID,
+		`UPDATE sessions SET transcript_path = ?
+		 WHERE session_id = ? AND (transcript_path IS NULL OR transcript_path != ?)`,
+		path, sessionID, path,
 	)
 	return err
 }

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -287,3 +287,28 @@ func TestTouchSessionIsSeparateFromAgentActivity(t *testing.T) {
 		t.Error("agent activity moved last_interacted_at")
 	}
 }
+
+// Claude Code moves a transcript when the session's cwd moves, so the path a
+// session was registered with is not the last word on where its transcript is.
+func TestUpdateSessionTranscriptPath_FollowsAMovedTranscript(t *testing.T) {
+	s := setupTestStore(t)
+	if err := s.UpsertSession(&Session{
+		SessionID:      "a",
+		Source:         "claude",
+		CWD:            "/tmp/repo",
+		Status:         "idle",
+		TranscriptPath: strPtr("/projects/-tmp-repo/a.jsonl"),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	moved := "/projects/-tmp-repo--worktrees-feature/a.jsonl"
+	if err := s.UpdateSessionTranscriptPath("a", moved); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	sess, _ := s.GetSession("a")
+	if sess.TranscriptPath == nil || *sess.TranscriptPath != moved {
+		t.Errorf("transcript path = %v, want %q", sess.TranscriptPath, moved)
+	}
+}


### PR DESCRIPTION
## Problem

A session that enters a git worktree loses its messages view. The terminal keeps working — only Helios' view of the conversation goes empty, and stays empty for the rest of the session's life.

Claude Code names a transcript's directory after the session's cwd, so the `.jsonl` moves when the cwd does. Observed on a live session:

| time | cwd |
|------|-----|
| 05:32:53 | `/workspace/opal-app` ← `SessionStart` recorded the path here |
| 05:34:23 | `/workspace/opal-app/frontend` |
| **05:35:25** | `/workspace/opal-app/.claude/worktrees/remove-workspace-tools-warning` |

`GET /api/sessions/<id>/transcript` then hands `transcript.Page` a path that is gone and answers **500 `failed to read transcript`** on every poll.

**54 of 237** sessions in one daemon's DB point at a transcript file that is not there. Those 54 are two different problems wearing the same 500: **2** are this bug and recover here (their `.jsonl` is intact under another project directory), while the other **52** are terminated sessions whose transcripts Claude Code has since deleted outright. Nothing can bring those back — they go from a 500 to an empty page, no more.

## Root cause

Two writers own `transcript_path`, and neither could correct it.

`UpdateSessionTranscriptPath` was write-once:

```sql
UPDATE sessions SET transcript_path = ?
WHERE session_id = ? AND transcript_path IS NULL
```

Every hook calls it with the *current* path, so the CLI reported the new location roughly 200 times after the move — all no-ops. `UpsertSession` can overwrite, but its only hook caller is `SessionStart`, which does not fire again for a cwd change.

## Fix

```text
 hook event    GET /transcript
      |               |
      v               v
 +---------+     +---------+
 | A store |<----| C serve |
 | last    | save| resolve |
 | one     |     | + repair|
 | wins    |     +----+----+
 +---------+          | miss
                      v
                 +---------+
                 | B find  |
                 | by id   |
                 +---------+
```

- **A — `internal/store`**: drop the `IS NULL` guard; the last hook to speak wins. Skips the write when nothing changed. This alone fixes every session running under current hooks.
- **B — `internal/discovery`**: `FindClaudeTranscript(sessionID)` walks `~/.claude/projects/*/` for `<id>.jsonl`, newest mtime wins. Needed for rows that went stale before this change and may never fire another hook.
- **C — `internal/server`**: `resolveTranscriptPath` stats the recorded path, falls back to the lookup, and **writes the result back**, so the walk happens once per relocation rather than once per poll. A genuinely missing file is now a 200 + empty page, not a 500 — the client polls and has nothing to retry.

Repair is on demand: an old session is fixed the first time something opens its transcript, not by a startup sweep.

Spec: `docs/specs/42-transcript-path-relocation.md`.

## Out of scope, argued in the spec

`sessions.cwd` goes stale the same way, which misdirects the diff and file-browser views. Hooks carry cwd on every event, but the agent also `cd`s into subdirectories, so following it blindly would flip the session's displayed project name back and forth. Needs its own rule.

## Testing

Three unit tests, each confirmed to fail against unmodified code with the same `500 … no such file or directory` seen in production:

- `internal/store` — the recorded path is overwritten when the transcript moves.
- `internal/discovery` — newest of two copies wins; `""` for an unknown ID.
- `internal/server` — a moved transcript is served *and* the new path recorded; a deleted one returns an empty page, not a 500.

End-to-end against a copy of a real daemon DB and the real `~/.claude/projects` tree, over HTTP:

| | unmodified | with this change |
|---|---|---|
| status | 500 `no such file or directory` | 200 |
| messages | — | 164 |
| path after request | stale | repaired to the worktree path |

`go build ./...`, `go vet ./internal/...`, `gofmt` clean. Full `go test ./...` passes except `TestE2EClaudeCodeBootsUnderHost` and `TestE2EClaudeSnapshotCatchesUpLateViewer` in `internal/terminal`, which fail identically on pristine `main` (they boot a real Claude CLI and hang on its theme prompt) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)