### PR TITLE
fix(mobile): show the daemon settings per host, not per app

### DIFF
--- a/mobile/lib/screens/host_detail_screen.dart
+++ b/mobile/lib/screens/host_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/host_connection.dart';
+import '../services/daemon_api_service.dart';
 import '../services/host_manager.dart';
 
 class HostDetailScreen extends StatefulWidget {
@@ -16,6 +17,11 @@ class _HostDetailScreenState extends State<HostDetailScreen> {
   late TextEditingController _labelController;
   late TextEditingController _urlController;
 
+  /// Where the budget thumb sits mid-drag. Null when nothing is being dragged,
+  /// so the service's value shows. Each step the thumb passes through would
+  /// otherwise be a request the host has to answer.
+  double? _budgetDrag;
+
   @override
   void initState() {
     super.initState();
@@ -23,6 +29,9 @@ class _HostDetailScreenState extends State<HostDetailScreen> {
     final host = hm.hostById(widget.hostId);
     _labelController = TextEditingController(text: host?.label ?? '');
     _urlController = TextEditingController(text: host?.serverUrl ?? '');
+
+    final service = hm.serviceFor(widget.hostId);
+    if (service != null && service.connected) service.fetchHostSettings();
   }
 
   @override
@@ -153,6 +162,9 @@ class _HostDetailScreenState extends State<HostDetailScreen> {
                   valueColor: isConnected ? Colors.green : theme.colorScheme.onSurfaceVariant),
               _infoRow('Paired', _formatDate(host.addedAt), theme),
 
+              const SizedBox(height: 24),
+              ..._buildHostSettings(hm.serviceFor(host.id), isConnected, theme),
+
               const SizedBox(height: 32),
 
               // Disconnect button
@@ -171,6 +183,142 @@ class _HostDetailScreenState extends State<HostDetailScreen> {
           ),
         );
       },
+    );
+  }
+
+  /// The host's own settings, not this device's. The daemon stores them, so
+  /// they belong on the page for one host rather than on a settings screen
+  /// that has to guess which machine is meant.
+  List<Widget> _buildHostSettings(
+    DaemonAPIService? service,
+    bool isConnected,
+    ThemeData theme,
+  ) {
+    final header = Text('Host settings', style: theme.textTheme.labelLarge);
+
+    // Nothing read yet. A spinner while the host is answering, and a plain
+    // statement when it cannot: an offline host that spins forever reads as a
+    // broken screen.
+    if (service == null || !service.hostSettingsLoaded) {
+      return [
+        header,
+        const SizedBox(height: 8),
+        if (isConnected)
+          const Row(
+            children: [
+              SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
+              SizedBox(width: 12),
+              Text('Loading…'),
+            ],
+          )
+        else
+          Text(
+            'Offline — settings unavailable until this host reconnects.',
+            style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+          ),
+      ];
+    }
+
+    // Loaded but unreachable. The last known values still say what the host is
+    // set to, so they are shown and locked rather than hidden.
+    final fraction = _budgetDrag ?? service.budgetFraction;
+
+    return [
+      header,
+      if (!isConnected)
+        Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            'Offline — showing the last known values. Reconnect to change them.',
+            style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+          ),
+        ),
+      const SizedBox(height: 8),
+      SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        secondary: const Icon(Icons.title),
+        title: const Text('Auto title'),
+        subtitle: const Text('Generate session titles automatically'),
+        value: service.autoTitleEnabled,
+        onChanged: isConnected
+            ? (value) => _saveHostSetting(
+                  () => service.setAutoTitleEnabled(value),
+                  'Auto title',
+                )
+            : null,
+      ),
+      if (service.autoTitleEnabled)
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          secondary: const Icon(Icons.emoji_emotions_outlined),
+          title: const Text('Title icon'),
+          subtitle: const Text('Needs a Nerd Font — boxes without one'),
+          value: service.autoTitleEmoji,
+          onChanged: isConnected
+              ? (value) => _saveHostSetting(
+                    () => service.setAutoTitleEmoji(value),
+                    'Title icon',
+                  )
+              : null,
+        ),
+      SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        secondary: const Icon(Icons.memory),
+        title: const Text('Save memory'),
+        subtitle: const Text(
+          'Stops the agents you have not opened lately. Opening one starts '
+          'it again, with the conversation intact.',
+        ),
+        value: service.evictEnabled,
+        onChanged: isConnected
+            ? (value) => _saveHostSetting(
+                  () => service.setEvictEnabled(value),
+                  'Save memory',
+                )
+            : null,
+      ),
+      if (service.evictEnabled)
+        ListTile(
+          contentPadding: EdgeInsets.zero,
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Memory limit'),
+              Text(
+                '${(fraction * 100).round()}% of host RAM',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+          subtitle: Slider(
+            value: fraction.clamp(DaemonAPIService.budgetMin, DaemonAPIService.budgetMax),
+            min: DaemonAPIService.budgetMin,
+            max: DaemonAPIService.budgetMax,
+            divisions: 17,
+            label: '${(fraction * 100).round()}%',
+            onChanged: isConnected ? (value) => setState(() => _budgetDrag = value) : null,
+            onChangeEnd: isConnected
+                ? (value) async {
+                    await _saveHostSetting(
+                      () => service.setBudgetFraction(value),
+                      'Memory limit',
+                    );
+                    if (mounted) setState(() => _budgetDrag = null);
+                  }
+                : null,
+          ),
+        ),
+    ];
+  }
+
+  /// Writes one setting and says so when it fails. The service puts the old
+  /// value back on its own; without a message the control would flick back
+  /// with no reason given.
+  Future<void> _saveHostSetting(Future<bool> Function() write, String label) async {
+    final ok = await write();
+    if (!mounted || ok) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Could not save $label — the host did not answer')),
     );
   }
 

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -1,8 +1,8 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/host_connection.dart';
 import '../providers/theme_provider.dart';
+import '../services/daemon_api_service.dart';
 import '../services/host_manager.dart';
 import '../services/notification_service.dart';
 import '../services/update_service.dart';
@@ -20,21 +20,6 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   late bool _soundEnabled;
   late bool _vibrationEnabled;
-  bool _settingsLoaded = false;
-
-  // Auto title settings
-  bool _autoTitleEnabled = false;
-  bool _autoTitleEmoji = true;
-
-  /// Share of the host's memory its warm sessions may hold. The budget belongs
-  /// to the daemon rather than to this device, so it is worth being able to
-  /// change it from here — otherwise you can watch a session go cold from the
-  /// phone and have to walk to the machine to adjust it.
-  double _memoryBudgetFraction = 0.25;
-
-  /// Off unless asked for. Eviction kills a running agent, so upgrading must
-  /// not start doing it to somebody's machine.
-  bool _evictEnabled = false;
 
   // Update check
   String _currentVersion = '';
@@ -48,36 +33,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
     super.initState();
     _soundEnabled = NotificationService.instance.soundEnabled;
     _vibrationEnabled = NotificationService.instance.vibrationEnabled;
-    _loadSettings();
+    _loadHostSettings();
     _loadVersionAndCheckUpdate();
   }
 
-  Future<void> _loadSettings() async {
+  /// Asks every reachable host what it is set to, so each row can summarise
+  /// itself. These settings live in the daemon, so there are as many answers
+  /// as there are hosts — reading one host and showing it as the app's
+  /// settings is what this replaces.
+  void _loadHostSettings() {
     final hm = context.read<HostManager>();
-    // Use the first connected host for settings
     for (final host in hm.hosts) {
       final service = hm.serviceFor(host.id);
       if (service == null || !service.connected) continue;
-      final data = await service.getSettings();
-      if (data != null && mounted) {
-        final settings = (data['settings'] as Map<String, dynamic>?) ?? {};
-        setState(() {
-          _autoTitleEnabled = (settings['autotitle.enabled'] as String?) == 'true';
-          // Off unless turned on: Flutter ships no Nerd Font, so the glyphs
-          // render as empty boxes on the phone.
-          _autoTitleEmoji = (settings['autotitle.emoji'] as String?) == 'true';
-          final budget = double.tryParse(
-            (settings['memory.budget_fraction'] as String?) ?? '',
-          );
-          // Clamped rather than trusted: the setting predates the slider, so a
-          // stored value can sit outside its travel.
-          _memoryBudgetFraction =
-              budget == null ? 0.25 : budget.clamp(_budgetMin, _budgetMax);
-          _evictEnabled = (settings['memory.evict'] as String?) == 'true';
-          _settingsLoaded = true;
-        });
-      }
-      break;
+      service.fetchHostSettings();
     }
   }
 
@@ -107,69 +76,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (mounted) setState(() => _updateProgress = p);
     });
     if (mounted) setState(() => _updateDownloading = false);
-  }
-
-  /// The slider's travel, as a share of the host's memory. It stops short of
-  /// the whole machine at both ends: below a twentieth the budget cannot hold
-  /// one agent, and at 100% eviction would only begin once the host was already
-  /// swapping.
-  static const _budgetMin = 0.05;
-  static const _budgetMax = 0.9;
-  static const _budgetDivisions = 17;
-
-  List<Widget> _buildMemoryBudgetTiles() {
-    return [
-      SwitchListTile(
-        secondary: const Icon(Icons.memory),
-        title: const Text('Save memory'),
-        subtitle: const Text(
-          'Stops the agents you have not opened lately. Opening one starts '
-          'it again, with the conversation intact.',
-        ),
-        value: _evictEnabled,
-        onChanged: (value) {
-          setState(() => _evictEnabled = value);
-          _updateSetting('memory.evict', value ? 'true' : 'false');
-        },
-      ),
-      if (_evictEnabled)
-        ListTile(
-          title: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text('Memory limit'),
-              Text(
-                '${(_memoryBudgetFraction * 100).round()}% of host RAM',
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          subtitle: Slider(
-            value: _memoryBudgetFraction.clamp(_budgetMin, _budgetMax),
-            min: _budgetMin,
-            max: _budgetMax,
-            divisions: _budgetDivisions,
-            label: '${(_memoryBudgetFraction * 100).round()}%',
-            // Dragging moves the label only. Each step the thumb passes through
-            // would otherwise be a request the daemon has to answer.
-            onChanged: (value) => setState(() => _memoryBudgetFraction = value),
-            onChangeEnd: (value) => _updateSetting(
-              'memory.budget_fraction',
-              value.toStringAsFixed(2),
-            ),
-          ),
-        ),
-    ];
-  }
-
-  Future<void> _updateSetting(String key, String value) async {
-    final hm = context.read<HostManager>();
-    for (final host in hm.hosts) {
-      final service = hm.serviceFor(host.id);
-      if (service == null || !service.connected) continue;
-      await service.updateSettings({key: value});
-      break;
-    }
   }
 
   @override
@@ -227,39 +133,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   );
                 },
               ),
-              const _SectionHeader('Sessions'),
-              if (!_settingsLoaded)
-                const ListTile(
-                  leading: SizedBox(
-                    width: 20, height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  title: Text('Loading settings...'),
-                ),
-              if (_settingsLoaded) ...[
-                SwitchListTile(
-                  secondary: const Icon(Icons.title),
-                  title: const Text('Auto title'),
-                  subtitle: const Text('Generate session titles automatically'),
-                  value: _autoTitleEnabled,
-                  onChanged: (value) {
-                    setState(() => _autoTitleEnabled = value);
-                    _updateSetting('autotitle.enabled', value ? 'true' : 'false');
-                  },
-                ),
-                if (_autoTitleEnabled)
-                  SwitchListTile(
-                    secondary: const Icon(Icons.emoji_emotions_outlined),
-                    title: const Text('Title icon'),
-                    subtitle: const Text('Needs a Nerd Font — boxes without one'),
-                    value: _autoTitleEmoji,
-                    onChanged: (value) {
-                      setState(() => _autoTitleEmoji = value);
-                      _updateSetting('autotitle.emoji', value ? 'true' : 'false');
-                    },
-                  ),
-                ..._buildMemoryBudgetTiles(),
-              ],
             ],
           ),
         );
@@ -341,8 +214,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// What a host is set to, in one line, so the list says it without a tap.
+  /// Null until the host has answered: a default shown here would be a claim
+  /// about a machine nobody has asked yet.
+  String? _hostSettingsSummary(DaemonAPIService? service) {
+    if (service == null || !service.hostSettingsLoaded) return null;
+    final title = service.autoTitleEnabled ? 'Auto title on' : 'Auto title off';
+    final memory = service.evictEnabled
+        ? 'Save memory ${(service.budgetFraction * 100).round()}%'
+        : 'Save memory off';
+    return '$title · $memory';
+  }
+
   Widget _buildHostTile(HostConnection host, HostManager hm) {
-    final isConnected = hm.serviceFor(host.id)?.connected == true;
+    final service = hm.serviceFor(host.id);
+    final isConnected = service?.connected == true;
+    final summary = _hostSettingsSummary(service);
 
     return ListTile(
       leading: Container(
@@ -354,10 +241,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
       ),
       title: Text(host.label),
-      subtitle: Text(
-        host.serverUrl,
-        style: TextStyle(fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant),
-        overflow: TextOverflow.ellipsis,
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            host.serverUrl,
+            style: TextStyle(fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant),
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (summary != null)
+            Text(
+              summary,
+              style: TextStyle(
+                fontSize: 11,
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurfaceVariant
+                    .withValues(alpha: isConnected ? 1.0 : 0.5),
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
       ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -884,6 +884,121 @@ class DaemonAPIService extends ChangeNotifier {
     return false;
   }
 
+  // ==================== Host settings ====================
+
+  /// Settings the daemon owns rather than this device. They live in this
+  /// host's database, so each paired host holds its own and a phone with two
+  /// hosts cannot set one and mean the other. Reading them from "whichever
+  /// host answered first" is how they came to look like app settings.
+  static const settingAutoTitle = 'autotitle.enabled';
+  static const settingAutoTitleEmoji = 'autotitle.emoji';
+  static const settingEvict = 'memory.evict';
+  static const settingBudgetFraction = 'memory.budget_fraction';
+
+  /// The budget slider's travel, as a share of the host's memory. It stops
+  /// short of the whole machine at both ends: below a twentieth the budget
+  /// cannot hold one agent, and at 100% eviction would only begin once the
+  /// host was already swapping.
+  static const budgetMin = 0.05;
+  static const budgetMax = 0.9;
+  static const budgetDefault = 0.25;
+
+  bool _autoTitleEnabled = false;
+  bool _autoTitleEmoji = false;
+  bool _evictEnabled = false;
+  double _budgetFraction = budgetDefault;
+  bool _hostSettingsLoaded = false;
+
+  bool get autoTitleEnabled => _autoTitleEnabled;
+  bool get autoTitleEmoji => _autoTitleEmoji;
+  bool get evictEnabled => _evictEnabled;
+  double get budgetFraction => _budgetFraction;
+
+  /// False until this host has answered once. A host that has never been read
+  /// shows nothing, rather than a default that is probably not its value.
+  bool get hostSettingsLoaded => _hostSettingsLoaded;
+
+  /// Reads every daemon-owned setting in one request. The sort mode arrives in
+  /// the same response, so fetching it on its own would ask the host the same
+  /// question twice.
+  Future<void> fetchHostSettings() async {
+    final body = await getSettings();
+    if (body == null) return;
+    final settings = (body['settings'] as Map<String, dynamic>?) ?? const {};
+    _manualOrder = settings[_sortModeSetting] == 'manual';
+    _autoTitleEnabled = settings[settingAutoTitle] == 'true';
+    // Off unless turned on: Flutter ships no Nerd Font, so the glyphs render
+    // as empty boxes on the phone.
+    _autoTitleEmoji = settings[settingAutoTitleEmoji] == 'true';
+    _evictEnabled = settings[settingEvict] == 'true';
+    // Clamped rather than trusted: the setting predates the slider, so a
+    // stored value can sit outside its travel.
+    final budget = double.tryParse('${settings[settingBudgetFraction] ?? ''}');
+    _budgetFraction =
+        budget == null ? budgetDefault : budget.clamp(budgetMin, budgetMax);
+    _hostSettingsLoaded = true;
+    notifyListeners();
+  }
+
+  Future<bool> setAutoTitleEnabled(bool value) {
+    final previous = _autoTitleEnabled;
+    return _writeHostSetting(
+      settingAutoTitle,
+      value ? 'true' : 'false',
+      () => _autoTitleEnabled = value,
+      () => _autoTitleEnabled = previous,
+    );
+  }
+
+  Future<bool> setAutoTitleEmoji(bool value) {
+    final previous = _autoTitleEmoji;
+    return _writeHostSetting(
+      settingAutoTitleEmoji,
+      value ? 'true' : 'false',
+      () => _autoTitleEmoji = value,
+      () => _autoTitleEmoji = previous,
+    );
+  }
+
+  Future<bool> setEvictEnabled(bool value) {
+    final previous = _evictEnabled;
+    return _writeHostSetting(
+      settingEvict,
+      value ? 'true' : 'false',
+      () => _evictEnabled = value,
+      () => _evictEnabled = previous,
+    );
+  }
+
+  Future<bool> setBudgetFraction(double value) {
+    final previous = _budgetFraction;
+    final clamped = value.clamp(budgetMin, budgetMax);
+    return _writeHostSetting(
+      settingBudgetFraction,
+      clamped.toStringAsFixed(2),
+      () => _budgetFraction = clamped,
+      () => _budgetFraction = previous,
+    );
+  }
+
+  /// Paints the new value first so the control answers the tap, and puts the
+  /// old one back if the host refuses or cannot be reached. Returning the
+  /// verdict is the point: a switch that flips and then quietly did nothing is
+  /// worse than one that says it failed.
+  Future<bool> _writeHostSetting(
+    String key,
+    String value,
+    void Function() apply,
+    void Function() revert,
+  ) async {
+    apply();
+    notifyListeners();
+    if (await updateSettings({key: value})) return true;
+    revert();
+    notifyListeners();
+    return false;
+  }
+
   // ==================== Session order ====================
 
   /// The daemon owns the mode, so every client of this host agrees on it.
@@ -891,15 +1006,9 @@ class DaemonAPIService extends ChangeNotifier {
   bool _manualOrder = false;
   bool get manualOrder => _manualOrder;
 
-  Future<void> fetchSortMode() async {
-    final body = await getSettings();
-    if (body == null) return;
-    final settings = body['settings'] as Map<String, dynamic>?;
-    final manual = settings?[_sortModeSetting] == 'manual';
-    if (manual == _manualOrder) return;
-    _manualOrder = manual;
-    notifyListeners();
-  }
+  /// The name the session list calls. The mode comes back with the rest of the
+  /// host's settings.
+  Future<void> fetchSortMode() => fetchHostSettings();
 
   /// Switching to manual freezes [visibleOrder] as it stands, so the list does
   /// not jump the moment it stops sorting itself.


### PR DESCRIPTION
## The problem

Auto title, the title icon, save memory and the memory limit live in each daemon's SQLite database. The mobile settings screen read them from **the first connected host and stopped** (`settings_screen.dart:55-82`), and wrote them back the same way.

With two hosts paired, that page:

- showed one machine's values under an "App"-level heading, with nothing naming the host;
- sent every write to that one machine;
- changed target silently when that host went offline;
- said "25% of host RAM" without saying which host;
- spun on "Loading settings…" forever when no host was connected;
- threw away the result of `updateSettings`, so a failed write looked like it worked.

## The change

**`daemon_api_service.dart`** — each host's service owns its own values, in the style of the existing `_manualOrder`. `fetchHostSettings()` reads `/api/settings` once and fills all four plus the sort mode, so `fetchSortMode()` no longer asks the same host the same question twice. Four setters write one key each; every one paints the value first and puts the old one back if the host refuses.

**`host_detail_screen.dart`** — a "Host settings" block, on the page that already names the host. An offline host shows its last known values, locked, with the reason. A failed write raises a snackbar naming the setting.

**`settings_screen.dart`** — the global "Sessions" section is gone. Each host row gains a summary line, "Auto title on · Save memory 25%", dimmed while that host is offline. On open, every connected host is asked for its values.

Sound, vibration, alerts, theme and updates stay on the settings screen. Those belong to the device.

## Verification

`flutter analyze` — one issue, pre-existing and not from this change: `sessions_screen.dart:365` uses the deprecated `onReorder`.
`flutter test` — all 80 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)