### PR TITLE
refactor: make terminated the one archival state

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -507,15 +507,6 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
               {session.pinned ? 'Unpin' : 'Pin'}
             </button>
             <button
-              onClick={() =>
-                void run(() =>
-                  api(hostId).patchSession(session.session_id, { archived: !session.archived }),
-                )
-              }
-            >
-              {session.archived ? 'Unarchive' : 'Archive'}
-            </button>
-            <button
               className="danger"
               onClick={() => {
                 // Deleting drops the daemon's record; the agent's own transcript

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -73,7 +73,6 @@ export function Sidebar({
   const notifications = useStore((s) => s.notifications)
   const selection = useStore((s) => s.selection)
   const query = useStore((s) => s.query)
-  const showArchived = useStore((s) => s.showArchived)
   const sortMode = useStore((s) => s.sortMode)
   const density = useStore((s) => s.density)
   // The card being dragged, so the row under the pointer can show where it
@@ -119,14 +118,12 @@ export function Sidebar({
         pendingByCwd.set(notif.source_session, (pendingByCwd.get(notif.source_session) ?? 0) + 1)
       }
 
-      const visible = (sessions[host.id] ?? [])
-        .filter((session) => showArchived || !session.archived)
-        .filter((session) => {
-          if (!needle) return true
-          return `${session.title ?? ''} ${session.project} ${session.cwd} ${session.last_user_message ?? ''}`
-            .toLowerCase()
-            .includes(needle)
-        })
+      const visible = (sessions[host.id] ?? []).filter((session) => {
+        if (!needle) return true
+        return `${session.title ?? ''} ${session.project} ${session.cwd} ${session.last_user_message ?? ''}`
+          .toLowerCase()
+          .includes(needle)
+      })
 
       // A terminated session the user searched for is a session they asked to
       // see, so the filter yields to an explicit query.
@@ -143,7 +140,7 @@ export function Sidebar({
       const loading = sessions[host.id] === undefined
       return { host, rows, hidden, loading }
     })
-  }, [hosts, sessions, notifications, query, showArchived, showTerminated, sortMode])
+  }, [hosts, sessions, notifications, query, showTerminated, sortMode])
 
   // One host answering "manual" is enough to show the switch as on: the click
   // writes the other way to every host, which settles any disagreement.
@@ -308,14 +305,6 @@ export function Sidebar({
       </div>
 
       <footer className="sidebar-foot">
-        <label className="check">
-          <input
-            type="checkbox"
-            checked={showArchived}
-            onChange={(event) => store.setShowArchived(event.target.checked)}
-          />
-          Show archived
-        </label>
         <button className="link" onClick={onAddHost}>
           Add host
         </button>

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -144,7 +144,6 @@ export interface State {
   promptDraft: PromptDraft | null
   /** Sidebar filter, matched against title, project and cwd. */
   query: string
-  showArchived: boolean
   /**
    * How each host's session list is ordered, by host id.
    *
@@ -182,7 +181,6 @@ const initial: State = {
   showNote: null,
   promptDraft: null,
   query: '',
-  showArchived: false,
   sortMode: {},
   loading: true,
   terminalTheme: bridge.theme.boot().terminal,
@@ -706,10 +704,6 @@ class Store {
 
   setQuery(query: string): void {
     this.set({ query })
-  }
-
-  setShowArchived(showArchived: boolean): void {
-    this.set({ showArchived })
   }
 
   setPairingLink(pairingLink: string | null): void {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -21,7 +21,6 @@ export interface Session {
   /** Place in a hand-arranged list; only meaningful in manual sort mode.
    *  Absent from a daemon older than the feature, which sorts by activity. */
   sort_order?: number
-  archived: boolean
   permission_mode?: string
   /** Socket path of the live terminal host, injected by the daemon. Absent means cold. */
   terminal?: string

--- a/desktop/test/session-state.test.ts
+++ b/desktop/test/session-state.test.ts
@@ -15,7 +15,6 @@ function session(patch: Partial<Session>): Session {
     project: 'repo',
     status: 'idle',
     pinned: false,
-    archived: false,
     created_at: '2026-01-01T00:00:00Z',
     supports_prompt_queue: true,
     ...patch,

--- a/docs/specs/45-one-archival-state.md
+++ b/docs/specs/45-one-archival-state.md
@@ -1,0 +1,243 @@
+# One Archival State: Terminated Replaces Archived
+
+## The claim
+
+A session has two ways to leave the working list. A person can archive it, or a
+person can terminate it. The two mean the same thing to the person who does it:
+put this away, I am not working on it.
+
+The code already says so. Three comments name terminated as the archival state:
+
+| Where | What it says |
+|---|---|
+| `internal/backend/backend.go:109` | "Terminated is the archival state" |
+| `internal/daemon/evict.go:196` | "Terminated is the archival state a person chooses" |
+| `internal/provider/claude/hooks.go:829` | "Terminated stamps ended_at and reads as archived" |
+
+Each client then carries the cost of the duplicate. Mobile shows an "Archived"
+chip at `sessions_screen.dart:470` **and** a separate show-terminated toggle at
+line 352. Desktop shows a "Show archived" checkbox at `sidebar.tsx:314` beside a
+"Show terminated" one. Two controls, one question.
+
+The TUI has no archive at all. It has never needed one.
+
+And nobody uses it. This developer's own database, the busiest one there is:
+
+| `archived` | `status` | rows |
+|---|---|---|
+| 0 | terminated | 241 |
+| 0 | idle | 7 |
+| 0 | active | 1 |
+
+249 sessions, 241 of them put away, and not one by the archive.
+
+## What actually differs today
+
+| | `archived` | `terminated` |
+|---|---|---|
+| Who sets it | a person, `PATCH archived` | a person via `/terminate`, or the agent's SessionEnd hook |
+| Effect on the agent | none | kills the terminal, `Backend.Kill` |
+| Undo | `PATCH archived: false` | `POST /resume` |
+| `ended_at` | untouched | stamped, `store/sessions.go:136` |
+| Eviction | exempt, `evict.go:49` | already cold |
+
+Two rows matter. The rest is bookkeeping.
+
+## What this costs, stated plainly
+
+**You can no longer archive a running agent.** Today you can put a working
+session out of sight and let it work. After this, putting it away stops it.
+
+This spec accepts that. A session hidden from the list while its agent still
+runs is invisible work, and the sort already drops a quiet session to the
+bottom. Anyone who wants a running session out of the way can pin the ones they
+want instead.
+
+**Resume is not the same as unarchive.** Unarchive gives back the same live
+session. Resume starts a new terminal in the same directory, and the agent picks
+the conversation up from the transcript. What is lost is the host's scrollback
+ring, which is 1 MiB and already truncating. See
+[42-cold-sessions.md](42-cold-sessions.md), which measures that trade.
+
+The UI must therefore say "Resume". It must not say "Restore".
+
+## The change
+
+### Store
+
+Two migrations, appended to `columnMigrations` in `internal/store/store.go` in
+this order:
+
+```sql
+-- promote_archived_to_terminated
+UPDATE sessions
+   SET status = 'terminated',
+       ended_at = COALESCE(ended_at, datetime('now'))
+ WHERE archived = 1;
+
+-- drop_sessions_archived
+ALTER TABLE sessions DROP COLUMN archived;
+```
+
+`DROP COLUMN` is proven in this codebase. `drop_sessions_tmux_pane` and
+`drop_sessions_managed` already use it, on the same `modernc.org/sqlite` driver.
+
+**The promote step must not use the ignore-errors loop.** `store.go:166-175`
+throws away the result of every `Exec`, which is right for an `ADD COLUMN` that
+may already exist and wrong here. If the `UPDATE` fails, the loop records it as
+done and the `DROP` on the next pass destroys the rows it was meant to save.
+
+Run the promote before the loop, or inside it with its error checked and
+returned. Only the `DROP` may be ignored.
+
+Drop `archived` from the base `CREATE TABLE sessions` at `store.go:72` as well.
+A fresh database then fails both migrations, the runner ignores the errors, and
+it records them as done. That is how the two existing drops already behave.
+
+Remove `Session.Archived` (`store/sessions.go:32`) and the column from every
+`SELECT` and `UpdateSessionFlags`. `UpdateSessionFlags` becomes
+`UpdateSessionPinned`.
+
+### List filter
+
+`ListSessionsFiltered` takes `"all"`, `"pinned"`, and `"archived"`. The third
+becomes `"terminated"` and selects `status = 'terminated'`. The default stops
+excluding anything.
+
+One visible consequence: sessions that were archived were hidden from the
+default list, so the TUI never saw them. They are terminated now, and the TUI
+shows terminated sessions in grey. They will appear there. That is correct —
+the TUI shows what ended, and these ended.
+
+### API
+
+Remove `archived` from the `PATCH /api/sessions/{id}` body (`api.go:914-932`),
+from the SSE payload (`api.go:962`) and from the response (`api.go:969`).
+`terminate` and `resume` already exist and do not change.
+
+An older client against a newer daemon reads `archived` as absent, so false. It
+then shows a session it used to hide. It shows more, never less. That is the
+safe direction to fail.
+
+### MCP
+
+`mcp/tools.go:261` drops to one condition:
+
+```go
+if !all && sess.Status == "terminated" {
+```
+
+The `all` description at line 100 loses the word "archived".
+
+### Eviction
+
+`evict.go:49` drops `|| sess.Archived`. Nothing becomes evictable that was not
+already safe: the line reads `!evictableStatuses[sess.Status] || sess.Archived`,
+and `terminated` is not an evictable status. An archived session was exempt, and
+as a terminated session it stays exempt by the first half of the same test.
+
+`TestCandidates_SkipsPinnedArchivedAndCold` (`evict_test.go:57`) loses its
+archived fixture and becomes `TestCandidates_SkipsPinnedAndCold`.
+
+### Mobile
+
+- `SessionFilter.archived` becomes `SessionFilter.terminated`, and the chip is
+  labelled "Terminated".
+- The show-terminated toggle above the list goes. The chip answers the same
+  question, and one control is enough.
+- `_statusOrder` loses its archived rung.
+- The batch bar action becomes Terminate. The context menu item becomes
+  Terminate or Resume.
+- `Session.archived` and `patchSession(archived:)` go.
+
+### Mobile swipe
+
+Right-swipe keeps two states, as it does now:
+
+| Session state | Action | Colour |
+|---|---|---|
+| terminated | Resume | green |
+| anything else | Terminate | teal |
+
+The gesture never dismisses the card. `confirmDismiss` returns false at
+`sessions_screen.dart:623`, and that shape stays.
+
+**Terminate asks first only while the agent is mid-turn** — that is, when
+`session.isActive`: `active`, `starting`, `compacting`, or
+`waiting_permission`. An idle session terminates on the swipe, because nothing
+is in flight and Resume brings it back. An agent in the middle of a turn loses
+that turn, so it is worth one tap.
+
+Resume never asks.
+
+### Desktop
+
+Desktop is the cheapest of the three, because its header already does what this
+spec asks for. `detail.tsx:455` shows Resume when the session is terminated, and
+`detail.tsx:465` shows Terminate with a confirm when it is not. Both are already
+one click, and the comment at line 463 already argues that ending a session is
+common enough to deserve that.
+
+So the Archive item in the overflow menu (`detail.tsx:509-517`) is **deleted,
+not replaced**. Putting a Terminate there would be the second Terminate in the
+same header.
+
+The sidebar stacks two filters that ask one question:
+
+| Filter | Scope | Lifetime | Where |
+|---|---|---|---|
+| `showArchived` | all hosts | app session | checkbox, `sidebar.tsx:314` |
+| `showTerminated` | one host | app session | link, `sidebar.tsx:221-230` |
+
+Delete the first. `sidebar.tsx:123` goes, `showArchived` leaves the store
+(`store.ts:147`, `185`, `711-713`), and the checkbox goes with it. It is held in
+memory only and never written to disk, so nothing stale is left behind.
+
+Previously-archived sessions then fall to the per-host control at line 135, get
+counted into `hidden` at line 139, and appear behind "Show N terminated". That
+is the better of the two controls: it is per host, and it names a count.
+
+Drop `archived` from `shared/models.ts:24` and from the fixture at
+`test/session-state.test.ts:18`. `patchSession` takes `Record<string, unknown>`
+(`main/api.ts:298`), so no signature changes.
+
+`canResume` and `isTerminated` in `shared/models.ts` already carry the whole
+idea, and `models.ts:60` already calls terminated "the one final state". This
+spec makes the data match a claim the desktop code has been making for a while.
+
+### Desktop keeps its confirm; mobile does not
+
+Desktop confirms every terminate. Mobile will confirm only mid-turn. That is on
+purpose, not an oversight.
+
+The two gestures differ. On desktop the person clicks a button labelled
+"Terminate", under a tooltip that says only Resume brings it back. On mobile the
+person swipes a card, and the swipe is the same gesture whether it terminates or
+resumes. Mobile's rule spends the confirm where the loss is real — a turn in
+flight — and stays out of the way for the idle sessions that make up most of the
+list.
+
+## Older specs
+
+`session-search-and-group-by-directory.md` documents the `archived` filter, and
+`41-helios-mcp-tools.md:107` and `42-cold-sessions.md:149` mention it. Leave
+them. They record what was true when they were written. This spec supersedes
+them, and a spec edited to match today's code stops being a record.
+
+## Tests
+
+- A store test: a row with `archived = 1` comes out terminated, with `ended_at`
+  set, and the column is gone.
+- A store test: a row already terminated keeps its original `ended_at`.
+- A filter test: `"terminated"` returns the ended sessions, and the default
+  returns everything.
+- A mobile test: the swipe asks before terminating a mid-turn session, and does
+  not ask for an idle one.
+
+  Written against `needsTerminateConfirm` in `models/session.dart` rather than
+  as a widget test. `SessionsScreen` needs a populated `HostManager` and a
+  stubbed daemon to pump, and a test of that size would be measuring the
+  scaffolding. The rule is one predicate, so it is a predicate.
+- `evict_test.go`: rename and drop the archived fixture.
+- `desktop/test/session-state.test.ts`: drop `archived` from the fixture. Its
+  four terminated tests already pass and must keep passing untouched.

--- a/internal/daemon/evict.go
+++ b/internal/daemon/evict.go
@@ -46,7 +46,7 @@ func evictionCandidates(sessions []store.Session, usage map[string]int64, now ti
 		if !warm || rss <= 0 {
 			continue
 		}
-		if !evictableStatuses[sess.Status] || sess.Archived {
+		if !evictableStatuses[sess.Status] {
 			continue
 		}
 		// Pinning already means "I am coming back to this".

--- a/internal/daemon/evict_integration_test.go
+++ b/internal/daemon/evict_integration_test.go
@@ -87,7 +87,7 @@ func (h *evictHarness) add(t *testing.T, id, status string, unread time.Duration
 		t.Fatalf("insert %s: %v", id, err)
 	}
 	if pinned {
-		if err := h.db.UpdateSessionFlags(id, true, false); err != nil {
+		if err := h.db.UpdateSessionPinned(id, true); err != nil {
 			t.Fatalf("pin %s: %v", id, err)
 		}
 	}

--- a/internal/daemon/evict_test.go
+++ b/internal/daemon/evict_test.go
@@ -54,17 +54,18 @@ func TestCandidates_OnlyIdle(t *testing.T) {
 	}
 }
 
-func TestCandidates_SkipsPinnedArchivedAndCold(t *testing.T) {
+func TestCandidates_SkipsPinnedTerminatedAndCold(t *testing.T) {
 	pinned := session("pinned", "idle", time.Hour)
 	pinned.Pinned = true
-	archived := session("archived", "idle", time.Hour)
-	archived.Archived = true
+	// Terminated is the archival state, and a session someone put away is not
+	// one to take memory from behind their back.
+	terminated := session("terminated", "terminated", time.Hour)
 	cold := session("cold", "idle", time.Hour)
 
-	sessions := []store.Session{pinned, archived, cold, session("ok", "idle", time.Hour)}
+	sessions := []store.Session{pinned, terminated, cold, session("ok", "idle", time.Hour)}
 	// cold has no entry in usage, which is how a session with no live terminal
 	// presents itself.
-	usage := map[string]int64{"pinned": 100, "archived": 100, "ok": 100}
+	usage := map[string]int64{"pinned": 100, "terminated": 100, "ok": 100}
 
 	got := evictionCandidates(sessions, usage, now)
 	if len(got) != 1 || got[0].SessionID != "ok" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -97,7 +97,7 @@ func (s *Server) registry() map[string]tool {
 			description: "List Helios sessions. Dead sessions are omitted unless all=true.",
 			schema: obj(map[string]interface{}{
 				"project": str("optional substring match on project or cwd"),
-				"all":     map[string]interface{}{"type": "boolean", "description": "include terminated and archived sessions"},
+				"all":     map[string]interface{}{"type": "boolean", "description": "include terminated sessions"},
 			}),
 			call: s.callSessions,
 		},
@@ -258,7 +258,7 @@ func (s *Server) callSessions(_ string, args map[string]interface{}) (string, er
 	for _, sess := range sessions {
 		// A long-lived install accumulates hundreds of dead sessions, nearly
 		// all untitled. Listing them buries the handful worth addressing.
-		if !all && (sess.Status == "terminated" || sess.Archived) {
+		if !all && sess.Status == "terminated" {
 			continue
 		}
 		if match != "" &&

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -912,10 +912,9 @@ func (s *PublicServer) handlePatchSession(w http.ResponseWriter, r *http.Request
 	}
 
 	var req struct {
-		Pinned   *bool   `json:"pinned"`
-		Archived *bool   `json:"archived"`
-		Title    *string `json:"title"`
-		Status   *string `json:"status"`
+		Pinned *bool   `json:"pinned"`
+		Title  *string `json:"title"`
+		Status *string `json:"status"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
@@ -923,15 +922,11 @@ func (s *PublicServer) handlePatchSession(w http.ResponseWriter, r *http.Request
 	}
 
 	pinned := session.Pinned
-	archived := session.Archived
 	if req.Pinned != nil {
 		pinned = *req.Pinned
 	}
-	if req.Archived != nil {
-		archived = *req.Archived
-	}
 
-	if err := s.shared.DB.UpdateSessionFlags(id, pinned, archived); err != nil {
+	if err := s.shared.DB.UpdateSessionPinned(id, pinned); err != nil {
 		jsonError(w, "failed to update session", http.StatusInternalServerError)
 		return
 	}
@@ -959,14 +954,12 @@ func (s *PublicServer) handlePatchSession(w http.ResponseWriter, r *http.Request
 		Data: map[string]interface{}{
 			"session_id": id,
 			"pinned":     pinned,
-			"archived":   archived,
 		},
 	})
 
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
-		"success":  true,
-		"pinned":   pinned,
-		"archived": archived,
+		"success": true,
+		"pinned":  pinned,
 	})
 }
 

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// The sessions table as it stood while archived was still a flag of its own.
+const legacySessionsSchema = `CREATE TABLE sessions (
+	session_id TEXT PRIMARY KEY,
+	source TEXT NOT NULL DEFAULT 'claude',
+	cwd TEXT NOT NULL,
+	project TEXT,
+	transcript_path TEXT,
+	model TEXT,
+	status TEXT NOT NULL DEFAULT 'active',
+	last_event TEXT,
+	last_event_at TEXT,
+	last_user_message TEXT,
+	pinned INTEGER NOT NULL DEFAULT 0,
+	archived INTEGER NOT NULL DEFAULT 0,
+	created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	ended_at TEXT
+)`
+
+// writeLegacyDB lays down a database as an older Helios left it, so Open has a
+// real upgrade to perform rather than a fresh schema to create.
+func writeLegacyDB(t *testing.T, rows ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(legacySessionsSchema); err != nil {
+		t.Fatalf("create legacy sessions: %v", err)
+	}
+	for _, row := range rows {
+		if _, err := db.Exec(row); err != nil {
+			t.Fatalf("seed legacy row: %v", err)
+		}
+	}
+	return path
+}
+
+func TestMigrate_ArchivedBecomesTerminated(t *testing.T) {
+	path := writeLegacyDB(t,
+		`INSERT INTO sessions (session_id, cwd, project, status, archived) VALUES ('put-away', '/tmp/a', 'a', 'idle', 1)`,
+		`INSERT INTO sessions (session_id, cwd, project, status, archived) VALUES ('working', '/tmp/b', 'b', 'idle', 0)`,
+	)
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	away, err := s.GetSession("put-away")
+	if err != nil {
+		t.Fatalf("get put-away: %v", err)
+	}
+	if away.Status != "terminated" {
+		t.Errorf("archived session status = %q, want terminated", away.Status)
+	}
+	// Without a stamp the session is terminated but claims never to have ended,
+	// and every "ended when?" in the UI reads blank.
+	if away.EndedAt == nil || *away.EndedAt == "" {
+		t.Error("archived session kept no ended_at")
+	}
+
+	working, err := s.GetSession("working")
+	if err != nil {
+		t.Fatalf("get working: %v", err)
+	}
+	if working.Status != "idle" {
+		t.Errorf("unarchived session status = %q, want idle", working.Status)
+	}
+}
+
+// A session terminated before it was archived already knows when it ended, and
+// the migration must not restamp it as ending today.
+func TestMigrate_KeepsAnExistingEndedAt(t *testing.T) {
+	path := writeLegacyDB(t,
+		`INSERT INTO sessions (session_id, cwd, project, status, archived, ended_at)
+		 VALUES ('old', '/tmp/a', 'a', 'terminated', 1, '2020-01-01T00:00:00Z')`,
+	)
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	sess, err := s.GetSession("old")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if sess.EndedAt == nil || *sess.EndedAt != "2020-01-01T00:00:00Z" {
+		t.Errorf("ended_at = %v, want it untouched", sess.EndedAt)
+	}
+}
+
+func TestMigrate_DropsTheArchivedColumn(t *testing.T) {
+	path := writeLegacyDB(t,
+		`INSERT INTO sessions (session_id, cwd, project, status, archived) VALUES ('put-away', '/tmp/a', 'a', 'idle', 1)`,
+	)
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	has, err := s.hasColumn("sessions", "archived")
+	if err != nil {
+		t.Fatalf("has column: %v", err)
+	}
+	if has {
+		t.Error("archived column survived the migration")
+	}
+}
+
+// Opening the same database twice is the ordinary case — every daemon restart
+// does it — and the second pass has no column left to read.
+func TestMigrate_IsSafeToRunTwice(t *testing.T) {
+	path := writeLegacyDB(t,
+		`INSERT INTO sessions (session_id, cwd, project, status, archived) VALUES ('put-away', '/tmp/a', 'a', 'idle', 1)`,
+	)
+
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	first.Close()
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	defer second.Close()
+
+	sess, err := second.GetSession("put-away")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if sess.Status != "terminated" {
+		t.Errorf("status = %q, want terminated", sess.Status)
+	}
+}
+
+// A fresh database never had the column, and the migration must not object.
+func TestMigrate_FreshDatabaseHasNoArchivedColumn(t *testing.T) {
+	s := setupTestStore(t)
+
+	has, err := s.hasColumn("sessions", "archived")
+	if err != nil {
+		t.Fatalf("has column: %v", err)
+	}
+	if has {
+		t.Error("fresh schema still declares archived")
+	}
+}

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -28,8 +28,7 @@ type Session struct {
 	// SortOrder is the session's place in a hand-arranged list. Lower sorts
 	// first and the scale is arbitrary — only the relative order is meaningful,
 	// and it is ignored entirely unless the list is set to sort manually.
-	SortOrder int  `json:"sort_order"`
-	Archived  bool `json:"archived"`
+	SortOrder int `json:"sort_order"`
 	// PermissionMode is the agent's permission mode. It is stored because the
 	// mode is a per-invocation flag rather than conversation state: without a
 	// record of it, a session that goes cold comes back in the default mode
@@ -197,12 +196,12 @@ func (s *Store) GetSession(sessionID string) (*Session, error) {
 	sess := &Session{}
 	err := s.db.QueryRow(
 		`SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-		        last_event, last_event_at, last_interacted_at, last_user_message, pinned, archived, sort_order,
+		        last_event, last_event_at, last_interacted_at, last_user_message, pinned, sort_order,
 		        permission_mode, created_at, ended_at
 		 FROM sessions WHERE session_id = ?`, sessionID,
 	).Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 		&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-		&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
+		&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.SortOrder,
 		&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -210,7 +209,7 @@ func (s *Store) GetSession(sessionID string) (*Session, error) {
 	return sess, err
 }
 
-// ListSessions returns all non-archived sessions ordered by most recent activity.
+// ListSessions returns all sessions ordered by most recent activity.
 func (s *Store) ListSessions() ([]Session, error) {
 	return s.SearchSessions("", "", "", "")
 }
@@ -218,7 +217,7 @@ func (s *Store) ListSessions() ([]Session, error) {
 // SearchSessions returns sessions matching the given filters.
 // query: free-text search (tokenized by spaces, all tokens must match).
 // status: exact match on session status (empty = no filter).
-// filter: "all" (default, excludes archived), "pinned", "archived".
+// filter: "all" (default, no flag filter), "pinned", "terminated".
 // cwd: exact match on session CWD (empty = no filter).
 func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, error) {
 	var where []string
@@ -239,14 +238,14 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 		args = append(args, status)
 	}
 
-	// Flag-based filter
+	// Flag-based filter. Terminated is the archival state: there is no separate
+	// archived flag to exclude here, and asking for the archive means asking
+	// for what has ended.
 	switch filter {
 	case "pinned":
-		where = append(where, `pinned = 1 AND archived = 0`)
-	case "archived":
-		where = append(where, `archived = 1`)
-	default: // "all" or empty
-		where = append(where, `archived = 0`)
+		where = append(where, `pinned = 1`)
+	case "terminated":
+		where = append(where, `status = 'terminated'`)
 	}
 
 	// CWD filter
@@ -256,7 +255,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 	}
 
 	q := `SELECT session_id, source, cwd, project, title, transcript_path, model, status,
-	        last_event, last_event_at, last_interacted_at, last_user_message, pinned, archived, sort_order,
+	        last_event, last_event_at, last_interacted_at, last_user_message, pinned, sort_order,
 	        permission_mode, created_at, ended_at
 	 FROM sessions`
 	if len(where) > 0 {
@@ -275,7 +274,7 @@ func (s *Store) SearchSessions(query, status, filter, cwd string) ([]Session, er
 		var sess Session
 		if err := rows.Scan(&sess.SessionID, &sess.Source, &sess.CWD, &sess.Project,
 			&sess.Title, &sess.TranscriptPath, &sess.Model, &sess.Status,
-			&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.Archived, &sess.SortOrder,
+			&sess.LastEvent, &sess.LastEventAt, &sess.LastInteractedAt, &sess.LastUserMessage, &sess.Pinned, &sess.SortOrder,
 			&sess.PermissionMode, &sess.CreatedAt, &sess.EndedAt); err != nil {
 			return nil, err
 		}
@@ -391,11 +390,11 @@ func (s *Store) ResetAutoTitleAttempts(sessionID string) error {
 	return err
 }
 
-// UpdateSessionFlags updates the pinned and archived flags for a session.
-func (s *Store) UpdateSessionFlags(sessionID string, pinned, archived bool) error {
+// UpdateSessionPinned updates the pinned flag for a session.
+func (s *Store) UpdateSessionPinned(sessionID string, pinned bool) error {
 	_, err := s.db.Exec(
-		`UPDATE sessions SET pinned = ?, archived = ? WHERE session_id = ?`,
-		pinned, archived, sessionID,
+		`UPDATE sessions SET pinned = ? WHERE session_id = ?`,
+		pinned, sessionID,
 	)
 	return err
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,7 +69,6 @@ func (s *Store) migrate() error {
 			last_event_at TEXT,
 			last_user_message TEXT,
 			pinned INTEGER NOT NULL DEFAULT 0,
-			archived INTEGER NOT NULL DEFAULT 0,
 			created_at TEXT NOT NULL DEFAULT (datetime('now')),
 			ended_at TEXT
 		)`,
@@ -133,6 +132,16 @@ func (s *Store) migrate() error {
 		}
 	}
 
+	// Terminated is the one archival state now, so every archived session has
+	// to be filed as terminated before the drop below takes the column away.
+	//
+	// Deliberately not an entry in the loop underneath, which throws away every
+	// error: an UPDATE that failed there would still be recorded as done, and
+	// the drop on the next line would destroy the rows it was meant to save.
+	if err := s.promoteArchivedToTerminated(); err != nil {
+		return fmt.Errorf("promote archived sessions: %w", err)
+	}
+
 	// Column migrations for existing DBs
 	columnMigrations := []struct {
 		id  string
@@ -161,6 +170,7 @@ func (s *Store) migrate() error {
 		// last did something. Eviction needs the first, and last_event_at only
 		// answers the second.
 		{"add_sessions_last_interacted_at", `ALTER TABLE sessions ADD COLUMN last_interacted_at TEXT`},
+		{"drop_sessions_archived", `ALTER TABLE sessions DROP COLUMN archived`},
 	}
 
 	for _, cm := range columnMigrations {
@@ -175,4 +185,40 @@ func (s *Store) migrate() error {
 	}
 
 	return nil
+}
+
+// promoteArchivedToTerminated files every archived session as terminated, which
+// is what archiving always meant. It does nothing once the column is gone, and
+// running it twice changes nothing the first run did not already change.
+func (s *Store) promoteArchivedToTerminated() error {
+	has, err := s.hasColumn("sessions", "archived")
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+	_, err = s.db.Exec(`UPDATE sessions
+		   SET status = 'terminated',
+		       ended_at = COALESCE(ended_at, datetime('now'))
+		 WHERE archived = 1`)
+	return err
+}
+
+func (s *Store) hasColumn(table, column string) (bool, error) {
+	rows, err := s.db.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		return false, fmt.Errorf("read %s columns: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, fmt.Errorf("scan %s column: %w", table, err)
+		}
+		if name == column {
+			return true, rows.Err()
+		}
+	}
+	return false, rows.Err()
 }

--- a/mobile/lib/models/session.dart
+++ b/mobile/lib/models/session.dart
@@ -12,7 +12,6 @@ class Session {
   final String? lastEventAt;
   final String? lastUserMessage;
   final bool pinned;
-  final bool archived;
 
   /// The agent's permission mode, or null for a session that has not reported
   /// one yet. Switching it restarts the agent, so it is only offered when the
@@ -48,7 +47,6 @@ class Session {
     this.lastEventAt,
     this.lastUserMessage,
     this.pinned = false,
-    this.archived = false,
     this.permissionMode,
     this.terminal,
     this.memoryBytes,
@@ -73,7 +71,6 @@ class Session {
       lastEventAt: json['last_event_at'] as String?,
       lastUserMessage: json['last_user_message'] as String?,
       pinned: json['pinned'] == true || json['pinned'] == 1,
-      archived: json['archived'] == true || json['archived'] == 1,
       permissionMode: json['permission_mode'] as String?,
       terminal: json['terminal'] as String?,
       memoryBytes: (json['memory_bytes'] as num?)?.toInt(),
@@ -132,7 +129,6 @@ class Session {
   Session copyWith({
     String? title,
     bool? pinned,
-    bool? archived,
     String? permissionMode,
     int? sortOrder,
   }) {
@@ -150,7 +146,6 @@ class Session {
       lastEventAt: lastEventAt,
       lastUserMessage: lastUserMessage,
       pinned: pinned ?? this.pinned,
-      archived: archived ?? this.archived,
       permissionMode: permissionMode ?? this.permissionMode,
       terminal: terminal,
       memoryBytes: memoryBytes,
@@ -187,6 +182,15 @@ class Session {
     }
   }
 }
+
+/// Whether terminating [sessions] is worth stopping to ask about.
+///
+/// Only a turn in flight is lost. An idle session gives up its terminal, and
+/// Resume brings the agent back to the same transcript, so a dialog about one
+/// would be a dialog with no decision in it. Mobile terminates by swipe, and a
+/// confirm on every swipe teaches people to dismiss confirms.
+bool needsTerminateConfirm(Iterable<Session> sessions) =>
+    sessions.any((s) => s.isActive);
 
 class Subagent {
   final String agentId;

--- a/mobile/lib/screens/sessions_screen.dart
+++ b/mobile/lib/screens/sessions_screen.dart
@@ -8,7 +8,7 @@ import '../services/host_manager.dart';
 import '../widgets/skeleton.dart';
 import 'session_detail_screen.dart';
 
-enum SessionFilter { all, pinned, archived }
+enum SessionFilter { all, pinned, terminated }
 
 class SessionsScreen extends StatefulWidget {
   const SessionsScreen({super.key});
@@ -28,11 +28,6 @@ class _SessionsScreenState extends State<SessionsScreen> {
   String? _cwdFilter;
   String? _cwdFilterProject;
 
-  /// Whether finished sessions are listed. Off by default: a machine that has
-  /// run a few hundred agents is mostly finished ones, and they are history
-  /// rather than work.
-  bool _showTerminated = false;
-
   @override
   void dispose() {
     _searchController.dispose();
@@ -44,12 +39,14 @@ class _SessionsScreenState extends State<SessionsScreen> {
   String _compositeKey(Session s) => '${s.hostId}:${s.sessionId}';
 
   /// A search or a directory filter is a request for particular sessions, and
-  /// answering it while holding some of them back would be a lie. The archive
-  /// tab is left alone too: it exists to show what was put away.
+  /// answering it while holding some of them back would be a lie. The
+  /// Terminated tab is left alone too: showing what has ended is its whole job.
+  ///
+  /// Off by default everywhere else: a machine that has run a few hundred
+  /// agents is mostly finished ones, and they are history rather than work.
   bool get _hidingTerminated =>
-      !_showTerminated &&
       _cwdFilter == null &&
-      _filter != SessionFilter.archived &&
+      _filter != SessionFilter.terminated &&
       !(_searchExpanded && _searchController.text.trim().isNotEmpty);
 
   List<Session> _filterSessions(List<Session> sessions) {
@@ -59,11 +56,11 @@ class _SessionsScreenState extends State<SessionsScreen> {
     }
     switch (_filter) {
       case SessionFilter.all:
-        return sessions.where((s) => !s.archived).toList();
+        return sessions;
       case SessionFilter.pinned:
-        return sessions.where((s) => s.pinned && !s.archived).toList();
-      case SessionFilter.archived:
-        return sessions.where((s) => s.archived).toList();
+        return sessions.where((s) => s.pinned).toList();
+      case SessionFilter.terminated:
+        return sessions.where((s) => s.isTerminated).toList();
     }
   }
 
@@ -71,8 +68,6 @@ class _SessionsScreenState extends State<SessionsScreen> {
     if (s.isActive) return 0;
     if (s.isIdle) return 1;
     if (s.pinned) return 2;
-    if (s.isTerminated) return 3;
-    if (s.archived) return 4;
     return 3;
   }
 
@@ -122,8 +117,8 @@ class _SessionsScreenState extends State<SessionsScreen> {
         return 'all';
       case SessionFilter.pinned:
         return 'pinned';
-      case SessionFilter.archived:
-        return 'archived';
+      case SessionFilter.terminated:
+        return 'terminated';
     }
   }
 
@@ -266,12 +261,44 @@ class _SessionsScreenState extends State<SessionsScreen> {
     _exitMultiSelect();
   }
 
-  Future<void> _batchArchive(bool archive) async {
-    final hm = context.read<HostManager>();
+  Future<bool> _confirmTerminate(List<Session> sessions) async {
+    if (!needsTerminateConfirm(sessions)) return true;
+    final busy = sessions.where((s) => s.isActive).length;
+    final many = sessions.length > 1;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(many ? 'Terminate sessions' : 'Terminate session'),
+        content: Text(
+          many
+              ? '$busy of ${sessions.length} are mid-turn. Terminating loses the work in flight. Resume starts them again.'
+              : 'The agent is mid-turn. Terminating loses the work in flight. Resume starts it again.',
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Terminate')),
+        ],
+      ),
+    );
+    return confirmed == true;
+  }
+
+  Future<void> _batchTerminate(HostManager hm) async {
+    final chosen = hm.filteredSessions
+        .where((s) => _selected.contains(_compositeKey(s)))
+        .toList();
+    if (!await _confirmTerminate(chosen)) return;
+    for (final session in chosen) {
+      hm.serviceFor(session.hostId)?.terminateSession(session.sessionId);
+    }
+    if (mounted) _exitMultiSelect();
+  }
+
+  Future<void> _batchResume(HostManager hm) async {
     for (final key in _selected.toList()) {
       final parts = key.split(':');
       if (parts.length == 2) {
-        hm.serviceFor(parts[0])?.patchSession(parts[1], archived: archive);
+        hm.serviceFor(parts[0])?.resumeSession(parts[1]);
       }
     }
     _exitMultiSelect();
@@ -334,8 +361,6 @@ class _SessionsScreenState extends State<SessionsScreen> {
         final manual = hm.manualOrder;
         final orderable = manual ? _orderableService(hm) : null;
         final matching = _filterSessions(sessions);
-        final hiddenTerminated =
-            _hidingTerminated ? matching.where((s) => s.isTerminated).length : 0;
         final filtered = _sortSessions(
           _hidingTerminated ? matching.where((s) => !s.isTerminated).toList() : matching,
           manual: manual,
@@ -343,14 +368,9 @@ class _SessionsScreenState extends State<SessionsScreen> {
 
         return Column(
           children: [
-            if (_multiSelect) _buildMultiSelectBar(),
+            if (_multiSelect) _buildMultiSelectBar(hm),
             _buildFilterRow(sessions, hm, filtered),
             if (_cwdFilter != null) _buildActiveFiltersRow(),
-            // Above the list rather than below it: revealed sessions are
-            // appended, so a control under them walks further down the screen
-            // with every use.
-            if (hiddenTerminated > 0 || (_showTerminated && _filter != SessionFilter.archived))
-              _buildTerminatedToggle(hiddenTerminated),
             Expanded(
               child: filtered.isEmpty
                   ? _buildEmptyFilterState()
@@ -384,36 +404,9 @@ class _SessionsScreenState extends State<SessionsScreen> {
     );
   }
 
-  /// The way back to the finished sessions, and the way out of them.
-  Widget _buildTerminatedToggle(int hidden) {
+  Widget _buildMultiSelectBar(HostManager hm) {
     final theme = Theme.of(context);
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
-        child: TextButton.icon(
-          onPressed: () => setState(() => _showTerminated = !_showTerminated),
-          icon: Icon(
-            _showTerminated ? Icons.visibility_off_outlined : Icons.history,
-            size: 16,
-          ),
-          label: Text(
-            _showTerminated ? 'Hide terminated' : 'Show $hidden terminated',
-            style: const TextStyle(fontSize: 12),
-          ),
-          style: TextButton.styleFrom(
-            visualDensity: VisualDensity.compact,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            foregroundColor: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildMultiSelectBar() {
-    final theme = Theme.of(context);
-    final isArchiveTab = _filter == SessionFilter.archived;
+    final isTerminatedTab = _filter == SessionFilter.terminated;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -423,12 +416,13 @@ class _SessionsScreenState extends State<SessionsScreen> {
           IconButton(icon: const Icon(Icons.close), onPressed: _exitMultiSelect),
           Text('${_selected.length} selected', style: const TextStyle(fontWeight: FontWeight.w600)),
           const Spacer(),
-          if (!isArchiveTab)
+          if (!isTerminatedTab)
             IconButton(icon: const Icon(Icons.push_pin_outlined), tooltip: 'Pin', onPressed: () => _batchPin(true)),
           IconButton(
-            icon: Icon(isArchiveTab ? Icons.unarchive_outlined : Icons.archive_outlined),
-            tooltip: isArchiveTab ? 'Unarchive' : 'Archive',
-            onPressed: () => _batchArchive(!isArchiveTab),
+            icon: Icon(isTerminatedTab ? Icons.play_arrow_outlined : Icons.stop_circle_outlined),
+            tooltip: isTerminatedTab ? 'Resume' : 'Terminate',
+            onPressed: () =>
+                isTerminatedTab ? _batchResume(hm) : _batchTerminate(hm),
           ),
           IconButton(
             icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
@@ -454,12 +448,12 @@ class _SessionsScreenState extends State<SessionsScreen> {
 
   Widget _buildFilterChips(List<Session> allSessions, HostManager hm, List<Session> visible) {
     // Counting what the tab would show, not what exists: a chip reading 155
-    // over a list of twelve is a chip that has to be explained. The archive is
-    // its own tab and holds terminated sessions on purpose.
-    bool counted(Session s) => !s.archived && !(_hidingTerminated && s.isTerminated);
+    // over a list of twelve is a chip that has to be explained. Terminated
+    // sessions have their own tab, and it holds them on purpose.
+    bool counted(Session s) => !(_hidingTerminated && s.isTerminated);
     final allCount = allSessions.where(counted).length;
     final pinnedCount = allSessions.where((s) => s.pinned && counted(s)).length;
-    final archivedCount = allSessions.where((s) => s.archived).length;
+    final terminatedCount = allSessions.where((s) => s.isTerminated).length;
 
     return Row(
       children: [
@@ -467,7 +461,7 @@ class _SessionsScreenState extends State<SessionsScreen> {
         const SizedBox(width: 8),
         _filterChip('Pinned', pinnedCount, SessionFilter.pinned),
         const SizedBox(width: 8),
-        _filterChip('Archived', archivedCount, SessionFilter.archived),
+        _filterChip('Terminated', terminatedCount, SessionFilter.terminated),
         const Spacer(),
         IconButton(
           icon: Icon(
@@ -579,7 +573,9 @@ class _SessionsScreenState extends State<SessionsScreen> {
   /// being moved.
   Widget _buildSwipeableCard(Session session, HostManager hm, {int? reorderIndex}) {
     final theme = Theme.of(context);
-    final isArchived = session.archived;
+    // Terminated is the archival state: putting a session away is ending it,
+    // and the way back out is Resume rather than an unarchive.
+    final isTerminated = session.isTerminated;
     final service = hm.serviceFor(session.hostId);
 
     return Dismissible(
@@ -587,17 +583,17 @@ class _SessionsScreenState extends State<SessionsScreen> {
       background: Container(
         margin: const EdgeInsets.only(bottom: 8),
         decoration: BoxDecoration(
-          color: isArchived ? Colors.green : Colors.teal,
+          color: isTerminated ? Colors.green : Colors.teal,
           borderRadius: BorderRadius.circular(12),
         ),
         alignment: Alignment.centerLeft,
         padding: const EdgeInsets.only(left: 20),
         child: Row(
           children: [
-            Icon(isArchived ? Icons.unarchive : Icons.archive, color: Colors.white),
+            Icon(isTerminated ? Icons.play_arrow : Icons.stop_circle_outlined, color: Colors.white),
             const SizedBox(width: 8),
             Text(
-              isArchived ? 'Unarchive' : 'Archive',
+              isTerminated ? 'Resume' : 'Terminate',
               style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
             ),
           ],
@@ -619,7 +615,11 @@ class _SessionsScreenState extends State<SessionsScreen> {
       ),
       confirmDismiss: (direction) async {
         if (direction == DismissDirection.startToEnd) {
-          service?.patchSession(session.sessionId, archived: !isArchived);
+          if (isTerminated) {
+            service?.resumeSession(session.sessionId);
+          } else if (await _confirmTerminate([session])) {
+            service?.terminateSession(session.sessionId);
+          }
           return false;
         } else {
           final confirmed = await showDialog<bool>(
@@ -824,7 +824,7 @@ class _SessionsScreenState extends State<SessionsScreen> {
 
   void _showContextMenu(Session session, HostManager hm) {
     final theme = Theme.of(context);
-    final isArchived = session.archived;
+    final isTerminated = session.isTerminated;
     final hostId = session.hostId;
     final sessionId = session.sessionId;
     final service = hm.serviceFor(hostId);
@@ -895,11 +895,18 @@ class _SessionsScreenState extends State<SessionsScreen> {
                 },
               ),
               ListTile(
-                leading: Icon(isArchived ? Icons.unarchive_outlined : Icons.archive_outlined),
-                title: Text(isArchived ? 'Unarchive' : 'Archive'),
-                onTap: () {
+                leading: Icon(
+                  isTerminated ? Icons.play_arrow_outlined : Icons.stop_circle_outlined,
+                ),
+                title: Text(isTerminated ? 'Resume' : 'Terminate'),
+                onTap: () async {
                   Navigator.pop(ctx);
-                  service?.patchSession(sessionId, archived: !isArchived);
+                  if (!mounted) return;
+                  if (isTerminated) {
+                    service?.resumeSession(sessionId);
+                  } else if (await _confirmTerminate([session])) {
+                    service?.terminateSession(sessionId);
+                  }
                 },
               ),
               ListTile(
@@ -1048,15 +1055,17 @@ class _SessionsScreenState extends State<SessionsScreen> {
     } else {
       label = switch (_filter) {
         SessionFilter.pinned => 'No pinned sessions.',
-        SessionFilter.archived => 'No archived sessions.',
+        SessionFilter.terminated => 'No terminated sessions.',
         SessionFilter.all => 'No sessions.',
       };
       hint = switch (_filter) {
         SessionFilter.pinned => 'Long-press a session to pin it.',
-        SessionFilter.archived => 'Swipe right on a session to archive it.',
+        SessionFilter.terminated => 'Swipe right on a session to terminate it.',
         SessionFilter.all => '',
       };
-      icon = _filter == SessionFilter.pinned ? Icons.push_pin_outlined : Icons.archive_outlined;
+      icon = _filter == SessionFilter.pinned
+          ? Icons.push_pin_outlined
+          : Icons.stop_circle_outlined;
     }
 
     return Center(

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -750,7 +750,6 @@ class DaemonAPIService extends ChangeNotifier {
   Future<bool> patchSession(
     String sessionId, {
     bool? pinned,
-    bool? archived,
     String? title,
   }) async {
     // Optimistically update the local session list for instant UI feedback.
@@ -763,7 +762,6 @@ class DaemonAPIService extends ChangeNotifier {
       original = _sessions[idx];
       _sessions[idx] = original.copyWith(
         pinned: pinned ?? original.pinned,
-        archived: archived ?? original.archived,
         title: title,
       );
       Future.microtask(() => notifyListeners());
@@ -772,7 +770,6 @@ class DaemonAPIService extends ChangeNotifier {
     try {
       final body = <String, dynamic>{};
       if (pinned != null) body['pinned'] = pinned;
-      if (archived != null) body['archived'] = archived;
       if (title != null) body['title'] = title;
       final resp = await _api.patch('/api/sessions/$sessionId', body: body);
       if (resp.statusCode == 200) {

--- a/mobile/test/session_test.dart
+++ b/mobile/test/session_test.dart
@@ -48,6 +48,43 @@ void main() {
     });
   });
 
+  // The right-swipe terminates, and a confirm on every swipe is a confirm
+  // people learn to tap through. It has to appear only where work is lost.
+  group('needsTerminateConfirm', () {
+    test('an idle session goes without asking', () {
+      expect(needsTerminateConfirm([sessionWithStatus('idle')]), isFalse);
+    });
+
+    test('a terminated or errored session goes without asking', () {
+      expect(needsTerminateConfirm([sessionWithStatus('terminated')]), isFalse);
+      expect(needsTerminateConfirm([sessionWithStatus('error')]), isFalse);
+    });
+
+    test('every mid-turn state asks first', () {
+      for (final status in ['active', 'waiting_permission', 'compacting', 'starting']) {
+        expect(needsTerminateConfirm([sessionWithStatus(status)]), isTrue,
+            reason: status);
+      }
+    });
+
+    // A batch hides what it holds: the user picked a dozen rows and cannot see
+    // which of them is still working.
+    test('one busy session in a batch is enough', () {
+      expect(
+        needsTerminateConfirm([
+          sessionWithStatus('idle'),
+          sessionWithStatus('terminated'),
+          sessionWithStatus('active'),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('an empty selection asks nothing', () {
+      expect(needsTerminateConfirm([]), isFalse);
+    });
+  });
+
   // The daemon reclaims no memory on its own, so this label is what tells the
   // user which session is worth closing.
   group('memoryLabel', () {


### PR DESCRIPTION
Collapses `archived` into `terminated`. One archival state, one control per client.

Spec: `docs/specs/45-one-archival-state.md`

## Why

Three comments in the codebase already named terminated as the archival state (`backend.go:109`, `evict.go:196`, `hooks.go:829`). Every client paid for the duplicate anyway — mobile showed an Archived chip beside a separate show-terminated toggle, desktop a global "Show archived" checkbox beside a per-host "Show N terminated" link. The TUI never had an archive at all.

Nor did anyone use it. On the busiest database available: 249 sessions, 241 terminated, 0 archived.

## Migration

`promoteArchivedToTerminated` sets `status='terminated'` and stamps `ended_at` via `COALESCE`, then `drop_sessions_archived` removes the column.

The promote deliberately runs **outside** the `columnMigrations` loop. That loop throws away every `Exec` error — right for an `ADD COLUMN` that may already exist, wrong here: a failed UPDATE would still be recorded as done, and the DROP would destroy the rows it was meant to save.

## Mobile

- `SessionFilter.archived` → `terminated`; the chip replaces the separate show-terminated toggle.
- Right-swipe terminates, or resumes a session that ended.
- **Confirm only while the agent is mid-turn** (`needsTerminateConfirm`). An idle session terminates on the swipe — nothing is in flight and Resume brings it back. Resume never asks.
- Batch bar and context menu follow the same rule.

## Desktop

The header already had Resume (`detail.tsx:455`) and Terminate-with-confirm (`detail.tsx:465`), so the overflow-menu Archive item is **deleted, not replaced**. `showArchived` goes; the per-host `showTerminated` link stays and inherits the previously-archived rows into its count. `showArchived` was in-memory only, so nothing stale is left behind.

Desktop keeps its always-confirm. A labelled button under an explanatory tooltip is not a swipe.

## What this costs

You can no longer archive a *running* agent — putting it away now stops it. Pinning covers the sessions worth keeping in view.

Previously-archived sessions were excluded from the default list, so the TUI never saw them. They are terminated now and will appear there in grey. That is correct: they ended.

## Verification

| | Result |
|---|---|
| `go vet ./...` | clean |
| `go test ./...` (minus `internal/terminal`) | all pass |
| `flutter analyze` | 1 issue, pre-existing and unrelated (`onReorder` deprecation from a newer SDK than the project floor) |
| `flutter test` | 85 pass (5 new) |
| `npm run typecheck` | clean |
| `npm test` | 111 pass |

`internal/terminal` e2e was excluded: it spawns a real `claude`, which hits the first-run theme picker in this environment. Untouched by this change.

New store tests exercise a real legacy → new upgrade against a seeded old-schema database: archived rows promote, an existing `ended_at` survives, the column goes, and a second `Open` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)