### PR TITLE
fix(desktop): keep the sidebar footer right-aligned

### DIFF
--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -727,19 +727,17 @@ small {
   margin-right: 2px;
 }
 
+/* The link and the menu stay together on the right, rather than each drifting
+   to its own third of the bar. The slack used to belong to a checkbox that
+   carried `margin-right: auto`; with the checkbox gone the bar owns it. */
 .sidebar-foot {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   padding: 8px 8px 8px 16px;
   color: var(--on-surface-variant);
   font-size: 12px;
-}
-
-/* The checkbox takes the slack so the link and the menu stay together on the
-   right, rather than each drifting to its own third of the bar. */
-.sidebar-foot .check {
-  margin-right: auto;
 }
 
 /* Smaller than the one in the session header: this bar is 12px text, and a


### PR DESCRIPTION
## The regression

#102 removed the "Show archived" checkbox from the sidebar footer. That checkbox was also the footer's spacer — it carried `margin-right: auto`, which is what held "Add host" and the app menu against the right edge.

With the checkbox gone, both collapsed to the extreme left and the `⋯` menu ended up floating beside the link instead of at the edge.

## The fix

Move the slack onto the bar itself:

```css
.sidebar-foot {
  justify-content: flex-end;
}
```

The layout no longer depends on a child that no longer exists. The now-dead `.sidebar-foot .check` rule goes with it.

## Verified

Ran the Electron app under Xvfb against the live daemon and measured the footer:

| | left | right |
|---|---|---|
| footer | 8 | 368 |
| Add host | 255 | 324 |
| `⋯` menu | 332 | 360 |

Both sit at the right edge again, 8px inside the footer padding. `npm run typecheck` clean, `npm test` 111 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)