### PR TITLE
feat(desktop): group the session list by project, and move a session's actions onto its row

### DIFF
--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -14,6 +14,10 @@ export function App(): JSX.Element {
   const toast = useStore((s) => s.toast)
   const pairingLink = useStore((s) => s.pairingLink)
   const [dialog, setDialog] = useState<'new' | 'hosts' | 'settings' | null>(null)
+  // Where the new-session dialog should start when it was opened from a
+  // project rather than from the toolbar: the point of the project's own
+  // button is that it does not ask again which project it meant.
+  const [seed, setSeed] = useState<{ hostId: string; cwd: string } | null>(null)
 
   useEffect(() => {
     void store.init()
@@ -31,6 +35,7 @@ export function App(): JSX.Element {
     const onKey = (event: KeyboardEvent): void => {
       if ((event.metaKey || event.ctrlKey) && event.key === 'n') {
         event.preventDefault()
+        setSeed(null)
         setDialog('new')
       }
       // ⌘W closes the selected session's terminal, not the window: the
@@ -69,7 +74,10 @@ export function App(): JSX.Element {
       <UpdateBanner />
       <div className="body">
         <Sidebar
-          onNewSession={() => setDialog('new')}
+          onNewSession={(from) => {
+            setSeed(from ?? null)
+            setDialog('new')
+          }}
           onAddHost={() => setDialog('hosts')}
           onSettings={() => setDialog('settings')}
         />
@@ -78,7 +86,7 @@ export function App(): JSX.Element {
         </main>
       </div>
 
-      {dialog === 'new' && <NewSessionDialog onClose={() => setDialog(null)} />}
+      {dialog === 'new' && <NewSessionDialog seed={seed} onClose={() => setDialog(null)} />}
       {dialog === 'hosts' && <HostsDialog onClose={() => setDialog(null)} />}
       {dialog === 'settings' && <SettingsDialog onClose={() => setDialog(null)} />}
 

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -344,30 +344,9 @@ function ShellTab({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
 function SessionHeader({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(session.title ?? '')
-  const overflow = useRef<HTMLDetailsElement | null>(null)
   const busy = BUSY_STATUSES.has(session.status)
   const terminated = canResume(session)
   const cold = needsRecovery(session)
-
-  // <details> only closes on its own summary, so a menu left open stays open
-  // over whatever the user clicks next.
-  useEffect(() => {
-    const close = (event: Event): void => {
-      const element = overflow.current
-      if (!element?.open) return
-      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
-      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
-      element.open = false
-    }
-    window.addEventListener('mousedown', close)
-    window.addEventListener('keydown', close)
-    window.addEventListener('blur', close)
-    return () => {
-      window.removeEventListener('mousedown', close)
-      window.removeEventListener('keydown', close)
-      window.removeEventListener('blur', close)
-    }
-  }, [])
 
   const run = async (fn: () => Promise<unknown>): Promise<void> => {
     try {
@@ -460,67 +439,12 @@ function SessionHeader({ hostId, session }: { hostId: string; session: Session }
 
         {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}
 
-        {/* Out of the overflow menu: ending a session is a thing done often
-            enough to be one click, and the confirm is what guards it. */}
-        {!terminated && (
-          <button
-            className="ghost danger"
-            title="End the agent — only Resume brings it back"
-            onClick={() => {
-              if (confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
-                void run(() => api(hostId).terminate(session.session_id))
-              }
-            }}
-          >
-            Terminate
-          </button>
-        )}
-
-        <details className="menu" ref={overflow}>
-          <summary>⋯</summary>
-          <div
-            className="menu-body"
-            onClick={() => {
-              if (overflow.current) overflow.current.open = false
-            }}
-          >
-            {/* The daemon waits for the model before answering, so this can sit
-                for several seconds. Saying what came back is the difference
-                between a slow button and a broken one. */}
-            <button
-              onClick={() =>
-                void run(async () => {
-                  store.notify('Naming the session…')
-                  const result = await api(hostId).generateTitle(session.session_id)
-                  if (result.title) store.notify(result.title)
-                  else store.notify('The model did not return a usable title', 'error')
-                })
-              }
-            >
-              Regenerate title
-            </button>
-            <button
-              onClick={() =>
-                void run(() => api(hostId).patchSession(session.session_id, { pinned: !session.pinned }))
-              }
-            >
-              {session.pinned ? 'Unpin' : 'Pin'}
-            </button>
-            <button
-              className="danger"
-              onClick={() => {
-                // Deleting drops the daemon's record; the agent's own transcript
-                // on disk is untouched, which is worth saying before the click.
-                if (confirm('Remove this session from Helios? The transcript file stays on disk.')) {
-                  store.closeTab(`${hostId}:${session.session_id}`)
-                  void run(() => api(hostId).deleteSession(session.session_id))
-                }
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        </details>
+        {/* Terminate, Pin, Delete and Regenerate title are on the row's own
+            right-click menu. They were here as a button and an overflow beside
+            it, which put the actions for one session at the far corner from
+            the list of them — and made acting on any other session a matter of
+            selecting it first and re-reading the header to be sure it had
+            changed. See sessionActions in sidebar.tsx. */}
       </div>
     </header>
   )

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -59,3 +59,70 @@ export function Cpu({ className = '' }: { className?: string }): JSX.Element {
     </svg>
   )
 }
+
+/**
+ * The sidebar's toolbar and list glyphs.
+ *
+ * These were typed characters — ⌕ ⇅ ▤ ▦ + — which is why they never lined up:
+ * each one is a different fraction of its em box in a different font, so four
+ * buttons of the same size held four glyphs of four sizes. A path fills the box
+ * it is given, and `ui-icon` gives them all the same one.
+ */
+
+/** The magnifier on the search field. */
+export function Search({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="11" cy="11" r="6.5" />
+      <path d="M16 16l4.5 4.5" />
+    </svg>
+  )
+}
+
+/** Two arrows facing apart: the sort-order toggle. */
+export function Sort({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M8 20V4M8 4L4.5 7.5M8 4l3.5 3.5" />
+      <path d="M16 4v16M16 20l3.5-3.5M16 20l-3.5-3.5" />
+    </svg>
+  )
+}
+
+/** Three even lines — one line a session. */
+export function SingleLine({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4 6.5h16M4 12h16M4 17.5h16" />
+    </svg>
+  )
+}
+
+/** Two sessions, each a title with a shorter line under it. */
+export function MultiLine({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4 5.5h16M4 9.5h9" />
+      <path d="M4 15h16M4 19h9" />
+    </svg>
+  )
+}
+
+/** New session. */
+export function Plus({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  )
+}
+
+/** A terminal, for the one action a row offers under the pointer. */
+export function Console({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="3" y="4.5" width="18" height="15" rx="2.5" />
+      <path d="M7.5 10l2.5 2.5-2.5 2.5M13 15h3.5" />
+    </svg>
+  )
+}

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -1,12 +1,20 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
 import type { DirectoryInfo, ModelInfo, ProviderInfo } from '../../shared/models.ts'
 
-export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Element {
+export function NewSessionDialog({
+  seed,
+  onClose,
+}: {
+  /** Host and directory the dialog was opened for, from a project's own
+   *  new-session button. Null when it was opened from the toolbar. */
+  seed?: { hostId: string; cwd: string } | null
+  onClose: () => void
+}): JSX.Element {
   const hosts = useStore((s) => s.hosts)
-  const [hostId, setHostId] = useState(hosts[0]?.id ?? '')
+  const [hostId, setHostId] = useState(seed?.hostId ?? hosts[0]?.id ?? '')
   const [providers, setProviders] = useState<ProviderInfo[]>([])
   const [models, setModels] = useState<ModelInfo[]>([])
   const [directories, setDirectories] = useState<DirectoryInfo[]>([])
@@ -16,6 +24,10 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
   const [mode, setMode] = useState('')
   const [prompt, setPrompt] = useState('')
   const [starting, setStarting] = useState(false)
+  // Spent on the first load and not again: switching hosts after that has to
+  // reset the directory, because a path from one machine is not a path on the
+  // next, and the seed was a path on the machine it came from.
+  const seeded = useRef(seed?.cwd ?? '')
 
   useEffect(() => {
     if (!hostId) return
@@ -31,7 +43,8 @@ export function NewSessionDialog({ onClose }: { onClose: () => void }): JSX.Elem
         // Reset rather than preserve: a directory is meaningful only on the
         // host it came from, and carrying one across a host switch starts the
         // session in a path that does not exist there.
-        setCwd(dirs[0]?.cwd ?? '')
+        setCwd(seeded.current || dirs[0]?.cwd || '')
+        seeded.current = ''
       })
       .catch((err: unknown) => store.fail(err))
     return () => {

--- a/desktop/src/renderer/components/projects.ts
+++ b/desktop/src/renderer/components/projects.ts
@@ -1,0 +1,49 @@
+// How the sidebar decides which project a session belongs to.
+//
+// Kept out of the component so it can be tested: the grouping is the one piece
+// of the sidebar that changes what the list contains rather than how it looks.
+
+import type { Session } from '../../shared/models.ts'
+
+/** Which project a session belongs to. */
+export interface Place {
+  /** What sessions are gathered on — the project's name, folded. */
+  key: string
+  name: string
+  cwd: string
+}
+
+/**
+ * The directory the agent was started in, and nothing inferred from it.
+ *
+ * The daemon already answers this: `project` is the provider's name for the
+ * session's directory, or its basename when the provider gives none
+ * (internal/store/sessions.go:89). A worktree is a working directory in its own
+ * right — `conductor/workspaces/opal-app/vilnius` is where that session lives
+ * and is the thing being worked in — so it groups as itself rather than being
+ * folded back under the checkout it was branched from. Grouping arranges what
+ * the daemon reports; it does not reinterpret it.
+ */
+export function placeOf(session: Session): Place {
+  const cwd = (session.cwd ?? '').replace(/\/+$/, '')
+  const base = cwd.split('/').pop() ?? ''
+  const name = session.project || base || 'sessions'
+  return { key: name.toLowerCase(), name, cwd }
+}
+
+/**
+ * A stable colour for a project, drawn from its name.
+ *
+ * Twelve hues rather than the whole wheel: adjacent hues are not
+ * distinguishable at 22px, so a continuous hash spends its range on
+ * differences nobody can see, while twelve stops are twelve badges the eye can
+ * actually tell apart. Saturation and lightness are fixed so no project gets a
+ * badge that shouts.
+ */
+export function tintOf(key: string): string {
+  let hash = 0
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) % 4096
+  }
+  return `hsl(${(hash % 12) * 30} 62% 62%)`
+}

--- a/desktop/src/renderer/components/selection-menu.tsx
+++ b/desktop/src/renderer/components/selection-menu.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 
 /** One entry of a popover: what it says, and what it does. */
 export interface MenuAction {
   label: string
   run: () => void
+  /** Destructive, and coloured to say so before it is clicked. */
+  danger?: boolean
 }
 
 /**
@@ -45,17 +47,33 @@ export function SelectionMenu({
 
   // Centred on the selection, so a menu near either edge would hang off it.
   const left = anchor === 'above' ? Math.min(Math.max(x, 110), window.innerWidth - 110) : x
+  const [shifted, setShifted] = useState<{ left: number; top: number } | null>(null)
+
+  // A menu opened near the bottom of the window would otherwise run off it —
+  // and the last item, which is where the destructive one goes, is the part
+  // that disappears. Measured rather than estimated, because the height is the
+  // number of actions the caller passed. Before paint, so it does not jump.
+  useLayoutEffect(() => {
+    if (anchor !== 'point') return
+    const rect = box.current?.getBoundingClientRect()
+    if (!rect) return
+    setShifted({
+      left: Math.max(8, Math.min(x, window.innerWidth - rect.width - 8)),
+      top: Math.max(8, Math.min(y, window.innerHeight - rect.height - 8)),
+    })
+  }, [anchor, x, y, actions.length])
 
   return (
     <div
       className={`line-menu${anchor === 'above' ? ' floating' : ''}`}
       ref={box}
-      style={{ left, top: y }}
+      style={shifted ?? { left, top: y }}
       onMouseDown={(event) => event.preventDefault()}
     >
       {actions.map((action) => (
         <button
           key={action.label}
+          className={action.danger ? 'danger' : undefined}
           onClick={() => {
             action.run()
             onClose()

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { bridge } from '../bridge.ts'
+import { api, bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
@@ -19,6 +19,7 @@ import {
 } from '../../shared/models.ts'
 import { Chevron, Console, Cpu, Memory, MultiLine, Plus, Search, SingleLine, Sort } from './icons.tsx'
 import { placeOf, tintOf } from './projects.ts'
+import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -107,6 +108,12 @@ export function Sidebar({
   // Per host, not global: a machine kept for finished work and one being
   // worked in want opposite answers, and the setting is one click away.
   const [showTerminated, setShowTerminated] = useState<Record<string, boolean>>({})
+  // The session a right-click named, and where the pointer was. Held for the
+  // whole list rather than per row, so a second right-click moves the one menu
+  // instead of opening another beside it.
+  const [menu, setMenu] = useState<{ hostId: string; session: Session; x: number; y: number } | null>(
+    null,
+  )
   const aside = useRef<HTMLElement | null>(null)
 
   // The width is a CSS variable rather than state: the value is read by the
@@ -353,6 +360,7 @@ export function Sidebar({
                                 })
                               }
                               onDragEnd={() => setDragging(null)}
+                              onContextMenu={(x, y) => setMenu({ hostId: host.id, session, x, y })}
                               onDropBefore={(draggedId) => {
                                 // The id off the drag itself, not React state: the
                                 // drop can arrive in the same tick as the drag
@@ -423,6 +431,15 @@ export function Sidebar({
         <AppMenu onSettings={onSettings} />
       </footer>
 
+      {menu && (
+        <SelectionMenu
+          x={menu.x}
+          y={menu.y}
+          actions={sessionActions(menu.hostId, menu.session)}
+          onClose={() => setMenu(null)}
+        />
+      )}
+
       {/* The panel's own edge, not a bar between the panels: the list is what
           the pointer is already near, and a gutter belongs to neither side. */}
       <div
@@ -438,6 +455,75 @@ export function Sidebar({
       />
     </aside>
   )
+}
+
+/**
+ * What can be done to a session, as the right-click on its row offers it.
+ *
+ * These were buttons in the detail header, where they applied to whichever
+ * session happened to be open: acting on any other one meant selecting it
+ * first and reading the header to check it had changed. On the row they name
+ * the session under the pointer, which is the one being pointed at.
+ */
+function sessionActions(hostId: string, session: Session): MenuAction[] {
+  const run = async (fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await fn()
+      await store.refreshSessions(hostId)
+    } catch (err) {
+      store.fail(err)
+    }
+  }
+
+  const actions: MenuAction[] = [
+    {
+      label: 'Regenerate title',
+      // The daemon waits for the model before answering, so this can sit for
+      // several seconds. Saying what came back is the difference between a
+      // slow menu item and a broken one.
+      run: () =>
+        void run(async () => {
+          store.notify('Naming the session…')
+          const result = await api(hostId).generateTitle(session.session_id)
+          if (result.title) store.notify(result.title)
+          else store.notify('The model did not return a usable title', 'error')
+        }),
+    },
+    {
+      label: session.pinned ? 'Unpin' : 'Pin',
+      run: () =>
+        void run(() => api(hostId).patchSession(session.session_id, { pinned: !session.pinned })),
+    },
+  ]
+
+  // Nothing to end when it has already ended, and the row itself carries the
+  // Resume that a terminated session is waiting for.
+  if (!canResume(session)) {
+    actions.push({
+      label: 'Terminate',
+      danger: true,
+      run: () => {
+        if (confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
+          void run(() => api(hostId).terminate(session.session_id))
+        }
+      },
+    })
+  }
+
+  actions.push({
+    label: 'Delete',
+    danger: true,
+    run: () => {
+      // Deleting drops the daemon's record; the agent's own transcript on disk
+      // is untouched, which is worth saying before the click.
+      if (confirm('Remove this session from Helios? The transcript file stays on disk.')) {
+        store.closeTab(`${hostId}:${session.session_id}`)
+        void run(() => api(hostId).deleteSession(session.session_id))
+      }
+    },
+  })
+
+  return actions
 }
 
 /**
@@ -507,6 +593,7 @@ function SessionRow({
   accepts,
   onDragStart,
   onDragEnd,
+  onContextMenu,
   onDropBefore,
 }: {
   hostId: string
@@ -520,6 +607,7 @@ function SessionRow({
   accepts: boolean
   onDragStart: () => void
   onDragEnd: () => void
+  onContextMenu: (x: number, y: number) => void
   onDropBefore: (draggedId: string) => void
 }): JSX.Element {
   const live = hasTerminal(session)
@@ -558,6 +646,13 @@ function SessionRow({
         onDropBefore(event.dataTransfer.getData('text/plain'))
       }}
       onClick={() => store.select(hostId, session.session_id)}
+      // Selected as well as pointed at: the menu acts on this session, and the
+      // panel beside it should be showing the one that is about to change.
+      onContextMenu={(event) => {
+        event.preventDefault()
+        store.select(hostId, session.session_id)
+        onContextMenu(event.clientX, event.clientY)
+      }}
       // A terminated session has to be resumed before it has a terminal worth
       // opening, so the shortcut resumes instead of waking one it will refuse.
       onDoubleClick={() =>

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -9,14 +9,16 @@ import {
   isTerminated,
   needsRecovery,
   sessionLabel,
-  shortCwd,
+  shortMode,
+  shortModel,
   statusLabel,
   timeAgo,
   type HostRecord,
   type Session,
   type HostStats,
 } from '../../shared/models.ts'
-import { Chevron, Cpu, Memory } from './icons.tsx'
+import { Chevron, Console, Cpu, Memory, MultiLine, Plus, Search, SingleLine, Sort } from './icons.tsx'
+import { placeOf, tintOf } from './projects.ts'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -43,18 +45,38 @@ function writeSidebarWidth(width: number | null): void {
 }
 
 interface Row {
-  host: HostRecord
   session: Session
   pending: number
 }
 
+/** One directory, and every session the host is running in it. */
+interface Project {
+  /** The project's name, folded — what its sessions are gathered on. */
+  key: string
+  name: string
+  /** Where a new session in this project starts. */
+  cwd: string
+  rows: Row[]
+  /** What this project's warm terminals hold, summed over its rows. */
+  memory: number
+}
+
 interface Group {
   host: HostRecord
-  rows: Row[]
+  projects: Project[]
+  /** Sessions shown, across every project — what the host head counts. */
+  count: number
   /** Terminated sessions withheld from rows, so the host can offer them. */
   hidden: number
   /** The host has not answered yet, which is not the same as having nothing. */
   loading: boolean
+}
+
+/** A session being dragged, and the project it may be dropped back into. */
+interface Drag {
+  hostId: string
+  projectKey: string
+  sessionId: string
 }
 
 export function Sidebar({
@@ -62,7 +84,7 @@ export function Sidebar({
   onAddHost,
   onSettings,
 }: {
-  onNewSession: () => void
+  onNewSession: (seed?: { hostId: string; cwd: string }) => void
   onAddHost: () => void
   onSettings: () => void
 }): JSX.Element {
@@ -77,8 +99,11 @@ export function Sidebar({
   const density = useStore((s) => s.density)
   // The card being dragged, so the row under the pointer can show where it
   // would land. Held per host: a drag never crosses from one daemon to another.
-  const [dragging, setDragging] = useState<{ hostId: string; sessionId: string } | null>(null)
+  const [dragging, setDragging] = useState<Drag | null>(null)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  // Folded projects, keyed by host and path together: two machines can hold
+  // checkouts at the same path, and folding one should not fold the other.
+  const [folded, setFolded] = useState<Record<string, boolean>>({})
   // Per host, not global: a machine kept for finished work and one being
   // worked in want opposite answers, and the setting is one click away.
   const [showTerminated, setShowTerminated] = useState<Record<string, boolean>>({})
@@ -128,17 +153,32 @@ export function Sidebar({
       // A terminated session the user searched for is a session they asked to
       // see, so the filter yields to an explicit query.
       const hideTerminated = !showTerminated[host.id] && !needle
-      const rows: Row[] = visible
+      const ordered = visible
         .filter((session) => !hideTerminated || !isTerminated(session))
-        .map((session) => ({ host, session, pending: pendingByCwd.get(session.session_id) ?? 0 }))
+        .map((session) => ({ session, pending: pendingByCwd.get(session.session_id) ?? 0 }))
         .sort(sortMode[host.id] === 'manual' ? byHand : compareRows)
+
+      // Projects take the position of their best session rather than an order
+      // of their own: grouping arranges the list, it does not re-rank it, so a
+      // session that wants attention still carries its project to the top.
+      const byProject = new Map<string, Project>()
+      for (const row of ordered) {
+        const place = placeOf(row.session)
+        let project = byProject.get(place.key)
+        if (!project) {
+          project = { key: place.key, name: place.name, cwd: place.cwd, rows: [], memory: 0 }
+          byProject.set(place.key, project)
+        }
+        project.rows.push(row)
+        project.memory += row.session.memory_bytes ?? 0
+      }
 
       const hidden = hideTerminated ? visible.filter(isTerminated).length : 0
       // An unfetched host has no entry at all, an empty one has []. Without the
       // distinction a daemon that is slow to answer looks like a daemon with
       // nothing on it.
       const loading = sessions[host.id] === undefined
-      return { host, rows, hidden, loading }
+      return { host, projects: [...byProject.values()], count: ordered.length, hidden, loading }
     })
   }, [hosts, sessions, notifications, query, showTerminated, sortMode])
 
@@ -150,19 +190,26 @@ export function Sidebar({
     <aside className="sidebar" ref={aside}>
       <header className="sidebar-head">
         <div className="search-field">
-          <span className="search-icon" aria-hidden="true">
-            ⌕
-          </span>
+          <Search className="search-icon" />
           <input
             className="search"
             placeholder="Search sessions"
             value={query}
             onChange={(event) => store.setQuery(event.target.value)}
           />
+          {/* Only once there is something to clear: an always-present × in a
+              field the user has not typed in reads as a control they have
+              missed the purpose of. */}
+          {query !== '' && (
+            <button className="search-clear" aria-label="Clear the search" onClick={() => store.setQuery('')}>
+              ×
+            </button>
+          )}
         </div>
         <button
-          className={manual ? 'fab sort-toggle on' : 'fab sort-toggle'}
+          className={manual ? 'tool sort-toggle on' : 'tool sort-toggle'}
           aria-label={manual ? 'Sorting by hand' : 'Sorting by activity'}
+          aria-pressed={manual}
           title={
             manual
               ? 'Sort: Manual — drag a session to move it.\nClick to sort by activity instead.'
@@ -170,124 +217,189 @@ export function Sidebar({
           }
           onClick={() => void store.setSortModeEverywhere(manual ? 'activity' : 'manual')}
         >
-          ⇅
+          <Sort />
         </button>
         {/* Beside the sort toggle because it is the same kind of control: not
             a preference set once, but a way of looking at the list, changed
             while looking at it. Shows the state it is in, as the sort does. */}
         <button
-          className={density === 'compact' ? 'fab density-toggle on' : 'fab density-toggle'}
+          className="tool density-toggle"
           aria-label={density === 'compact' ? 'Compact list' : 'Comfortable list'}
           title={
             density === 'compact'
-              ? 'Compact — one line a session.\nClick for the fuller card.'
-              : 'Comfortable — status, title, directory and model.\nClick to fit more on screen.'
+              ? 'Compact — one line a session, title and time.\nClick for the second line back.'
+              : 'Comfortable — a second line with the agent, model and memory.\nClick to fit more on screen.'
           }
           onClick={() => void store.setDensity(density === 'compact' ? 'comfortable' : 'compact')}
         >
-          {density === 'compact' ? '▤' : '▦'}
+          {density === 'compact' ? <SingleLine /> : <MultiLine />}
         </button>
-        <button className="fab" title="New session (⌘N)" onClick={onNewSession}>
-          +
+        <button
+          className="tool primary"
+          aria-label="New session"
+          title="New session (⌘N)"
+          onClick={() => onNewSession()}
+        >
+          <Plus />
         </button>
       </header>
 
       <div className="sidebar-list">
-        {grouped.map(({ host, rows, hidden, loading }) => {
+        {grouped.map(({ host, projects, count, hidden, loading }) => {
           const status = hostStatus[host.id]?.state ?? 'connecting'
           const isCollapsed = collapsed[host.id] ?? false
+          const revealed = showTerminated[host.id] ?? false
+          // The whole host in display order, which is what a reorder posts.
+          const order = projects.flatMap((project) => project.rows.map((row) => row.session.session_id))
           return (
             <section key={host.id} className="host-group">
-              <button
-                className="host-head"
-                onClick={() => setCollapsed((c) => ({ ...c, [host.id]: !isCollapsed }))}
-              >
-                <span className={`dot ${status}`} title={hostStatus[host.id]?.error ?? status} />
-                <span className="host-name">{host.name}</span>
-                {/* No count until there is one: a 0 that turns into 12 reads as
-                    an answer, and it was not one. */}
-                {!loading && <span className="host-count">{rows.length}</span>}
-                <Chevron className="chevron" open={!isCollapsed} />
-              </button>
-
-              {!isCollapsed && <HostMeter stats={stats[host.id]} />}
-
-              {/* Above the list, not below it: revealed sessions are appended,
-                  so a toggle under them walks further down the page with every
-                  use and the way back is a scroll. */}
-              {!isCollapsed && (hidden > 0 || showTerminated[host.id]) && (
+              <div className="host-head">
                 <button
-                  className="link show-terminated"
-                  onClick={() =>
-                    setShowTerminated((current) => ({ ...current, [host.id]: !current[host.id] }))
-                  }
+                  className="host-title"
+                  aria-expanded={!isCollapsed}
+                  onClick={() => setCollapsed((c) => ({ ...c, [host.id]: !isCollapsed }))}
                 >
-                  {showTerminated[host.id] ? 'Hide terminated' : `Show ${hidden} terminated`}
+                  <span className={`host-dot ${status}`} title={hostStatus[host.id]?.error ?? status} />
+                  <span className="host-name">{host.name}</span>
+                  {/* No count until there is one: a 0 that turns into 12 reads
+                      as an answer, and it was not one. */}
+                  {!loading && (
+                    <span className="host-count">
+                      {count} {count === 1 ? 'session' : 'sessions'}
+                    </span>
+                  )}
+                  <Chevron className="chevron" open={!isCollapsed} />
                 </button>
-              )}
+
+                {/* One line under the host: what its terminals cost on the
+                    left, and the sessions it is not showing on the right. Both
+                    are facts about this machine, and neither is worth a row of
+                    its own. */}
+                {!isCollapsed && (
+                  <div className="host-meta">
+                    <HostMeter stats={stats[host.id]} />
+                    {(hidden > 0 || revealed) && (
+                      <button
+                        className="link show-terminated"
+                        onClick={() =>
+                          setShowTerminated((current) => ({ ...current, [host.id]: !current[host.id] }))
+                        }
+                      >
+                        {revealed ? 'Hide terminated' : `Show ${hidden} terminated`}
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
 
               {!isCollapsed &&
-                rows.map(({ session, pending }) => (
-                  <SessionRow
-                    key={session.session_id}
-                    hostId={host.id}
-                    session={session}
-                    pending={pending}
-                    selected={
-                      selection?.hostId === host.id && selection.sessionId === session.session_id
-                    }
-                    draggable={sortMode[host.id] === 'manual'}
-                    dragging={dragging?.sessionId === session.session_id}
-                    onDragStart={() => setDragging({ hostId: host.id, sessionId: session.session_id })}
-                    onDragEnd={() => setDragging(null)}
-                    onDropBefore={(draggedId) => {
-                      // The id off the drag itself, not React state: the drop
-                      // can arrive in the same tick as the drag start, before
-                      // a setState has committed, and then nothing moves.
-                      const ids = rows.map((row) => row.session.session_id)
-                      const from = ids.indexOf(draggedId)
-                      const to = ids.indexOf(session.session_id)
-                      setDragging(null)
-                      if (from === -1 || to === -1 || from === to) return
-                      ids.splice(to, 0, ids.splice(from, 1)[0] as string)
-                      void store.reorderSessions(host.id, ids)
-                    }}
-                  />
-                ))}
+                projects.map((project) => {
+                  const foldKey = `${host.id}:${project.key}`
+                  const isFolded = folded[foldKey] ?? false
+                  return (
+                    <div className="project" key={project.key}>
+                      <div className={isFolded ? 'project-head folded' : 'project-head'}>
+                        <button
+                          className="project-title"
+                          title={project.cwd}
+                          aria-expanded={!isFolded}
+                          onClick={() => setFolded((f) => ({ ...f, [foldKey]: !isFolded }))}
+                        >
+                          <span className="project-badge" style={{ '--tint': tintOf(project.key) } as React.CSSProperties}>
+                            {project.name.slice(0, 1).toUpperCase()}
+                          </span>
+                          <span className="project-name">{project.name}</span>
+                          <span className="project-count">{project.rows.length}</span>
+                          {project.memory > 0 && (
+                            <>
+                              <span className="project-sep">·</span>
+                              <span className="project-ram">{formatBytes(project.memory)}</span>
+                            </>
+                          )}
+                          <Chevron className="chevron project-chevron" open={!isFolded} />
+                        </button>
+                        <button
+                          className="project-add"
+                          aria-label={`New session in ${project.name}`}
+                          title={`New session in ${project.name}`}
+                          onClick={() => onNewSession({ hostId: host.id, cwd: project.cwd })}
+                        >
+                          <Plus />
+                        </button>
+                      </div>
+
+                      {!isFolded && (
+                        <div className="project-rows">
+                          {project.rows.map(({ session, pending }) => (
+                            <SessionRow
+                              key={session.session_id}
+                              hostId={host.id}
+                              session={session}
+                              pending={pending}
+                              selected={
+                                selection?.hostId === host.id && selection.sessionId === session.session_id
+                              }
+                              draggable={sortMode[host.id] === 'manual'}
+                              dragging={dragging?.sessionId === session.session_id}
+                              // Only inside its own project: the daemon holds one
+                              // flat order per host, so a card dropped across the
+                              // divide would drag its whole project with it.
+                              accepts={dragging?.hostId === host.id && dragging.projectKey === project.key}
+                              onDragStart={() =>
+                                setDragging({
+                                  hostId: host.id,
+                                  projectKey: project.key,
+                                  sessionId: session.session_id,
+                                })
+                              }
+                              onDragEnd={() => setDragging(null)}
+                              onDropBefore={(draggedId) => {
+                                // The id off the drag itself, not React state: the
+                                // drop can arrive in the same tick as the drag
+                                // start, before a setState has committed, and then
+                                // nothing moves.
+                                const ids = [...order]
+                                const from = ids.indexOf(draggedId)
+                                const to = ids.indexOf(session.session_id)
+                                setDragging(null)
+                                if (from === -1 || to === -1 || from === to) return
+                                ids.splice(to, 0, ids.splice(from, 1)[0] as string)
+                                void store.reorderSessions(host.id, ids)
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
 
               {/* Skeletons rather than a spinner: the list is about to be a
                   list, and showing its shape keeps the sidebar from resizing
                   under the cursor when the rows arrive.
 
-                  Built from the card's own elements rather than a stack of
-                  bars, so it is the height of a session card by construction
-                  and stays that way when the card changes. */}
+                  Built from the row's own elements rather than a stack of bars,
+                  so it is the height of a session row by construction and stays
+                  that way when the row changes. */}
               {!isCollapsed &&
                 loading &&
                 [0, 1, 2].map((index) => (
-                  <div key={index} className="session-card skeleton" aria-hidden="true">
-                    <div className="card-inner">
-                      <div className="card-top">
-                        <span className="skeleton-line chip" />
-                        <span className="grow" />
-                        <span className="skeleton-line time" />
-                      </div>
-                      <div className="card-title">
+                  <div key={index} className="session-row skeleton" aria-hidden="true">
+                    <div className="row-main">
+                      <span className="row-dot" />
+                      <span className="row-title">
                         <span className="skeleton-line" />
-                      </div>
-                      <div className="card-cwd">
-                        <span className="skeleton-line cwd" />
-                      </div>
-                      <div className="card-bottom">
-                        <span className="skeleton-line meta" />
-                        <span className="skeleton-line btn" />
-                      </div>
+                      </span>
+                      <span className="skeleton-line time" />
+                    </div>
+                    <div className="row-sub">
+                      <span className="skeleton-line" />
                     </div>
                   </div>
                 ))}
 
-              {!isCollapsed && !loading && rows.length === 0 && hidden === 0 && (
-                <p className="empty-note">No sessions</p>
+              {!isCollapsed && !loading && count === 0 && hidden === 0 && (
+                <p className="empty-note">{query ? 'Nothing matches' : 'No sessions'}</p>
               )}
             </section>
           )
@@ -376,6 +488,15 @@ function AppMenu({ onSettings }: { onSettings: () => void }): JSX.Element {
   )
 }
 
+/**
+ * One session, two lines: what it is called, and what it is.
+ *
+ * The first line is identity — status, title, the one action, how long ago —
+ * and the title has the whole width of it. The second is configuration, in
+ * small print: which agent, which model, under which permissions, holding how
+ * much. Compact folds the second line away, which is the difference between
+ * the two densities.
+ */
 function SessionRow({
   hostId,
   session,
@@ -383,6 +504,7 @@ function SessionRow({
   selected,
   draggable,
   dragging,
+  accepts,
   onDragStart,
   onDragEnd,
   onDropBefore,
@@ -394,6 +516,8 @@ function SessionRow({
   /** Only in manual mode: dragging a card in an auto-sorted list means nothing. */
   draggable: boolean
   dragging: boolean
+  /** A drag is in flight and this row is somewhere it may be dropped. */
+  accepts: boolean
   onDragStart: () => void
   onDragEnd: () => void
   onDropBefore: (draggedId: string) => void
@@ -402,9 +526,17 @@ function SessionRow({
   const busy = BUSY_STATUSES.has(session.status)
   const terminated = canResume(session)
   const cold = needsRecovery(session)
+  const label = sessionLabel(session)
+  const classes = [
+    'session-row',
+    session.status,
+    selected ? 'selected' : '',
+    dragging ? 'dragging' : '',
+    draggable ? 'movable' : '',
+  ]
   return (
     <article
-      className={`session-card ${session.status} ${selected ? 'selected' : ''}${dragging ? ' dragging' : ''}${draggable ? ' movable' : ''}`}
+      className={classes.filter(Boolean).join(' ')}
       draggable={draggable}
       onDragStart={(event) => {
         // Firefox and Chromium both want data on the transfer or the drag never
@@ -415,13 +547,13 @@ function SessionRow({
       }}
       onDragEnd={onDragEnd}
       onDragOver={(event) => {
-        if (!draggable) return
+        if (!draggable || !accepts) return
         // Without this the drop never fires: the default is to refuse.
         event.preventDefault()
         event.dataTransfer.dropEffect = 'move'
       }}
       onDrop={(event) => {
-        if (!draggable) return
+        if (!draggable || !accepts) return
         event.preventDefault()
         onDropBefore(event.dataTransfer.getData('text/plain'))
       }}
@@ -434,66 +566,89 @@ function SessionRow({
           : store.openTerminal(hostId, session, !live))
       }
     >
-      <div className="card-inner">
-        <div className="card-top">
-          <span className={`chip ${session.status}`}>
-            <span className={busy ? 'dot pulse' : 'dot'} />
-            {statusLabel(session.status)}
+      <div className="row-main">
+        <span
+          className={`row-dot ${session.status}${busy ? ' pulse' : ''}`}
+          title={statusLabel(session.status)}
+        />
+        <span className="row-title" title={label}>
+          {label}
+        </span>
+        {cold && (
+          <span className="cold-mark" title="Cold — no live terminal">
+            ⚯
           </span>
-          {cold && (
-            <span className="cold-mark" title="Cold — no live terminal">
-              ⚯
-            </span>
-          )}
-          {session.pinned && (
-            <span className="pin" title="Pinned">
-              ★
-            </span>
-          )}
-          {pending > 0 && <span className="badge">{pending}</span>}
-          {session.memory_bytes !== undefined && (
-            <span className="card-ram" title="Memory this terminal holds">
-              {formatBytes(session.memory_bytes)}
-            </span>
-          )}
-          <span className="grow" />
-          <span className="time">{timeAgo(session.last_event_at ?? session.created_at)}</span>
-        </div>
-
-        <div className="card-title">{sessionLabel(session)}</div>
-        <div className="card-cwd" title={session.cwd}>
-          {shortCwd(session.cwd)}
-        </div>
-
-        <div className="card-bottom">
-          <span className="card-meta">
-            {session.model ?? session.source}
-            {session.permission_mode ? ` · ${shortMode(session.permission_mode)}` : ''}
+        )}
+        {session.pinned && (
+          <span className="pin" title="Pinned">
+            ★
           </span>
+        )}
+        {pending > 0 && (
+          <span className="badge" title={pending === 1 ? '1 waiting on you' : `${pending} waiting on you`}>
+            {pending}
+          </span>
+        )}
+        {/* Two shapes for two situations. A live or cold session offers an icon
+            that is already in the row before the pointer arrives and only fades
+            in — a button that appears into the layout re-measures the title
+            under the cursor, and a list that reflows as the pointer crosses it
+            is what makes hovering feel jarring. A terminated one gets the word,
+            because resuming is the only move it has left and it should not have
+            to be hovered to say so. */}
+        {terminated ? (
           <button
-            className={terminated ? 'row-btn resume' : 'row-btn'}
-            title={
-              terminated
-                ? 'Resume — bring the agent back'
-                : live
-                  ? 'Open terminal'
-                  : 'Cold — wake and open terminal'
-            }
+            className="row-btn resume"
+            title="Resume — bring the agent back"
             onClick={(event) => {
               event.stopPropagation()
-              if (terminated) void store.resumeSession(hostId, session.session_id)
-              else void store.openTerminal(hostId, session, !live)
+              void store.resumeSession(hostId, session.session_id)
             }}
           >
-            {terminated ? 'Resume' : live ? 'Terminal' : 'Wake'}
+            Resume
           </button>
-        </div>
+        ) : (
+          <button
+            className="row-act"
+            aria-label={live ? 'Open terminal' : 'Wake and open terminal'}
+            title={live ? 'Open terminal' : 'Cold — wake and open terminal'}
+            onClick={(event) => {
+              event.stopPropagation()
+              void store.openTerminal(hostId, session, !live)
+            }}
+          >
+            <Console />
+          </button>
+        )}
+        <span className="row-time">{timeAgo(session.last_event_at ?? session.created_at)}</span>
+      </div>
+
+      {/* What the session is, under what it is called. Kept off the title's
+          line so the title gets the whole width — a long one is the common
+          case, and it was losing half its room to a trail of small print. */}
+      <div className="row-sub">
+        <span className="row-provider">{session.source}</span>
+        {session.model !== undefined && (
+          <span className="row-model" title={session.model}>
+            {shortModel(session.model, session.source)}
+          </span>
+        )}
+        {session.permission_mode !== undefined && (
+          <span className="row-mode" title={session.permission_mode}>
+            {shortMode(session.permission_mode)}
+          </span>
+        )}
+        <span className="grow" />
+        {session.memory_bytes !== undefined && (
+          <span className="row-ram" title="Memory this terminal holds">
+            {formatBytes(session.memory_bytes)}
+          </span>
+        )}
       </div>
     </article>
   )
 }
 
-/** Pending approvals first, then live sessions, then most recent activity. */
 /**
  * The order the user put them in, and nothing else.
  *
@@ -508,6 +663,7 @@ function byHand(a: Row, b: Row): number {
   return b.session.created_at.localeCompare(a.session.created_at)
 }
 
+/** Pending approvals first, then live sessions, then most recent activity. */
 function compareRows(a: Row, b: Row): number {
   if (a.pending !== b.pending) return b.pending - a.pending
   if (a.session.pinned !== b.session.pinned) return a.session.pinned ? -1 : 1
@@ -519,26 +675,15 @@ function compareRows(a: Row, b: Row): number {
   )
 }
 
-function shortMode(mode: string): string {
-  switch (mode) {
-    case 'acceptEdits':
-      return 'accept edits'
-    case 'bypassPermissions':
-      return 'bypass'
-    case 'plan':
-      return 'plan'
-    default:
-      return mode
-  }
-}
-
 /**
  * What this host is carrying: its warm terminals, then the machine behind
  * them.
  *
  * The daemon lets idle sessions go cold once the pool passes the budget, so
- * this reads as consumed against allowed rather than against the machine. The
- * machine's own figure stays as context: the budget is a share of it.
+ * the budget is what the reading turns amber against — but it is a number the
+ * user chose, and the machine's own free memory is the one they can check
+ * against anything else. So the line reads warm against the machine, and the
+ * budget stays in the tooltip with the advice that depends on it.
  *
  * It belongs to the host and not the window — memory is a machine's to run out
  * of, and a session on the laptop says nothing about the one on the VM.
@@ -560,13 +705,11 @@ function HostMeter({ stats }: { stats?: HostStats }): JSX.Element | null {
       }
     >
       <Memory />
-      {metered ? (
-        <span>{formatPair(stats.warm_rss, stats.budget)}</span>
-      ) : (
-        <span>{formatBytes(stats.warm_rss)}</span>
-      )}
+      <span>{formatBytes(stats.warm_rss)}</span>
+      {/* The machine's own figure is context for the pool's, not a thing to
+          act on, so it is the first thing a narrow sidebar drops. */}
       {machine && (
-        <span className="host-machine">machine {formatPair(stats.memory_used, stats.memory_total)}</span>
+        <span className="host-machine">of {formatPair(stats.memory_used, stats.memory_total)}</span>
       )}
       <Cpu />
       <span>{Math.round(stats.load * 100)}%</span>

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -323,11 +323,11 @@ small {
 }
 
 .show-terminated {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 2px 16px 8px;
-  font-size: 12px;
+  flex: none;
+  margin-left: auto;
+  padding: 0 2px;
+  font-size: 11px;
+  white-space: nowrap;
 }
 
 .error-text {
@@ -605,12 +605,12 @@ small {
   background: transparent;
 }
 
-/* Cards carry the surface they sit on down with them. Left opaque they read as
-   pasted onto the panel rather than part of it — the mismatch is far more
-   obvious than the transparency itself. */
-[data-glass='on'] .session-card {
+/* Only the selected row paints, so only the selected row has a surface to
+   carry down. Left opaque it would read as pasted onto the panel rather than
+   part of it — the mismatch is far more obvious than the transparency. */
+[data-glass='on'] .session-row.selected {
   background: var(--glass-container);
-  /* Half the panel's blur. A card is a sheet on a sheet, and blurring it as
+  /* Half the panel's blur. A row is a sheet on a sheet, and blurring it as
      hard again flattens the difference between the two. */
   backdrop-filter: var(--glass-frost-soft);
 }
@@ -626,8 +626,22 @@ small {
 .sidebar-head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
+  gap: 6px;
+  padding: 12px 12px 10px;
+}
+
+/* One size for every drawn glyph in the sidebar, so four buttons of the same
+   size hold four icons of the same size — which is not what four typed
+   characters gave. */
+.ui-icon {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .search-field {
@@ -635,23 +649,34 @@ small {
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
+  height: 36px;
+  padding: 0 5px 0 11px;
   background: var(--surface-high);
   border-radius: 999px;
-  padding-left: 12px;
+  /* Drawn always and coloured only on focus, so taking the caret does not move
+     the text inside by a pixel. */
+  box-shadow: inset 0 0 0 1px transparent;
+  transition: box-shadow 120ms ease;
+}
+
+.search-field:focus-within {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 55%, transparent);
 }
 
 .search-icon {
+  width: 15px;
+  height: 15px;
   color: var(--on-surface-variant);
-  font-size: 15px;
 }
 
 .search {
   flex: 1;
   min-width: 0;
+  height: 100%;
   background: none;
   border: none;
-  padding: 9px 12px 9px 0;
+  padding: 0;
   font-size: 13px;
 }
 
@@ -659,39 +684,77 @@ small {
   border-color: transparent;
 }
 
-/* Small FAB. */
-.fab {
-  width: 40px;
-  height: 40px;
+.search-clear {
   flex: none;
+  width: 24px;
+  height: 24px;
   padding: 0;
-  border-radius: var(--r-md);
-  background: var(--primary-container);
-  color: var(--on-primary-container);
-  font-size: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--on-surface-variant);
+  font-size: 16px;
   line-height: 1;
 }
 
-.fab:hover:not(:disabled) {
+.search-clear:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+  color: var(--on-surface);
+}
+
+/* Toolbar buttons. Outlined rather than filled: three filled tiles beside a
+   search field read as three equal invitations, and only one of them is one.
+   The button that starts a session keeps the fill; the two that change how the
+   list is shown are quieter until they are the one holding it. */
+.tool {
+  width: 36px;
+  height: 36px;
+  flex: none;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--on-surface-variant);
+  box-shadow: inset 0 0 0 1px var(--outline-variant);
+}
+
+.tool:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+  color: var(--on-surface);
+}
+
+.tool.on,
+.tool.primary {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+  box-shadow: none;
+}
+
+.tool.on:hover:not(:disabled),
+.tool.primary:hover:not(:disabled) {
   background: color-mix(in srgb, var(--primary-container) 88%, white);
+  color: var(--on-primary-container);
 }
 
 .sidebar-list {
   flex: 1;
   overflow-y: auto;
-  padding: 0 12px;
+  padding: 0 8px 8px;
+  /* A row measures itself against this panel, not the window: what it can
+     afford to show depends on how far the user has dragged the sidebar out. */
+  container-type: inline-size;
+  container-name: sidebar;
 }
 
-/* Under the host it belongs to: what that machine's warm terminals hold, and
-   what the machine itself has left. One line, because it is a reading and not
-   a message — the advice lives in its tooltip. */
+/* What a host's warm terminals hold, and what the machine behind them has
+   left. One line, because it is a reading and not a message — the advice lives
+   in its tooltip. */
 .host-meter {
   display: flex;
   align-items: center;
-  gap: 4px;
-  /* Left edge on the host head's, so the reading starts under the dot rather
-     than floating in from the session cards. */
-  padding: 0 4px 6px;
+  gap: 5px;
+  min-width: 0;
   color: var(--on-surface-variant);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
@@ -701,13 +764,6 @@ small {
 
 .host-meter.heavy {
   color: var(--s-waiting);
-}
-
-/* The machine's own figure is context for the pool's, not a thing to act on. */
-.host-machine {
-  opacity: 0.7;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Sized in em like the chevron, so the glyph follows the row's font size. */
@@ -722,9 +778,14 @@ small {
   stroke-linejoin: round;
 }
 
+/* The machine's own figure is context for the pool's, not a thing to act on. */
+.host-machine {
+  opacity: 0.7;
+}
+
 /* The second icon in the row starts a new reading; a little air marks that. */
-.host-meter .meter-icon + span {
-  margin-right: 2px;
+.host-meter .meter-icon:not(:first-child) {
+  margin-left: 4px;
 }
 
 /* The link and the menu stay together on the right, rather than each drifting
@@ -748,28 +809,41 @@ small {
 }
 
 .host-group {
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
+/* The list's one header: the machine on the first line, what it costs on the
+   second. Ruled off rather than spaced off, and bled out past the list's own
+   padding, so the rule reads as the edge of a band the sessions below belong
+   to rather than a line drawn near them. */
 .host-head {
+  padding: 8px 14px 9px;
+  margin: 0 -8px 10px;
+  border-bottom: 1px solid var(--outline-variant);
+}
+
+.host-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   width: 100%;
-  padding: 6px 4px;
-  border-radius: var(--r-sm);
-  color: var(--on-surface-variant);
-  font-size: 11px;
-  font-weight: 600;
+  padding: 1px 0;
+  border-radius: 0;
+  background: none;
+  color: var(--on-surface);
+  font-size: 12px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.09em;
 }
 
-.host-head:hover {
-  background: color-mix(in srgb, var(--on-surface) 6%, transparent);
+.host-title:hover:not(:disabled),
+.host-title:active:not(:disabled) {
+  background: none;
+  color: var(--on-surface);
 }
 
-.host-head .dot {
+.host-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -777,16 +851,19 @@ small {
   flex: none;
 }
 
-.host-head .dot.online {
+/* A halo only while it is online: the state worth showing at a glance is the
+   good one, because the others already say so in the sessions underneath. */
+.host-dot.online {
   background: var(--s-active);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--s-active) 18%, transparent);
 }
 
-.host-head .dot.connecting {
+.host-dot.connecting {
   background: var(--s-waiting);
 }
 
-.host-head .dot.offline,
-.host-head .dot.unpaired {
+.host-dot.offline,
+.host-dot.unpaired {
   background: var(--error);
 }
 
@@ -798,7 +875,28 @@ small {
   white-space: nowrap;
 }
 
-.host-count,
+/* Counted in words, not digits: a bare 12 beside a machine name is a number
+   the reader has to guess the unit of. */
+.host-count {
+  flex: none;
+  color: var(--on-surface-variant);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0.01em;
+}
+
+/* Wraps rather than clips. The reading and the toggle are both whole things —
+   an ellipsis through "37.6/48.0 GB" says less than nothing — so on a sidebar
+   too narrow for both, the toggle takes a line of its own. */
+.host-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 8px;
+  margin-top: 6px;
+}
+
 /* Drawn, so it fills its box: sized in em to follow the row it sits in rather
    than pinning a size of its own. See components/icons.tsx. */
 .chevron-icon {
@@ -816,116 +914,372 @@ small {
   opacity: 0.7;
 }
 
-/* Quieter than the new-session button beside it, and filled only while it is
-   the one holding the list still. */
-.sort-toggle,
-.density-toggle {
-  background: transparent;
+/* ── Projects ───────────────────────────────────────────────────────────────
+   The daemon lists sessions; people keep them by repository. The header is the
+   thing the sessions under it have in common — which checkout, how many, and
+   what they are holding between them — so the rows themselves no longer have
+   to each repeat a directory. */
+
+.project {
+  margin-bottom: 18px;
+}
+
+/* Indented under the header, so the eye can run down one project's rows
+   without the next project's header pulling it back to the margin. */
+.project-rows {
+  padding-left: 8px;
+}
+
+.project-head {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2px;
+  border-radius: var(--r-sm);
+  padding-right: 4px;
+}
+
+.project-head:hover {
+  background: color-mix(in srgb, var(--on-surface) 5%, transparent);
+}
+
+.project-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 4px 6px 5px;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--on-surface);
+  font-size: 13.5px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.project-title:hover:not(:disabled),
+.project-title:active:not(:disabled) {
+  background: none;
+}
+
+/* The initial on a tinted tile. Colour is the fastest way back to a project
+   once there are six of them, and it costs no width. */
+.project-badge {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--tint) 20%, transparent);
+  color: var(--tint);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.project-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-count,
+.project-sep,
+.project-ram {
+  flex: none;
   color: var(--on-surface-variant);
-  font-size: 16px;
+  font-size: 11.5px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
 }
 
-.sort-toggle:hover:not(:disabled),
-.density-toggle:hover:not(:disabled) {
-  background: var(--surface-container);
+.project-sep {
+  opacity: 0.5;
 }
 
-.sort-toggle.on,
-.density-toggle.on {
-  background: var(--primary-container);
-  color: var(--on-primary-container);
+/* Out of the way until the pointer is on the row — and back for good once it
+   is the thing holding a project shut. */
+.project-chevron {
+  margin-left: auto;
+  padding-left: 6px;
+  opacity: 0;
+  transition: opacity 120ms ease;
 }
 
-/* Only in manual mode: a card that offers to be dragged in a list that
+.project-head:hover .project-chevron,
+.project-head.folded .project-chevron {
+  opacity: 0.55;
+}
+
+.project-add {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  color: var(--on-surface-variant);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.project-head:hover .project-add,
+.project-add:focus-visible {
+  opacity: 1;
+}
+
+.project-add:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--on-surface) 10%, transparent);
+  color: var(--on-surface);
+}
+
+.project-add .ui-icon {
+  width: 15px;
+  height: 15px;
+}
+
+/* ── Session rows ───────────────────────────────────────────────────────────
+   One session, one line, read left to right as a sentence: how it is doing,
+   what it is called, which worktree it is in, and what it costs. Everything
+   after the title is a trail of fixed pieces the title yields to, so a long
+   title takes the room the trail does not need and the trail still lines up
+   down the whole list.
+
+   No card: at this size a rounded, filled tile per session turns a list into a
+   grid of twelve objects to count. Rows butted together are one list, and the
+   only things that paint are the pointer and the selection. */
+
+.session-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 7px 8px 7px 9px;
+  margin-bottom: 2px;
+  border-radius: var(--r-sm);
+  color: var(--on-surface);
+  cursor: default;
+  transition: background-color 120ms ease;
+}
+
+/* Identity: status, title, the one action, how long ago. */
+.row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Configuration, in small print, indented to start under the title rather
+   than under the status dot — it describes the session the title names, and a
+   second line that begins in the margin reads as a second row. */
+.row-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 16px;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--on-surface-variant);
+}
+
+/* Only in manual mode: a row that offers to be dragged in a list that
    rearranges itself would be lying about what the drag achieves. */
-.session-card.movable {
+.session-row.movable {
   cursor: grab;
 }
 
-.session-card.dragging {
+.session-row.dragging {
   opacity: 0.4;
   cursor: grabbing;
 }
 
-/* Session card — the mobile list item, one column narrower. */
-.session-card {
-  position: relative;
-  margin-bottom: 8px;
-  border-radius: var(--r-md);
-  background: var(--surface-container);
-  border: 1px solid transparent;
-  overflow: hidden;
-  cursor: default;
-  transition:
-    background-color 120ms ease,
-    border-color 120ms ease;
+.session-row:hover {
+  background: color-mix(in srgb, var(--on-surface) 7%, transparent);
 }
 
-.session-card::before {
-  content: '';
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: var(--s-off);
-  opacity: 0.5;
-}
-
-.session-card.active::before {
-  background: var(--s-active);
-}
-
-.session-card.starting::before {
-  background: var(--s-starting);
-}
-
-.session-card.compacting::before {
-  background: var(--s-compacting);
-}
-
-.session-card.waiting_permission::before,
-.session-card.waiting_input::before {
-  background: var(--s-waiting);
-}
-
-.session-card.idle::before {
-  background: var(--s-idle);
-}
-
-.session-card.error::before {
-  background: var(--error);
-}
-
-.session-card:hover {
+.session-row.selected {
   background: var(--surface-high);
 }
 
-.session-card.selected {
-  border-color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 10%, var(--surface-container));
+.row-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--s-off);
 }
 
-.card-inner {
-  padding: 10px 12px 8px 14px;
+.row-dot.active {
+  background: var(--s-active);
 }
 
-.card-top {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+.row-dot.starting {
+  background: var(--s-starting);
 }
 
-.card-top .time {
-  font-size: 11px;
+.row-dot.compacting {
+  background: var(--s-compacting);
+}
+
+.row-dot.waiting_permission,
+.row-dot.waiting_input {
+  background: var(--s-waiting);
+}
+
+.row-dot.idle {
+  background: var(--s-idle);
+}
+
+.row-dot.error {
+  background: var(--s-error);
+}
+
+/* Hollow, for the two states that are over: a filled dot says something is
+   there, and for these there is not. */
+.row-dot.ended,
+.row-dot.terminated {
+  background: none;
+  box-shadow: inset 0 0 0 1.5px var(--s-off);
+}
+
+.row-title {
+  flex: 1;
+  min-width: 0;
+  /* The glyph font is first, but only claims the Private Use Area — the words
+     fall through to the stack behind it. */
+  font-family: 'Helios Glyphs', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif;
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* A session that has ended is still worth listing and no longer worth reading
+   first. */
+.session-row.terminated .row-title,
+.session-row.ended .row-title {
   color: var(--on-surface-variant);
 }
 
+.row-provider,
+.row-mode,
+.row-model,
+.row-ram {
+  flex: none;
+  white-space: nowrap;
+}
+
+.row-time {
+  flex: none;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+  white-space: nowrap;
+}
+
+/* The agent that is running, which is the thing the line is for. Carried at
+   full strength while the rest of the line is dimmed, because it is the one
+   part of it that is read rather than checked. */
+.row-provider {
+  color: var(--on-surface);
+  font-weight: 500;
+}
+
+/* Set apart by a rule rather than a bullet: at this size a middot between
+   every pair is more ink than the words. */
+.row-model,
+.row-mode {
+  max-width: 12em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  opacity: 0.8;
+}
+
+/* Permissions are a state to notice, not a label to read past. */
+.row-mode {
+  padding: 0 4px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--on-surface) 9%, transparent);
+  opacity: 1;
+}
+
+.row-ram {
+  font-variant-numeric: tabular-nums;
+}
+
+.row-time {
+  min-width: 2.3em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .pin {
+  flex: none;
   color: var(--primary);
+  font-size: 11px;
+}
+
+.badge {
+  flex: none;
+}
+
+/* No live host behind the status: the row says idle, this says it will take a
+   moment to prove it. */
+.cold-mark {
+  flex: none;
+  color: var(--s-waiting);
   font-size: 12px;
 }
 
-/* What the session's terminal is holding. Only warm sessions have one, so the
-   slot is simply absent the rest of the time. */
+/* Held in the layout whether or not it is showing, and faded rather than
+   switched. A button that appears into the row pushes the title it is next to,
+   so the words move under the pointer that came to read them — which is what
+   made hovering feel jarring. Nothing in a row moves now; only the ink
+   changes. It also sets the row's height, and so the list's rhythm. */
+.row-act {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  color: var(--on-surface-variant);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.session-row:hover .row-act,
+.session-row.selected .row-act,
+.row-act:focus-visible {
+  opacity: 1;
+}
+
+.row-act:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+  color: var(--on-surface);
+}
+
+.row-act .ui-icon {
+  width: 14px;
+  height: 14px;
+}
+
+/* The word, not the glyph: resuming is the only move a terminated session has
+   left, so it says so without being hovered — and being always-on, it never
+   moves anything either. */
+.row-btn {
+  flex: none;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11.5px;
+}
+
+/* What a session's terminal is holding. Also the detail header's, which is why
+   it outlives the card it was named for. */
 .card-ram {
   font-size: 11px;
   color: var(--on-surface-variant);
@@ -933,160 +1287,63 @@ small {
   white-space: nowrap;
 }
 
-/* No live host behind the status: the card says idle, this says it will take a
-   moment to prove it. */
-.cold-mark {
-  color: var(--s-waiting);
-  font-size: 12px;
+/* ── Narrow ─────────────────────────────────────────────────────────────────
+   Dragged in, a row gives things up in the order they matter least: the
+   worktree, then the model, then the memory. The title and the time never go.
+   Measured against the list rather than the window, because the list is what
+   was resized. */
+@container sidebar (max-width: 430px) {
+  /* Context for the pool's figure, not a thing to act on, and the first thing
+     to go when the header has to choose between it and the toggle beside it. */
+  .host-machine {
+    display: none;
+  }
 }
 
-.card-title {
-  margin-top: 8px;
-  /* The glyph font is first, but only claims the Private Use Area — the words
-     fall through to the stack behind it. */
-  font-family: 'Helios Glyphs', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.35;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+@container sidebar (max-width: 300px) {
+  .row-ram {
+    display: none;
+  }
 }
 
-.card-cwd {
-  margin-top: 5px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
-  color: var(--on-surface-variant);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+/* ── Compact ────────────────────────────────────────────────────────────────
+   One line a session: which session, how it is doing, how long ago. What goes
+   is the second line, not the room around the first — that is already a whole
+   line saved, and rows pressed together are harder to pick one out of. */
+
+[data-density='compact'] .session-row {
+  padding: 6px 8px 6px 9px;
+  margin-bottom: 2px;
+  border-radius: 6px;
 }
 
-.card-bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+[data-density='compact'] .row-main {
   gap: 8px;
-  margin-top: 4px;
-  min-height: 28px;
 }
 
-.card-meta {
-  font-size: 11px;
-  color: var(--on-surface-variant);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.row-btn {
-  padding: 3px 10px;
-  font-size: 12px;
-  opacity: 0;
-  transition: opacity 120ms ease;
-}
-
-.session-card:hover .row-btn,
-.session-card.selected .row-btn,
-/* The only move a terminated session has left, so it does not wait for a
-   hover to admit it exists. */
-.row-btn.resume {
-  opacity: 1;
-}
-
-/* ── Compact sidebar ────────────────────────────────────────────────────────
-   One line a session: the status dot, the title, and how long ago. Text stays
-   the size it is elsewhere — the space saved is the working directory, the
-   model line and the padding around them, not the reading. */
-
-/* Square, and touching. At this height a rounded card reads as a tile, and a
-   column of tiles reads as a grid rather than a list; square rows butted
-   together read as one list, which is what compact is for. Nothing separates
-   them but the hover and the selection, so the eye follows the pointer instead
-   of counting edges. */
-[data-density='compact'] .session-card {
-  margin-bottom: 0;
-  border-radius: 0;
-}
-
-/* The selected row is the one place a border would show, and on a row with no
-   gap around it the border shifts the text by a pixel. The background says it
-   without moving anything. */
-[data-density='compact'] .session-card.selected {
-  border-color: transparent;
-}
-
-[data-density='compact'] .card-inner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px 8px 14px;
-}
-
-/* The status row's children become the row's children, so the title can sit
-   among them rather than under them. */
-[data-density='compact'] .card-top {
-  display: contents;
-}
-
-/* The chip keeps its dot and loses its word: the colour already says it, and
-   the stripe down the card says it again. */
-[data-density='compact'] .chip {
-  order: 1;
-  height: auto;
-  padding: 0;
-  background: none;
-  font-size: 0;
-  gap: 0;
-}
-
-[data-density='compact'] .card-title {
-  order: 2;
-  flex: 1;
-  min-width: 0;
-  margin-top: 0;
-  font-size: 14px;
-  line-height: 1.4;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-[data-density='compact'] .cold-mark {
-  order: 3;
-}
-
-[data-density='compact'] .pin {
-  order: 4;
-}
-
-/* Kept in the row: a session waiting on an answer should not need a hover to
-   say so. */
-[data-density='compact'] .badge {
-  order: 5;
-}
-
-/* The compact card is one line of status and time; the memory reading belongs
-   to the roomier layout, and to the detail header. */
-[data-density='compact'] .card-ram {
+/* The second line is what comfortable buys. Compact is the same row without
+   it, which is a difference worth a button. */
+[data-density='compact'] .row-sub {
   display: none;
 }
 
-[data-density='compact'] .card-top .grow {
-  display: none;
+[data-density='compact'] .row-act {
+  width: 18px;
+  height: 18px;
 }
 
-[data-density='compact'] .card-top .time {
-  order: 6;
-  font-size: 11px;
+[data-density='compact'] .project {
+  margin-bottom: 13px;
 }
 
-[data-density='compact'] .card-cwd,
-[data-density='compact'] .card-bottom {
-  display: none;
+[data-density='compact'] .project-title {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+[data-density='compact'] .host-head {
+  padding-top: 6px;
+  padding-bottom: 7px;
 }
 
 .check {
@@ -3627,16 +3884,21 @@ hr {
 }
 
 /* A placeholder shaped like the rows it stands in for, so the list does not
-   jump when they arrive. Its height comes from the card's own elements —
-   card-top, card-title, card-cwd, card-bottom — and follows them if they
-   change; only the bars inside are drawn here. */
-.session-card.skeleton {
+   jump when they arrive. Its height comes from the row's own elements — the
+   dot and the title — and follows them if they change; only the bars inside
+   are drawn here. */
+.session-row.skeleton {
   cursor: default;
   pointer-events: none;
 }
 
-.session-card.skeleton::before {
-  opacity: 0.15;
+.session-row.skeleton .row-dot {
+  opacity: 0.25;
+}
+
+.row-sub .skeleton-line {
+  width: 34%;
+  height: 0.9em;
 }
 
 .skeleton-line {
@@ -3653,34 +3915,14 @@ hr {
   animation: shimmer 1.4s ease infinite;
 }
 
-.card-title .skeleton-line {
-  width: 72%;
-  height: 1.35em;
-}
-
-.skeleton-line.chip {
-  width: 66px;
-  height: 22px;
+.row-title .skeleton-line {
+  width: 68%;
+  height: 1.05em;
 }
 
 .skeleton-line.time {
-  width: 36px;
+  width: 32px;
   height: 11px;
-}
-
-.skeleton-line.cwd {
-  width: 48%;
-  height: 17px;
-}
-
-.skeleton-line.meta {
-  width: 92px;
-  height: 12px;
-}
-
-.skeleton-line.btn {
-  width: 64px;
-  height: 24px;
 }
 
 @keyframes shimmer {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2697,6 +2697,10 @@ small {
   background: var(--surface-highest);
 }
 
+.line-menu button.danger {
+  color: var(--error);
+}
+
 .git-diff pre,
 .ws-plain {
   flex: 1;

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -102,6 +102,32 @@ export function statusLabel(status: string): string {
   }
 }
 
+/**
+ * The model, without what the provider beside it already said.
+ *
+ * The ids are qualified for an API, not for a list: `claude-opus-5` under a
+ * provider called `claude` spends half its width repeating the word next to
+ * it, and `claude-haiku-4-5-20251001` spends the rest on a release date that
+ * distinguishes nothing here. Callers keep the full id in a tooltip.
+ */
+export function shortModel(model: string, source: string): string {
+  const withoutVendor = model.startsWith(`${source}-`) ? model.slice(source.length + 1) : model
+  // A trailing release date, but not a version: 20251001 is a date, 4-5 is not.
+  return withoutVendor.replace(/-\d{8}$/, '')
+}
+
+/** Permission modes as a list can afford to say them. */
+export function shortMode(mode: string): string {
+  switch (mode) {
+    case 'acceptEdits':
+      return 'accept'
+    case 'bypassPermissions':
+      return 'bypass'
+    default:
+      return mode
+  }
+}
+
 /** Compact relative time — "3m", "2h", "5d" — as on the mobile cards. */
 export function timeAgo(iso?: string): string {
   if (!iso) return ''

--- a/desktop/test/projects.test.ts
+++ b/desktop/test/projects.test.ts
@@ -1,0 +1,76 @@
+// Grouping follows the daemon's own `project` field and infers nothing from
+// the shape of a path. The layouts below are real ones, from a store holding
+// 253 sessions across four worktree tools — they are here to pin that a
+// worktree stays a project of its own rather than being folded back under the
+// checkout it was branched from.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { placeOf, tintOf } from '../src/renderer/components/projects.ts'
+import type { Session } from '../src/shared/models.ts'
+
+/** The daemon fills `project` with the basename of `cwd` when the provider
+ *  gives no better name (internal/store/sessions.go:89), so the fixture does
+ *  the same. */
+function at(cwd: string): Session {
+  return {
+    session_id: 's1',
+    source: 'claude',
+    cwd,
+    project: cwd.split('/').filter(Boolean).pop() ?? '',
+    status: 'idle',
+    pinned: false,
+    created_at: '2026-01-01T00:00:00Z',
+    supports_prompt_queue: true,
+  }
+}
+
+test('a checkout is its own project', () => {
+  const place = placeOf(at('/Users/x/work/opal-app'))
+  assert.equal(place.key, 'opal-app')
+  assert.equal(place.name, 'opal-app')
+  assert.equal(place.cwd, '/Users/x/work/opal-app')
+})
+
+test('a workspace is its own project, not a branch of the checkout', () => {
+  const place = placeOf(at('/Users/x/conductor/workspaces/opal-app/vilnius'))
+  assert.equal(place.key, 'vilnius')
+  assert.equal(place.name, 'vilnius')
+})
+
+test('workspaces of one repository stay separate from each other', () => {
+  const keys = [
+    '/Users/x/work/opal-app',
+    '/Users/x/conductor/workspaces/opal-app/vilnius',
+    '/Users/x/conductor/workspaces/opal-app/el-paso',
+    '/Users/x/.wtx/workspaces/opal-app/life-review',
+    '/Users/x/personal/apps/helios/.worktrees/feature-x',
+  ].map((cwd) => placeOf(at(cwd)).key)
+  assert.deepEqual(keys, ['opal-app', 'vilnius', 'el-paso', 'life-review', 'feature-x'])
+})
+
+test('the provider name wins over the directory it sits in', () => {
+  // Only the basename is a fallback; a provider that names the session's
+  // project is the one that decides.
+  const session = { ...at('/Users/x/conductor/workspaces/opal-app/vilnius'), project: 'opal-app' }
+  assert.equal(placeOf(session).key, 'opal-app')
+})
+
+test('case does not split a project in two', () => {
+  assert.equal(placeOf(at('/Users/x/work/Opal-App')).key, placeOf(at('/Users/x/work/opal-app')).key)
+})
+
+test('a trailing slash does not split a project in two', () => {
+  const place = placeOf(at('/Users/x/work/opal-app/'))
+  assert.equal(place.key, 'opal-app')
+  assert.equal(place.cwd, '/Users/x/work/opal-app')
+})
+
+test('the root directory still names something', () => {
+  assert.equal(placeOf({ ...at('/'), project: '' }).name, 'sessions')
+})
+
+test('a project is tinted from its name, and stays that colour', () => {
+  assert.equal(tintOf('opal-app'), tintOf('opal-app'))
+  assert.match(tintOf('helios'), /^hsl\(\d+ 62% 62%\)$/)
+})

--- a/desktop/test/session-state.test.ts
+++ b/desktop/test/session-state.test.ts
@@ -5,7 +5,14 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { canResume, hasTerminal, needsRecovery, type Session } from '../src/shared/models.ts'
+import {
+  canResume,
+  hasTerminal,
+  needsRecovery,
+  shortMode,
+  shortModel,
+  type Session,
+} from '../src/shared/models.ts'
 
 function session(patch: Partial<Session>): Session {
   return {
@@ -62,4 +69,34 @@ test('a busy session is neither cold nor resumable', () => {
   const busy = session({ status: 'active', terminal: '/tmp/helios/s1.sock' })
   assert.equal(needsRecovery(busy), false)
   assert.equal(canResume(busy), false)
+})
+
+// The model ids the daemon carries are API-qualified — `claude-opus-5` under a
+// provider called `claude`, and release dates on the dated ones. These are the
+// real values from a store with 251 sessions in it.
+test('a model sheds the vendor its provider already named', () => {
+  assert.equal(shortModel('claude-opus-5', 'claude'), 'opus-5')
+  assert.equal(shortModel('claude-sonnet-4-5-20250929', 'claude'), 'sonnet-4-5')
+  assert.equal(shortModel('claude-haiku-4-5-20251001', 'claude'), 'haiku-4-5')
+})
+
+test('a context-window suffix is part of the name, not a date', () => {
+  assert.equal(shortModel('claude-opus-5[1m]', 'claude'), 'opus-5[1m]')
+})
+
+test('a version is not mistaken for a release date', () => {
+  // Eight digits at the end are a date; four dash-separated parts are not.
+  assert.equal(shortModel('claude-opus-4-8', 'claude'), 'opus-4-8')
+})
+
+test('a model from another provider keeps its whole name', () => {
+  assert.equal(shortModel('gpt-5', 'openai'), 'gpt-5')
+  assert.equal(shortModel('<synthetic>', 'claude'), '<synthetic>')
+})
+
+test('permission modes are said the short way, and unknown ones verbatim', () => {
+  assert.equal(shortMode('bypassPermissions'), 'bypass')
+  assert.equal(shortMode('acceptEdits'), 'accept')
+  assert.equal(shortMode('plan'), 'plan')
+  assert.equal(shortMode('auto'), 'auto')
 })


### PR DESCRIPTION
## What

Two things, both about the desktop session list.
<img width="1714" height="1362" alt="image" src="https://github.com/user-attachments/assets/823c2f53-44e9-4c0e-b222-0ec526a249c2" />

### 1. Sessions are grouped by project

The sidebar listed every session flat under its host, so twelve sessions across five checkouts read as twelve unrelated lines. They are now gathered under the directory they run in.

Each project gets a header: a tinted initial, the session count, what its terminals are holding, and a `+` that starts a new session there without asking which project it meant. Grouping arranges the list, it does not re-rank it — a project takes the position of its best session, so one that wants attention still carries its project to the top. Manual drags stay inside their own project, because the daemon holds one flat order per host.

Grouping follows the daemon's own `project` field and infers nothing from the shape of a path, so a worktree stays a project of its own rather than being folded back under the checkout it was branched from.

### 2. A session's actions are on its row, not in the header

Terminate, Pin, Delete and Regenerate title sat in the detail header — a button and an overflow menu at the far corner of the window from the list they act on. Acting on any session other than the open one meant selecting it first, then re-reading the header to be sure it had changed.

Right-click a row instead. The menu names the session under the pointer, and the click that opens it also selects that session, so the panel beside the list shows what is about to change. Terminate is left out for a session that has already ended, where the row's own Resume is the move. Both destructive items keep their confirms.

The popover is the one the editor and chat already use for right-click, rather than a second one. It gains a `danger` flag for the two red items and a clamp to the viewport — a point-anchored menu opened near the bottom edge used to run off it, and what it dropped was the last item, which is where the destructive action goes. That fix reaches the editor and chat menus too.

The header keeps what is state rather than action: the status chip, memory, Cold, Resume, the permission-mode dropdown, and Stop while the agent is mid-turn.

## Also in the list

- **Two densities**, on a toolbar toggle: one line a session, or a second line under it with the agent, model, permission mode and memory. The icons draw the two views rather than naming them. Compact drops the second line, not the room around the first.
- **Drawn toolbar icons.** The search, sort and density buttons were typed characters (`⌕ ⇅ ▤ ▦`), which is why they never lined up: each is a different fraction of its em box in a different font, so four same-sized buttons held four different sizes.
- **Shorter model labels.** `claude-opus-5` under a provider called `claude` spent half its width repeating the word beside it, and `claude-haiku-4-5-20251001` spent the rest on a release date. Vendor prefix and trailing date go; the full id stays in the tooltip.
- **Host header meter** — what the warm terminals hold, against the machine's own memory, with the eviction budget in the tooltip.
- The new-session dialog accepts a seeded host and directory, spent on first load only: a path from one machine is not a path on the next.

## Testing

- `npm test` — 124 pass, including new coverage for project grouping (`desktop/test/projects.test.ts`) and the model/mode shorteners.
- `npm run typecheck` and `npm run build` clean.
- Ran the app and worked through the list: grouping, folding, the density toggle, manual drag inside a project, a new session started from a project header, and the row's right-click menu including both confirms.

Rebased on `main` after #102 and #103 — the `archived` flag those removed is gone from the new fixtures, and #103's footer alignment is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
