### PR TITLE
Put the MCP tools behind HELIOS_EXPERIMENTAL_MCP

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/discovery"
+	"github.com/kamrul1157024/helios/internal/featureflag"
 	"github.com/kamrul1157024/helios/internal/notifications"
 	claude "github.com/kamrul1157024/helios/internal/provider/claude"
 	"github.com/kamrul1157024/helios/internal/server"
@@ -118,8 +119,14 @@ func startDaemon(cfg *Config) error {
 	mgr := notifications.NewManager(db)
 	mgr.StartCleanup()
 
-	// Register providers
-	claude.Register(cfg.Server.InternalPort)
+	// Register providers. A zero port is how the provider is told to leave
+	// --mcp-config off the argv, which is what the flag being off means for a
+	// session Helios launches itself.
+	mcpPort := 0
+	if featureflag.MCP() {
+		mcpPort = cfg.Server.InternalPort
+	}
+	claude.Register(mcpPort)
 
 	// Terminal hosts are separate processes, so any that survived the last
 	// daemon are still serving; adopt them before anything else looks at

--- a/internal/featureflag/featureflag.go
+++ b/internal/featureflag/featureflag.go
@@ -1,0 +1,14 @@
+// Package featureflag reads the environment switches that turn unfinished
+// Helios features on. Each flag is read fresh, so a process picks up whatever
+// its own environment held at startup.
+package featureflag
+
+import "os"
+
+// MCP reports whether the experimental MCP tools are served.
+//
+// Off by default. A tool call can only name the session it came from when
+// Helios launched the agent and injected the session header; an agent started
+// by hand reaches the same server anonymously, and every tool that needs an
+// identity refuses it. Until that is solved the tools are opt-in.
+func MCP() bool { return os.Getenv("HELIOS_EXPERIMENTAL_MCP") == "1" }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -46,9 +46,15 @@ type tool struct {
 	call func(sessionID string, args map[string]interface{}) (string, error)
 }
 
-func New(sessions Sessions, notify Notifier, review Review) *Server {
-	s := &Server{sessions: sessions, notify: notify, review: review}
-	s.tools = s.registry()
+// New builds the server. When enabled is false it serves the protocol but
+// registers no tools, rather than refusing the connection: a client that
+// already has "helios" in its own config would otherwise report a failing
+// server on every session start.
+func New(sessions Sessions, notify Notifier, review Review, enabled bool) *Server {
+	s := &Server{sessions: sessions, notify: notify, review: review, tools: map[string]tool{}}
+	if enabled {
+		s.tools = s.registry()
+	}
 	return s
 }
 
@@ -126,7 +132,10 @@ func (s *Server) dispatch(req request, sessionID string, resp *response) interfa
 	case "tools/list":
 		listed := make([]map[string]interface{}, 0, len(s.tools))
 		for _, name := range toolOrder {
-			t := s.tools[name]
+			t, ok := s.tools[name]
+			if !ok {
+				continue
+			}
 			listed = append(listed, map[string]interface{}{
 				"name":        name,
 				"description": t.description,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -45,7 +45,7 @@ func setup(t *testing.T) (*Server, *fakeNotifier, *store.Store) {
 	t.Cleanup(func() { db.Close() })
 
 	notify := &fakeNotifier{clients: 1}
-	return New(db, notify, fakeReview{root: "/repo"}), notify, db
+	return New(db, notify, fakeReview{root: "/repo"}, true), notify, db
 }
 
 // post sends one JSON-RPC request. session goes in the header, as Helios
@@ -123,6 +123,30 @@ func TestHandshake(t *testing.T) {
 		if entry["name"] != want {
 			t.Fatalf("tool %d = %v, want %s", i, entry["name"], want)
 		}
+	}
+}
+
+// Disabled has to look like a server with nothing to offer, not a broken one:
+// a client with "helios" already in its own config still connects here, and a
+// refusal would surface as a failing MCP server on every session start.
+func TestDisabledServesTheProtocolWithNoTools(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	s := New(db, &fakeNotifier{clients: 1}, fakeReview{root: "/repo"}, false)
+
+	init := post(t, s, "", "initialize", map[string]interface{}{})
+	if result, _ := init["result"].(map[string]interface{}); result["protocolVersion"] != protocolVersion {
+		t.Fatalf("protocolVersion = %v, want %s", result["protocolVersion"], protocolVersion)
+	}
+
+	list := post(t, s, "", "tools/list", nil)
+	listResult, _ := list["result"].(map[string]interface{})
+	if tools, _ := listResult["tools"].([]interface{}); len(tools) != 0 {
+		t.Fatalf("got %d tools, want none", len(tools))
 	}
 }
 
@@ -275,7 +299,7 @@ func TestShow_ReportsWhenNobodyIsWatching(t *testing.T) {
 		t.Fatalf("open store: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	s := New(db, &fakeNotifier{clients: 0}, fakeReview{root: "/repo"})
+	s := New(db, &fakeNotifier{clients: 0}, fakeReview{root: "/repo"}, true)
 
 	got := callTool(t, s, "s1", "helios_show", map[string]interface{}{"view": "terminal"})
 	if got["shown"] != false {
@@ -343,7 +367,7 @@ func TestReviewState_SeparatesSeenFromUnseen(t *testing.T) {
 		root:     "/repo",
 		changed:  []string{"a.go", "b.go", "c.go"},
 		reviewed: []string{"b.go"},
-	})
+	}, true)
 
 	got := callTool(t, s, "s1", "helios_review_state", map[string]interface{}{"base": "main"})
 	if got["remaining"] != float64(2) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kamrul1157024/helios/internal/backend"
+	"github.com/kamrul1157024/helios/internal/featureflag"
 	"github.com/kamrul1157024/helios/internal/hitl"
 	"github.com/kamrul1157024/helios/internal/mcp"
 	"github.com/kamrul1157024/helios/internal/notifications"
@@ -154,7 +155,7 @@ func NewInternalServer(port int, shared *Shared) *InternalServer {
 	// MCP lives here rather than on the public server because this listener is
 	// already what it needs to be: loopback only, no auth. Agents reach it with
 	// a session id from their prompt; see docs/specs/39-agent-driven-explain-ui.md.
-	mux.Handle("/mcp", mcp.New(shared.DB, shared, shared))
+	mux.Handle("/mcp", mcp.New(shared.DB, shared, shared, featureflag.MCP()))
 
 	s.httpServer = &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", port),

--- a/internal/tui/start.go
+++ b/internal/tui/start.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kamrul1157024/helios/internal/daemon"
+	"github.com/kamrul1157024/helios/internal/featureflag"
 	"github.com/kamrul1157024/helios/internal/tailscale"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -462,7 +463,7 @@ func (m StartModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "m":
 		// The summary screen is where this is usually read: a set-up install
 		// sits there waiting on enter, and never reaches the dashboard.
-		if (m.screen == screenMain || (m.screen == screenLoading && m.daemonOK)) && !m.mcpRegistered {
+		if featureflag.MCP() && (m.screen == screenMain || (m.screen == screenLoading && m.daemonOK)) && !m.mcpRegistered {
 			m.mcpDeclined = false
 			m.mcpMsg = "Registering..."
 			return m, registerMCPCmd(m.internalPort)
@@ -582,7 +583,7 @@ func (m StartModel) proceedAfterHooks() (tea.Model, tea.Cmd) {
 func (m StartModel) proceedAfterShell() (tea.Model, tea.Cmd) {
 	// Asked once, and only once. Registering gives agents tools they did not
 	// have, which is the user's call rather than a step to get past.
-	if !m.mcpRegistered && !m.mcpDeclined {
+	if featureflag.MCP() && !m.mcpRegistered && !m.mcpDeclined {
 		m.screen = screenMCPSetup
 		return m, nil
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/kamrul1157024/helios/internal/featureflag"
 	"github.com/kamrul1157024/helios/internal/tailscale"
 )
 
@@ -113,21 +114,23 @@ func (m StartModel) viewLoading() string {
 			b.WriteString(cross("Claude hooks not installed"))
 		}
 
-		if m.mcpRegistered {
-			b.WriteString(check("Agent tools registered with Claude Code"))
-		} else if m.mcpDeclined {
-			// Opted out during setup. Still reachable, but it stops asking:
-			// a suggestion that survives being declined is a nag.
-			b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
-			b.WriteString("\n")
-		} else {
-			b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
-			b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
-			b.WriteString("\n")
-		}
-		if m.mcpMsg != "" {
-			b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
-			b.WriteString("\n")
+		if featureflag.MCP() {
+			if m.mcpRegistered {
+				b.WriteString(check("Agent tools registered with Claude Code"))
+			} else if m.mcpDeclined {
+				// Opted out during setup. Still reachable, but it stops asking:
+				// a suggestion that survives being declined is a nag.
+				b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
+				b.WriteString("\n")
+			} else {
+				b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
+				b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
+				b.WriteString("\n")
+			}
+			if m.mcpMsg != "" {
+				b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
+				b.WriteString("\n")
+			}
 		}
 
 		if m.shellInstalled {
@@ -160,7 +163,7 @@ func (m StartModel) viewLoading() string {
 		}
 
 		keys := "  enter continue  t change tunnel  N notifications  s settings  q quit"
-		if !m.mcpRegistered {
+		if featureflag.MCP() && !m.mcpRegistered {
 			keys = "  m agent tools" + keys
 		}
 		b.WriteString(helpStyle.Render(keys))
@@ -429,22 +432,24 @@ func (m StartModel) viewMain() string {
 	} else if m.hooksOK {
 		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Claude hooks outdated"))
 	}
-	if m.mcpRegistered {
-		b.WriteString(check("Agent tools registered with Claude Code"))
-	} else if m.mcpDeclined {
-		// Opted out during setup. Still reachable, but it stops asking:
-		// a suggestion that survives being declined is a nag.
-		b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
-		b.WriteString("\n")
-	} else {
-		// A suggestion, not a fault: everything else works without it.
-		b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
-		b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
-		b.WriteString("\n")
-	}
-	if m.mcpMsg != "" {
-		b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
-		b.WriteString("\n")
+	if featureflag.MCP() {
+		if m.mcpRegistered {
+			b.WriteString(check("Agent tools registered with Claude Code"))
+		} else if m.mcpDeclined {
+			// Opted out during setup. Still reachable, but it stops asking:
+			// a suggestion that survives being declined is a nag.
+			b.WriteString(dimStyle.Render("  · Agent tools are off. Press m to turn them on."))
+			b.WriteString("\n")
+		} else {
+			// A suggestion, not a fault: everything else works without it.
+			b.WriteString(fmt.Sprintf("  %s %s\n", warnStyle.Render("~"), "Agent tools not registered with Claude Code"))
+			b.WriteString(dimStyle.Render("  · Lets an agent open a file or a diff in Helios. Press m to register."))
+			b.WriteString("\n")
+		}
+		if m.mcpMsg != "" {
+			b.WriteString(dimStyle.Render("  · " + m.mcpMsg))
+			b.WriteString("\n")
+		}
 	}
 	if m.shellInstalled {
 		b.WriteString(check(fmt.Sprintf("Shell wrapper (%s)", m.shellInfo.Name)))
@@ -552,7 +557,7 @@ func (m StartModel) viewMain() string {
 	// The MCP key is advertised only while there is something to do with it,
 	// so the bar does not carry a permanently dead binding.
 	keys := "  t change tunnel  N notifications  s settings  q quit"
-	if !m.mcpRegistered {
+	if featureflag.MCP() && !m.mcpRegistered {
 		keys = "  m agent tools" + keys
 	}
 	b.WriteString(helpStyle.Render(keys))

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -90,6 +90,7 @@ func TestMainReportsMissingTunnel(t *testing.T) {
 // it sits on "enter continue" and most people never press it. An offer only the
 // dashboard carries is an offer nobody sees.
 func TestLoadingScreenAlsoOffersMCPRegistration(t *testing.T) {
+	t.Setenv("HELIOS_EXPERIMENTAL_MCP", "1")
 	m := StartModel{screen: screenLoading, daemonOK: true, hooksOK: true}
 	rendered := stripANSI(m.viewLoading())
 
@@ -105,6 +106,26 @@ func TestLoadingScreenAlsoOffersMCPRegistration(t *testing.T) {
 	}.viewLoading())
 	if strings.Contains(registered, "not registered") {
 		t.Error("still nagging after registration")
+	}
+}
+
+// Behind the flag the tools do not exist, so neither should the offer: a key
+// advertised in the bar that answers nothing is worse than no key at all.
+func TestAgentToolsAreInvisibleWithoutTheFlag(t *testing.T) {
+	for name, rendered := range map[string]string{
+		"summary": stripANSI(StartModel{
+			screen: screenLoading, daemonOK: true, hooksOK: true,
+		}.viewLoading()),
+		"dashboard": stripANSI(StartModel{screen: screenMain}.viewMain()),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(rendered, "Agent tools") {
+				t.Error("agent tools mentioned while the flag is off")
+			}
+			if strings.Contains(rendered, "m agent tools") {
+				t.Error("the m key is advertised while the flag is off")
+			}
+		})
 	}
 }
 
@@ -127,6 +148,7 @@ func TestMCPSetupIsSkippable(t *testing.T) {
 
 // Declining during setup must stop the nagging, and must still leave a way in.
 func TestDeclinedMCPStopsNaggingButStaysReachable(t *testing.T) {
+	t.Setenv("HELIOS_EXPERIMENTAL_MCP", "1")
 	for name, rendered := range map[string]string{
 		"summary": stripANSI(StartModel{
 			screen: screenLoading, daemonOK: true, hooksOK: true, mcpDeclined: true,
@@ -148,6 +170,7 @@ func TestDeclinedMCPStopsNaggingButStaysReachable(t *testing.T) {
 }
 
 func TestMainOffersMCPRegistrationWithoutTreatingItAsAFault(t *testing.T) {
+	t.Setenv("HELIOS_EXPERIMENTAL_MCP", "1")
 	rendered := stripANSI(StartModel{screen: screenMain}.viewMain())
 
 	line := lineWith(rendered, "Agent tools not registered")


### PR DESCRIPTION
## Why

An MCP tool call can only name the session it came from when Helios launched the agent and injected the `X-Helios-Session` header (`internal/provider/claude/register.go:133-150`). An agent started by hand reaches the same server anonymously, so `helios_show` and `helios_review_state` refuse it:

> this session was not started by Helios, so it has no panel to show anything in

That is the common case, not an edge case — Helios's own setup flow offers `claude mcp add` (`internal/tui/start.go:970-980`), which writes a header-less server into `~/.claude.json`. The session is otherwise fully known: hooks report it, the sidebar lists it, the transcript renders. Only the MCP call is anonymous.

So the tools are opt-in until the identity problem is solved.

## What

New `internal/featureflag` package holding `MCP()`, which reads `HELIOS_EXPERIMENTAL_MCP=1`.

| Site | Off (default) | On |
|---|---|---|
| `mcp.New` (`server.go:157`) | empty registry | 4 tools |
| `claude.Register` (`daemon.go:122`) | port `0`, so no `--mcp-config` | header injected |
| `proceedAfterShell` (`start.go:586`) | setup screen skipped | offered once |
| `m` key (`start.go:466`) | inert | registers |
| summary + dashboard (`view.go` ×4) | no mention, no key in the bar | unchanged |

Disabled means an **empty `tools/list`**, not an unmounted route. Anyone who already ran `claude mcp add` still connects; unmounting would surface as a failing MCP server on every session start.

The provider needed no change: `mcpConfig` already treats a zero port as "inject nothing" (`register.go:120-124,134`), so the daemon just passes zero.

## Drive-by fix

`tools/list` ranged `toolOrder` and indexed the map, so an empty registry would have listed four nameless tools. It now skips names the map does not hold.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l` clean, `go vet` clean
- [x] New: disabled server completes the handshake and lists no tools
- [x] New: neither the summary nor the dashboard mentions agent tools with the flag off
- [x] Existing TUI view tests set the flag and still pass
- [ ] Manual: restart the daemon unset, confirm a session's argv has no `--mcp-config` and the agent sees no `helios` tools
- [ ] Manual: restart with `HELIOS_EXPERIMENTAL_MCP=1`, confirm `helios_show` still opens a panel

## Not included

`docs/specs/41-helios-mcp-tools.md` still describes the tools as always on. The desktop `applyShow` handler is untouched and simply never fires while the flag is off.