### PR TITLE
Order directory groups, including by hand

### DIFF
--- a/desktop/src/renderer/components/group-picker.tsx
+++ b/desktop/src/renderer/components/group-picker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { store, useStore } from '../store.ts'
-import type { GroupMode, SortMode } from '../store.ts'
+import type { GroupMode, GroupOrder, SortMode } from '../store.ts'
 
 /** The choices, in the order they widen: nothing, then a tree the user keeps,
  *  then one the app works out. */
@@ -21,6 +21,17 @@ const GROUP_MODES: { mode: GroupMode; label: string; hint: string }[] = [
       "One group per working directory, worked out from the sessions themselves. Nothing to set up and " +
       'nothing to maintain, but it is a single level and you cannot move a session between directories.',
   },
+]
+
+/**
+ * What orders the directory groups. Offered only in that mode: a made group
+ * sits where the user dragged its header to, and a choice here would fight the
+ * drag rather than add to it.
+ */
+const GROUP_ORDERS: { order: GroupOrder; label: string }[] = [
+  { order: 'activity', label: 'Activity' },
+  { order: 'name', label: 'Name A→Z' },
+  { order: 'manual', label: 'Manual — drag to move' },
 ]
 
 /**
@@ -45,6 +56,7 @@ export function GroupPicker({
   onClose: () => void
 }): JSX.Element {
   const grouping = useStore((s) => s.grouping)
+  const groupOrder = useStore((s) => s.groupOrder)
   const unsupported = useStore((s) => (hostId ? Boolean(s.groupsUnsupported[hostId]) : false))
   const panel = useRef<HTMLDivElement | null>(null)
   const [busy, setBusy] = useState(false)
@@ -101,6 +113,25 @@ export function GroupPicker({
             {hostName || 'This machine'} is running a daemon without grouping. Update it to make
             groups here.
           </div>
+        </>
+      )}
+
+      {/* Auto only, and hidden rather than disabled: the manual tree's order is
+          the drag, the way the other manual-only affordances are absent here
+          rather than greyed out. */}
+      {grouping === 'auto' && (
+        <>
+          <div className="picker-sep" />
+          <div className="picker-head">Order groups by</div>
+          {GROUP_ORDERS.map(({ order, label }) => (
+            <button
+              key={order}
+              className={groupOrder === order ? 'picker-item on' : 'picker-item'}
+              onClick={() => store.orderGroupsBy(order)}
+            >
+              <span className="picker-radio">{groupOrder === order ? '●' : '○'}</span> {label}
+            </button>
+          ))}
         </>
       )}
 

--- a/desktop/src/renderer/components/grouping.ts
+++ b/desktop/src/renderer/components/grouping.ts
@@ -139,6 +139,65 @@ export function buildTree(sessions: Session[], groups: SessionGroup[] = []): Gro
   return roots
 }
 
+/** What decides the order of the directory groups themselves. */
+export type GroupOrder = 'activity' | 'name' | 'manual'
+
+/** Where each directory has been dragged to, by path.
+ *
+ *  A directory has no id to hang a position on, so the path is the key. Held on
+ *  the client rather than in the daemon because the grouping it orders is
+ *  itself derived — there is no row to attach a number to. */
+export type PathOrder = Record<string, number>
+
+/**
+ * When a group last did anything: the newest moment across the sessions in it.
+ *
+ * `last_event_at` is missing until a session has produced something, so a
+ * freshly created one falls back to when it was made — otherwise a brand new
+ * directory would sort as the oldest thing on the list.
+ */
+export function lastActivityOf(node: GroupNode): string {
+  let newest = ''
+  for (const session of node.sessions) {
+    const at = session.last_event_at ?? session.created_at
+    if (at > newest) newest = at
+  }
+  return newest
+}
+
+/**
+ * Orders the directory groups.
+ *
+ * Only the derived tree comes through here. A made group carries a position the
+ * user dragged it to, and an ordering choice over the top of that would undo
+ * the drag the moment it landed.
+ *
+ * Sorted, not left to arrive in order. Activity is close to the order the
+ * sessions already came in, but "close to" is the problem: it held only while
+ * the caller's comparator agreed, and nothing said so. Ties keep the order they
+ * arrived in, which sort is required to preserve.
+ */
+export function orderGroups(
+  nodes: GroupNode[],
+  order: GroupOrder,
+  placed: PathOrder = {},
+): GroupNode[] {
+  if (order === 'name') {
+    return [...nodes].sort((a, b) => a.name.localeCompare(b.name))
+  }
+  if (order === 'manual') {
+    // A directory nobody has dragged sorts after every one that has, by
+    // activity — so turning manual on does not scatter the untouched ones, and
+    // a directory seen for the first time lands at the end rather than
+    // somewhere arbitrary in the middle.
+    const at = (node: GroupNode): number => placed[node.key] ?? Number.MAX_SAFE_INTEGER
+    return [...nodes].sort(
+      (a, b) => at(a) - at(b) || lastActivityOf(b).localeCompare(lastActivityOf(a)),
+    )
+  }
+  return [...nodes].sort((a, b) => lastActivityOf(b).localeCompare(lastActivityOf(a)))
+}
+
 /**
  * The label an auto group wears: the last segment of its directory.
  *
@@ -163,11 +222,15 @@ export function cwdLabel(cwd: string): string {
  * happen and there is nothing here to keep an empty one alive for: unlike a
  * made group, an auto group is not somewhere the user can file anything.
  *
- * Sessions arrive already sorted, and both the sessions inside a node and the
- * nodes themselves keep that order — the directory holding the session the
- * caller ranked first comes first.
+ * Sessions arrive already sorted and the sessions inside a node keep that
+ * order. The nodes themselves are ordered by `order`, which is the reader's
+ * choice and not the caller's arrangement.
  */
-export function buildCwdTree(sessions: Session[]): GroupNode[] {
+export function buildCwdTree(
+  sessions: Session[],
+  order: GroupOrder = 'activity',
+  placed: PathOrder = {},
+): GroupNode[] {
   const nodes = new Map<string, GroupNode>()
   for (const session of sessions) {
     const cwd = session.cwd
@@ -187,7 +250,7 @@ export function buildCwdTree(sessions: Session[]): GroupNode[] {
     node.sessions.push(session)
     node.total += 1
   }
-  return [...nodes.values()]
+  return orderGroups([...nodes.values()], order, placed)
 }
 
 function sortNodes(nodes: GroupNode[]): void {

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -181,6 +181,8 @@ export function Sidebar({
   // comparison against a string repeated thirty times.
   const grouping = groupMode !== 'off'
   const derived = groupMode === 'auto'
+  const groupOrder = useStore((s) => s.groupOrder)
+  const dirOrder = useStore((s) => s.dirOrder)
   const groupsByHost = useStore((s) => s.groups)
   const groupsUnsupported = useStore((s) => s.groupsUnsupported)
   // The card being dragged, so the row under the pointer can show where it
@@ -324,7 +326,7 @@ export function Sidebar({
       const nodes = tree
         ? buildTree(sorted.map((row) => row.session), groupsByHost[host.id] ?? [])
         : derived
-          ? buildCwdTree(sorted.map((row) => row.session))
+          ? buildCwdTree(sorted.map((row) => row.session), groupOrder, dirOrder)
           : []
 
       const hidden = hideTerminated ? visible.filter(isTerminated).length : 0
@@ -335,7 +337,19 @@ export function Sidebar({
       const pending = new Map(sorted.map((row) => [row.session.session_id, row.pending]))
       return { host, rows: sorted, nodes, pending, count: ordered.length, hidden, loading }
     })
-  }, [hosts, sessions, notifications, query, showTerminated, sortMode, groupMode, derived, groupsByHost])
+  }, [
+    hosts,
+    sessions,
+    notifications,
+    query,
+    showTerminated,
+    sortMode,
+    groupMode,
+    derived,
+    groupOrder,
+    dirOrder,
+    groupsByHost,
+  ])
 
   // One host answering "manual" is enough to show the switch as on: the click
   // writes the other way to every host, which settles any disagreement.
@@ -499,7 +513,7 @@ export function Sidebar({
                       <button
                         className="group-title"
                         aria-expanded={!isFolded}
-                        draggable={real}
+                        draggable={real || derived}
                         onDragStart={(event) => {
                           event.stopPropagation()
                           event.dataTransfer.effectAllowed = 'move'
@@ -530,11 +544,21 @@ export function Sidebar({
                             setGroupDrop({ key: node.key, mode: 'inside' })
                             return
                           }
-                          if (!real || !kinds.includes(GROUP_DRAG)) return
+                          // A directory header accepts a drag whatever the
+                          // current order is: dragging one is itself the
+                          // request to arrange them by hand, and requiring the
+                          // mode first would mean choosing it before there was
+                          // any reason to.
+                          const arrangeable = real || derived
+                          if (!arrangeable || !kinds.includes(GROUP_DRAG)) return
                           if (groupDrag?.hostId !== host.id || groupDrag.key === node.key) return
                           event.preventDefault()
                           event.dataTransfer.dropEffect = 'move'
-                          setGroupDrop({ key: node.key, mode: dropModeFor(event, event.currentTarget) })
+                          const over = dropModeFor(event, event.currentTarget)
+                          setGroupDrop({
+                            key: node.key,
+                            mode: derived && over === 'inside' ? 'after' : over,
+                          })
                         }}
                         onDragLeave={() => setGroupDrop((d) => (d?.key === node.key ? null : d))}
                         // The payload and the mode both come off the event rather
@@ -549,13 +573,26 @@ export function Sidebar({
                             void store.setSessionGroup(host.id, moved, node.key)
                             return
                           }
-                          if (!real) return
+                          if (!real && !derived) return
                           event.preventDefault()
                           const dragged = event.dataTransfer.getData(GROUP_DRAG)
-                          const mode = dropModeFor(event, event.currentTarget)
+                          const raw = dropModeFor(event, event.currentTarget)
+                          const mode = derived && raw === 'inside' ? 'after' : raw
                           setGroupDrag(null)
                           setGroupDrop(null)
                           if (!dragged || dragged === node.key) return
+                          if (derived) {
+                            // Directories are one flat level, so there is
+                            // nothing to nest into: every drop is a reorder,
+                            // and the half of the header you hit only decides
+                            // which side of it you land on.
+                            const paths = nodes.map((n) => n.key).filter((k) => k !== dragged)
+                            const at = paths.indexOf(node.key)
+                            if (at === -1) return
+                            paths.splice(mode === 'before' ? at : at + 1, 0, dragged)
+                            store.reorderDirectories(paths)
+                            return
+                          }
                           void moveOrReorder(host.id, dragged, node.key, mode)
                         }}
                         onClick={() => setFolded((f) => ({ ...f, [foldKey]: !isFolded }))}

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
 
 import { api, bridge, statusOf } from './bridge.ts'
+import type { GroupOrder, PathOrder } from './components/grouping.ts'
 import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type {
@@ -68,6 +69,10 @@ export type SortMode = 'activity' | 'manual'
  * data and nothing about it can be edited.
  */
 export type GroupMode = 'off' | 'manual' | 'auto'
+
+/** Defined with the tree builders that apply it; re-exported so the picker and
+ *  the sidebar can read it from the store like every other setting. */
+export type { GroupOrder, PathOrder } from './components/grouping.ts'
 
 /**
  * A file the user asked to see, from a chip in the transcript. The counter is
@@ -191,6 +196,17 @@ export interface State {
    */
   grouping: GroupMode
   /**
+   * What orders the directory groups against each other.
+   *
+   * Only read in 'auto': a made group sits where it was dragged to, and that
+   * position is the daemon's. Client-side and unsent for the same reason
+   * `grouping` is — it is a reading of the arrangement, not the arrangement.
+   */
+  groupOrder: GroupOrder
+  /** Where each directory has been dragged to, by path. Only read when
+   *  groupOrder is 'manual'. */
+  dirOrder: PathOrder
+  /**
    * Hosts whose daemon has no grouping routes, by host id.
    *
    * A daemon older than the feature answers 404, and offering to make a group
@@ -228,6 +244,49 @@ function writeGroupMode(mode: GroupMode): void {
   }
 }
 
+const GROUP_ORDER_KEY = 'helios.groupOrder'
+const DIR_ORDER_KEY = 'helios.dirOrder'
+
+/** Anything but the one other name means activity, which is the default and is
+ *  also what an install from before this setting was showing. */
+const GROUP_ORDERS: GroupOrder[] = ['activity', 'name', 'manual']
+
+function readGroupOrder(): GroupOrder {
+  try {
+    const saved = localStorage.getItem(GROUP_ORDER_KEY)
+    // Checked against the list rather than one value at a time: the previous
+    // form recognised 'name' and treated everything else as 'activity', so
+    // adding a third order silently reverted it on every reload.
+    return GROUP_ORDERS.find((order) => order === saved) ?? 'activity'
+  } catch {
+    return 'activity'
+  }
+}
+
+function readDirOrder(): PathOrder {
+  try {
+    const raw = localStorage.getItem(DIR_ORDER_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: PathOrder = {}
+    for (const [path, at] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof at === 'number' && Number.isFinite(at)) out[path] = at
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function writeGroupOrder(order: GroupOrder): void {
+  try {
+    localStorage.setItem(GROUP_ORDER_KEY, order)
+  } catch {
+    // A full or unavailable store costs the preference, not the setting.
+  }
+}
+
 const initial: State = {
   hosts: [],
   hostStatus: {},
@@ -253,6 +312,8 @@ const initial: State = {
   groups: {},
   groupsUnsupported: {},
   grouping: readGroupMode(),
+  groupOrder: readGroupOrder(),
+  dirOrder: readDirOrder(),
 }
 
 type Listener = () => void
@@ -490,6 +551,33 @@ class Store {
     writeGroupMode(mode)
     if ((before === 'manual') === (mode === 'manual')) return
     await Promise.all(this.state.hosts.map((host) => this.refreshHost(host.id)))
+  }
+
+  /**
+   * Changes what orders the directory groups.
+   *
+   * Nothing is refetched: both orders are worked out from fields the sessions
+   * already carry, so this is a re-render.
+   */
+  /** Records a hand-arranged directory order, first path first. Dragging one
+   *  is itself the request to sort by hand, so it selects that mode. */
+  reorderDirectories(paths: string[]): void {
+    const dirOrder: PathOrder = {}
+    paths.forEach((path, index) => {
+      dirOrder[path] = index
+    })
+    this.set({ dirOrder, groupOrder: 'manual' })
+    try {
+      localStorage.setItem(DIR_ORDER_KEY, JSON.stringify(dirOrder))
+      writeGroupOrder('manual')
+    } catch {
+      // A full or unavailable store costs the arrangement, not the list.
+    }
+  }
+
+  orderGroupsBy(order: GroupOrder): void {
+    this.set({ groupOrder: order })
+    writeGroupOrder(order)
   }
 
   async refreshGroups(hostId: string): Promise<void> {

--- a/desktop/test/grouping.test.ts
+++ b/desktop/test/grouping.test.ts
@@ -9,6 +9,8 @@ import {
   cwdLabel,
   depthOf,
   headerFor,
+  lastActivityOf,
+  orderGroups,
   rankOf,
   tintOf,
 } from '../src/renderer/components/grouping.ts'
@@ -197,8 +199,8 @@ test('a node is keyed and pathed by the directory itself', () => {
   assert.deepEqual(node?.path, ['/w/helios'])
 })
 
-// Single level: the ordering inside a node is the caller's, and the nodes
-// follow the session that opened each one.
+// Single level: the ordering inside a node is the caller's, and nodes that
+// cannot be told apart by activity keep the order the sessions arrived in.
 test('the nodes keep the order the sessions arrived in', () => {
   const roots = buildCwdTree([inDir('a', '/w/z'), inDir('b', '/w/a'), inDir('c', '/w/z')])
   assert.deepEqual(roots.map((node) => node.key), ['/w/z', '/w/a'])
@@ -223,5 +225,88 @@ test('the manual filing is ignored', () => {
 
 test('no sessions means no nodes', () => {
   assert.deepEqual(buildCwdTree([]), [])
+})
+
+// ─── Ordering the directory groups ───────────────────────────────────────
+//
+// The groups themselves, not the sessions in them. Only the derived tree is
+// ordered this way: a made group sits at the position it was dragged to.
+
+/** A session in a directory that last did something at a given moment. */
+function busy(id: string, cwd: string, lastEventAt: string): Session {
+  return { ...session(id, 0), cwd, last_event_at: lastEventAt }
+}
+
+test('activity puts the group holding the newest session first', () => {
+  const roots = buildCwdTree(
+    [
+      busy('a', '/w/apples', '2026-08-28T01:00:00Z'),
+      busy('b', '/w/zebra', '2026-08-28T03:00:00Z'),
+      busy('c', '/w/mango', '2026-08-28T02:00:00Z'),
+    ],
+    'activity',
+  )
+  assert.deepEqual(roots.map((node) => node.name), ['zebra', 'mango', 'apples'])
+})
+
+// The two orders have to be able to disagree, or neither is worth offering.
+test('name sorts A→Z, which the same sessions do not sort into by activity', () => {
+  const sessions = [
+    busy('a', '/w/apples', '2026-08-28T01:00:00Z'),
+    busy('b', '/w/zebra', '2026-08-28T03:00:00Z'),
+    busy('c', '/w/mango', '2026-08-28T02:00:00Z'),
+  ]
+  assert.deepEqual(buildCwdTree(sessions, 'name').map((node) => node.name), [
+    'apples',
+    'mango',
+    'zebra',
+  ])
+  assert.notDeepEqual(
+    buildCwdTree(sessions, 'name').map((node) => node.name),
+    buildCwdTree(sessions, 'activity').map((node) => node.name),
+  )
+})
+
+// Nothing else can decide it, and a list that shuffles two equally idle
+// directories on every refresh is a list nobody can read.
+test('groups that are equally active keep the order they arrived in', () => {
+  const same = '2026-08-28T01:00:00Z'
+  const roots = buildCwdTree([busy('a', '/w/zebra', same), busy('b', '/w/apples', same)], 'activity')
+  assert.deepEqual(roots.map((node) => node.name), ['zebra', 'apples'])
+})
+
+test("a group's activity is its newest session, not its first", () => {
+  const [node] = buildCwdTree([
+    busy('a', '/w/helios', '2026-08-28T01:00:00Z'),
+    busy('b', '/w/helios', '2026-08-28T05:00:00Z'),
+  ])
+  assert.equal(lastActivityOf(node!), '2026-08-28T05:00:00Z')
+})
+
+// A session that has produced nothing yet has no last_event_at. Reading that as
+// no activity would file a directory made a minute ago below one nobody has
+// touched all week.
+test('a session with no events falls back to when it was created', () => {
+  const fresh = { ...session('fresh', 0), cwd: '/w/fresh', created_at: '2026-08-28T09:00:00Z' }
+  const roots = buildCwdTree([busy('old', '/w/old', '2026-08-28T04:00:00Z'), fresh], 'activity')
+  assert.deepEqual(roots.map((node) => node.name), ['fresh', 'old'])
+})
+
+test('activity is the order when none is asked for', () => {
+  const sessions = [
+    busy('a', '/w/apples', '2026-08-28T01:00:00Z'),
+    busy('b', '/w/zebra', '2026-08-28T03:00:00Z'),
+  ]
+  assert.deepEqual(
+    buildCwdTree(sessions).map((node) => node.name),
+    buildCwdTree(sessions, 'activity').map((node) => node.name),
+  )
+})
+
+test('ordering answers with a new list and leaves the one it was given alone', () => {
+  const nodes = buildCwdTree([busy('a', '/w/zebra', '2026-08-28T03:00:00Z'), busy('b', '/w/apples', '2026-08-28T01:00:00Z')])
+  const byName = orderGroups(nodes, 'name')
+  assert.deepEqual(nodes.map((node) => node.name), ['zebra', 'apples'])
+  assert.deepEqual(byName.map((node) => node.name), ['apples', 'zebra'])
 })
 


### PR DESCRIPTION
## Why

Directory groups — the `Directory` grouping mode added in #107 — came out in
whatever order the session list happened to produce. There was no way to
influence it.

## What

An **Order groups by** choice in the sort popover: **Activity**, **Name A→Z**,
or **Manual**. Manual is drag: pick up a directory header and drop it where you
want it.

### Where a hand-arranged order lives

A directory has no id to hang a position on, so the order keys on the path. It
lives on the client rather than in the daemon, because the grouping it orders is
itself derived — there is no row to attach a number to. A manual *group* keeps
its position in `groups.position` server-side, as before; the two do not
interact.

### Three decisions worth reviewing

- **Dragging is the request.** Headers drag whatever the current order is, and
  the drop selects Manual. Requiring the mode first was a chicken-and-egg —
  nothing would suggest picking it before there was an arrangement to keep. The
  first test run caught this.
- **Untouched directories sort after arranged ones**, by activity. So switching
  to Manual does not scatter everything, and a directory seen for the first time
  lands at the end rather than somewhere arbitrary in the middle.
- **A drop on the middle of a header reorders**, rather than nesting. Directories
  are one flat level, so there is nothing to nest into.

## Fixed along the way

`readGroupOrder` recognised `'name'` and treated everything else as
`'activity'`, so a third order was silently discarded on every boot. It
validates against the list now. The reload assertion is what found it.

## Test plan

- [x] `tsc`, build, 144 desktop tests (unit coverage for all three orders,
      including a tie and a case where alphabetical and activity disagree)
- [x] `go build`, Go suite unaffected
- [x] End to end over CDP against an isolated daemon, with trusted drag events:
      a header drags, the order changes, the mode switches to Manual, the
      arrangement persists, and it survives a reload
- [ ] Someone other than me dragging one

## Not included

Manual ordering for a directory group does not sync between machines, since it
is client-side. If that matters it needs a table keyed by path, which is a
migration and worth its own change.