### PR TITLE
fix: hold theme text to a readable contrast floor

### DIFF
--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -413,8 +413,11 @@ small {
 /* The dot marks a session mid-turn. It steps between two opacities from a
    timer rather than animating: a CSS animation ticks the compositor every
    vsync whatever its duration, and the whole window is recomposited for each
-   tick, so a 1.4s fade and a 120th-of-a-second one cost the same. */
-:root.dim-pulse .pulse {
+   tick, so a 1.4s fade and a 120th-of-a-second one cost the same.
+
+   Only the dot fades. The same class rides the status word, and a word at a
+   third of its opacity is a word nobody can read for two thirds of the time. */
+:root.dim-pulse .dot.pulse {
   opacity: 0.35;
 }
 
@@ -1174,7 +1177,6 @@ small {
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  opacity: 0.8;
 }
 
 /* Permissions are a state to notice, not a label to read past. */
@@ -1182,7 +1184,6 @@ small {
   padding: 0 4px;
   border-radius: 4px;
   background: color-mix(in srgb, var(--on-surface) 9%, transparent);
-  opacity: 1;
 }
 
 .row-ram {
@@ -1903,7 +1904,7 @@ small {
 .file-chip-icon {
   display: inline-flex;
   align-items: center;
-  opacity: 0.7;
+  color: var(--on-surface-variant);
 }
 
 /* ─── Tool calls ────────────────────────────────────────────────────────── */
@@ -4324,8 +4325,10 @@ hr {
   font-size: 12px;
 }
 
+/* The note carries the detail and the headline carries the version, so the
+   two are told apart by weight rather than by fading one of them. */
 .update-note {
-  opacity: 0.8;
+  font-weight: 400;
 }
 
 .update-banner .ext-link {
@@ -4335,7 +4338,6 @@ hr {
 
 .update-banner .dismiss {
   color: inherit;
-  opacity: 0.8;
 }
 
 /* ─── Agent note ────────────────────────────────────────────────────────── */
@@ -4483,7 +4485,7 @@ hr {
   min-width: 230px;
   padding: 6px;
   border-radius: 8px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--outline-variant);
   background: var(--surface);
   box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
 }
@@ -4493,19 +4495,19 @@ hr {
   font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--on-surface-variant);
 }
 
 .picker-note {
   padding: 0 8px 6px;
   font-size: 11px;
-  color: var(--muted);
+  color: var(--on-surface-variant);
 }
 
 .picker-sep {
   height: 1px;
   margin: 4px 0;
-  background: var(--border);
+  background: var(--outline-variant);
 }
 
 .picker-check {
@@ -4533,7 +4535,7 @@ hr {
 }
 
 .picker-item:hover:not(:disabled) {
-  background: var(--hover);
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
 }
 
 .picker-item:disabled {
@@ -4543,11 +4545,11 @@ hr {
 
 .picker-radio {
   width: 12px;
-  color: var(--muted);
+  color: var(--on-surface-variant);
 }
 
 .picker-item.on .picker-radio {
-  color: var(--accent);
+  color: var(--primary);
 }
 
 /* No rail and no rounding. The status is a word on the second line now, and
@@ -4559,16 +4561,14 @@ hr {
 
 .row-status {
   font-weight: 600;
-  color: var(--muted);
+  color: var(--on-surface-variant);
 }
 
 .session-row.active .row-status,
-.session-row.starting .row-status { color: var(--ok, #3fb950); }
-.session-row.waiting_permission .row-status { color: var(--warn, #d29922); }
-.session-row.compacting .row-status { color: var(--info, #58a6ff); }
-.session-row.error .row-status { color: var(--danger, #e5484d); }
-
-.row-status.pulse { animation: pulse 2s ease-in-out infinite; }
+.session-row.starting .row-status { color: var(--s-active); }
+.session-row.waiting_permission .row-status { color: var(--s-waiting); }
+.session-row.compacting .row-status { color: var(--s-compacting); }
+.session-row.error .row-status { color: var(--s-error); }
 
 /* Always shown now: there is one row shape, so there is nothing to toggle. */
 .row-sub { display: flex; }
@@ -4585,9 +4585,9 @@ hr {
   width: calc(100% - 8px);
   margin: 2px 0 4px;
   padding: 4px 6px;
-  border: 1px solid var(--accent, #58a6ff);
+  border: 1px solid var(--primary);
   border-radius: 4px;
-  background: var(--bg);
+  background: var(--surface);
   color: inherit;
   font: inherit;
   font-size: 13px;
@@ -4620,7 +4620,7 @@ hr {
 }
 
 .group-add:hover {
-  background: var(--hover);
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
   color: var(--on-surface);
 }
 
@@ -4663,15 +4663,15 @@ hr {
 /* Where a dragged group would land. One gesture, two meanings, so the edge and
    the middle have to look different before the drop, not after it. */
 .group-head.drop-before {
-  box-shadow: inset 0 2px 0 0 var(--accent, #58a6ff);
+  box-shadow: inset 0 2px 0 0 var(--primary);
 }
 
 .group-head.drop-after {
-  box-shadow: inset 0 -2px 0 0 var(--accent, #58a6ff);
+  box-shadow: inset 0 -2px 0 0 var(--primary);
 }
 
 .group-head.drop-inside {
-  background: color-mix(in srgb, var(--accent, #58a6ff) 18%, transparent);
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
   border-radius: var(--r-sm);
 }
 

--- a/desktop/src/shared/theme/mapping.ts
+++ b/desktop/src/shared/theme/mapping.ts
@@ -161,6 +161,27 @@ export interface RoleSpec {
 }
 
 /**
+ * The hardest background a role has to survive.
+ *
+ * `editor.background` is the wrong thing to measure against, and measuring
+ * against it was how sixteen of the seventeen bundled themes shipped text below
+ * the WCAG floor. The app draws on a ladder of raised surfaces, and every rung
+ * is mixed towards the foreground — so the top rung eats the most contrast and
+ * is the only one worth checking. Clearing it clears every rung below.
+ */
+const onRaised = (c: DeriveContext): Rgb => c.role('surface-highest')
+
+/**
+ * The WCAG AA floor for text below 18px.
+ *
+ * The status and error colours were held to 3:1 on the theory that they are
+ * drawn as dots. They are not: they are the "Active" label on a session row and
+ * the tick on every tool result, at 10.5px and 11.5px. A dot at 3:1 beside a
+ * word at 3:1 means the word is the part that fails.
+ */
+const SMALL_TEXT = 4.5
+
+/**
  * The UI roles, in resolution order — later entries may read earlier ones
  * through `ctx.role`.
  *
@@ -177,12 +198,21 @@ export const UI_ROLES: [string, RoleSpec][] = [
   ['surface-high', { keys: [], derive: (c) => c.ladder(0.13) }],
   ['surface-highest', { keys: [], derive: (c) => c.ladder(0.19) }],
 
-  ['on-surface', { keys: ['editor.foreground', 'foreground'], derive: (c) => c.fg }],
+  [
+    'on-surface',
+    {
+      keys: ['editor.foreground', 'foreground'],
+      minContrast: 4.5,
+      against: onRaised,
+      derive: (c) => c.fg,
+    },
+  ],
   [
     'on-surface-variant',
     {
       keys: ['descriptionForeground'],
-      minContrast: 3,
+      minContrast: 3.5,
+      against: onRaised,
       derive: (c) => mix(c.fg, c.bg, 0.28),
     },
   ],
@@ -209,7 +239,8 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'primary',
     {
       keys: ['textLink.foreground', 'focusBorder', 'button.background', 'progressBar.background'],
-      minContrast: 3,
+      minContrast: SMALL_TEXT,
+      against: onRaised,
       derive: (c) => c.ansi.blue,
     },
   ],
@@ -217,7 +248,7 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-primary',
     {
       keys: ['button.foreground'],
-      minContrast: 4,
+      minContrast: SMALL_TEXT,
       against: (c) => c.role('primary'),
       derive: (c) => pickReadable(c.role('primary'), [c.bg, c.fg]),
     },
@@ -233,7 +264,7 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-primary-container',
     {
       keys: ['list.activeSelectionForeground'],
-      minContrast: 4,
+      minContrast: SMALL_TEXT,
       against: (c) => c.role('primary-container'),
       derive: (c) => pickReadable(c.role('primary-container'), [c.fg, c.bg, mix(c.role('primary'), c.fg, 0.6)]),
     },
@@ -243,7 +274,8 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'error',
     {
       keys: ['errorForeground', 'editorError.foreground', 'list.errorForeground'],
-      minContrast: 2.2,
+      minContrast: SMALL_TEXT,
+      against: onRaised,
       derive: (c) => c.ansi.red,
     },
   ],
@@ -258,7 +290,7 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-error-container',
     {
       keys: ['inputValidation.errorForeground'],
-      minContrast: 4,
+      minContrast: SMALL_TEXT,
       against: (c) => c.role('error-container'),
       derive: (c) => pickReadable(c.role('error-container'), [c.fg, c.bg, mix(c.role('error'), c.fg, 0.6)]),
     },
@@ -279,13 +311,13 @@ export const UI_ROLES: [string, RoleSpec][] = [
   // dots and short labels on a panel, and a terminal yellow picked to sit on a
   // light theme's white background is legible as output and invisible as a
   // six-pixel dot.
-  ['s-starting', { keys: [], minContrast: 3, derive: (c) => c.ansi.cyan }],
-  ['s-active', { keys: [], minContrast: 3, derive: (c) => c.ansi.green }],
-  ['s-compacting', { keys: [], minContrast: 3, derive: (c) => c.ansi.magenta }],
-  ['s-waiting', { keys: [], minContrast: 3, derive: (c) => c.ansi.yellow }],
-  ['s-idle', { keys: [], minContrast: 3, derive: (c) => c.ansi.blue }],
-  ['s-error', { keys: [], minContrast: 3, derive: (c) => c.role('error') }],
-  ['s-off', { keys: ['disabledForeground'], minContrast: 2, derive: (c) => c.role('outline') }],
+  ['s-starting', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.ansi.cyan }],
+  ['s-active', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.ansi.green }],
+  ['s-compacting', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.ansi.magenta }],
+  ['s-waiting', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.ansi.yellow }],
+  ['s-idle', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.ansi.blue }],
+  ['s-error', { keys: [], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.role('error') }],
+  ['s-off', { keys: ['disabledForeground'], minContrast: SMALL_TEXT, against: onRaised, derive: (c) => c.role('outline') }],
 ]
 
 /**

--- a/desktop/src/shared/theme/mapping.ts
+++ b/desktop/src/shared/theme/mapping.ts
@@ -211,7 +211,9 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-surface-variant',
     {
       keys: ['descriptionForeground'],
-      minContrast: 3.5,
+      // Secondary, but still text, and the app sets it at 10.5px on the
+      // session rows and 11.5px on every tool summary.
+      minContrast: SMALL_TEXT,
       against: onRaised,
       derive: (c) => mix(c.fg, c.bg, 0.28),
     },

--- a/desktop/src/shared/theme/mapping.ts
+++ b/desktop/src/shared/theme/mapping.ts
@@ -182,6 +182,18 @@ const onRaised = (c: DeriveContext): Rgb => c.role('surface-highest')
 const SMALL_TEXT = 4.5
 
 /**
+ * The floor for the colour most of the window is read in.
+ *
+ * AAA rather than AA, because AA is a minimum and this is the one role where
+ * the minimum becomes the actual value. Most themes state a foreground well
+ * clear of it — monokai's is 11:1 — so this only bites on the few that are
+ * deliberately low-contrast, which are the ones that read as grey mush.
+ * Solarized dark resolved to 5.14:1 body text under AA, which passes and is
+ * still tiring on dark teal.
+ */
+const BODY_TEXT = 7
+
+/**
  * The UI roles, in resolution order — later entries may read earlier ones
  * through `ctx.role`.
  *
@@ -202,7 +214,7 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-surface',
     {
       keys: ['editor.foreground', 'foreground'],
-      minContrast: 4.5,
+      minContrast: BODY_TEXT,
       against: onRaised,
       derive: (c) => c.fg,
     },
@@ -266,7 +278,8 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-primary-container',
     {
       keys: ['list.activeSelectionForeground'],
-      minContrast: SMALL_TEXT,
+      // The user's own messages are set on this container, at 14px.
+      minContrast: BODY_TEXT,
       against: (c) => c.role('primary-container'),
       derive: (c) => pickReadable(c.role('primary-container'), [c.fg, c.bg, mix(c.role('primary'), c.fg, 0.6)]),
     },
@@ -292,7 +305,7 @@ export const UI_ROLES: [string, RoleSpec][] = [
     'on-error-container',
     {
       keys: ['inputValidation.errorForeground'],
-      minContrast: SMALL_TEXT,
+      minContrast: BODY_TEXT,
       against: (c) => c.role('error-container'),
       derive: (c) => pickReadable(c.role('error-container'), [c.fg, c.bg, mix(c.role('error'), c.fg, 0.6)]),
     },

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -200,6 +200,14 @@ export function resolveTheme(
   }
 
   const resolved = new Map<string, Rgb>()
+  /**
+   * The same roles before the contrast floor moved them.
+   *
+   * Only the backdrop reads these. A mesh painted behind glass carries no text,
+   * so nudging its colours towards white to make them legible buys nothing and
+   * costs the theme the palette it was designed around.
+   */
+  const stated = new Map<string, Rgb>()
   const ctx: DeriveContext = {
     bg,
     fg,
@@ -213,9 +221,11 @@ export function resolveTheme(
   for (const [name, spec] of UI_ROLES) {
     const against = spec.against ? spec.against(ctx) : bg
     let value: Rgb | null = null
+    let declared: Rgb | null = null
     for (const key of spec.keys) {
       const candidate = colour(key)
       if (!candidate) continue
+      declared ??= candidate
       // Prefer a key that already works over nudging one that does not.
       if (spec.minContrast && contrast(candidate, against) < spec.minContrast) continue
       value = candidate
@@ -224,6 +234,7 @@ export function resolveTheme(
     const chosen = value ?? spec.derive(ctx)
     const final = spec.minContrast ? ensureContrast(chosen, against, spec.minContrast) : chosen
     resolved.set(name, final)
+    stated.set(name, declared ?? chosen)
     vars[`--${name}`] = toHex(final)
   }
 
@@ -271,7 +282,7 @@ export function resolveTheme(
   // Only meaningful under glass: the backdrop is what the translucent surfaces
   // are translucent onto, and painting one behind an opaque app would be work
   // no pixel ever shows.
-  const palette = derivedStops(resolved.get('primary') ?? bg, ansi.magenta, ansi.cyan, mode === 'dark')
+  const palette = derivedStops(stated.get('primary') ?? bg, ansi.magenta, ansi.cyan, mode === 'dark')
   const spec = glass ? theme['helios.backdrop'] : undefined
   const style = styleOf(spec)
 

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -244,7 +244,7 @@ export function resolveTheme(
   // recede further because receding is what they are for.
   const tokens = indexTokenColors(theme, bg)
   const codeBg = resolved.get('code-bg') ?? bg
-  vars['--syn-fg'] = toHex(ensureContrast(fg, codeBg, 4.5))
+  vars['--syn-fg'] = toHex(ensureContrast(fg, codeBg, 7))
   for (const [role, candidates] of Object.entries(SYNTAX_SCOPES)) {
     let value: Rgb | null = null
     for (const scope of candidates) {

--- a/desktop/src/shared/theme/resolve.ts
+++ b/desktop/src/shared/theme/resolve.ts
@@ -95,6 +95,23 @@ const FALLBACK_BG: Record<ThemeMode, Rgb> = { dark: rgb(0x11, 0x13, 0x18), light
 const FALLBACK_FG: Record<ThemeMode, Rgb> = { dark: rgb(0xe2, 0xe2, 0xe6), light: rgb(0x1f, 0x1f, 0x1f) }
 
 /**
+ * The four palette entries left exactly as the theme states them.
+ *
+ * The other twelve are text: a CLI writes its warnings in yellow and its
+ * timestamps in bright black, and a light theme's yellow on a white terminal
+ * measures around 2:1. These four are the poles, and a program that asks for
+ * them is usually asking for a fill or for the inverse of one — forcing
+ * `brightWhite` to stand off a white terminal would turn white-on-blue text
+ * black.
+ */
+const TERMINAL_POLES = new Set<AnsiName>(['black', 'white', 'brightWhite'])
+
+/** The floor for terminal text, which is dense and small. */
+const TERMINAL_CONTRAST = 4.5
+
+const readable = (colour: Rgb, background: Rgb): Rgb => ensureContrast(colour, background, TERMINAL_CONTRAST)
+
+/**
  * `uiTheme` from the extension's `package.json`, for the many themes that omit
  * the top-level `type` field.
  */
@@ -210,8 +227,13 @@ export function resolveTheme(
     vars[`--${name}`] = toHex(final)
   }
 
+  // A theme's token colours are chosen against its editor background, and the
+  // app puts them on a code block that is a rung further up the surface ladder.
+  // Held to the same floor as the rest of the UI, with comments allowed to
+  // recede further because receding is what they are for.
   const tokens = indexTokenColors(theme, bg)
-  vars['--syn-fg'] = toHex(fg)
+  const codeBg = resolved.get('code-bg') ?? bg
+  vars['--syn-fg'] = toHex(ensureContrast(fg, codeBg, 4.5))
   for (const [role, candidates] of Object.entries(SYNTAX_SCOPES)) {
     let value: Rgb | null = null
     for (const scope of candidates) {
@@ -219,7 +241,8 @@ export function resolveTheme(
       if (value) break
     }
     const fallback = SYNTAX_FALLBACK[role]
-    vars[`--syn-${role}`] = toHex(value ?? (fallback ? fallback(ansi, fg, bg) : fg))
+    const chosen = value ?? (fallback ? fallback(ansi, fg, bg) : fg)
+    vars[`--syn-${role}`] = toHex(ensureContrast(chosen, codeBg, role === 'comment' ? 3 : 3.5))
   }
 
   Object.assign(vars, overlayVars(mode === 'dark'))
@@ -284,13 +307,19 @@ export function resolveTheme(
     // Eight-digit hex rather than rgb(): xterm parses this itself, and does
     // not accept the slash form.
     background: glass ? toHexAlpha(terminalBg, glass.terminal) : toHex(terminalBg),
-    foreground: toHex(colour('terminal.foreground') ?? fg),
-    cursor: toHex(colour('terminalCursor.foreground') ?? colour('editorCursor.foreground') ?? fg),
+    foreground: toHex(readable(colour('terminal.foreground') ?? fg, terminalBg)),
+    // A caret is a shape rather than a word, so it is held to the non-text
+    // floor — but it still has to be findable.
+    cursor: toHex(
+      ensureContrast(colour('terminalCursor.foreground') ?? colour('editorCursor.foreground') ?? fg, terminalBg, 3),
+    ),
     selectionBackground: toHex(
       colour('terminal.selectionBackground') ?? colour('editor.selectionBackground') ?? mix(terminalBg, fg, 0.25),
     ),
   } as XtermTheme
-  for (const name of ANSI_NAMES) ansiTheme[name] = toHex(ansi[name])
+  for (const name of ANSI_NAMES) {
+    ansiTheme[name] = toHex(TERMINAL_POLES.has(name) ? ansi[name] : readable(ansi[name], terminalBg))
+  }
 
   return {
     id,

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -223,6 +223,10 @@ test('an on- role is measured against its container, not the surface', () => {
     },
   })
   const container = parseColor(theme.vars['--error-container']) as never
+  // Four, not seven: this fixture's container is a mid red, and no colour
+  // reaches 7:1 against it. The floor is best-effort where the container makes
+  // it unreachable; what is asserted here is that the container is what the
+  // role is measured against at all.
   assert.ok(contrast(parseColor(theme.vars['--on-error-container']) as never, container) >= 4)
 })
 
@@ -528,7 +532,7 @@ const THEME_DIR = path.join(import.meta.dirname, '..', '..', 'themes')
 
 /** Text roles and the floor each is held to, against every surface it lands on. */
 const TEXT_FLOORS: [string, number][] = [
-  ['on-surface', 4.5],
+  ['on-surface', 7],
   ['on-surface-variant', 4.5],
   ['primary', 3],
   // Status and error are drawn as words, not only as dots: the "Active" label
@@ -568,7 +572,7 @@ for (const entry of fs.readdirSync(THEME_DIR).filter((f) => f.endsWith('.json'))
     const codeBg = colour('--code-bg')
     for (const [name, value] of Object.entries(theme.vars)) {
       if (!name.startsWith('--syn-')) continue
-      const floor = name === '--syn-fg' ? 4.5 : name === '--syn-comment' ? 3 : 3.5
+      const floor = name === '--syn-fg' ? 7 : name === '--syn-comment' ? 3 : 3.5
       const ratio = contrast(parseColor(value) as Rgb, codeBg)
       assert.ok(ratio >= floor, `${name} on --code-bg is ${ratio.toFixed(2)}, below ${floor}`)
     }

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -3,6 +3,8 @@
 // a theme with nothing but a background, one that states no type, one whose
 // colours carry alpha, and one with no syntax rules at all.
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
 import { test } from 'node:test'
 
 import { resolveTheme, mergeThemes, modeFromUiTheme } from '../src/shared/theme/resolve.ts'
@@ -18,6 +20,7 @@ import {
   toHex,
   type BackdropStyle,
   type Rgb,
+  type VSCodeTheme,
 } from '../src/shared/theme/vscode.ts'
 
 test('parseJsonc tolerates comments and trailing commas', () => {
@@ -129,19 +132,21 @@ test('a theme with no tokenColors still gets syntax roles, from its terminal pal
 test('syntax roles match a token scope by its longest prefix', () => {
   const theme = resolveTheme('tokens', {
     colors: { 'editor.background': '#000000', 'editor.foreground': '#ffffff' },
+    // Legible against the code bed, so what is asserted here is the scope
+    // matching rather than the contrast floor that would otherwise move them.
     tokenColors: [
-      { scope: 'keyword', settings: { foreground: '#111111' } },
-      { scope: ['comment', 'punctuation.definition.comment'], settings: { foreground: '#222222' } },
-      { scope: 'string.quoted, string.template', settings: { foreground: '#333333' } },
+      { scope: 'keyword', settings: { foreground: '#aaaaaa' } },
+      { scope: ['comment', 'punctuation.definition.comment'], settings: { foreground: '#bbbbbb' } },
+      { scope: 'string.quoted, string.template', settings: { foreground: '#cccccc' } },
       // A descendant selector keys off its final segment.
-      { scope: 'meta.function entity.name.function', settings: { foreground: '#444444' } },
+      { scope: 'meta.function entity.name.function', settings: { foreground: '#dddddd' } },
     ],
   })
   // `keyword.control` is tried first and is absent, so it falls back to `keyword`.
-  assert.equal(theme.vars['--syn-keyword'], '#111111')
-  assert.equal(theme.vars['--syn-comment'], '#222222')
-  assert.equal(theme.vars['--syn-string'], '#333333')
-  assert.equal(theme.vars['--syn-function'], '#444444')
+  assert.equal(theme.vars['--syn-keyword'], '#aaaaaa')
+  assert.equal(theme.vars['--syn-comment'], '#bbbbbb')
+  assert.equal(theme.vars['--syn-string'], '#cccccc')
+  assert.equal(theme.vars['--syn-function'], '#dddddd')
 })
 
 test('the last rule naming a scope wins', () => {
@@ -512,3 +517,70 @@ test('mix travels the requested fraction', () => {
   assert.equal(toHex(mix(black, white, 1)), '#ffffff')
   assert.equal(toHex(mix(black, white, 0.5)), '#808080')
 })
+
+// Every bundled theme, swept against the surfaces the app actually draws on.
+// The resolver used to measure its floors against `editor.background`, which is
+// the lowest surface in the app and therefore the easiest one — sixteen of the
+// seventeen themes below shipped text under the floor on the raised surfaces
+// nobody was checking. Reading the themes off disk rather than fixturing them
+// is the point: a theme added later is covered without touching this file.
+const THEME_DIR = path.join(import.meta.dirname, '..', '..', 'themes')
+
+/** Text roles and the floor each is held to, against every surface it lands on. */
+const TEXT_FLOORS: [string, number][] = [
+  ['on-surface', 4.5],
+  ['on-surface-variant', 3.5],
+  ['primary', 3],
+  // Status and error are drawn as words, not only as dots: the "Active" label
+  // on a session row is 10.5px and the tick on a tool result is 11.5px.
+  ['error', 4.5],
+  ['s-starting', 4.5],
+  ['s-active', 4.5],
+  ['s-compacting', 4.5],
+  ['s-waiting', 4.5],
+  ['s-idle', 4.5],
+  ['s-error', 4.5],
+  ['s-off', 4.5],
+]
+
+/**
+ * Left as the theme states them: the poles are asked for as fills, or as the
+ * inverse of one, far more often than as text on the terminal's own background.
+ */
+const ANSI_POLES = new Set(['black', 'white', 'brightWhite'])
+
+const SURFACES = ['surface', 'surface-low', 'surface-container', 'surface-high', 'surface-highest']
+
+for (const entry of fs.readdirSync(THEME_DIR).filter((f) => f.endsWith('.json')).sort()) {
+  const id = entry.slice(0, -'.json'.length)
+  test(`${id} keeps its text legible on every surface`, () => {
+    const theme = resolveTheme(id, parseJsonc(fs.readFileSync(path.join(THEME_DIR, entry), 'utf8')) as VSCodeTheme)
+    const colour = (name: string): Rgb => parseColor(theme.vars[name]) as Rgb
+
+    for (const [role, floor] of TEXT_FLOORS) {
+      for (const surface of SURFACES) {
+        const ratio = contrast(colour(`--${role}`), colour(`--${surface}`))
+        assert.ok(ratio >= floor, `--${role} on --${surface} is ${ratio.toFixed(2)}, below ${floor}`)
+      }
+    }
+
+    // Syntax has a bed of its own, and a theme may set it to anything.
+    const codeBg = colour('--code-bg')
+    for (const [name, value] of Object.entries(theme.vars)) {
+      if (!name.startsWith('--syn-')) continue
+      const floor = name === '--syn-fg' ? 4.5 : name === '--syn-comment' ? 3 : 3.5
+      const ratio = contrast(parseColor(value) as Rgb, codeBg)
+      assert.ok(ratio >= floor, `${name} on --code-bg is ${ratio.toFixed(2)}, below ${floor}`)
+    }
+
+    // The terminal palette is text too. A light theme's yellow measures around
+    // 2:1 on a white terminal, which is what a CLI writes its warnings in.
+    const termBg = parseColor(theme.ansi.background.slice(0, 7)) as Rgb
+    for (const [name, value] of Object.entries(theme.ansi)) {
+      if (name === 'background' || name === 'selectionBackground' || name === 'cursor') continue
+      if (ANSI_POLES.has(name)) continue
+      const ratio = contrast(parseColor((value as string).slice(0, 7)) as Rgb, termBg)
+      assert.ok(ratio >= 4.5, `ansi ${name} on the terminal background is ${ratio.toFixed(2)}, below 4.5`)
+    }
+  })
+}

--- a/desktop/test/theme-resolve.test.ts
+++ b/desktop/test/theme-resolve.test.ts
@@ -529,7 +529,7 @@ const THEME_DIR = path.join(import.meta.dirname, '..', '..', 'themes')
 /** Text roles and the floor each is held to, against every surface it lands on. */
 const TEXT_FLOORS: [string, number][] = [
   ['on-surface', 4.5],
-  ['on-surface-variant', 3.5],
+  ['on-surface-variant', 4.5],
   ['primary', 3],
   // Status and error are drawn as words, not only as dots: the "Active" label
   // on a session row is 10.5px and the tick on a tool result is 11.5px.

--- a/internal/tui/general_settings.go
+++ b/internal/tui/general_settings.go
@@ -11,10 +11,10 @@ import (
 )
 
 var toggleOnStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("42"))
+	Foreground(accentColor)
 
 var toggleOffStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("196"))
+	Foreground(dangerColor)
 
 var generalSettingsKeys = []struct {
 	key     string

--- a/internal/tui/schemes_test.go
+++ b/internal/tui/schemes_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Every scheme that paints its own card, checked against both the resting and
+// the selected card. The schemes were originally hand-picked against one
+// background and reused across all of them, which is how `forest` ended up
+// drawing a green "active" dot on a green card at 2.89:1.
+
+// xterm256 is the standard 256-colour palette: sixteen system colours, a
+// 6×6×6 cube, then a 24-step grey ramp.
+func xterm256() [256][3]float64 {
+	var p [256][3]float64
+	system := [16][3]float64{
+		{0, 0, 0}, {128, 0, 0}, {0, 128, 0}, {128, 128, 0},
+		{0, 0, 128}, {128, 0, 128}, {0, 128, 128}, {192, 192, 192},
+		{128, 128, 128}, {255, 0, 0}, {0, 255, 0}, {255, 255, 0},
+		{0, 0, 255}, {255, 0, 255}, {0, 255, 255}, {255, 255, 255},
+	}
+	copy(p[:16], system[:])
+	levels := [6]float64{0, 95, 135, 175, 215, 255}
+	i := 16
+	for _, r := range levels {
+		for _, g := range levels {
+			for _, b := range levels {
+				p[i] = [3]float64{r, g, b}
+				i++
+			}
+		}
+	}
+	for step := range 24 {
+		v := float64(8 + step*10)
+		p[i] = [3]float64{v, v, v}
+		i++
+	}
+	return p
+}
+
+var palette = xterm256()
+
+func luminance(t *testing.T, c lipgloss.Color) float64 {
+	t.Helper()
+	index, err := strconv.Atoi(string(c))
+	if err != nil || index < 0 || index > 255 {
+		t.Fatalf("colour %q is not an xterm index", string(c))
+	}
+	rgb := palette[index]
+	channel := func(v float64) float64 {
+		s := v / 255
+		if s <= 0.03928 {
+			return s / 12.92
+		}
+		return math.Pow((s+0.055)/1.055, 2.4)
+	}
+	return 0.2126*channel(rgb[0]) + 0.7152*channel(rgb[1]) + 0.0722*channel(rgb[2])
+}
+
+func contrast(t *testing.T, a, b lipgloss.Color) float64 {
+	t.Helper()
+	la, lb := luminance(t, a), luminance(t, b)
+	return (math.Max(la, lb) + 0.05) / (math.Min(la, lb) + 0.05)
+}
+
+func TestSchemes_KeepTheirTextLegibleOnBothCardStates(t *testing.T) {
+	for name, c := range schemes {
+		if !c.hasBG {
+			// The card is the terminal's own background, which the app does
+			// not choose and therefore cannot measure against.
+			continue
+		}
+		roles := []struct {
+			label  string
+			colour lipgloss.Color
+			floor  float64
+		}{
+			{"onSurface", c.onSurface, 4.5},
+			{"onSurfaceDim", c.onSurfaceDim, 4.5},
+			{"onSurfaceMuted", c.onSurfaceMuted, 3},
+			{"outline", c.outline, 3},
+			{"primary", c.primary, 3},
+			{"statusActive", c.statusActive, 3},
+			{"statusWaiting", c.statusWaiting, 3},
+			{"statusCompacting", c.statusCompacting, 3},
+			{"statusError", c.statusError, 3},
+			{"statusIdle", c.statusIdle, 3},
+			{"statusTerminated", c.statusTerminated, 3},
+			// A rule, not a label: visible without competing with the text.
+			{"separator", c.separator, 1.8},
+		}
+		for _, card := range []struct {
+			label  string
+			colour lipgloss.Color
+		}{{"surface", c.surface}, {"surfaceSelected", c.surfaceSelected}} {
+			for _, role := range roles {
+				got := contrast(t, role.colour, card.colour)
+				if got < role.floor {
+					t.Errorf("%s: %s on %s is %.2f, want at least %.2f",
+						name, role.label, card.label, got, role.floor)
+				}
+			}
+		}
+	}
+}

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -28,75 +28,155 @@ const schemeSettKey = "tui_color_scheme"
 var schemeOrder = []string{"dark", "surface", "ocean", "forest", "dracula", "solarized"}
 
 // schemeColors holds the palette for a given color scheme.
+//
+// Every colour here is stated per scheme rather than shared, because a scheme
+// that paints its own card background changes what is legible on it: the green
+// that reads as "active" on a near-black card is green on green in `forest`.
+// The values below clear 4.5:1 for body text and 3:1 for everything else
+// against both `surface` and `surfaceSelected`.
 type schemeColors struct {
 	surface         lipgloss.Color // card bg (empty string = transparent)
 	surfaceSelected lipgloss.Color
 	onSurface       lipgloss.Color // primary text
 	onSurfaceDim    lipgloss.Color // secondary text
 	onSurfaceMuted  lipgloss.Color // tertiary text
-	outline         lipgloss.Color // borders
+	outline         lipgloss.Color // borders and hints
+	separator       lipgloss.Color // the rule above the help line, deliberately fainter
 	primary         lipgloss.Color
 	hasBG           bool // whether to apply Background()
+
+	statusActive     lipgloss.Color
+	statusWaiting    lipgloss.Color
+	statusCompacting lipgloss.Color
+	statusError      lipgloss.Color
+	statusIdle       lipgloss.Color
+	statusTerminated lipgloss.Color
+}
+
+// statusColor is the accent stripe and icon colour for a session's status.
+func (c schemeColors) statusColor(status string) lipgloss.Color {
+	switch status {
+	case "active":
+		return c.statusActive
+	case "waiting_permission":
+		return c.statusWaiting
+	case "compacting":
+		return c.statusCompacting
+	case "error":
+		return c.statusError
+	case "terminated":
+		return c.statusTerminated
+	default:
+		return c.statusIdle
+	}
 }
 
 var schemes = map[string]schemeColors{
+	// The one scheme that paints no card of its own, so its text lands on
+	// whatever the terminal's background is. Judged against a dark terminal,
+	// which is the assumption the scheme is named for.
 	"dark": {
-		onSurface:      lipgloss.Color("252"),
-		onSurfaceDim:   lipgloss.Color("245"),
-		onSurfaceMuted: lipgloss.Color("240"),
-		outline:        lipgloss.Color("238"),
-		primary:        lipgloss.Color("70"),
-		hasBG:          false,
+		onSurface:        lipgloss.Color("252"),
+		onSurfaceDim:     lipgloss.Color("245"),
+		onSurfaceMuted:   lipgloss.Color("240"),
+		outline:          lipgloss.Color("242"),
+		separator:        lipgloss.Color("238"),
+		primary:          lipgloss.Color("70"),
+		hasBG:            false,
+		statusActive:     lipgloss.Color("114"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("203"),
+		statusIdle:       lipgloss.Color("247"),
+		statusTerminated: lipgloss.Color("102"),
 	},
 	"surface": {
-		surface:         lipgloss.Color("235"),
-		surfaceSelected: lipgloss.Color("237"),
-		onSurface:       lipgloss.Color("252"),
-		onSurfaceDim:    lipgloss.Color("245"),
-		onSurfaceMuted:  lipgloss.Color("240"),
-		outline:         lipgloss.Color("238"),
-		primary:         lipgloss.Color("70"),
-		hasBG:           true,
+		surface:          lipgloss.Color("235"),
+		surfaceSelected:  lipgloss.Color("237"),
+		onSurface:        lipgloss.Color("252"),
+		onSurfaceDim:     lipgloss.Color("250"),
+		onSurfaceMuted:   lipgloss.Color("248"),
+		outline:          lipgloss.Color("245"),
+		separator:        lipgloss.Color("242"),
+		primary:          lipgloss.Color("70"),
+		hasBG:            true,
+		statusActive:     lipgloss.Color("114"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("203"),
+		statusIdle:       lipgloss.Color("247"),
+		statusTerminated: lipgloss.Color("102"),
 	},
 	"ocean": {
-		surface:         lipgloss.Color("17"),  // deep navy
-		surfaceSelected: lipgloss.Color("18"),  // brighter navy
-		onSurface:       lipgloss.Color("159"), // light cyan
-		onSurfaceDim:    lipgloss.Color("110"), // steel blue
-		onSurfaceMuted:  lipgloss.Color("67"),  // muted blue
-		outline:         lipgloss.Color("24"),
-		primary:         lipgloss.Color("81"), // bright cyan
-		hasBG:           true,
+		surface:          lipgloss.Color("17"),  // deep navy
+		surfaceSelected:  lipgloss.Color("18"),  // brighter navy
+		onSurface:        lipgloss.Color("159"), // light cyan
+		onSurfaceDim:     lipgloss.Color("110"), // steel blue
+		onSurfaceMuted:   lipgloss.Color("74"),  // muted blue
+		outline:          lipgloss.Color("67"),
+		separator:        lipgloss.Color("60"),
+		primary:          lipgloss.Color("81"), // bright cyan
+		hasBG:            true,
+		statusActive:     lipgloss.Color("114"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("203"),
+		statusIdle:       lipgloss.Color("247"),
+		statusTerminated: lipgloss.Color("66"),
 	},
+	// The tightest scheme: its card is a mid green, so the greens and reds the
+	// other schemes use for status land on their own hue and have to be
+	// lightened until they separate from it.
 	"forest": {
-		surface:         lipgloss.Color("22"),  // deep green
-		surfaceSelected: lipgloss.Color("23"),  // teal
-		onSurface:       lipgloss.Color("194"), // light mint
-		onSurfaceDim:    lipgloss.Color("108"), // sage
-		onSurfaceMuted:  lipgloss.Color("65"),  // olive
-		outline:         lipgloss.Color("28"),
-		primary:         lipgloss.Color("114"), // bright green
-		hasBG:           true,
+		surface:          lipgloss.Color("22"),  // deep green
+		surfaceSelected:  lipgloss.Color("23"),  // teal
+		onSurface:        lipgloss.Color("194"), // light mint
+		onSurfaceDim:     lipgloss.Color("151"), // sage
+		onSurfaceMuted:   lipgloss.Color("108"), // olive
+		outline:          lipgloss.Color("109"),
+		separator:        lipgloss.Color("102"),
+		primary:          lipgloss.Color("114"), // bright green
+		hasBG:            true,
+		statusActive:     lipgloss.Color("120"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("209"),
+		statusIdle:       lipgloss.Color("248"),
+		statusTerminated: lipgloss.Color("145"),
 	},
 	"dracula": {
-		surface:         lipgloss.Color("236"), // bg
-		surfaceSelected: lipgloss.Color("238"), // current line
-		onSurface:       lipgloss.Color("231"), // foreground
-		onSurfaceDim:    lipgloss.Color("183"), // purple-ish
-		onSurfaceMuted:  lipgloss.Color("61"),  // comment
-		outline:         lipgloss.Color("60"),
-		primary:         lipgloss.Color("212"), // pink
-		hasBG:           true,
+		surface:          lipgloss.Color("236"), // bg
+		surfaceSelected:  lipgloss.Color("238"), // current line
+		onSurface:        lipgloss.Color("231"), // foreground
+		onSurfaceDim:     lipgloss.Color("183"), // purple-ish
+		onSurfaceMuted:   lipgloss.Color("146"), // comment
+		outline:          lipgloss.Color("104"),
+		separator:        lipgloss.Color("242"),
+		primary:          lipgloss.Color("212"), // pink
+		hasBG:            true,
+		statusActive:     lipgloss.Color("114"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("203"),
+		statusIdle:       lipgloss.Color("247"),
+		statusTerminated: lipgloss.Color("246"),
 	},
 	"solarized": {
-		surface:         lipgloss.Color("0"),   // base03
-		surfaceSelected: lipgloss.Color("234"), // base02
-		onSurface:       lipgloss.Color("187"), // base1
-		onSurfaceDim:    lipgloss.Color("246"), // base0
-		onSurfaceMuted:  lipgloss.Color("242"), // base01
-		outline:         lipgloss.Color("240"),
-		primary:         lipgloss.Color("136"), // yellow
-		hasBG:           true,
+		surface:          lipgloss.Color("0"),   // base03
+		surfaceSelected:  lipgloss.Color("234"), // base02
+		onSurface:        lipgloss.Color("187"), // base1
+		onSurfaceDim:     lipgloss.Color("246"), // base0
+		onSurfaceMuted:   lipgloss.Color("245"), // base01
+		outline:          lipgloss.Color("242"),
+		separator:        lipgloss.Color("239"),
+		primary:          lipgloss.Color("136"), // yellow
+		hasBG:            true,
+		statusActive:     lipgloss.Color("114"),
+		statusWaiting:    lipgloss.Color("215"),
+		statusCompacting: lipgloss.Color("111"),
+		statusError:      lipgloss.Color("203"),
+		statusIdle:       lipgloss.Color("247"),
+		statusTerminated: lipgloss.Color("102"),
 	},
 }
 
@@ -109,31 +189,6 @@ func nextScheme(current string) string {
 	}
 	return schemeOrder[0]
 }
-
-// Status accent colors (left border)
-var (
-	colorActive     = lipgloss.Color("70")  // green
-	colorWaiting    = lipgloss.Color("214") // amber
-	colorCompact    = lipgloss.Color("75")  // blue
-	colorError      = lipgloss.Color("196") // red
-	colorIdle       = lipgloss.Color("241") // grey
-	colorTerminated = lipgloss.Color("245") // muted grey
-)
-
-// ── Styles (scheme-independent) ──
-
-var (
-	sessBorderStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("238")).
-			Padding(0, 1)
-
-	sessSepStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("236"))
-
-	sessSearchLabel = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("75"))
-)
 
 func sessStatusIcon(status string) string {
 	switch status {
@@ -158,23 +213,6 @@ func sessStatusIcon(status string) string {
 
 func sessCanResume(status string) bool {
 	return status == "terminated"
-}
-
-func sessStatusColor(status string) lipgloss.Color {
-	switch status {
-	case "active":
-		return colorActive
-	case "waiting_permission":
-		return colorWaiting
-	case "compacting":
-		return colorCompact
-	case "error":
-		return colorError
-	case "terminated":
-		return colorTerminated
-	default:
-		return colorIdle
-	}
 }
 
 // ── Messages ──
@@ -233,7 +271,6 @@ func (m *SessionsModel) colors() schemeColors {
 func NewSessionsModel(internalPort int) SessionsModel {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 
 	ti := textinput.New()
 	ti.Placeholder = "filter sessions..."
@@ -249,13 +286,23 @@ func NewSessionsModel(internalPort int) SessionsModel {
 		}
 	}
 
-	return SessionsModel{
+	m := SessionsModel{
 		client:  c,
 		spinner: s,
 		search:  ti,
 		loading: true,
 		scheme:  scheme,
 	}
+	m.styleSpinner()
+	return m
+}
+
+// styleSpinner repaints the spinner for the current scheme. The spinner carries
+// its own style rather than being rendered through one, so it is the one piece
+// of the view that has to be updated when the scheme changes rather than read
+// from the palette at draw time.
+func (m *SessionsModel) styleSpinner() {
+	m.spinner.Style = lipgloss.NewStyle().Foreground(m.colors().primary)
 }
 
 func (m SessionsModel) Init() tea.Cmd {
@@ -423,6 +470,7 @@ func (m *SessionsModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "c":
 		m.scheme = nextScheme(m.scheme)
+		m.styleSpinner()
 		go m.client.updateSettings(map[string]string{schemeSettKey: m.scheme}) //nolint:errcheck
 		return m, nil
 	}
@@ -515,7 +563,7 @@ const cardLines = 2
 
 func (m SessionsModel) renderCard(sess sessionInfo, selected bool, width int) string {
 	c := m.colors()
-	accent := sessStatusColor(sess.Status)
+	accent := c.statusColor(sess.Status)
 
 	// Card uses lipgloss border on left side only for the accent stripe.
 	// Inner width: total - border(1) - padding(2)
@@ -622,6 +670,13 @@ func (m SessionsModel) View() string {
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(c.primary)
 	countStyle := lipgloss.NewStyle().Foreground(c.onSurfaceMuted)
 	dimText := lipgloss.NewStyle().Foreground(c.onSurfaceDim)
+	searchLabel := lipgloss.NewStyle().Foreground(c.primary)
+	sepStyle := lipgloss.NewStyle().Foreground(c.separator)
+	errStyle := lipgloss.NewStyle().Foreground(c.statusError)
+	frame := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(c.outline).
+		Padding(0, 1)
 
 	var content strings.Builder
 
@@ -638,7 +693,7 @@ func (m SessionsModel) View() string {
 	content.WriteString(title + strings.Repeat(" ", titleGap) + count + "\n")
 
 	// ── Search box ──
-	searchContent := sessSearchLabel.Render("🔍 ")
+	searchContent := searchLabel.Render("🔍 ")
 	if m.searching {
 		searchContent += m.search.View()
 	} else if m.search.Value() != "" {
@@ -656,13 +711,13 @@ func (m SessionsModel) View() string {
 	// ── Loading / error / empty ──
 	if m.loading && len(m.sessions) == 0 {
 		content.WriteString(fmt.Sprintf("\n  Loading... %s\n", m.spinner.View()))
-		return sessBorderStyle.Width(m.width - 4).Render(content.String())
+		return frame.Width(m.width - 4).Render(content.String())
 	}
 
 	if m.errMsg != "" {
-		content.WriteString("\n" + errorStyle.Render("  "+m.errMsg) + "\n")
+		content.WriteString("\n" + errStyle.Render("  "+m.errMsg) + "\n")
 		content.WriteString(m.renderHelp(iw))
-		return sessBorderStyle.Width(m.width - 4).Render(content.String())
+		return frame.Width(m.width - 4).Render(content.String())
 	}
 
 	if len(m.filtered) == 0 {
@@ -673,7 +728,7 @@ func (m SessionsModel) View() string {
 			content.WriteString(dimText.Render("  No matches.") + "\n")
 		}
 		content.WriteString(m.renderHelp(iw))
-		return sessBorderStyle.Width(m.width - 4).Render(content.String())
+		return frame.Width(m.width - 4).Render(content.String())
 	}
 
 	content.WriteString("\n")
@@ -702,12 +757,12 @@ func (m SessionsModel) View() string {
 	}
 
 	// ── Separator ──
-	content.WriteString(sessSepStyle.Render(strings.Repeat("┈", iw)) + "\n")
+	content.WriteString(sepStyle.Render(strings.Repeat("┈", iw)) + "\n")
 
 	// ── Help ──
 	content.WriteString(m.renderHelp(iw))
 
-	return sessBorderStyle.Width(m.width - 4).Render(content.String())
+	return frame.Width(m.width - 4).Render(content.String())
 }
 
 func (m SessionsModel) renderHelp(width int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -11,40 +11,53 @@ import (
 	"github.com/kamrul1157024/helios/internal/tailscale"
 )
 
+// The setup screens paint no background of their own, so this text lands on
+// whatever the terminal's is. Every colour is stated for both, because the
+// single values these used to be were picked against a dark terminal and left
+// the light one with a pale amber warning and a pale blue URL on white — the
+// two lines on the screen a user most needs to read. Each side clears 4.5:1.
+var (
+	accentColor = lipgloss.AdaptiveColor{Light: "28", Dark: "70"}   // green
+	dimColor    = lipgloss.AdaptiveColor{Light: "241", Dark: "245"} // grey
+	linkColor   = lipgloss.AdaptiveColor{Light: "25", Dark: "75"}   // blue
+	dangerColor = lipgloss.AdaptiveColor{Light: "124", Dark: "203"} // red
+	warnColor   = lipgloss.AdaptiveColor{Light: "130", Dark: "214"} // amber
+)
+
 var (
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("70"))
+			Foreground(accentColor)
 
 	subtitleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
+			Foreground(dimColor)
 
 	checkStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("70"))
+			Foreground(accentColor)
 
 	crossStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
+			Foreground(dangerColor)
 
 	dimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
+			Foreground(dimColor)
 
 	selectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("70")).
+			Foreground(accentColor).
 			Bold(true)
 
 	urlStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("75")).
+			Foreground(linkColor).
 			Underline(true)
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
+			Foreground(dangerColor)
 
 	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241")).
+			Foreground(dimColor).
 			MarginTop(1)
 
 	warnStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("214"))
+			Foreground(warnColor)
 )
 
 // copyableURL renders a URL on a line of its own, flush left and with nothing


### PR DESCRIPTION
## Summary

Text was unreadable in most themes other than the default. I measured the running app over CDP rather than trusting the resolver's output, walking every leaf text node and comparing its colour against the background actually painted behind it.

**All 17 bundled themes report 0 failing text nodes in the real DOM**, checked by switching theme at runtime and re-auditing each one.

### Floors

| role | floor | why |
|---|---|---|
| `--on-surface`, `--syn-fg` | **7** (AAA) | the colour most of the window is read in |
| `--on-primary-container`, `--on-error-container` | **7**, best-effort | the user's own messages sit here at 14px |
| `--on-surface-variant` | 4.5 | secondary, but set at 10.5px on session rows |
| `--primary`, `--error`, `--s-*` | 4.5 | words, not just dots — "Active" is 10.5px |
| terminal ANSI | 4.5 | dense small text |
| `--syn-comment` | 3 | receding is what a comment is for |

AA is a minimum, and for `--on-surface` the minimum had become the actual value: solarized-dark resolved to 5.14:1 body text, which passes and still reads as grey mush on dark teal. Most themes state a foreground well clear of 7 already — monokai's is 11:1 — so the higher floor only bites on the few that are deliberately low-contrast.

### Causes

**Floors were measured against the wrong background.** Every role was compared to `editor.background`, the *lowest* surface in the app. The UI draws on a ladder of raised surfaces (`--surface-high` and `--surface-highest` back 29 rules in `styles.css`) and every rung is mixed towards the foreground, so each one ate contrast nobody re-checked. Sixteen of seventeen themes shipped text under the floor. Roles now measure against `surface-highest` — clearing the worst rung clears every rung below.

**Syntax and terminal colours were never enforced at all.** Nord's comment sat at 1.44:1 on the code bed. github-light's terminal yellow sat at 2.13:1 on white, which is the colour a CLI writes its warnings in; solarized-light had 15 of 18 palette entries under floor.

`black`, `white` and `brightWhite` are deliberately left as the theme states them — those are asked for as fills or as the inverse of one, and forcing `brightWhite` off a white terminal would turn white-on-blue text black.

**Nine stylesheet variables were undefined.** `--muted --ok --warn --info --danger --accent --bg --border --hover`, 18 uses, all in the session-row and picker block. Four carried hardcoded dark-theme hex fallbacks painted on white; the other five had no fallback, so the declaration was invalid at computed-value time and the element silently inherited its parent's colour.

**`opacity` scaled compliant colours back under the floor.** `.row-model` 0.8, `.file-chip-icon` 0.7, `.update-note` 0.8, and worst `:root.dim-pulse .pulse` at 0.35 — that one rode the status *word*, taking "Active" to 1.28:1 for half of every timer cycle. The fade is now scoped to the `.dot` graphic. `.row-status.pulse` referenced a `@keyframes pulse` that exists nowhere, so that rule is gone.

**The TUI had the same shape of bug from a different mechanism.** Status accents, borders and the separator were package-level constants shared by every scheme, so `forest` drew a green "active" dot on its green card at 2.89:1 and its separator was invisible at 1.00:1. Per-scheme now. The setup screens have no scheme — they draw on the terminal's own background — so their colours became `lipgloss.AdaptiveColor`; the amber warning measured 1.84:1 on a light terminal.

## Liquid glass

Both glass themes resolve **byte-identical to `main`** — glass spec, mesh backdrop, blur, palette and translucent terminal background.

That needed one extra change. The backdrop derives its mesh from `--primary`, and a floor high enough for that role to read as text rejects a key the theme declared and falls through to the next, so liquid-glass-light's gradient initially came out a deeper blue than asked for. The backdrop now reads the accent the theme *states* rather than the one the floor settled on: a mesh behind glass carries no text, so nudging it towards white buys nothing and costs the theme its palette.

The only remaining movement is the backdrop picker's swatches for the two solarized themes, which follow their declared accent (`focusBorder`) instead of the derived ANSI fallback. Neither is a glass theme, so neither paints a backdrop.

## Trade-offs

`ensureContrast` travels towards white or black and keeps hue, so themes stay recognisable, but strongly-tinted accents read brighter than their originals. Where a mid-tone container makes 7:1 unreachable in either direction the floor is best-effort. Dropping the opacity on `.update-note` and `.row-model` removes the hierarchy those bought; the banner keeps its separation via font-weight, but the session row's model label is now the same weight as its siblings.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all pass
- [x] `npx tsc --noEmit` clean; `npm test` 161/161
- [x] Both sweeps read the real themes rather than fixtures, so a theme or scheme added later is covered without editing the test: `desktop/test/theme-resolve.test.ts` over `themes/*.json`, `internal/tui/schemes_test.go` over `schemes`
- [x] **All 17 themes driven through the running app over CDP**, switching at runtime via `theme.set()`, auditing every leaf text node against its real composited background and folding in `opacity` — 0 failures each. Hover-reveal affordances at `opacity: 0` and disabled controls excluded, both WCAG-exempt
- [x] Terminal tab checked in light mode; ANSI palette verified against the terminal background for all 17
- [x] TUI run in tmux across all six schemes, reading SGR codes off the pane: `forest` now emits 194/151/108/109/102/114/120/248 on its 22/23 cards
- [x] liquid-glass and liquid-glass-light diffed against `main` — identical