### PR TITLE
fix(desktop): keep the app resident on close, and stop the HUD taking focus

### DIFF
--- a/desktop/src/main/hud.ts
+++ b/desktop/src/main/hud.ts
@@ -98,6 +98,13 @@ export class Hud {
       show: false,
       frame: false,
       transparent: true,
+      // An NSPanel rather than an ordinary window, which is what lets the HUD
+      // be clicked without Helios becoming the frontmost app. A normal window
+      // can be made key, and `acceptFirstMouse` below means the first click
+      // both presses the button and activates — so answering an approval
+      // dragged application focus across with it, and a tiling window manager
+      // followed. A non-activating panel hosts controls without any of that.
+      ...(process.platform === 'darwin' ? { type: 'panel' } : {}),
       // The cards draw their own shadow; a window shadow would outline the
       // transparent region instead of the cards.
       hasShadow: false,

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -217,9 +217,28 @@ function createWindow(): void {
   })
 
   window.once('ready-to-show', () => window?.show())
+
+  /*
+   * The close button puts the window away; it does not end the app.
+   *
+   * Staying resident is the point of the tray, and tearing the window down took
+   * every terminal with it — so the app that was still "running" had dropped
+   * exactly the connections it was staying alive to keep. Hiding keeps them,
+   * and reopening is then instant rather than a reconnect.
+   *
+   * The dock icon goes with the window. An icon in the dock says there is
+   * something to switch to, and after this there is not: the tray is where the
+   * app now lives, and it has an Open Helios item to come back through.
+   */
+  window.on('close', (event) => {
+    if (quitting) return
+    event.preventDefault()
+    window?.hide()
+    if (process.platform === 'darwin') app.dock?.hide()
+  })
+
   window.on('closed', () => {
     window = null
-    terminals?.closeAll()
   })
 
   // Nothing in this app should navigate. Links open in the user's browser, and
@@ -279,6 +298,9 @@ function serveBackdrops(): void {
 }
 
 function focusWindow(): void {
+  // Put the icon back before the window, so the app is a switchable one again
+  // by the time it appears.
+  if (process.platform === 'darwin') void app.dock?.show()
   if (!window) {
     createWindow()
     return


### PR DESCRIPTION
## Summary

Two reported problems: the close button didn't close the app the way Quit does, and notifications disturbed window-manager focus.

### The close button

`quitting` is only ever set inside `quit()`, so `window-all-closed` (`main.ts:140`) rejected the close on every platform — on macOS for the platform check, on Linux and Windows because the flag was still false. The process survived; Quit set the flag first, so it got through. That much is conventional for a tray app, but two things made it read as broken:

- The window's `closed` handler called `terminals.closeAll()`, four lines below a comment saying that staying resident is the point and *"closing the window should not stop approvals from arriving"*. Notifications did survive — `Notifier` only depends on `hosts`/SSE — but every terminal was torn down and rebuilt on reopen. The resident app was half-alive.
- The dock still showed an icon for a window that no longer existed. There's no `LSUIElement` and no `app.dock.hide()` anywhere.

The window is now hidden instead of destroyed, so terminals stay connected and reopening is instant, and the dock icon goes with it so the tray reads as where the app lives. `focusWindow` restores the icon before showing the window.

Quit is untouched. `before-quit` sets `quitting` before any window closes, so the menu item, the tray item and Cmd+Q all still exit — verified below.

### The HUD

`hud.ts` created an ordinary `BrowserWindow`, held it at the `screen-saver` level and marked it visible on all workspaces. The show path was already correct — `showInactive()`, never `show()` — but the window *class* was the problem: an ordinary `NSWindow` can be made key, and with `acceptFirstMouse: true` the first click both presses the button and activates the app. So answering an approval pulled application focus across with it, and a tiling window manager followed.

On macOS it is now an `NSPanel` (`type: 'panel'`), which can host controls without making its app frontmost. Non-macOS is unchanged.

## Verification

Driven through the Electron main process over the inspector, calling `BrowserWindow.close()` — the same path the red cross fires:

| | before close | after close | after reopen |
|---|---|---|---|
| windows | 1 | 1 | 1 |
| `isDestroyed()` | false | **false** | false |
| `isVisible()` | true | **false** | true |
| dock icon | true | **false** | true |
| renderer alive | yes | **yes** | yes |

The renderer surviving is what keeps the terminals connected. `app.quit()` afterwards exited cleanly.

Worth knowing: a renderer-side `window.close()` bypasses the `close` event and destroys the window outright. Nothing in `src/renderer` or `src/preload` calls it, so that path is unreachable in the app, but it's why the first attempt at reproducing this looked like the fix hadn't worked.

For the HUD, a window created with the same options confirms macOS accepts `type: 'panel'` and that it does not become the focused window when shown with `showInactive()`.

## Test plan

- [x] `npx tsc --noEmit` clean; `npm test` 161/161
- [x] `go build ./... && go vet ./...` clean
- [x] Close / reopen / quit cycle exercised against the running app via the main-process inspector, table above
- [x] Panel type accepted on macOS, does not take focus on `showInactive()`
- [ ] **Needs your confirmation:** that answering a HUD approval no longer moves AeroSpace's focus. I can make the change but can't verify the tiling-WM interaction from here

If the panel still misbehaves, the next lever is `setVisibleOnAllWorkspaces` at `hud.ts:123` — it sets `NSWindowCollectionBehaviorCanJoinAllSpaces`, which is what puts the HUD on every AeroSpace workspace. It's there so approvals reach you wherever you are, so I left it alone.