### PR TITLE
fix(desktop): keep the files panel's state per session

### DIFF
--- a/desktop/src/renderer/components/editor.tsx
+++ b/desktop/src/renderer/components/editor.tsx
@@ -22,6 +22,20 @@ export interface Cursor {
   seq: number
 }
 
+/**
+ * Where a file was last being read.
+ *
+ * The scroll offset is kept as well as the caret because the two are not the
+ * same answer: a caret scrolled back into view lands wherever the editor
+ * chooses to put it, which is rarely where the reader had it.
+ */
+export interface ReadingPosition {
+  line: number
+  column: number
+  /** Pixels down the scroller. */
+  top: number
+}
+
 /** Where the pointer was, and the lines it was pointing at. */
 export interface ContextTarget {
   x: number
@@ -38,6 +52,9 @@ interface Props {
   onChange: (text: string) => void
   onSave: () => void
   cursor?: Cursor | null
+  /** Where the file was left last time. Applied once, as the buffer is built. */
+  restore?: ReadingPosition | null
+  onViewChange?: (at: ReadingPosition) => void
   onContextMenu?: (target: ContextTarget) => void
 }
 
@@ -56,13 +73,27 @@ export function CodeEditor({
   onChange,
   onSave,
   cursor,
+  restore,
+  onViewChange,
   onContextMenu,
 }: Props): JSX.Element {
   const host = useRef<HTMLDivElement | null>(null)
   const view = useRef<EditorView | null>(null)
   // Held in refs so a new callback identity does not tear down the editor.
-  const handlers = useRef({ onChange, onSave, onContextMenu })
-  handlers.current = { onChange, onSave, onContextMenu }
+  const handlers = useRef({ onChange, onSave, onContextMenu, onViewChange })
+  handlers.current = { onChange, onSave, onContextMenu, onViewChange }
+  // Read once, when the buffer is built. As a prop it would rebuild the editor
+  // every time the position it describes changed, which is every keystroke.
+  const restoreRef = useRef(restore)
+  restoreRef.current = restore
+
+  const report = (editor: EditorView): void => {
+    const handle = handlers.current.onViewChange
+    if (!handle) return
+    const head = editor.state.selection.main.head
+    const line = editor.state.doc.lineAt(head)
+    handle({ line: line.number, column: head - line.from + 1, top: editor.scrollDOM.scrollTop })
+  }
 
   useEffect(() => {
     if (!host.current) return
@@ -88,6 +119,7 @@ export function CodeEditor({
         EditorView.editable.of(!readOnly),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) handlers.current.onChange(update.state.doc.toString())
+          if (update.docChanged || update.selectionSet) report(update.view)
         }),
         EditorView.domEventHandlers({
           contextmenu: (event, editor) => {
@@ -115,7 +147,23 @@ export function CodeEditor({
     const created = new EditorView({ state, parent: host.current })
     view.current = created
     created.focus()
+
+    const start = restoreRef.current
+    if (start) {
+      const line = created.state.doc.line(Math.min(Math.max(start.line, 1), created.state.doc.lines))
+      created.dispatch({ selection: { anchor: Math.min(line.from + Math.max(start.column - 1, 0), line.to) } })
+      // After a frame: the scroller has no height until the buffer is laid out,
+      // and a scrollTop set against a zero height is silently clamped to nought.
+      requestAnimationFrame(() => {
+        if (view.current === created) created.scrollDOM.scrollTop = start.top
+      })
+    }
+
+    const onScroll = (): void => report(created)
+    created.scrollDOM.addEventListener('scroll', onScroll, { passive: true })
+
     return () => {
+      created.scrollDOM.removeEventListener('scroll', onScroll)
       created.destroy()
       view.current = null
     }

--- a/desktop/src/renderer/components/file-tree.tsx
+++ b/desktop/src/renderer/components/file-tree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
 import type { FileEntry } from '../../shared/models.ts'
@@ -11,6 +11,13 @@ interface Props {
   selected: string | null
   /** A file to scroll to and expand the ancestors of, e.g. from quick open. */
   reveal: string | null
+  /**
+   * Directories to show open. Owned by the panel because it is remembered per
+   * session, and a root is not a session: two sessions in one repository share
+   * one.
+   */
+  expanded: Set<string>
+  onExpandedChange: (next: Set<string>) => void
   onOpen: (path: string) => void
 }
 
@@ -21,10 +28,21 @@ interface Props {
  * agent's repository is big enough that reading it all up front would stall the
  * panel, and small enough that holding what was opened costs nothing.
  */
-export function FileTree({ hostId, root, selected, reveal, onOpen }: Props): JSX.Element {
+export function FileTree({
+  hostId,
+  root,
+  selected,
+  reveal,
+  expanded,
+  onExpandedChange,
+  onOpen,
+}: Props): JSX.Element {
   const [children, setChildren] = useState<Record<string, FileEntry[]>>({})
-  const [expanded, setExpanded] = useState<Set<string>>(new Set([root]))
   const [busy, setBusy] = useState<Set<string>>(new Set())
+  // Read by the reveal effect, which adds to what is already open without
+  // wanting to re-run every time that changes.
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(
@@ -49,46 +67,44 @@ export function FileTree({ hostId, root, selected, reveal, onOpen }: Props): JSX
     [hostId],
   )
 
-  // A new root is a different session's directory: start over.
+  // A new root is a different directory: nothing listed for the old one means
+  // anything here.
   useEffect(() => {
     setChildren({})
-    setExpanded(new Set([root]))
     void load(root)
   }, [hostId, root, load])
 
+  // Whatever is open has to be listed, wherever the instruction came from — a
+  // restore for this session, a reveal, or a click. Listing converges because
+  // it fills `children`, and `busy` keeps a slow directory from being asked for
+  // twice.
+  useEffect(() => {
+    for (const dir of expanded) {
+      if (dir.startsWith(root) && !children[dir] && !busy.has(dir)) void load(dir)
+    }
+  }, [expanded, children, busy, root, load])
+
   const toggle = (dir: string): void => {
-    setExpanded((current) => {
-      const next = new Set(current)
-      if (next.has(dir)) next.delete(dir)
-      else {
-        next.add(dir)
-        if (!children[dir]) void load(dir)
-      }
-      return next
-    })
+    const next = new Set(expanded)
+    if (next.has(dir)) next.delete(dir)
+    else next.add(dir)
+    onExpandedChange(next)
   }
 
   // Opening a file from quick open or the transcript should show where it
   // lives, which means listing every directory between it and the root.
   useEffect(() => {
     if (!reveal || !reveal.startsWith(root)) return
-    let cancelled = false
-    const expand = async (): Promise<void> => {
-      const parts = reveal.slice(root.length).split('/').filter(Boolean)
-      parts.pop()
-      let dir = root
-      for (const part of parts) {
-        dir = `${dir}/${part}`
-        if (cancelled) return
-        setExpanded((current) => new Set(current).add(dir))
-        if (!children[dir]) await load(dir)
-      }
+    const parts = reveal.slice(root.length).split('/').filter(Boolean)
+    parts.pop()
+    const next = new Set(expandedRef.current)
+    let dir = root
+    for (const part of parts) {
+      dir = `${dir}/${part}`
+      next.add(dir)
     }
-    void expand()
-    return () => {
-      cancelled = true
-    }
-  }, [reveal, root, load])
+    onExpandedChange(next)
+  }, [reveal, root, onExpandedChange])
 
   const rows: JSX.Element[] = []
   const push = (dir: string, depth: number): void => {

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -4,7 +4,7 @@ import { api, statusOf } from '../bridge.ts'
 import { isMarkdownPath, languageForPath, renderMarkdownBlocks } from '../markdown.ts'
 import { store, useStore } from '../store.ts'
 import { byLastTouched, type Worktree } from '../../shared/models.ts'
-import { CodeEditor, type Cursor } from './editor.tsx'
+import { CodeEditor, type Cursor, type ReadingPosition } from './editor.tsx'
 import { FileTree } from './file-tree.tsx'
 import { FindInFiles } from './find-in-files.tsx'
 import { Chevron } from './icons.tsx'
@@ -15,6 +15,12 @@ import { SelectionMenu, useTextSelection, type MenuAction } from './selection-me
 
 /** Past this the editor is read-only: CodeMirror is not a log viewer. */
 const MAX_EDIT_BYTES = 1_000_000
+
+/**
+ * How long scrolling has to stop before the position is written down. Every
+ * wheel tick is a scroll event, and none of them is worth a write on its own.
+ */
+const VIEW_SETTLE = 500
 
 interface OpenFile {
   path: string
@@ -56,6 +62,15 @@ export function FilesPanel({
   const [worktrees, setWorktrees] = useState<Worktree[]>([])
   const [files, setFiles] = useState<OpenFile[]>([])
   const [activePath, setActivePath] = useState<string | null>(null)
+  /**
+   * The directories open in the tree, held here rather than in the tree itself.
+   *
+   * The tree used to keep them and reset on a change of root, which is not the
+   * same thing as a change of session: two sessions in one repository share a
+   * root, so one silently inherited the other's open folders, and two sessions
+   * in different repositories lost them on every switch.
+   */
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [side, setSide] = useState<'tree' | 'find'>('tree')
   const [findSeq, setFindSeq] = useState(0)
   const [quickOpen, setQuickOpen] = useState(false)
@@ -66,6 +81,26 @@ export function FilesPanel({
 
   // Drafts live outside React state: a keystroke should not re-render the tree.
   const drafts = useRef<Record<string, string>>({})
+  /**
+   * Where each open file was last being read, by path.
+   *
+   * A ref for the same reason as the drafts — scrolling should not re-render
+   * the panel — with a counter to wake the save below once the reader settles.
+   */
+  const views = useRef<Record<string, ReadingPosition>>({})
+  const [viewTick, setViewTick] = useState(0)
+  const viewTimer = useRef<number | null>(null)
+  const noteView = useCallback((path: string, at: ReadingPosition): void => {
+    views.current[path] = at
+    if (viewTimer.current !== null) window.clearTimeout(viewTimer.current)
+    viewTimer.current = window.setTimeout(() => setViewTick((tick) => tick + 1), VIEW_SETTLE)
+  }, [])
+  useEffect(
+    () => () => {
+      if (viewTimer.current !== null) window.clearTimeout(viewTimer.current)
+    },
+    [],
+  )
   const filesRef = useRef<OpenFile[]>(files)
   filesRef.current = files
 
@@ -152,7 +187,17 @@ export function FilesPanel({
   // A session is looked away from and come back to all day; losing the tabs
   // every time makes the panel a viewer rather than a place to work.
   const memory = `helios.files.${hostId}.${sessionId}`
-  const restored = useRef<string | null>(null)
+  /**
+   * Which session the tabs below currently belong to, or null mid-restore.
+   *
+   * State rather than a ref, because the save effect has to see this change in
+   * the same commit as `files`. A ref was visible to the render that still held
+   * the outgoing session's tabs: switching to a session with nothing saved left
+   * the restore with nothing to await, so it ran to completion synchronously
+   * and marked itself done before React had flushed the clear — and the save
+   * that followed wrote the previous session's files under the new key.
+   */
+  const [loadedFor, setLoadedFor] = useState<string | null>(null)
   // Set when something asked for a specific file while the restore below was
   // still running. Opening the panel *by* asking for a file is the common case
   // — an agent's helios_show mounts it — and the restore finishes last, so
@@ -160,7 +205,7 @@ export function FilesPanel({
   const claimed = useRef(false)
 
   useEffect(() => {
-    restored.current = null
+    setLoadedFor(null)
     claimed.current = false
     setFiles([])
     setActivePath(null)
@@ -169,6 +214,8 @@ export function FilesPanel({
 
     const saved = readWorkspace(memory)
     setRootOverride(saved?.root ?? null)
+    setExpanded(new Set(saved?.expanded ?? []))
+    views.current = saved?.view ?? {}
 
     let cancelled = false
     void (async () => {
@@ -180,7 +227,7 @@ export function FilesPanel({
       }
       if (cancelled) return
       if (saved?.active && !claimed.current) setActivePath(saved.active)
-      restored.current = memory
+      setLoadedFor(memory)
     })()
     return () => {
       cancelled = true
@@ -190,13 +237,19 @@ export function FilesPanel({
   useEffect(() => {
     // Not before the restore for this session has finished, or the empty state
     // it starts from would overwrite what is on disk.
-    if (restored.current !== memory) return
+    if (loadedFor !== memory) return
     writeWorkspace(memory, {
       root: rootOverride,
       open: files.map((file) => file.path),
       active: activePath,
+      expanded: [...expanded],
+      // Pruned to what is open: a closed tab's position is not worth carrying,
+      // and the record would otherwise grow for the life of the session.
+      view: Object.fromEntries(
+        files.map((file) => [file.path, views.current[file.path]]).filter(([, at]) => at !== undefined),
+      ) as Record<string, ReadingPosition>,
     })
-  }, [memory, rootOverride, files, activePath])
+  }, [memory, loadedFor, rootOverride, files, activePath, expanded, viewTick])
 
   const save = useCallback(
     async (path: string): Promise<void> => {
@@ -408,6 +461,8 @@ export function FilesPanel({
             root={root}
             selected={activePath}
             reveal={reveal}
+            expanded={expanded}
+            onExpandedChange={setExpanded}
             onOpen={(path) => void openFile(path)}
           />
         ) : (
@@ -458,6 +513,8 @@ export function FilesPanel({
             onMode={(mode) =>
               setFiles((current) => current.map((f) => (f.path === active.path ? { ...f, mode } : f)))
             }
+            restore={views.current[active.path] ?? null}
+            onPositionChange={(at) => noteView(active.path, at)}
           />
         ) : (
           <div className="ws-blank">
@@ -504,6 +561,8 @@ function FileView({
   onSave,
   onReload,
   onMode,
+  restore,
+  onPositionChange,
 }: {
   file: OpenFile
   root: string
@@ -514,6 +573,9 @@ function FileView({
   onSave: () => void
   onReload: () => void
   onMode: (mode: 'edit' | 'preview') => void
+  /** Where this file was last left, or null if it has not been opened before. */
+  restore: ReadingPosition | null
+  onPositionChange: (at: ReadingPosition) => void
 }): JSX.Element {
   const markdown = isMarkdownPath(file.path)
   const rendered = markdown && file.mode === 'preview'
@@ -697,6 +759,8 @@ function FileView({
           onChange={onChange}
           onSave={onSave}
           cursor={file.cursor}
+          restore={restore}
+          onViewChange={onPositionChange}
           onContextMenu={(at) => setMenu({ x: at.x, y: at.y, range: { start: at.startLine, end: at.endLine } })}
         />
       )}
@@ -804,6 +868,10 @@ interface Workspace {
   root: string | null
   open: string[]
   active: string | null
+  /** Directories open in the tree. Absent in records written before this. */
+  expanded?: string[]
+  /** Where each file was left, by path. Absent in older records. */
+  view?: Record<string, ReadingPosition>
 }
 
 function readWorkspace(key: string): Workspace | null {


### PR DESCRIPTION
## Summary

Reported as "opened files aren't per session". They already were — `helios.files.<hostId>.<sessionId>` in localStorage — but three things around them were not, and the first lost the tabs outright.

**A race moved one session's files into another's key.** `restored` was a ref. When the session being switched to had nothing saved, the restore had nothing to `await`, so it ran to completion synchronously and set that ref before React had flushed `setFiles([])`. The save effect, declared immediately after and reading the ref in the same commit, then wrote the *outgoing* session's `files` under the *incoming* session's key. I reproduced it: session A's two tabs ended up stored under session B, and A was left empty. The marker is state now, so it cannot be read out of step with the files it describes.

**Tree expansion was not per-session.** It lived in `FileTree` and reset on a change of `root`, which is not the same thing as a change of session — two sessions in one repository silently shared their open folders, and two sessions in different repositories lost them on every switch. The panel owns it now, since the panel is what knows about sessions, and it is stored with the tabs. `FileTree` gained one effect that lists whatever is marked open, so a restored expansion fills in wherever the instruction came from — a restore, a reveal, or a click.

**Scroll and cursor were not kept at all.** Now saved per open file, debounced 500 ms so a wheel spin is not a write per tick, and pruned to the files still open so the record does not grow for the life of the session. The scroll offset is kept alongside the caret on purpose: restoring only the caret lands the reader wherever the editor decides to scroll it, which is rarely where they were.

## Verification

Driven through the running app over CDP:

| | seeded | on another session | back | after app restart |
|---|---|---|---|---|
| open tabs | `Makefile` | *(none)* | `Makefile` | `Makefile` |
| tree rows visible | 37 | 19 | 37 | 37 |
| editor scroll | 900 | — | 900 | 900 |

The other session keeps its own empty record throughout — no leak in either direction. Cursor round-trips too: clicking a line while scrolled saved `{line: 34, column: 1, top: 900}` and restored to it.

## Notes

- The new type is `ReadingPosition` rather than the obvious `FileView`, because `files.tsx` already has a local component by that name.
- `expanded` and `view` are optional on the stored record, so workspaces written before this read as empty rather than breaking.
- Scroll memory covers the CodeMirror editor only. The markdown preview and the read-only `<pre>` are separate render paths and still open at the top.

## Test plan

- [x] `npx tsc --noEmit` clean; `npm test` 161/161
- [x] `go build ./...` clean
- [x] Session switch, return, and app restart exercised against the running app — table above
- [x] Second session verified to keep its own empty record while the first holds tabs, expansion and scroll