### PR TITLE
refactor: drop the unused terminals query

### DIFF
--- a/desktop/src/renderer/keys.ts
+++ b/desktop/src/renderer/keys.ts
@@ -34,7 +34,6 @@ export const keys = {
   directories: (hostId: string) => ['host', hostId, 'directories'] as const,
   providers: (hostId: string) => ['host', hostId, 'providers'] as const,
   models: (hostId: string, provider: string) => ['host', hostId, 'models', provider] as const,
-  terminals: (hostId: string, sessionId: string) => ['host', hostId, 'terminals', sessionId] as const,
   /**
    * The epoch is deliberately not in this key.
    *
@@ -209,16 +208,13 @@ export function effectsFor(hostId: string, event: SSEEvent): CacheEffect[] {
         { kind: 'invalidate', queryKey: keys.allSessions(hostId) },
       ]
 
-    case 'terminal_opened': {
-      const sessionId = text(event.data.session_id)
-      return sessionId ? [{ kind: 'invalidate', queryKey: keys.terminals(hostId, sessionId) }] : []
-    }
-
     case 'session_evicted':
       return [{ kind: 'invalidate', queryKey: keys.host(hostId) }]
 
-    // 'show' instructs the window and 'terminal_closed' tears down a
-    // connection. Neither is a fact about anything cached.
+    // 'show' instructs the window, and the terminal events move connections:
+    // 'terminal_opened' re-lists a session's shells and attaches the ones this
+    // client is missing, 'terminal_closed' tears a tab down. The store handles
+    // all three directly. None is a fact about anything cached.
     default:
       return []
   }

--- a/desktop/src/renderer/queries.ts
+++ b/desktop/src/renderer/queries.ts
@@ -46,14 +46,6 @@ export function notificationsQuery(hostId: string) {
   })
 }
 
-export function terminalsQuery(hostId: string, sessionId: string) {
-  return queryOptions({
-    queryKey: keys.terminals(hostId, sessionId),
-    queryFn: () => api(hostId).terminals(sessionId),
-    enabled: sessionId !== '',
-  })
-}
-
 // ─── Settings ───────────────────────────────────────────────────────────────
 
 /**

--- a/desktop/test/cache-keys.test.ts
+++ b/desktop/test/cache-keys.test.ts
@@ -169,12 +169,6 @@ test('a notification invalidates the sessions as well as the notifications', () 
   }
 })
 
-test('terminal_opened invalidates that session terminals', () => {
-  assert.deepEqual(effectsFor(HOST, { type: 'terminal_opened', data: { session_id: 's1' } }), [
-    { kind: 'invalidate', queryKey: keys.terminals(HOST, 's1') },
-  ])
-})
-
 test('session_evicted takes out the whole host', () => {
   assert.deepEqual(effectsFor(HOST, { type: 'session_evicted', data: {} }), [
     { kind: 'invalidate', queryKey: keys.host(HOST) },
@@ -182,8 +176,10 @@ test('session_evicted takes out the whole host', () => {
 })
 
 test('events that are not about data touch no keys', () => {
-  // 'show' instructs the window; 'terminal_closed' tears down a connection.
+  // 'show' instructs the window; the terminal events move connections, and the
+  // store attaches or tears down the tab itself.
   assert.deepEqual(effectsFor(HOST, { type: 'show', data: {} }), [])
+  assert.deepEqual(effectsFor(HOST, { type: 'terminal_opened', data: { session_id: 's1' } }), [])
   assert.deepEqual(effectsFor(HOST, { type: 'terminal_closed', data: { terminal_id: 't1' } }), [])
   assert.deepEqual(effectsFor(HOST, { type: 'something_new', data: {} }), [])
 })


### PR DESCRIPTION
## Summary

The desktop terminal path never read through the React Query cache, but the scaffolding for it was still there.

`terminal_opened` reaches `syncShells` (`store.ts:824` → `:1092`), which lists a session's shells and attaches the ones this client is missing. It calls `api(hostId).terminals(sessionId)` directly, because it has to *act* on the answer rather than render it.

That left two paths for one event, one of which did nothing:

- `terminalsQuery` (`queries.ts`) — no callers anywhere.
- `keys.terminals` — used only by that query and by the effect below.
- The `terminal_opened` case in `effectsFor` — invalidated a key no component watched, so `invalidateQueries` was a no-op.

All three are gone. `terminal_opened` now falls to the `default` branch alongside `terminal_closed`, which is where it belonged: both move connections, and the store handles them directly.

No runtime behaviour changes. Every deleted line was unreachable or a no-op.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 193/193 pass (run under Node 22; the default v20 here predates `--experimental-strip-types`)
- [x] `npm run build` — clean
- [x] No references to `terminalsQuery` or `keys.terminals` remain in `src/` or `test/`
- [x] `syncShells` and the IPC byte stream through `bridge.term.open` are untouched