### PR TITLE
ci: build the desktop release on Node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Must match .nvmrc: `make desktop` refuses to build on anything
+          # older, because the renderer's test script strips types at runtime.
+          node-version: 22
           cache: npm
           cache-dependency-path: desktop/package-lock.json
 
@@ -88,7 +90,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Must match .nvmrc: `make desktop` refuses to build on anything
+          # older, because the renderer's test script strips types at runtime.
+          node-version: 22
           cache: npm
           cache-dependency-path: desktop/package-lock.json
 


### PR DESCRIPTION
## Summary

The v3.1.0 release failed on both desktop jobs with:

```
No Node 22+ found — run 'nvm use' in this repo (see .nvmrc), or install one
make: *** [desktop] Error 1
```

PR #114 raised the desktop's floor to Node 22 — the renderer's test script strips types at runtime, which older Node refuses to do — and added `.nvmrc` plus a guard in `make desktop`. It bumped `test.yml` to 22 to match, but `release.yml` was missed: both `Desktop (macOS)` and `Desktop (Linux)` still asked for Node 20.

Only the release path was affected, which is why CI stayed green on every PR since and this surfaced the first time a release was cut.

Both jobs now pin 22, matching `.nvmrc`, with a comment saying why so the next person does not quietly lower it again.

## Test plan

- [x] Root cause confirmed from the failed job log on run 33303207702
- [x] `.nvmrc` says 22; `test.yml` already uses 22; `release.yml` was the only place left on 20
- [ ] Re-run the Release workflow for 3.1.0 once this is merged — that is the real verification, since these jobs only run on `workflow_dispatch`