### PR TITLE
fix(desktop): let the host own the terminal's grid size

### DIFF
--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -105,6 +105,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
+  const hostSized = useRef(false)
   const theme = useStore((s) => s.terminalTheme)
 
   // Assigned rather than passed on construction: rebuilding the terminal to
@@ -188,8 +189,19 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     const apply = (): void => {
       // A hidden element measures as zero; fit() would then propose 1×1.
       if (container.clientWidth === 0 || container.clientHeight === 0) return
-      fit.fit()
-      void bridge.term.resize(tab.id, term.cols, term.rows)
+      const dims = fit.proposeDimensions()
+      if (!dims?.cols || !dims.rows) return
+      // Proposed, not applied. fit() would resize the grid here, and the host
+      // is free to refuse — it takes the smallest interactive viewer, and it
+      // stays silent when the negotiated size does not change. A grid resized
+      // to a size the host never adopted therefore never hears otherwise, and
+      // renders every redraw against a width the agent is not using.
+      //
+      // Until the first status there is nothing to adopt, so the proposal is
+      // also what to render at: a host that never reports a size would
+      // otherwise strand the terminal at xterm's 80×24 default.
+      if (!hostSized.current) term.resize(dims.cols, dims.rows)
+      void bridge.term.resize(tab.id, dims.cols, dims.rows)
     }
 
     apply()
@@ -215,6 +227,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
   useEffect(() => {
     const term = termRef.current
     if (!term || !hostCols || !hostRows) return
+    hostSized.current = true
     if (term.cols === hostCols && term.rows === hostRows) return
     term.resize(hostCols, hostRows)
   }, [hostCols, hostRows])


### PR DESCRIPTION
## Summary

The desktop terminal could end up rendering at a different width from the PTY behind it, and never recover. Typing then looked like it jumped or duplicated: the shell wraps and rewrites its line at the PTY's width, and each of those cursor moves landed in the wrong cell of a grid that disagreed, so the rewritten characters appeared beside the originals instead of over them.

Two places wrote the grid size and could disagree permanently:

- `apply()` called `fit.fit()`, which resizes the grid immediately, then asked the host for that size.
- The adopt effect resizes the grid to the host's size, but only when `tab.status.cols/rows` change.

The host takes the smallest interactive viewer (`internal/terminal/host.go:445-462`) and returns early without broadcasting when the negotiated size is unchanged (`host.go:465-471`). So when the host refused the proposed size, no status was sent, the adopt effect never re-ran, and the local grid stayed wrong.

`proposeDimensions()` sends the proposal without touching the grid, which leaves the host's status as the only thing that resizes it. The grid still follows the proposal until the first status arrives, so a host that never reports a size does not strand the terminal at xterm's 80x24 default.

## Test plan

Measured xterm's columns against the PTY's over CDP, with a second interactive viewer pinned at 60 columns.

- [x] Clamped to 60, then resize the window — was 130 vs 60, now 60 vs 60
- [x] 2px nudge — was 131 vs 60, now 60 vs 60
- [x] Leave the terminal panel and return — was 131 vs 60, now 60 vs 60
- [x] Undo the resize — was 81 vs 60, now 60 vs 60
- [x] No clamping viewer: the terminal still follows the window (81 → 130 → 131 → 81), matched at every step
- [x] `npm test` — 193/193
- [x] `tsc --noEmit`
- [x] `go build ./...`