### PR TITLE
fix: reinstall desktop deps when node_modules is stale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,10 +160,15 @@ NPM = $(shell \
 # npm's shebang is `env node`, so its directory has to be on PATH too.
 NODE_ENV_PATH = PATH="$(patsubst %/npm,%,$(NPM)):$$PATH"
 
-## Install node deps if missing, then bundle main, preload and renderer
+## Install node deps if missing or stale, then bundle main, preload and renderer
 desktop:
 	@test -n "$(NPM)" || (echo "No Node $(NODE_MIN)+ found — run 'nvm use' in this repo (see .nvmrc), or install one" >&2 && exit 1)
-	@if [ ! -d desktop/node_modules ]; then cd desktop && $(NODE_ENV_PATH) npm install; fi
+	# Reinstall when node_modules is absent OR older than the lockfile: a stale
+	# tree left over from before a dependency was added would otherwise be used,
+	# and the build fails with confusing "cannot find module" typecheck errors.
+	@if [ ! -d desktop/node_modules ] || [ desktop/package-lock.json -nt desktop/node_modules ]; then \
+		cd desktop && $(NODE_ENV_PATH) npm ci; \
+	fi
 	cd desktop && $(NODE_ENV_PATH) npm run typecheck && $(NODE_ENV_PATH) npm run build
 	@echo "Desktop bundles: desktop/dist"
 


### PR DESCRIPTION
Closes #123

## Description

`make desktop-install` (and any target that depends on `desktop`) failed with a wall of `TS2307: Cannot find module '@tanstack/react-query'` and cascading implicit-`any` errors, even though the dependency is declared in `desktop/package.json` and present in `package-lock.json`.

### Root cause

The `desktop` make target only installed deps when `node_modules` was **absent**:

```makefile
@if [ ! -d desktop/node_modules ]; then cd desktop && npm install; fi
```

A `node_modules` tree left over from before a dependency was added (e.g. `@tanstack/react-query`, introduced in #114) satisfies the existence check, so `npm install` is skipped and the stale tree is used — producing the confusing "cannot find module" typecheck errors.

### Fix

Also reinstall when `package-lock.json` is newer than `node_modules`, and use `npm ci` so the installed tree deterministically matches the lockfile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- Touched `desktop/package-lock.json` to simulate a stale `node_modules`, ran `make desktop` → the guard triggered `npm ci`, then `npm run typecheck` and `npm run build` both passed.
- Ran `make desktop-install` end-to-end → DMG built and `Helios.app` installed to `/Applications`.

## Testing Instructions

1. With an existing `desktop/node_modules`, run `touch desktop/package-lock.json`.
2. Run `make desktop` — it should reinstall deps (`npm ci`) before building, rather than failing typecheck.
