### PR TITLE
fix(desktop): key the detail panels by session

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,39 @@ jobs:
       - run: npm run build
         working-directory: desktop
 
+  desktop-e2e:
+    name: Desktop e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - run: npm ci
+        working-directory: desktop
+
+      # Electron is a browser, and a runner has no display or the libraries one
+      # would draw with. Playwright's own installer knows which they are.
+      - run: npx playwright install-deps chromium
+        working-directory: desktop
+
+      # xvfb-run, not a headless flag: Electron has no headless mode, and the
+      # app under test is the real window the user would see.
+      - run: xvfb-run -a npm run e2e
+        working-directory: desktop
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-traces
+          path: desktop/test-results/
+          retention-days: 7
+
   mobile:
     name: Mobile
     runs-on: ubuntu-latest

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist/
 release/
+test-results/
+playwright-report/

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -1,0 +1,172 @@
+// A daemon the app can be pointed at, with none of a daemon behind it.
+//
+// The end-to-end tests are about what the UI does when the user moves between
+// sessions, and a real daemon would make that a test of git, a real repository
+// and two live agents as well. This serves the handful of reads the panels make
+// and nothing else, so a failure is a failure of the app.
+import http from 'node:http'
+import { AddressInfo } from 'node:net'
+
+import type { FileEntry, GrepMatch, Session, Worktree } from '../src/shared/models.ts'
+
+/** The directory both sessions run in — the whole point, see session-state.spec.ts. */
+export const REPO = '/repo'
+export const OTHER_WORKTREE = '/repo-hotfix'
+
+export const ALPHA = 's-alpha'
+export const BETA = 's-beta'
+
+export interface StubDaemon {
+  url: string
+  close(): Promise<void>
+}
+
+function session(id: string, title: string): Session {
+  return {
+    session_id: id,
+    source: 'claude',
+    cwd: REPO,
+    project: 'repo',
+    title,
+    status: 'idle',
+    pinned: false,
+    created_at: '2026-01-01T00:00:00Z',
+    last_event_at: '2026-01-01T00:00:00Z',
+    supports_prompt_queue: true,
+    // Warm, so neither session reads as terminated: a terminated one closes its
+    // panels for its own reasons and would hide the behaviour under test.
+    terminal: `/tmp/helios/${id}.sock`,
+  }
+}
+
+const SESSIONS = [session(ALPHA, 'Alpha'), session(BETA, 'Beta')]
+
+const WORKTREES: Worktree[] = [
+  {
+    path: REPO,
+    branch: 'main',
+    is_main: true,
+    detached: false,
+    locked: false,
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+    date: '2026-01-02T00:00:00Z',
+  },
+  {
+    path: OTHER_WORKTREE,
+    branch: 'hotfix',
+    is_main: false,
+    detached: false,
+    locked: false,
+    ahead: 1,
+    behind: 0,
+    dirty: 2,
+    date: '2026-01-03T00:00:00Z',
+  },
+]
+
+/** One file per worktree, named after it, so a wrong root is visible on sight. */
+const TREES: Record<string, FileEntry[]> = {
+  [REPO]: [file(REPO, 'main.go'), file(REPO, 'README.md')],
+  [OTHER_WORKTREE]: [file(OTHER_WORKTREE, 'hotfix.go')],
+}
+
+function file(root: string, name: string): FileEntry {
+  return { name, path: `${root}/${name}`, is_dir: false, size: 12, mod_time: '2026-01-01T00:00:00Z' }
+}
+
+function grepMatches(root: string, query: string): GrepMatch[] {
+  const entries = TREES[root] ?? []
+  return entries.map((entry, index) => ({
+    path: entry.path,
+    rel: entry.name,
+    line: index + 1,
+    column: 1,
+    text: `${query} in ${entry.name}`,
+  }))
+}
+
+export async function startDaemon(): Promise<StubDaemon> {
+  // Held open so the process can be shut down without waiting for the event
+  // stream, which by design never ends on its own.
+  const streams = new Set<http.ServerResponse>()
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const path = url.pathname
+    const q = (name: string): string => url.searchParams.get(name) ?? ''
+
+    if (path === '/api/events') {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' })
+      res.write(': open\n\n')
+      streams.add(res)
+      req.on('close', () => streams.delete(res))
+      return
+    }
+
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(answer(path, q)))
+  })
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const stream of streams) stream.end()
+        server.close(() => resolve())
+      }),
+  }
+}
+
+/**
+ * Every read a panel makes, and an empty object for the rest.
+ *
+ * The fallback is deliberate: the app asks for more than these tests care
+ * about — settings, providers, notifications — and an empty answer is enough
+ * for all of it. A 404 would put an error where a panel should be.
+ */
+function answer(path: string, q: (name: string) => string): unknown {
+  switch (path) {
+    case '/api/health':
+      return { ok: true }
+    case '/api/sessions':
+      return {
+        sessions: SESSIONS,
+        host: { warm: 2, warm_rss: 0, budget: 8, load: 0.1, memory_used: 1, memory_total: 8 },
+      }
+    case '/api/sessions/directories':
+      return { directories: [{ cwd: REPO, project: 'repo', session_count: 2, active_count: 2 }] }
+    case '/api/git/worktrees':
+      return { worktrees: WORKTREES }
+    case '/api/git/status':
+      return {
+        root: q('path'),
+        branch: q('path') === OTHER_WORKTREE ? 'hotfix' : 'main',
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        staged: [],
+        unstaged: [],
+        untracked: [],
+      }
+    case '/api/git/log':
+      // No base branch and no commits: the git panel then opens on the working
+      // tree, which is the view these tests drive.
+      return { root: q('path'), branch: 'main', base: '', scope: 'all', commits: [], has_more: false }
+    case '/api/files':
+      return { path: q('path'), entries: TREES[q('path')] ?? [] }
+    case '/api/file':
+      return { path: q('path'), size: 12, mod_time: '2026-01-01T00:00:00Z', content: 'package main\n' }
+    case '/api/files/grep':
+      return { root: q('path'), matches: grepMatches(q('path'), q('q')), scanned: 2, truncated: false }
+    case '/api/files/search':
+      return { root: q('path'), matches: [], scanned: 0, truncated: false }
+    default:
+      if (path.endsWith('/transcript')) return { messages: [], total: 0, returned: 0, offset: 0, has_more: false }
+      return {}
+  }
+}

--- a/desktop/e2e/fixtures.ts
+++ b/desktop/e2e/fixtures.ts
@@ -1,0 +1,63 @@
+// Launching the packaged renderer against the stub daemon, once per test.
+//
+// The app is given a throwaway user data directory with a host already in it.
+// Pairing is not what these tests are about, and the registry reads a host from
+// hosts.json exactly as it would after a real pairing — a plaintext seed is the
+// same shape it stores on a machine with no keyring.
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { _electron as electron, test as base, type ElectronApplication, type Page } from '@playwright/test'
+
+import { startDaemon, type StubDaemon } from './daemon.ts'
+
+export const HOST_ID = 'e2e-host'
+
+interface Fixtures {
+  daemon: StubDaemon
+  app: ElectronApplication
+  window: Page
+}
+
+export const test = base.extend<Fixtures>({
+  daemon: async ({}, use) => {
+    const daemon = await startDaemon()
+    await use(daemon)
+    await daemon.close()
+  },
+
+  app: async ({ daemon }, use) => {
+    const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'helios-e2e-'))
+    await fs.writeFile(
+      path.join(userData, 'hosts.json'),
+      JSON.stringify([
+        {
+          id: HOST_ID,
+          name: 'stub',
+          url: daemon.url,
+          device_id: HOST_ID,
+          local: false,
+          secret: crypto.randomBytes(32).toString('base64url'),
+          encrypted: false,
+        },
+      ]),
+    )
+
+    // '.' is the desktop package: the suite is run by `npm run e2e`, which puts
+    // the working directory there and has already built dist/.
+    const app = await electron.launch({ args: ['.', `--user-data-dir=${userData}`] })
+    await use(app)
+    await app.close()
+    await fs.rm(userData, { recursive: true, force: true })
+  },
+
+  window: async ({ app }, use) => {
+    const window = await app.firstWindow()
+    await window.waitForLoadState('domcontentloaded')
+    await use(window)
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/desktop/e2e/session-state.spec.ts
+++ b/desktop/e2e/session-state.spec.ts
@@ -1,0 +1,97 @@
+// Two sessions, one directory.
+//
+// Everything a panel holds is per session, and the case that used to break it
+// is two sessions in the same checkout: the panels reset themselves on a change
+// of directory, which never came, so the second session opened on the first
+// one's search, file and worktree. These drive that switch and check what is on
+// screen afterwards.
+import type { Locator, Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+const BETA = 'Beta'
+
+/**
+ * The panel on screen.
+ *
+ * Panels the user has visited stay mounted behind `hidden` so a tab switch does
+ * not throw away where they were, which means an unscoped selector matches the
+ * panel nobody is looking at as readily as the one they are.
+ */
+function shown(window: Page): Locator {
+  return window.locator('.panel-keep:not([hidden])')
+}
+
+async function open(window: Page, title: string): Promise<void> {
+  await window.locator('.session-row', { hasText: title }).click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+}
+
+async function showPanel(window: Page, label: string): Promise<void> {
+  await window.locator('.panel-tabs button', { hasText: label }).first().click()
+  await expect(shown(window)).toBeVisible()
+}
+
+/**
+ * Leaves both sessions on the same panel, which is the state the leak needs.
+ *
+ * Which panel a session is on is remembered per session, so a session that has
+ * never been shown one opens on the agent transcript — and a panel that is not
+ * on screen for either session is torn down for reasons that have nothing to do
+ * with what is under test. Two sessions sat on the same panel is also the
+ * ordinary way to work: read the same file on two branches.
+ */
+async function bothOn(window: Page, label: string): Promise<void> {
+  await open(window, BETA)
+  await showPanel(window, label)
+  await open(window, ALPHA)
+  await showPanel(window, label)
+}
+
+test.beforeEach(async ({ window }) => {
+  await expect(window.locator('.session-row', { hasText: ALPHA })).toBeVisible()
+})
+
+test('a search typed in one session does not follow into the next', async ({ window }) => {
+  await bothOn(window, 'files')
+
+  await shown(window).locator('.ws-view', { hasText: 'Search' }).click()
+  await shown(window).locator('.find-input').fill('needle')
+  await shown(window).locator('.find-input').press('Enter')
+  await expect(shown(window).locator('.find-input')).toHaveValue('needle')
+
+  await open(window, BETA)
+
+  // Beta opens on the explorer, which is where a session with no history of
+  // its own starts. The search field belongs to a view nobody asked for here.
+  await expect(shown(window).locator('.find-input')).toHaveCount(0)
+  await expect(shown(window).locator('.ws-view.on')).toHaveText('Explorer')
+})
+
+test('an open file does not follow into the next session', async ({ window }) => {
+  await bothOn(window, 'files')
+
+  await shown(window).locator('.tree-row', { hasText: 'main.go' }).click()
+  await expect(shown(window).locator('.ws-tab')).toHaveCount(1)
+
+  await open(window, BETA)
+
+  await expect(shown(window).locator('.ws-tab')).toHaveCount(0)
+  await expect(shown(window).locator('.ws-blank')).toBeVisible()
+})
+
+test('a worktree picked in one session does not follow into the next', async ({ window }) => {
+  await bothOn(window, 'git')
+
+  await shown(window).locator('.ws-view', { hasText: 'Worktrees' }).click()
+  await shown(window).locator('.worktree', { hasText: 'hotfix' }).click()
+  // The pill is the panel saying it is pointed somewhere other than the
+  // session's own checkout.
+  await expect(shown(window).locator('.git-head .pill')).toHaveText(/repo-hotfix/)
+
+  await open(window, BETA)
+
+  await expect(shown(window).locator('.git-head .pill')).toHaveCount(0)
+  await expect(shown(window).locator('.git-head .branch')).toHaveText('main')
+})

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -25,6 +25,7 @@
         "@codemirror/search": "^6.7.1",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.8",
+        "@playwright/test": "^1.62.1",
         "@tanstack/react-query": "^5.102.8",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
@@ -1455,6 +1456,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -3742,6 +3759,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5279,6 +5311,38 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/plist": {
       "version": "3.1.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,6 +15,7 @@
     "dev": "node build.mjs && electron .",
     "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types test/*.test.ts",
+    "e2e": "node build.mjs && playwright test",
     "dist": "node build.mjs && electron-builder --config electron-builder.yml"
   },
   "dependencies": {
@@ -35,6 +36,7 @@
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.8",
+    "@playwright/test": "^1.62.1",
     "@tanstack/react-query": "^5.102.8",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test'
+
+// One worker: each test launches its own Electron app, and several at once on
+// a CI runner is how an end-to-end suite becomes a flaky one.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['github']] : [['list']],
+  // A failure here is a failure of a window nobody was watching, so it has to
+  // leave enough behind to be read afterwards.
+  use: { trace: 'retain-on-failure', screenshot: 'only-on-failure' },
+})

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -215,8 +215,13 @@ export function Detail(): JSX.Element {
 
         {hostId &&
           session &&
+          // Keyed by session as well as panel. A panel holds where the user was
+          // in one session — the file open, the worktree picked, the search
+          // typed — and none of that means anything in the next one. Without
+          // the session in the key the instance survives the switch, and every
+          // panel has to remember to clear itself.
           KEEP_MOUNTED.filter((name) => name === panel || kept[name]).map((name) => (
-            <div key={name} className="panel-keep" hidden={name !== panel}>
+            <div key={`${sessionKey}:${name}`} className="panel-keep" hidden={name !== panel}>
               <PanelBoundary resetKey={`${hostId}:${session.session_id}:${name}`}>
                 {/* Approvals ride alongside the transcript instead of behind
                     their own tab: an agent that stops for permission stops the

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -20,5 +20,12 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "build.mjs"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "e2e/**/*.ts",
+    "playwright.config.ts",
+    "build.mjs"
+  ]
 }


### PR DESCRIPTION
## The bug

Switching sessions carried panel state across: the file search typed in one
session, the worktree picked in another, the selected diff.

`detail.tsx` rendered each kept panel under `key={name}` — the panel's name,
not the session's. React therefore kept the same `FilesPanel` and `GitPanel`
instances alive across a switch, and each panel was left to notice the change
and clear itself. They all did that by watching the working directory
(`[hostId, cwd]`, `[hostId, root]`), which does not change between two sessions
in the same checkout. Two agents on one repository is the ordinary case here,
so the reset never ran.

## The fix

One line: put the session in the key.

```diff
-<div key={name} className="panel-keep" hidden={name !== panel}>
+<div key={`${sessionKey}:${name}`} className="panel-keep" hidden={name !== panel}>
```

A switch is now a remount, so the whole class goes — including the state no
panel had thought to clear (`side`, the find query, the quick-open and root
pickers, per-file folds) and the same trap for any panel added later. Nothing
the user chose is lost: the files workspace and the git scope are already
persisted per session and restore on mount.

## Tests

New Playwright + Electron suite (`desktop/e2e/`). It launches the real window
against a stub daemon serving two sessions that share one directory, seeded
through a throwaway `hosts.json` so pairing is not part of the test.

- a search typed in one session does not follow into the next — **fails without the fix**
- a worktree picked in one session does not follow into the next — **fails without the fix**
- an open file does not follow into the next session — passes either way; it guards the restore path that already handled this

`npm run e2e` builds and runs it. CI gets a `Desktop e2e` job under xvfb, with
traces uploaded on failure.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 193 pass
- [x] `npm run e2e` — 3 pass
- [x] reverted the fix and re-ran: 2 of 3 fail