### PR TITLE
feat(desktop): editor groups, so two panels can sit side by side

### DIFF
--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -4,13 +4,26 @@ import { useQuery } from '@tanstack/react-query'
 import { api } from '../bridge.ts'
 import { useHostNotifications, useHostSessions } from '../host-data.ts'
 import { providersQuery } from '../queries.ts'
-import { currentPanel, currentTab, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
+import { currentLayout, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { ChatPanel } from './chat.tsx'
 import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
 import { GitPanel } from './git.tsx'
-import { TerminalPanes } from './terminal.tsx'
+import {
+  isVisible,
+  panelItem,
+  panelOf,
+  placedItems,
+  sweep,
+  tabOf,
+  termItem,
+  type Edge,
+  type Group,
+  type ItemId,
+  type Layout,
+} from './layout.ts'
+import { TerminalPane, TerminalPlaceholder } from './terminal.tsx'
 import {
   BUSY_STATUSES,
   canResume,
@@ -32,33 +45,52 @@ const PANEL_LABELS: Record<RightPanel, string> = {
   files: 'files',
 }
 
-/**
- * Every panel but the terminal, which keeps itself mounted a level up.
- *
- * A panel holds work as much as it displays it — a file open in the editor, a
- * diff scrolled to the hunk being read, a transcript scrolled back through —
- * and unmounting on a tab switch throws all of it away. Once opened they stay
- * mounted and hidden.
- */
-const KEEP_MOUNTED: RightPanel[] = ['chat', 'approvals', 'git', 'files']
-
 /** How long an unseen panel keeps its state before it is unmounted. */
 const PANEL_TTL = 5 * 60 * 1000
 const SWEEP_INTERVAL = 60 * 1000
 
+/** The gutter between two groups, in pixels. */
+const SASH = 6
+
+/** Below this a row of groups is two unreadable columns, so they stack. */
+const NARROW = 1240
+
+/** The drag's own type, so a strip can refuse a payload it cannot hold. */
+const TAB_DRAG = 'application/x-helios-tab'
+
 /**
- * Panels the sweep leaves alone. What they hold is a place the user chose —
- * the file they were reading, the diff they were working through — and losing
- * it to a timer means finding it again by hand. They cost nothing while
- * hidden, so they stay until the session does.
+ * Which items the idle sweep may unmount.
+ *
+ * Git and files hold a place the user chose — the file they were reading, the
+ * diff they were working through — and losing it to a timer means finding it
+ * again by hand. A terminal holds scrollback nothing can replay. What is left
+ * is the transcript and the approvals list, both of which come back fetched.
  */
-const NO_TTL: RightPanel[] = ['git', 'files']
+function sweepable(item: ItemId): boolean {
+  const panel = panelOf(item)
+  return panel === 'chat' || panel === 'approvals'
+}
+
+/**
+ * Whether a panel is mounted at all, as against merely listed in a strip.
+ *
+ * A tab is a thing the session has; mounting is what happens the first time it
+ * is looked at. Terminals do not go through this at all — see `PaneDeck`.
+ */
+function mountable(item: ItemId, layout: Layout, seen: Record<ItemId, number>): boolean {
+  return isVisible(layout, item) || seen[item] !== undefined
+}
+
+/** The item a tab is shown under: its own for a shell, the panel for an agent. */
+function slotOf(tab: Tab): ItemId {
+  return tab.kind === 'agent' ? panelItem('terminal') : termItem(tab.id)
+}
 
 export function Detail(): JSX.Element {
   const selection = useStore((s) => s.selection)
   const { sessions } = useHostSessions()
   const notifications = useHostNotifications()
-  const panel = useStore(currentPanel)
+  const layout = useStore(currentLayout)
   const tabs = useStore((s) => s.tabs)
 
   const hostId = selection?.hostId ?? null
@@ -70,11 +102,9 @@ export function Detail(): JSX.Element {
     ? (notifications[hostId ?? ''] ?? []).filter((n) => n.source_session === session.session_id).length
     : 0
   const term = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
-  const activeTab = useStore(currentTab)
   const shells = tabs.filter(
     (t) => t.kind === 'shell' && t.hostId === hostId && t.sessionId === session?.session_id,
   )
-  const onAgentTab = !activeTab || activeTab === term?.id
 
   // Shells outlive the app, so a restart would leave them running and
   // invisible. Listing them is also how a second window learns about one.
@@ -83,41 +113,66 @@ export function Detail(): JSX.Element {
     void store.syncShells(hostId, session.session_id)
   }, [hostId, session?.session_id])
 
-  // When each panel was last on screen, for the idle sweep below.
-  const [kept, setKept] = useState<Partial<Record<RightPanel, number>>>({})
   const sessionKey = hostId && session ? `${hostId}:${session.session_id}` : ''
   // A terminated session's file and diff describe a working tree nobody is
   // changing any more, so they close with it. Switching sessions drops them
   // too: they belong to the tree they were opened from.
   const terminated = session ? canResume(session) : false
 
+  // When each item was last on screen, for the idle sweep below.
+  const [seen, setSeen] = useState<Record<ItemId, number>>({})
   useEffect(() => {
-    setKept({})
+    setSeen({})
   }, [sessionKey, terminated])
 
+  const onScreen = layout.groups.map((group) => group.active).join('|')
   useEffect(() => {
-    if (!KEEP_MOUNTED.includes(panel) || terminated) return
-    setKept((current) => ({ ...current, [panel]: Date.now() }))
-  }, [panel, terminated])
+    if (terminated || !onScreen) return
+    const now = Date.now()
+    setSeen((current) => {
+      const next = { ...current }
+      for (const item of onScreen.split('|')) next[item] = now
+      return next
+    })
+  }, [onScreen, terminated])
 
   // Held state is worth memory for as long as the user is moving between
   // panels, and not much longer. A panel untouched for the timeout is
-  // unmounted, and comes back fetched fresh.
+  // unmounted, and comes back fetched fresh. An item still in front of any
+  // group is in use however long ago the user last touched it, which is what
+  // `sweep` checks and is the whole point of a split.
+  const held = useRef(layout)
+  held.current = layout
   useEffect(() => {
-    const sweep = setInterval(() => {
-      setKept((current) => {
-        const cutoff = Date.now() - PANEL_TTL
-        const next = Object.fromEntries(
-          Object.entries(current).filter(
-            ([name, seen]) =>
-              name === panel || NO_TTL.includes(name as RightPanel) || seen > cutoff,
-          ),
-        ) as Partial<Record<RightPanel, number>>
-        return Object.keys(next).length === Object.keys(current).length ? current : next
+    const timer = setInterval(() => {
+      setSeen((current) => {
+        const dead = sweep(held.current, current, Date.now(), PANEL_TTL).filter(sweepable)
+        if (dead.length === 0) return current
+        const next = { ...current }
+        for (const item of dead) delete next[item]
+        return next
       })
     }, SWEEP_INTERVAL)
-    return () => clearInterval(sweep)
-  }, [panel])
+    return () => clearInterval(timer)
+  }, [])
+
+  // A row of groups needs room. Below the breakpoint they stack instead, and
+  // the stored axis is left alone: a narrow window is not a decision.
+  const axis = useNarrow() ? 'column' : layout.axis
+  const [drag, setDrag] = useState<ItemId | null>(null)
+
+  const placed = placedItems(layout)
+  // Rendered in an order that does not depend on the arrangement: the node a
+  // panel lives in must not move when its tab does, or React remounts it and
+  // the panel loses what it was holding.
+  const mounted = PANELS.map(panelItem).filter(
+    (item) =>
+      placed.includes(item) &&
+      mountable(item, layout, seen) &&
+      // The terminal slot is the deck's cell once a pane is in it. Leaving an
+      // empty wrapper there would stack a transparent box over the terminal.
+      !(item === panelItem('terminal') && term),
+  )
 
   return (
     <div className="detail">
@@ -130,74 +185,28 @@ export function Detail(): JSX.Element {
             hostId={hostId}
             session={session}
           />
-
-          {/* One strip: the panels, the session's own terminal, then the
-              shells opened beside it. Tabs within a tab would be a hierarchy
-              nobody asked for — a shell is a sibling of the transcript, not a
-              mode of the terminal. */}
-          <nav className="panel-tabs">
-            {PANELS.map((name) => (
-              <button
-                key={name}
-                className={panel === name && (name !== 'terminal' || onAgentTab) ? 'active' : ''}
-                onClick={() => (name === 'terminal' ? store.showTerminal(hostId, session) : store.setPanel(name))}
-              >
-                {/* The old tabstrip carried the connection state, and it is
-                    still the one thing about a terminal worth seeing from
-                    another panel. */}
-                {name === 'terminal' && term && <span className={`dot ${term.status.state}`} />}
-                {PANEL_LABELS[name]}
-                {name === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
-                {name === 'terminal' && term && (
-                  <>
-                    <span
-                      className="tab-close reload"
-                      role="button"
-                      aria-label="Reconnect"
-                      title="Reconnect — the agent keeps running"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        void store.reconnectTab(term.id)
-                      }}
-                    >
-                      ⟳
-                    </span>
-                    <span
-                      className="tab-close"
-                      role="button"
-                      aria-label="Disconnect"
-                      title="Disconnect — the agent keeps running"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        store.disconnectTab(term.id)
-                      }}
-                    >
-                      ⏻
-                    </span>
-                  </>
-                )}
-              </button>
-            ))}
-
-            {shells.map((shell) => (
-              <ShellTab key={shell.id} tab={shell} active={panel === 'terminal' && activeTab === shell.id} />
-            ))}
-
-            <button
-              className="tab-add"
-              title="New shell in this session's directory"
-              aria-label="New shell"
-              onClick={() => void store.openShell(hostId, session.session_id)}
-            >
-              +
-            </button>
-          </nav>
+          <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />
         </>
       )}
 
-      {hostId && session && <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />}
-
-      <div className="panel-body">
+      <div
+        className={`panel-body ${axis}`}
+        style={
+          axis === 'row'
+            ? {
+                gridTemplateColumns: layout.groups
+                  .map((group) => `minmax(0,${group.size}fr)`)
+                  .join(` ${SASH}px `),
+                gridTemplateRows: 'auto minmax(0,1fr)',
+              }
+            : {
+                gridTemplateColumns: 'minmax(0,1fr)',
+                gridTemplateRows: layout.groups
+                  .map((group) => `auto minmax(0,${group.size}fr)`)
+                  .join(` ${SASH}px `),
+              }
+        }
+      >
         {!session &&
           (pendingList ? (
             // An unfetched host has no entry at all, an empty one has []. Without
@@ -215,61 +224,515 @@ export function Detail(): JSX.Element {
 
         {hostId &&
           session &&
-          // Keyed by session as well as panel. A panel holds where the user was
-          // in one session — the file open, the worktree picked, the search
-          // typed — and none of that means anything in the next one. Without
-          // the session in the key the instance survives the switch, and every
-          // panel has to remember to clear itself.
-          KEEP_MOUNTED.filter((name) => name === panel || kept[name]).map((name) => (
-            <div key={`${sessionKey}:${name}`} className="panel-keep" hidden={name !== panel}>
-              <PanelBoundary resetKey={`${hostId}:${session.session_id}:${name}`}>
-                {/* Approvals ride alongside the transcript instead of behind
-                    their own tab: an agent that stops for permission stops the
-                    panel the user is already looking at, and a tab round-trip
-                    per approval is the whole interaction. */}
-                {name === 'chat' && (
-                  <div className="agent-split">
-                    <ChatPanel hostId={hostId} session={session} active={name === panel} />
-                    {pending > 0 && (
-                      <aside className="approvals-dock">
-                        <h3 className="dock-title">
-                          Approvals <span className="badge">{pending}</span>
-                        </h3>
-                        <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
-                      </aside>
-                    )}
-                  </div>
-                )}
-                {name === 'approvals' && (
-                  <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
-                )}
-                {name === 'git' && (
-                  <GitPanel
-                    hostId={hostId}
-                    cwd={session.cwd}
-                    revision={session.last_event_at}
-                    sessionId={session.session_id}
-                    active={name === panel}
-                  />
-                )}
-                {name === 'files' && (
-                  <FilesPanel
-                    hostId={hostId}
-                    sessionId={session.session_id}
-                    cwd={session.cwd}
-                    visible={name === panel}
-                  />
-                )}
-              </PanelBoundary>
-            </div>
+          layout.groups.map((group, index) => (
+            <GroupTabs
+              key={group.id}
+              group={group}
+              style={stripAt(axis, index)}
+              focused={group.id === layout.focused}
+              hostId={hostId}
+              session={session}
+              tabs={tabs}
+              term={term}
+              pending={pending}
+              showAdd={group.id === layout.focused}
+              dragging={drag}
+              onDragItem={setDrag}
+            />
           ))}
 
-        {/* Outside the switch above, and outside the boundary: the panes stay
-            mounted whatever is selected, or every terminal would lose its
-            scrollback the moment the user looked at another panel. */}
-        <TerminalPanes hostId={hostId} session={session} visible={panel === 'terminal' && Boolean(session)} />
+        {hostId &&
+          session &&
+          mounted.map((item) => {
+            const owner = layout.groups.find((group) => group.items.includes(item))
+            if (!owner) return null
+            const index = layout.groups.indexOf(owner)
+            return (
+              // Keyed by session as well as item. A panel holds where the user
+              // was in one session — the file open, the worktree picked, the
+              // search typed — and none of that means anything in the next one.
+              <div
+                key={`${sessionKey}:${item}`}
+                className="panel-keep"
+                style={bodyAt(axis, index)}
+                hidden={owner.active !== item}
+                onPointerDownCapture={() => store.focusGroup({ hostId, sessionId: session.session_id }, owner.id)}
+              >
+                <PanelBoundary resetKey={`${sessionKey}:${item}`}>
+                  <ItemContent
+                    item={item}
+                    hostId={hostId}
+                    session={session}
+                    tabs={tabs}
+                    pending={pending}
+                    visible={owner.active === item}
+                    focused={owner.id === layout.focused}
+                  />
+                </PanelBoundary>
+              </div>
+            )
+          })}
+
+        {/* Every terminal there is, whatever session is on screen. A pane that
+            unmounts disposes its xterm, and the connection behind it lives in
+            the main process and keeps counting bytes — so the replacement asks
+            the host to catch it up from a sequence it has already passed, and
+            gets a delta rather than a screen. An empty grid with a cursor in
+            it, until a reconnect. Hence: mounted for as long as the tab is. */}
+        {tabs.map((tab) => {
+          const mine = tab.hostId === hostId && tab.sessionId === session?.session_id
+          const owner = mine
+            ? layout.groups.find((group) => group.items.includes(slotOf(tab)))
+            : undefined
+          const shown = Boolean(owner && owner.active === slotOf(tab))
+          const index = owner ? layout.groups.indexOf(owner) : 0
+          return (
+            <div
+              key={`pane:${tab.id}`}
+              className="panel-keep"
+              style={bodyAt(axis, index)}
+              hidden={!shown}
+              onPointerDownCapture={() =>
+                owner && hostId && session
+                  ? store.focusGroup({ hostId, sessionId: session.session_id }, owner.id)
+                  : undefined
+              }
+            >
+              <TerminalPane
+                tab={tab}
+                active={shown}
+                focused={shown && owner?.id === layout.focused}
+              />
+            </div>
+          )
+        })}
+
+        {/* One per gap, and only while something is being dragged: a permanent
+            overlay would eat the clicks meant for the panel beneath it. */}
+        {hostId &&
+          session &&
+          drag &&
+          layout.groups.map((group, index) => (
+            <DropZone
+              key={`drop-${group.id}`}
+              style={bodyAt(axis, index)}
+              axis={axis}
+              onDrop={(edge) => {
+                const target = { hostId, sessionId: session.session_id }
+                if (edge) store.splitItem(target, drag, group.id, edge)
+                else store.moveItem(target, drag, group.id, group.items.length)
+                setDrag(null)
+              }}
+            />
+          ))}
+
+        {hostId &&
+          session &&
+          layout.groups.slice(0, -1).map((group, index) => (
+            <Sash
+              key={`sash-${group.id}`}
+              style={sashAt(axis, index)}
+              axis={axis}
+              onMove={(delta) => store.resizeGroups({ hostId, sessionId: session.session_id }, index, delta)}
+              onReset={() => store.evenGroups({ hostId, sessionId: session.session_id })}
+            />
+          ))}
       </div>
     </div>
+  )
+}
+
+/** Whether the window is too narrow for groups to sit beside each other. */
+function useNarrow(): boolean {
+  const [narrow, setNarrow] = useState(() => window.matchMedia(`(max-width: ${NARROW}px)`).matches)
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${NARROW}px)`)
+    const update = (event: MediaQueryListEvent): void => setNarrow(event.matches)
+    query.addEventListener('change', update)
+    return () => query.removeEventListener('change', update)
+  }, [])
+  return narrow
+}
+
+type Axis = 'row' | 'column'
+type Placement = { gridColumn: string; gridRow: string }
+
+// A row lays the groups across the columns with one shared pair of rows; a
+// column gives each group its own strip and body rows in a single column. Both
+// leave a track between neighbours for the sash.
+function stripAt(axis: Axis, index: number): Placement {
+  return axis === 'row'
+    ? { gridColumn: `${index * 2 + 1}`, gridRow: '1' }
+    : { gridColumn: '1', gridRow: `${index * 3 + 1}` }
+}
+
+function bodyAt(axis: Axis, index: number): Placement {
+  return axis === 'row'
+    ? { gridColumn: `${index * 2 + 1}`, gridRow: '2' }
+    : { gridColumn: '1', gridRow: `${index * 3 + 2}` }
+}
+
+function sashAt(axis: Axis, index: number): Placement {
+  return axis === 'row'
+    ? { gridColumn: `${index * 2 + 2}`, gridRow: '1 / -1' }
+    : { gridColumn: '1', gridRow: `${index * 3 + 3}` }
+}
+
+/** What an item draws. The switch the single panel body used to be. */
+function ItemContent({
+  item,
+  hostId,
+  session,
+  tabs,
+  pending,
+  visible,
+  focused,
+}: {
+  item: ItemId
+  hostId: string
+  session: Session
+  tabs: Tab[]
+  pending: number
+  visible: boolean
+  focused: boolean
+}): JSX.Element | null {
+  // Terminals are drawn by the deck in Detail, which outlives the session being
+  // selected. Nothing to render here but the panel behind them.
+  if (tabOf(item) !== null) return null
+
+  const panel = panelOf(item)
+  const agent = tabs.find((one) => one.id === terminalId(hostId, session.session_id))
+
+  // Approvals ride alongside the transcript instead of behind their own tab: an
+  // agent that stops for permission stops the panel the user is already looking
+  // at, and a tab round-trip per approval is the whole interaction.
+  if (panel === 'chat') {
+    return (
+      <div className="agent-split">
+        <ChatPanel hostId={hostId} session={session} active={visible} />
+        {pending > 0 && (
+          <aside className="approvals-dock">
+            <h3 className="dock-title">
+              Approvals <span className="badge">{pending}</span>
+            </h3>
+            <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
+          </aside>
+        )}
+      </div>
+    )
+  }
+
+  // The session's own terminal. The pane is the deck's; what is left here is
+  // the button that goes and gets one, for a session with no terminal yet.
+  if (panel === 'terminal') {
+    return agent ? null : <TerminalPlaceholder hostId={hostId} session={session} visible={visible} />
+  }
+
+  if (panel === 'approvals') return <ApprovalsPanel hostId={hostId} sessionId={session.session_id} />
+
+  if (panel === 'git') {
+    return (
+      <GitPanel
+        hostId={hostId}
+        cwd={session.cwd}
+        revision={session.last_event_at}
+        sessionId={session.session_id}
+        active={visible}
+      />
+    )
+  }
+
+  if (panel === 'files') {
+    return (
+      <FilesPanel hostId={hostId} sessionId={session.session_id} cwd={session.cwd} visible={visible} />
+    )
+  }
+
+  return null
+}
+
+/**
+ * One group's strip: the items in it, in the order they were dragged into.
+ *
+ * Tabs within a tab would be a hierarchy nobody asked for — a shell is a
+ * sibling of the transcript, not a mode of the terminal — so panels and
+ * terminals share one row here, as they always have.
+ */
+function GroupTabs({
+  group,
+  style,
+  focused,
+  hostId,
+  session,
+  tabs,
+  term,
+  pending,
+  showAdd,
+  dragging,
+  onDragItem,
+}: {
+  group: Group
+  style: Placement
+  focused: boolean
+  hostId: string
+  session: Session
+  tabs: Tab[]
+  term: Tab | undefined
+  pending: number
+  showAdd: boolean
+  dragging: ItemId | null
+  onDragItem: (item: ItemId | null) => void
+}): JSX.Element {
+  const [over, setOver] = useState<number | null>(null)
+  const target = { hostId, sessionId: session.session_id }
+
+  // Which slot the pointer is in, from the buttons themselves rather than from
+  // state: a drop can land in the same tick as the drag start.
+  const slotFor = (event: React.DragEvent<HTMLElement>): number => {
+    const buttons = [...event.currentTarget.querySelectorAll('[data-item]')]
+    for (const [index, button] of buttons.entries()) {
+      const rect = button.getBoundingClientRect()
+      if (event.clientX < rect.left + rect.width / 2) return index
+    }
+    return buttons.length
+  }
+
+  return (
+    <nav
+      className={`panel-tabs ${focused ? 'focused' : ''} ${over !== null ? 'dropping' : ''}`}
+      style={style}
+      onPointerDown={() => store.focusGroup(target, group.id)}
+      onDragOver={(event) => {
+        if (!event.dataTransfer.types.includes(TAB_DRAG)) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+        setOver(slotFor(event))
+      }}
+      onDragLeave={() => setOver(null)}
+      onDrop={(event) => {
+        const item = event.dataTransfer.getData(TAB_DRAG)
+        setOver(null)
+        onDragItem(null)
+        if (!item) return
+        event.preventDefault()
+        store.moveItem(target, item, group.id, slotFor(event))
+      }}
+    >
+      {group.items.map((item, index) => (
+        <TabButton
+          key={item}
+          item={item}
+          active={group.active === item}
+          insertBefore={over === index}
+          hostId={hostId}
+          session={session}
+          tabs={tabs}
+          term={term}
+          pending={pending}
+          onDragItem={onDragItem}
+        />
+      ))}
+      {dragging && over === group.items.length && <span className="tab-insert" />}
+
+      {showAdd && (
+        <button
+          className="tab-add"
+          title="New shell in this session's directory"
+          aria-label="New shell"
+          onClick={() => void store.openShell(hostId, session.session_id)}
+        >
+          +
+        </button>
+      )}
+    </nav>
+  )
+}
+
+function TabButton({
+  item,
+  active,
+  insertBefore,
+  hostId,
+  session,
+  tabs,
+  term,
+  pending,
+  onDragItem,
+}: {
+  item: ItemId
+  active: boolean
+  insertBefore: boolean
+  hostId: string
+  session: Session
+  tabs: Tab[]
+  term: Tab | undefined
+  pending: number
+  onDragItem: (item: ItemId | null) => void
+}): JSX.Element {
+  const tabId = tabOf(item)
+  const shell = tabId !== null ? tabs.find((one) => one.id === tabId) : undefined
+  const panel = panelOf(item) as RightPanel | null
+
+  const drag = {
+    draggable: true,
+    onDragStart: (event: React.DragEvent) => {
+      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.setData(TAB_DRAG, item)
+      event.dataTransfer.setData('text/plain', item)
+      onDragItem(item)
+    },
+    onDragEnd: () => onDragItem(null),
+  }
+
+  if (shell) {
+    return (
+      <ShellTab tab={shell} active={active} insertBefore={insertBefore} drag={drag} />
+    )
+  }
+  if (!panel) return <></>
+
+  return (
+    <button
+      data-item={item}
+      className={`${active ? 'active' : ''} ${insertBefore ? 'insert' : ''}`}
+      {...drag}
+      onClick={() =>
+        panel === 'terminal' ? store.showTerminal(hostId, session) : store.setPanel(panel)
+      }
+    >
+      {/* The old tabstrip carried the connection state, and it is still the one
+          thing about a terminal worth seeing from another panel. */}
+      {panel === 'terminal' && term && <span className={`dot ${term.status.state}`} />}
+      {PANEL_LABELS[panel]}
+      {panel === 'approvals' && pending > 0 && <span className="badge">{pending}</span>}
+      {panel === 'terminal' && term && (
+        <>
+          <span
+            className="tab-close reload"
+            role="button"
+            aria-label="Reconnect"
+            title="Reconnect — the agent keeps running"
+            onClick={(event) => {
+              event.stopPropagation()
+              void store.reconnectTab(term.id)
+            }}
+          >
+            ⟳
+          </span>
+          <span
+            className="tab-close"
+            role="button"
+            aria-label="Disconnect"
+            title="Disconnect — the agent keeps running"
+            onClick={(event) => {
+              event.stopPropagation()
+              store.disconnectTab(term.id)
+            }}
+          >
+            ⏻
+          </span>
+        </>
+      )}
+    </button>
+  )
+}
+
+/**
+ * The half of a group's body a drop would land in.
+ *
+ * Only mounted while a tab is in flight. A permanent overlay would swallow
+ * every click meant for the panel underneath it.
+ */
+function DropZone({
+  style,
+  axis,
+  onDrop,
+}: {
+  style: Placement
+  axis: Axis
+  onDrop: (edge: Edge | null) => void
+}): JSX.Element {
+  const [edge, setEdge] = useState<Edge | null | 'none'>('none')
+
+  // The edges claim a quarter each and split; the middle half moves the tab
+  // into the group. Along the layout's axis only: a flat row of groups has
+  // nowhere to put a cross-axis split.
+  const edgeFor = (event: React.DragEvent<HTMLElement>): Edge | null => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const along =
+      axis === 'row'
+        ? (event.clientX - rect.left) / rect.width
+        : (event.clientY - rect.top) / rect.height
+    if (along < 0.25) return 'before'
+    if (along > 0.75) return 'after'
+    return null
+  }
+
+  return (
+    <div
+      className={`group-drop ${edge === 'none' ? '' : `over ${edge ?? 'into'}`}`}
+      style={style}
+      onDragOver={(event) => {
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+        setEdge(edgeFor(event))
+      }}
+      onDragLeave={() => setEdge('none')}
+      onDrop={(event) => {
+        event.preventDefault()
+        const landed = edgeFor(event)
+        setEdge('none')
+        onDrop(landed)
+      }}
+    />
+  )
+}
+
+/** The gutter between two groups, and the handle that moves it. */
+function Sash({
+  style,
+  axis,
+  onMove,
+  onReset,
+}: {
+  style: Placement
+  axis: Axis
+  onMove: (delta: number) => void
+  onReset: () => void
+}): JSX.Element {
+  // The drag reads as a fraction of the row rather than in pixels, so the same
+  // gesture means the same thing at any window width — and the weights it
+  // moves are what the grid is built from.
+  const resize = (event: React.PointerEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    const body = event.currentTarget.parentElement
+    if (!body) return
+    const rect = body.getBoundingClientRect()
+    const span = axis === 'row' ? rect.width : rect.height
+    let from = axis === 'row' ? event.clientX : event.clientY
+    const move = (moved: PointerEvent): void => {
+      const at = axis === 'row' ? moved.clientX : moved.clientY
+      onMove((at - from) / span)
+      from = at
+    }
+    const done = (): void => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', done)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', done)
+  }
+
+  return (
+    <div
+      className={`group-sash ${axis}`}
+      role="separator"
+      aria-label="Resize the panels"
+      title="Drag to resize — double-click to even them out"
+      onPointerDown={resize}
+      onDoubleClick={onReset}
+      style={style}
+    />
   )
 }
 
@@ -278,7 +741,17 @@ export function Detail(): JSX.Element {
  * which is the session's and only ever detaches — so the cross is the real
  * thing here, and the name is the user's to set.
  */
-function ShellTab({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
+function ShellTab({
+  tab,
+  active,
+  insertBefore,
+  drag,
+}: {
+  tab: Tab
+  active: boolean
+  insertBefore: boolean
+  drag: Record<string, unknown>
+}): JSX.Element {
   const [renaming, setRenaming] = useState(false)
   const [draft, setDraft] = useState(tab.title)
 
@@ -306,7 +779,9 @@ function ShellTab({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
 
   return (
     <button
-      className={active ? 'active' : ''}
+      data-item={termItem(tab.id)}
+      className={`${active ? 'active' : ''} ${insertBefore ? 'insert' : ''}`}
+      {...drag}
       onClick={() => store.selectTab(tab.id)}
       onDoubleClick={() => {
         setDraft(tab.title)

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -102,7 +102,9 @@ export function FilesPanel({
    * in different repositories lost them on every switch.
    */
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const [side, setSide] = useState<'tree' | 'find'>('tree')
+  // null is collapsed. A narrow Files pane beside a transcript has no room for
+  // a tree as well as an editor, and the tree is the half you can do without.
+  const [side, setSide] = useState<Side>('tree')
   const [findSeq, setFindSeq] = useState(0)
   const [quickOpen, setQuickOpen] = useState(false)
   const [quickOpenQuery, setQuickOpenQuery] = useState('')
@@ -225,6 +227,7 @@ export function FilesPanel({
     const saved = readWorkspace(memory)
     setRootOverride(saved?.root ?? null)
     setExpanded(new Set(saved?.expanded ?? []))
+    setSide(saved?.side === undefined ? 'tree' : saved.side)
     views.current = saved?.view ?? {}
 
     let cancelled = false
@@ -253,13 +256,14 @@ export function FilesPanel({
       open: tabs.map((tab) => tab.path),
       active: activePath,
       expanded: [...expanded],
+      side,
       // Pruned to what is open: a closed tab's position is not worth carrying,
       // and the record would otherwise grow for the life of the session.
       view: Object.fromEntries(
         tabs.map((tab) => [tab.path, views.current[tab.path]]).filter(([, at]) => at !== undefined),
       ) as Record<string, ReadingPosition>,
     })
-  }, [memory, loadedFor, rootOverride, tabs, activePath, expanded, viewTick])
+  }, [memory, loadedFor, rootOverride, tabs, activePath, expanded, side, viewTick])
 
   const save = useCallback(
     async (path: string): Promise<void> => {
@@ -377,6 +381,9 @@ export function FilesPanel({
       if (key === 'p' && !event.shiftKey) {
         event.preventDefault()
         setQuickOpen(true)
+      } else if (key === 'b' && !event.shiftKey) {
+        event.preventDefault()
+        setSide((current) => (current === null ? 'tree' : null))
       } else if (key === 'f' && event.shiftKey) {
         event.preventDefault()
         setSide('find')
@@ -417,14 +424,25 @@ export function FilesPanel({
 
   return (
     <div className="workspace">
-      <aside className="ws-side">
+      <aside className="ws-side" hidden={side === null}>
         <div className="ws-side-head">
-          <button className={side === 'tree' ? 'ws-view on' : 'ws-view'} onClick={() => setSide('tree')}>
+          {/* Clicking the one already showing puts it away, which is how the
+              activity bar this borrows from behaves. */}
+          <button
+            className={side === 'tree' ? 'ws-view on' : 'ws-view'}
+            title="Explorer (⌘B)"
+            onClick={() => setSide(side === 'tree' ? null : 'tree')}
+          >
             Explorer
           </button>
           <button
             className={side === 'find' ? 'ws-view on' : 'ws-view'}
+            title="Search (⇧⌘F)"
             onClick={() => {
+              if (side === 'find') {
+                setSide(null)
+                return
+              }
               setSide('find')
               setFindSeq((seq) => seq + 1)
             }}
@@ -487,6 +505,18 @@ export function FilesPanel({
 
       <section className="ws-main">
         <div className="ws-tabs">
+          {/* The way back. Collapsing from inside the explorer would otherwise
+              leave nothing on screen saying it is there, and a keyboard
+              shortcut is not something you can see. */}
+          <button
+            className={`ws-side-toggle ${side === null ? 'off' : ''}`}
+            title={side === null ? 'Show the explorer (⌘B)' : 'Hide the explorer (⌘B)'}
+            aria-label={side === null ? 'Show the explorer' : 'Hide the explorer'}
+            aria-expanded={side !== null}
+            onClick={() => setSide(side === null ? 'tree' : null)}
+          >
+            <Chevron dir={side === null ? 'right' : 'left'} />
+          </button>
           {tabs.map((tab) => (
             <div
               key={tab.path}
@@ -937,6 +967,9 @@ function basename(path: string): string {
   return path.split('/').pop() || path
 }
 
+/** Which list the explorer shows, or nothing at all. */
+type Side = 'tree' | 'find' | null
+
 /** What the panel remembers about a session between visits. */
 interface Workspace {
   root: string | null
@@ -946,6 +979,9 @@ interface Workspace {
   expanded?: string[]
   /** Where each file was left, by path. Absent in older records. */
   view?: Record<string, ReadingPosition>
+  /** The explorer, or null for collapsed. Absent in records written before it
+   *  could be, which read as the tree — the panel has always opened that way. */
+  side?: Side
 }
 
 function readWorkspace(key: string): Workspace | null {

--- a/desktop/src/renderer/components/layout.ts
+++ b/desktop/src/renderer/components/layout.ts
@@ -1,0 +1,354 @@
+// How a session's panels are arranged: a flat row of groups, each with its own
+// tab strip, and one of its items in front.
+//
+// Kept out of the components and reaching nothing, so it can be tested. Every
+// function here takes a layout and returns one; a nested pane tree would be a
+// change of representation behind the same calls.
+
+export type ItemId = string
+
+/** One tab strip and the items behind it. `size` is an fr weight, not pixels:
+ *  a width measured in today's window leaves gutters in a wider one. */
+export interface Group {
+  id: string
+  items: ItemId[]
+  active: ItemId
+  size: number
+}
+
+export interface Layout {
+  axis: 'row' | 'column'
+  groups: Group[]
+  /** Which group a reveal lands in, and which one owns the keyboard. */
+  focused: string
+}
+
+/** Where a drop on a group's body lands. */
+export type Edge = 'before' | 'after'
+
+export function panelItem(panel: string): ItemId {
+  return `panel:${panel}`
+}
+
+export function termItem(tabId: string): ItemId {
+  return `term:${tabId}`
+}
+
+/** The panel an item names, or null if it is a terminal. */
+export function panelOf(item: ItemId): string | null {
+  return item.startsWith('panel:') ? item.slice(6) : null
+}
+
+/** The tab an item names, or null if it is a panel. */
+export function tabOf(item: ItemId): string | null {
+  return item.startsWith('term:') ? item.slice(5) : null
+}
+
+/**
+ * The panels every session has, in the order the strip lists them.
+ *
+ * `panel:terminal` is the session's own terminal — the live pane when one is
+ * attached and the attach button when there is not. Shells are `term:` items
+ * of their own, because a session can have any number of them.
+ */
+export const PANEL_ITEMS: ItemId[] = ['chat', 'terminal', 'approvals', 'git', 'files'].map(panelItem)
+
+/**
+ * One group, holding every panel, reading the transcript.
+ *
+ * A tab in the strip is not a mounted panel: the strip lists what the session
+ * *has*, and the view mounts an item the first time it is looked at. Seeding
+ * the layout with all five therefore costs nothing, and it is what lets a panel
+ * be dragged somewhere before it has ever been opened.
+ */
+export function defaultLayout(): Layout {
+  return {
+    axis: 'row',
+    groups: [{ id: 'g1', items: [...PANEL_ITEMS], active: panelItem('chat'), size: 1 }],
+    focused: 'g1',
+  }
+}
+
+let counter = 0
+
+function newGroupId(layout: Layout): string {
+  let id = ''
+  do {
+    counter += 1
+    id = `g${counter}`
+  } while (layout.groups.some((group) => group.id === id))
+  return id
+}
+
+export function groupOf(layout: Layout, item: ItemId): Group | null {
+  return layout.groups.find((group) => group.items.includes(item)) ?? null
+}
+
+/** Every item on screen — one per group, which is what "visible" means here. */
+export function visibleItems(layout: Layout): ItemId[] {
+  return layout.groups.map((group) => group.active)
+}
+
+export function isVisible(layout: Layout, item: ItemId): boolean {
+  return layout.groups.some((group) => group.active === item)
+}
+
+/** Every item the layout holds, whether or not it is in front. */
+export function placedItems(layout: Layout): ItemId[] {
+  return layout.groups.flatMap((group) => group.items)
+}
+
+function focusedGroup(layout: Layout): Group | undefined {
+  return layout.groups.find((group) => group.id === layout.focused) ?? layout.groups[0]
+}
+
+/**
+ * Brings an item to the front.
+ *
+ * Already placed means activate it where it is and focus that group — a reveal
+ * must not drag a panel out of the group the user put it in. Otherwise it joins
+ * the focused group.
+ */
+export function reveal(layout: Layout, item: ItemId): Layout {
+  const holder = groupOf(layout, item)
+  if (holder) {
+    if (holder.active === item && layout.focused === holder.id) return layout
+    return {
+      ...layout,
+      focused: holder.id,
+      groups: layout.groups.map((group) =>
+        group.id === holder.id ? { ...group, active: item } : group,
+      ),
+    }
+  }
+
+  const target = focusedGroup(layout)
+  if (!target) return layout
+  return {
+    ...layout,
+    focused: target.id,
+    groups: layout.groups.map((group) =>
+      group.id === target.id ? { ...group, items: [...group.items, item], active: item } : group,
+    ),
+  }
+}
+
+/** Moves an item into a group, or reorders it within the one it is in. */
+export function moveItem(layout: Layout, item: ItemId, toGroup: string, index: number): Layout {
+  if (!layout.groups.some((group) => group.id === toGroup)) return layout
+  const from = groupOf(layout, item)
+  if (!from) return layout
+
+  const stripped = layout.groups.map((group) =>
+    group.items.includes(item) ? { ...group, items: group.items.filter((id) => id !== item) } : group,
+  )
+  const placed = stripped.map((group) => {
+    if (group.id !== toGroup) return group
+    const items = [...group.items]
+    items.splice(Math.max(0, Math.min(index, items.length)), 0, item)
+    return { ...group, items, active: item }
+  })
+
+  return collapse({ ...layout, focused: toGroup, groups: placed }, from.id)
+}
+
+/** Splits an item out into a group of its own, beside the one it was dropped on. */
+export function splitInto(layout: Layout, item: ItemId, atGroup: string, edge: Edge): Layout {
+  const at = layout.groups.findIndex((group) => group.id === atGroup)
+  const host = layout.groups[at]
+  if (!host) return layout
+  const from = groupOf(layout, item)
+  // A lone item splitting off its own group would dissolve and rebuild the
+  // same group, which reads as the drag having done nothing.
+  if (from && from.id === atGroup && from.items.length === 1) return layout
+
+  const id = newGroupId(layout)
+  const half = host.size / 2
+  const stripped = layout.groups.map((group) =>
+    group.items.includes(item)
+      ? { ...group, items: group.items.filter((one) => one !== item), size: group.id === atGroup ? half : group.size }
+      : group.id === atGroup
+        ? { ...group, size: half }
+        : group,
+  )
+
+  const groups = [...stripped]
+  groups.splice(edge === 'before' ? at : at + 1, 0, { id, items: [item], active: item, size: half })
+
+  return collapse({ ...layout, focused: id, groups }, from?.id ?? '')
+}
+
+/**
+ * Drops an item wherever it sits.
+ *
+ * The group it leaves keeps a neighbour in front rather than nothing: closing
+ * the middle of three shells is not a request to leave the shells, and the one
+ * before it is usually the one it was opened beside.
+ */
+export function removeItem(layout: Layout, item: ItemId): Layout {
+  const holder = groupOf(layout, item)
+  if (!holder) return layout
+
+  const at = holder.items.indexOf(item)
+  const rest = holder.items.filter((one) => one !== item)
+  const next = holder.active === item ? (rest[at - 1] ?? rest[0] ?? '') : holder.active
+
+  const groups = layout.groups.map((group) =>
+    group.id === holder.id ? { ...group, items: rest, active: next } : group,
+  )
+  return collapse({ ...layout, groups }, holder.id)
+}
+
+/**
+ * Drops a group that has been emptied and hands its weight to a neighbour.
+ *
+ * The last group is never dropped — there would be nothing left to draw — so it
+ * falls back to the transcript, which is where a session starts.
+ */
+function collapse(layout: Layout, emptied: string): Layout {
+  const at = layout.groups.findIndex((group) => group.id === emptied)
+  const gone = layout.groups[at]
+  if (!gone || gone.items.length > 0) return normalise(layout)
+
+  const only = layout.groups[0]
+  if (layout.groups.length === 1 && only) {
+    // Nothing left to draw. The transcript is where a session starts, so it is
+    // what an emptied last group falls back to.
+    const chat = panelItem('chat')
+    return normalise({ ...layout, groups: [{ ...only, items: [chat], active: chat }] })
+  }
+
+  const heir = layout.groups[at - 1] ?? layout.groups[at + 1]
+  if (!heir) return normalise(layout)
+  const groups = layout.groups
+    .filter((group) => group.id !== emptied)
+    .map((group) => (group.id === heir.id ? { ...group, size: group.size + gone.size } : group))
+
+  return normalise({ ...layout, groups })
+}
+
+/** Keeps `focused` and every `active` pointing at something that exists. */
+function normalise(layout: Layout): Layout {
+  const groups = layout.groups.map((group) =>
+    group.items.includes(group.active) ? group : { ...group, active: group.items[0] ?? group.active },
+  )
+  const focused = groups.some((group) => group.id === layout.focused)
+    ? layout.focused
+    : (groups[0]?.id ?? layout.focused)
+  return { ...layout, groups, focused }
+}
+
+/** The smallest share of the row a group may be dragged down to. */
+const MIN_SIZE = 0.15
+
+/**
+ * Moves weight across one sash. `delta` is the fraction of the whole row the
+ * pointer travelled, so a drag reads the same at any window width.
+ */
+export function resize(layout: Layout, sash: number, delta: number): Layout {
+  const left = layout.groups[sash]
+  const right = layout.groups[sash + 1]
+  if (!left || !right) return layout
+
+  const total = left.size + right.size
+  // Rounded because these are serialised: a drag that accumulated
+  // 0.30000000000000004 writes that to disk and reads it back for ever.
+  const size = round(Math.min(Math.max(left.size + delta * totalSize(layout), MIN_SIZE), total - MIN_SIZE))
+  if (size === left.size) return layout
+
+  return {
+    ...layout,
+    groups: layout.groups.map((group) =>
+      group.id === left.id
+        ? { ...group, size }
+        : group.id === right.id
+          ? { ...group, size: round(total - size) }
+          : group,
+    ),
+  }
+}
+
+function round(size: number): number {
+  return Math.round(size * 1e4) / 1e4
+}
+
+export function totalSize(layout: Layout): number {
+  return layout.groups.reduce((sum, group) => sum + group.size, 0)
+}
+
+/** Even weights again, for a double-click on a sash. */
+export function evenSizes(layout: Layout): Layout {
+  return { ...layout, groups: layout.groups.map((group) => ({ ...group, size: 1 })) }
+}
+
+/**
+ * Places terminals the layout has not seen yet.
+ *
+ * Append-only, deliberately. A saved layout is read the moment a session is
+ * selected, but its shells are re-attached over an await — pruning items with
+ * no live tab would delete the arrangement in that window, before it could be
+ * shown. Terminals are removed when they close, by `removeItem`.
+ */
+export function reconcile(layout: Layout, liveTabs: string[]): Layout {
+  const placed = new Set(placedItems(layout))
+  const missing = liveTabs.map(termItem).filter((item) => !placed.has(item))
+  if (missing.length === 0) return layout
+
+  const target = focusedGroup(layout)
+  if (!target) return layout
+  return {
+    ...layout,
+    groups: layout.groups.map((group) =>
+      group.id === target.id ? { ...group, items: [...group.items, ...missing] } : group,
+    ),
+  }
+}
+
+/**
+ * Which held panels may be unmounted, given when each was last in front.
+ *
+ * An item visible in any group is in use, even when the focus is elsewhere —
+ * that is the whole point of a split, and sweeping it would take a panel out
+ * from under someone reading it.
+ */
+export function sweep(layout: Layout, lastSeen: Record<ItemId, number>, now: number, ttl: number): ItemId[] {
+  return Object.entries(lastSeen)
+    .filter(([item, seen]) => !isVisible(layout, item) && now - seen > ttl)
+    .map(([item]) => item)
+}
+
+/** A stored layout, or the default if it is anything else. */
+export function parseLayout(raw: unknown): Layout {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return defaultLayout()
+  const value = raw as Partial<Layout>
+  if (!Array.isArray(value.groups) || value.groups.length === 0) return defaultLayout()
+
+  const groups: Group[] = []
+  for (const entry of value.groups) {
+    if (!entry || typeof entry !== 'object') return defaultLayout()
+    const { id, items, active, size } = entry as Partial<Group>
+    if (typeof id !== 'string' || !id) return defaultLayout()
+    if (!Array.isArray(items) || items.some((item) => typeof item !== 'string')) return defaultLayout()
+    const head = items[0]
+    if (head === undefined) continue
+    groups.push({
+      id,
+      items,
+      active: typeof active === 'string' && items.includes(active) ? active : head,
+      size: typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : 1,
+    })
+  }
+  const first = groups[0]
+  if (!first) return defaultLayout()
+
+  // Ids seen here must not be handed out again, or a later split would collide
+  // with a group restored from disk.
+  for (const group of groups) {
+    const n = Number(group.id.slice(1))
+    if (group.id.startsWith('g') && Number.isInteger(n) && n > counter) counter = n
+  }
+
+  const axis = value.axis === 'column' ? 'column' : 'row'
+  const focused = groups.some((group) => group.id === value.focused) ? (value.focused as string) : first.id
+  return { axis, groups, focused }
+}

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -7,7 +7,7 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import { silenceDeviceReports } from './deviceReports.ts'
 import { linkHandler, webLinkActivate } from './links.ts'
 import { bridge } from '../bridge.ts'
-import { currentTab, store, terminalId, useStore, type Tab } from '../store.ts'
+import { store, terminalId, useStore, type Tab } from '../store.ts'
 import { canResume, hasTerminal, needsRecovery, type Session } from '../../shared/models.ts'
 
 /**
@@ -21,14 +21,14 @@ bridge.term.onOutput(({ tabId, data }) => sinks.get(tabId)?.(data))
 const encoder = new TextEncoder()
 
 /**
- * The terminal panel: the selected session's terminal, and every other open one
- * kept mounted behind it.
+ * The `panel:terminal` item: what stands in for a terminal there is not one of
+ * yet, and the thing that goes and gets one.
  *
- * Mounted, not rendered on demand, because an xterm that unmounts loses its
- * scrollback and neither the daemon nor the main process can replay it — only
- * the visible pane is `active`, and the rest sit hidden and silent.
+ * It holds the item's place in the strip, so a session whose agent attaches
+ * while the user is reading it does not shuffle the arrangement underneath
+ * them — the tab is already there, and the pane arrives inside it.
  */
-export function TerminalPanes({
+export function TerminalPlaceholder({
   hostId,
   session,
   visible,
@@ -36,14 +36,9 @@ export function TerminalPanes({
   hostId: string | null
   session: Session | null
   visible: boolean
-}): JSX.Element {
+}): JSX.Element | null {
   const tabs = useStore((s) => s.tabs)
-  const activeTab = useStore(currentTab)
   const agent = hostId && session ? tabs.find((t) => t.id === terminalId(hostId, session.session_id)) : undefined
-  // The strip decides which of the session's terminals is in front; the
-  // agent's is the one a session starts with and the fallback for everything
-  // that does not name one.
-  const current = (activeTab ? tabs.find((t) => t.id === activeTab) : undefined) ?? agent
   const detached = useStore((s) => s.detached)
   const isDetached = Boolean(hostId && session && detached.includes(terminalId(hostId, session.session_id)))
 
@@ -64,48 +59,63 @@ export function TerminalPanes({
     else if (needsRecovery(session)) void store.openTerminal(hostId, session, true)
   }, [visible, agent, isDetached, hostId, session])
 
-  return (
-    <div className={visible ? 'panes' : 'panes hidden'}>
-      {tabs.map((tab) => (
-        <TerminalPane key={tab.id} tab={tab} active={visible && tab.id === current?.id} />
-      ))}
+  if (!hostId || !session) return null
 
-      {visible && !current && hostId && session && (
-        <div className="pane-empty">
-          {/* Resume, not wake, for a terminated session: a wake would start the
-              host and attach to a session the daemon still refuses prompts for.
-              Resuming moves it back to idle, and the effect above attaches as
-              soon as the handle lands. */}
-          <p>
-            {canResume(session)
-              ? 'Session terminated — resume to bring the agent back.'
-              : isDetached
-                ? 'Disconnected — the agent kept running.'
-                : 'No terminal attached to this session.'}
-          </p>
-          {canResume(session) ? (
-            <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
-              Resume
-            </button>
-          ) : (
-            <button
-              className="filled"
-              onClick={() => void store.openTerminal(hostId, session, !hasTerminal(session))}
-            >
-              {hasTerminal(session) ? 'Attach' : 'Wake and attach'}
-            </button>
-          )}
-        </div>
+  return (
+    <div className="pane-empty">
+      {/* Resume, not wake, for a terminated session: a wake would start the
+          host and attach to a session the daemon still refuses prompts for.
+          Resuming moves it back to idle, and the effect above attaches as
+          soon as the handle lands. */}
+      <p>
+        {canResume(session)
+          ? 'Session terminated — resume to bring the agent back.'
+          : isDetached
+            ? 'Disconnected — the agent kept running.'
+            : 'No terminal attached to this session.'}
+      </p>
+      {canResume(session) ? (
+        <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
+          Resume
+        </button>
+      ) : (
+        <button
+          className="filled"
+          onClick={() => void store.openTerminal(hostId, session, !hasTerminal(session))}
+        >
+          {hasTerminal(session) ? 'Attach' : 'Wake and attach'}
+        </button>
       )}
     </div>
   )
 }
 
-function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Element {
+/**
+ * One terminal, mounted for as long as its tab exists.
+ *
+ * Mounted, not rendered on demand, because an xterm that unmounts loses its
+ * scrollback and neither the daemon nor the main process can replay it. A pane
+ * whose tab is not in front of its group is hidden rather than dropped.
+ *
+ * `visible` is whether it is on screen anywhere — several are, once the session
+ * is split. `focused` is whether its group is the one the keyboard belongs to,
+ * which is a narrower question and the only one worth stealing the caret for.
+ */
+export function TerminalPane({
+  tab,
+  active,
+  focused,
+}: {
+  tab: Tab
+  active: boolean
+  focused: boolean
+}): JSX.Element {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const hostSized = useRef(false)
+  /** Whether the terminal has met the DOM yet; see `apply` below. */
+  const opened = useRef(false)
   const theme = useStore((s) => s.terminalTheme)
 
   // Assigned rather than passed on construction: rebuilding the terminal to
@@ -142,13 +152,18 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.loadAddon(new WebLinksAddon(webLinkActivate))
-    term.open(container)
 
-    try {
-      term.loadAddon(new WebglAddon())
-    } catch {
-      // No GPU context — the canvas renderer is slower but always available.
-    }
+    // Deliberately not opened here. `open` measures a character against the
+    // element it is given, and a pane that mounts behind another tab has no
+    // layout to measure — the cell comes out zero wide, and nothing ever
+    // measures again: xterm has no resize observer of its own, and
+    // `proposeDimensions` gives up on a zero cell, so the pane can no longer
+    // even ask the host for a size. It renders an empty grid with a cursor in
+    // it until a reconnect builds a new terminal.
+    //
+    // So the element waits until it has been laid out; see the effect below.
+    // Writing before `open` is fine — the bytes land in the buffer, and the
+    // snapshot the host replays on attach is there when the pane is shown.
 
     term.onData((data) => void bridge.term.input(tab.id, encoder.encode(data)))
     term.onBinary((data) => {
@@ -167,6 +182,7 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
       term.dispose()
       termRef.current = null
       fitRef.current = null
+      opened.current = false
     }
   }, [tab.id])
 
@@ -189,6 +205,31 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     const apply = (): void => {
       // A hidden element measures as zero; fit() would then propose 1×1.
       if (container.clientWidth === 0 || container.clientHeight === 0) return
+      // First time this pane has had a size: this is where the terminal meets
+      // the DOM. Opening earlier would measure a character against an element
+      // with no layout and leave the cell zero wide for good.
+      if (!opened.current) {
+        opened.current = true
+        term.open(container)
+        // The renderer needs the element, so it cannot be loaded before the
+        // open above. One WebGL context per terminal, and the browser evicts
+        // the oldest past its limit — a split puts more of them on screen at
+        // once, so a lost context is now something that happens.
+        try {
+          const webgl = new WebglAddon()
+          webgl.onContextLoss(() => {
+            webgl.dispose()
+            try {
+              term.loadAddon(new WebglAddon())
+            } catch {
+              // The canvas renderer is slower and always available.
+            }
+          })
+          term.loadAddon(webgl)
+        } catch {
+          // No GPU context — the canvas renderer is slower but always available.
+        }
+      }
       const dims = fit.proposeDimensions()
       if (!dims?.cols || !dims.rows) return
       // Proposed, not applied. fit() would resize the grid here, and the host
@@ -205,12 +246,15 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     }
 
     apply()
-    term.focus()
+    // Only the focused group's terminal takes the caret. With two panes on
+    // screen every one of them would otherwise claim it, and the last to
+    // render would win on every layout change.
+    if (focused) term.focus()
 
     const observer = new ResizeObserver(apply)
     observer.observe(container)
     return () => observer.disconnect()
-  }, [active, tab.id])
+  }, [active, focused, tab.id])
 
   /**
    * Adopt the size the host settled on, which is not always the one proposed
@@ -242,8 +286,10 @@ function TerminalPane({ tab, active }: { tab: Tab; active: boolean }): JSX.Eleme
     return () => clearTimeout(timer)
   }, [live])
 
+  // Whether it is on screen is the group's business, not the pane's: the item
+  // wrapper carries `hidden`, and a pane that is up fills the cell it is in.
   return (
-    <div className={`pane ${active ? 'active' : ''}`}>
+    <div className="pane">
       <div className="pane-term" ref={hostRef} />
       {tab.status.state !== 'live' && (
         <div className="pane-overlay">

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -12,6 +12,25 @@ import {
   type SortMode,
 } from './keys.ts'
 import type { GroupOrder, PathOrder } from './components/grouping.ts'
+import {
+  defaultLayout,
+  evenSizes,
+  isVisible,
+  moveItem,
+  panelItem,
+  panelOf,
+  parseLayout,
+  reconcile,
+  removeItem,
+  resize,
+  reveal,
+  splitInto,
+  tabOf,
+  termItem,
+  type Edge,
+  type ItemId,
+  type Layout,
+} from './components/layout.ts'
 import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type {
@@ -150,14 +169,13 @@ export interface State {
   /** Open terminal connections, one per session, keyed by `terminalId`. */
   tabs: Tab[]
   selection: Selection | null
-  /** The panel each session was last reading, by `sessionKey`. */
-  panels: Record<string, RightPanel>
   /**
-   * Which terminal a session's panel shows, as a tab id, by `sessionKey`. A
-   * session has several once the user opens shells beside its agent, and the
-   * strip needs to know which one is in front.
+   * How each session's panels are arranged, by `sessionKey`: which groups sit
+   * beside each other, what is in each strip, and which item of each is in
+   * front. Materialised from localStorage the first time a session is touched
+   * and written back on every change.
    */
-  activeTabs: Record<string, string>
+  layouts: Record<string, Layout>
   /**
    * Terminals the user disconnected on purpose, by tab id. Without this the
    * panel would attach again the moment it is shown, and a disconnect would
@@ -274,13 +292,34 @@ function writeGroupOrder(order: GroupOrder): void {
   }
 }
 
+/** Beside the files panel's own per-session record, and keyed the same way. */
+function layoutKey(hostId: string, sessionId: string): string {
+  return `helios.layout.${hostId}.${sessionId}`
+}
+
+function readLayout(hostId: string, sessionId: string): Layout {
+  try {
+    const raw = localStorage.getItem(layoutKey(hostId, sessionId))
+    return parseLayout(raw ? JSON.parse(raw) : null)
+  } catch {
+    return defaultLayout()
+  }
+}
+
+function writeLayout(hostId: string, sessionId: string, layout: Layout): void {
+  try {
+    localStorage.setItem(layoutKey(hostId, sessionId), JSON.stringify(layout))
+  } catch {
+    // A full or unavailable store costs the arrangement, not the panel.
+  }
+}
+
 const initial: State = {
   hosts: [],
   hostStatus: {},
   tabs: [],
   selection: null,
-  panels: {},
-  activeTabs: {},
+  layouts: {},
   detached: [],
   fileTarget: null,
   diffTarget: null,
@@ -859,7 +898,10 @@ class Store {
   // ─── Selection and panels ──────────────────────────────────────────────
 
   select(hostId: string, sessionId: string): void {
-    this.set({ selection: { hostId, sessionId } })
+    this.set((s) => ({
+      selection: { hostId, sessionId },
+      layouts: withLayout(s.layouts, hostId, sessionId),
+    }))
     this.touch(hostId, sessionId)
   }
 
@@ -894,14 +936,82 @@ class Store {
     }, TOUCH_INTERVAL)
   }
 
+  // ─── Layout ────────────────────────────────────────────────────────────
+
+  /**
+   * Rewrites one session's arrangement.
+   *
+   * Reads through localStorage rather than the state alone: an agent's
+   * `helios_show` can name a session this window has never opened, and starting
+   * that one from the default would throw away an arrangement the user built
+   * the last time they were in it.
+   */
+  private editLayout(target: Selection | null, edit: (layout: Layout) => Layout): void {
+    if (!target) return
+    const { hostId, sessionId } = target
+    const key = sessionKey(hostId, sessionId)
+    const layouts = withLayout(this.state.layouts, hostId, sessionId)
+    const current = layouts[key]
+    if (!current) return
+    const next = edit(current)
+    if (next === current && layouts === this.state.layouts) return
+
+    this.set({ layouts: { ...layouts, [key]: next } })
+    writeLayout(hostId, sessionId, next)
+  }
+
+  /** Brings an item to the front of whichever group holds it. */
+  revealItem(target: Selection | null, item: ItemId): void {
+    this.editLayout(target, (layout) => reveal(layout, item))
+  }
+
   setPanel(panel: RightPanel): void {
-    this.set((s) => ({ panels: showPanel(s, s.selection, panel) }))
+    this.revealItem(this.state.selection, panelItem(panel))
+  }
+
+  /** Drops a tab into a group's strip, or reorders it within one. */
+  moveItem(target: Selection, item: ItemId, toGroup: string, index: number): void {
+    this.editLayout(target, (layout) => moveItem(layout, item, toGroup, index))
+  }
+
+  /** Splits a tab out into a group of its own, beside the one it was dropped on. */
+  splitItem(target: Selection, item: ItemId, atGroup: string, edge: Edge): void {
+    this.editLayout(target, (layout) => splitInto(layout, item, atGroup, edge))
+  }
+
+  /** Takes an item out of the arrangement, when its tab closes. */
+  dropItem(target: Selection, item: ItemId): void {
+    this.editLayout(target, (layout) => removeItem(layout, item))
+  }
+
+  focusGroup(target: Selection, groupId: string): void {
+    this.editLayout(target, (layout) =>
+      layout.focused === groupId ? layout : { ...layout, focused: groupId },
+    )
+  }
+
+  /** `delta` is the fraction of the row the pointer travelled. */
+  resizeGroups(target: Selection, sash: number, delta: number): void {
+    this.editLayout(target, (layout) => resize(layout, sash, delta))
+  }
+
+  evenGroups(target: Selection): void {
+    this.editLayout(target, evenSizes)
+  }
+
+  setLayoutAxis(target: Selection, axis: 'row' | 'column'): void {
+    this.editLayout(target, (layout) => (layout.axis === axis ? layout : { ...layout, axis }))
+  }
+
+  /** Puts terminals the arrangement has not seen into the focused group. */
+  placeTerminals(target: Selection, tabIds: string[]): void {
+    this.editLayout(target, (layout) => reconcile(layout, tabIds))
   }
 
   /** Shows a file in the Files panel, switching to it. */
   openFile(hostId: string, path: string): void {
+    this.revealItem(this.state.selection, panelItem('files'))
     this.set((s) => ({
-      panels: showPanel(s, s.selection, 'files'),
       fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open' },
     }))
   }
@@ -912,8 +1022,8 @@ class Store {
    * searching by name finds it wherever the panel is currently rooted.
    */
   findFile(hostId: string, path: string): void {
+    this.revealItem(this.state.selection, panelItem('files'))
     this.set((s) => ({
-      panels: showPanel(s, s.selection, 'files'),
       fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'find' },
     }))
   }
@@ -946,7 +1056,7 @@ class Store {
       const session = this.sessionById(hostId, sessionId)
       if (session) void this.showTerminal(hostId, session)
     } else if (panel) {
-      this.set((s) => ({ panels: showPanel(s, target, panel) }))
+      this.revealItem(target, panelItem(panel))
     }
 
     if (view === 'file') {
@@ -990,8 +1100,8 @@ class Store {
 
   /** Puts text in the session's composer and shows it, without sending. */
   appendPrompt(hostId: string, sessionId: string, text: string): void {
+    this.revealItem({ hostId, sessionId }, panelItem('chat'))
     this.set((s) => ({
-      panels: showPanel(s, { hostId, sessionId }, 'chat'),
       promptDraft: { hostId, sessionId, text, seq: (s.promptDraft?.seq ?? 0) + 1 },
     }))
   }
@@ -1023,12 +1133,13 @@ class Store {
     const target = { hostId, sessionId: session.session_id }
     this.set((s) => ({
       selection: target,
-      panels: showPanel(s, target, 'terminal'),
-      activeTabs: showTab(s, target, id),
       detached: s.detached.filter((tabId) => tabId !== id),
     }))
 
-    if (this.state.tabs.some((t) => t.id === id)) return
+    if (this.state.tabs.some((t) => t.id === id)) {
+      this.revealItem(target, panelItem('terminal'))
+      return
+    }
 
     const tab: Tab = {
       id,
@@ -1042,7 +1153,12 @@ class Store {
       // long reads as a hang.
       status: wake ? { state: 'connecting', detail: 'starting the agent' } : { state: 'connecting' },
     }
+    // The tab and the strip move together. The agent's terminal has an item of
+    // its own either way — `panel:terminal` is the pane once one is attached
+    // and the attach button before that — so the arrangement does not shift
+    // under the user at the moment the terminal lands.
     this.set((s) => ({ tabs: [...s.tabs, tab] }))
+    this.revealItem(target, panelItem('terminal'))
 
     try {
       // Zero is an abstention, not a guess. The size is unknown until xterm has
@@ -1071,11 +1187,11 @@ class Store {
    */
   async openShell(hostId: string, sessionId: string): Promise<void> {
     const target = { hostId, sessionId }
-    this.set((s) => ({ selection: target, panels: showPanel(s, target, 'terminal') }))
+    this.set({ selection: target })
     try {
       const info = await api(hostId).openShell(sessionId)
       await this.attachTerminal(hostId, sessionId, info.id, shellLabel(info.id))
-      this.set((s) => ({ activeTabs: showTab(s, target, terminalId(hostId, info.id)) }))
+      this.revealItem(target, termItem(terminalId(hostId, info.id)))
     } catch (err) {
       this.fail(err)
     }
@@ -1116,6 +1232,9 @@ class Store {
       tabs: [...s.tabs, tab],
       detached: s.detached.filter((tabId) => tabId !== id),
     }))
+    // Placed, not revealed. A shell re-listed on startup belongs in a strip;
+    // bringing it to the front would push aside whatever the user was reading.
+    this.placeTerminals({ hostId, sessionId }, [id])
     try {
       // Abstain until the pane has measured itself; see openTerminal above.
       await bridge.term.open({ tabId: id, hostId, sessionId, cols: 0, rows: 0, terminalId: termId })
@@ -1222,7 +1341,7 @@ class Store {
   showTerminal(hostId: string, session: Session): void {
     const id = terminalId(hostId, session.session_id)
     const target = { hostId, sessionId: session.session_id }
-    this.set((s) => ({ panels: showPanel(s, target, 'terminal'), activeTabs: showTab(s, target, id) }))
+    this.revealItem(target, panelItem('terminal'))
     if (this.state.tabs.some((t) => t.id === id)) return
     // Looking at a terminal that was disconnected on purpose is not a request
     // to attach again: the panel offers the button for that.
@@ -1231,44 +1350,24 @@ class Store {
   }
 
   /**
-   * Drops a tab, handing the front to the one beside it.
+   * Drops a tab. The arrangement decides what takes its place — the item before
+   * it in the same strip, which is where `removeItem` puts the front.
    *
-   * Naming nothing would do instead — the strip falls back to the agent's
-   * terminal when it finds no name — but closing the middle of three shells is
-   * not a request to leave the shells. The neighbour is the one before it,
-   * since a tab is usually opened after the one it belongs with; the last one
-   * closed leaves the entry empty, and the fallback is right again.
+   * The agent's terminal keeps its place as the placeholder rather than leaving
+   * the strip: closing it is a disconnect, and the panel has something to say
+   * about that which vanishing would swallow.
    */
   closeTab(tabId: string): void {
     void bridge.term.close(tabId)
-    this.set((s) => {
-      const closing = s.tabs.find((t) => t.id === tabId)
-      const tabs = s.tabs.filter((t) => t.id !== tabId)
-      const activeTabs = { ...s.activeTabs }
-      const key = closing ? sessionKey(closing.hostId, closing.sessionId) : null
+    const closing = this.state.tabs.find((t) => t.id === tabId)
+    this.set((s) => ({ tabs: s.tabs.filter((t) => t.id !== tabId) }))
+    if (!closing) return
 
-      // Naming nothing would do — the strip falls back to the agent's terminal
-      // when it finds no name — but closing the middle of three shells is not
-      // a request to leave the shells. The one before it, since a shell is
-      // usually opened after the one it belongs with; the last shell closed
-      // names nothing, and the fallback is right again.
-      //
-      // Shells only. Closing the agent's terminal is a disconnect, and the
-      // panel has something to say about that which a shell would cover up.
-      if (key && closing?.kind === 'shell' && activeTabs[key] === tabId) {
-        const shells = s.tabs.filter(
-          (t) => t.kind === 'shell' && t.hostId === closing.hostId && t.sessionId === closing.sessionId,
-        )
-        const at = shells.findIndex((t) => t.id === tabId)
-        const next = shells[at - 1] ?? shells[at + 1]
-        if (next) activeTabs[key] = next.id
-        else delete activeTabs[key]
-      } else {
-        for (const [k, id] of Object.entries(activeTabs)) if (id === tabId) delete activeTabs[k]
-      }
-
-      return { tabs, activeTabs }
-    })
+    // A shell that closes leaves the strip. The agent's terminal does not: its
+    // item is the panel, which goes back to offering the attach button.
+    if (closing.kind === 'shell') {
+      this.dropItem({ hostId: closing.hostId, sessionId: closing.sessionId }, termItem(tabId))
+    }
   }
 
   /** Brings one of a session's terminals to the front. */
@@ -1276,7 +1375,7 @@ class Store {
     const tab = this.state.tabs.find((t) => t.id === tabId)
     if (!tab) return
     const target = { hostId: tab.hostId, sessionId: tab.sessionId }
-    this.set((s) => ({ panels: showPanel(s, target, 'terminal'), activeTabs: showTab(s, target, tabId) }))
+    this.revealItem(target, tab.kind === 'agent' ? panelItem('terminal') : termItem(tabId))
   }
 
   // ─── Feedback ──────────────────────────────────────────────────────────
@@ -1317,25 +1416,50 @@ export function useStore<T>(select: (state: State) => T): T {
   return useSyncExternalStore(store.subscribe, () => select(store.getSnapshot()))
 }
 
-/** The panel the selected session is reading. */
+/** How the selected session's panels are arranged. */
+export function currentLayout(state: State): Layout {
+  if (!state.selection) return EMPTY_LAYOUT
+  return state.layouts[sessionKey(state.selection.hostId, state.selection.sessionId)] ?? EMPTY_LAYOUT
+}
+
+/** Stable so a selector comparing by identity does not loop. */
+const EMPTY_LAYOUT = defaultLayout()
+
+/**
+ * Reads a session's arrangement in, if this window has not seen it yet.
+ *
+ * Once in state it is never re-read: an agent's show can rearrange a session
+ * that is not on screen, and re-reading on select would undo it.
+ */
+function withLayout(
+  layouts: Record<string, Layout>,
+  hostId: string,
+  sessionId: string,
+): Record<string, Layout> {
+  const key = sessionKey(hostId, sessionId)
+  if (layouts[key]) return layouts
+  return { ...layouts, [key]: readLayout(hostId, sessionId) }
+}
+
+/** The panel the selected session has in front, for the callers that ask in
+ *  those terms. A terminal item reads as the terminal panel. */
 export function currentPanel(state: State): RightPanel {
-  if (!state.selection) return 'chat'
-  return state.panels[sessionKey(state.selection.hostId, state.selection.sessionId)] ?? 'chat'
+  const layout = currentLayout(state)
+  const active = layout.groups.find((group) => group.id === layout.focused)?.active
+  if (!active) return 'chat'
+  return (panelOf(active) as RightPanel | null) ?? 'terminal'
 }
 
-/** The terminal the selected session has in front, if it has named one. */
+/** The terminal the selected session has in front, if one is. */
 export function currentTab(state: State): string | null {
-  if (!state.selection) return null
-  return state.activeTabs[sessionKey(state.selection.hostId, state.selection.sessionId)] ?? null
+  const layout = currentLayout(state)
+  const active = layout.groups.find((group) => group.id === layout.focused)?.active
+  return active ? tabOf(active) : null
 }
 
-function showPanel(state: State, target: Selection | null, panel: RightPanel): Record<string, RightPanel> {
-  if (!target) return state.panels
-  return { ...state.panels, [sessionKey(target.hostId, target.sessionId)]: panel }
-}
-
-function showTab(state: State, target: Selection, tabId: string): Record<string, string> {
-  return { ...state.activeTabs, [sessionKey(target.hostId, target.sessionId)]: tabId }
+/** Whether an item is on screen in any group — what decides a pane's size vote. */
+export function itemVisible(state: State, item: ItemId): boolean {
+  return isVisible(currentLayout(state), item)
 }
 
 function str(value: unknown): string {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -600,8 +600,8 @@ small {
 
 /* The panels inside a session — transcript, terminal, git, files — sit on the
    detail panel, so anything of theirs that paints has to give way too. */
-[data-glass='on'] .panes,
 [data-glass='on'] .pane,
+[data-glass='on'] .pane-empty,
 [data-glass='on'] .pane-term,
 [data-glass='on'] .chat,
 [data-glass='on'] .chat-scroll {
@@ -1360,13 +1360,17 @@ small {
 }
 
 /* A mounted panel waiting its turn. hidden alone would be overridden by the
-   flex display its contents need. */
+   flex display its contents need.
+
+   Several of these share one grid cell — the items of one group, one of which
+   is in front. The hidden ones generate no box and so size no track: a wide
+   diff sitting behind a file tree cannot widen the group it is in. */
 .panel-keep {
-  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
   min-width: 0;
+  overflow: hidden;
 }
 
 .panel-keep[hidden] {
@@ -1557,11 +1561,112 @@ small {
   border-radius: var(--r-sm);
 }
 
+/* The groups, laid out flat.
+
+   One grid rather than nested containers, and every child a direct child of it:
+   moving a tab from one group to another is then a change to one `grid-column`
+   on a node that stays exactly where it is in the DOM. A nested layout would
+   have to re-parent the node, and a re-parent in React is an unmount — which
+   disposes the xterm and takes the scrollback with it.
+
+   The tracks come from the layout as inline styles, because they are data: one
+   `fr` per group, a fixed gutter between neighbours. */
 .panel-body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  display: flex;
+  display: grid;
+}
+
+/* Nothing is selected, or the session is still loading: one child, filling it. */
+.panel-body > .panel-empty,
+.panel-body > .panel-loading {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+}
+
+/* A group that is not the focused one still reads its tabs, but the underline
+   marking the one in front belongs to the group with the keyboard. */
+.panel-tabs:not(.focused) button.active {
+  color: var(--on-surface-variant);
+  border-bottom-color: var(--outline-variant);
+}
+
+/* Where a dragged tab would land in this strip. */
+.panel-tabs button.insert {
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.tab-insert {
+  align-self: center;
+  width: 2px;
+  height: 20px;
+  flex: none;
+  background: var(--primary);
+}
+
+/* The gutter between two groups. Wider to the pointer than it looks, because a
+   6px target is a miss most of the time. */
+.group-sash {
+  position: relative;
+  z-index: 2;
+  background: var(--outline-variant);
+  opacity: 0.5;
+}
+
+.group-sash.row {
+  cursor: col-resize;
+}
+
+.group-sash.column {
+  cursor: row-resize;
+}
+
+.group-sash::after {
+  content: '';
+  position: absolute;
+  inset: -3px;
+}
+
+.group-sash:hover,
+.group-sash:active {
+  background: var(--primary);
+  opacity: 1;
+}
+
+/* Only mounted while a tab is in flight; see DropZone in detail.tsx. */
+.group-drop {
+  z-index: 3;
+  border-radius: var(--r-md);
+  transition: background 90ms ease;
+}
+
+.group-drop.over {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--primary) 50%, transparent);
+  outline-offset: -1px;
+}
+
+/* The half the new group would take, drawn where it would go. */
+.group-drop.over.before,
+.group-drop.over.after {
+  background: linear-gradient(
+    var(--drop-angle, 90deg),
+    color-mix(in srgb, var(--primary) 22%, transparent) 0 50%,
+    transparent 50% 100%
+  );
+}
+
+.group-drop.over.after {
+  --drop-angle: 270deg;
+}
+
+.panel-body.column .group-drop.over.before {
+  --drop-angle: 180deg;
+}
+
+.panel-body.column .group-drop.over.after {
+  --drop-angle: 0deg;
 }
 
 .panel-error {
@@ -2735,6 +2840,39 @@ small {
   background: color-mix(in srgb, var(--on-surface) 3%, transparent);
 }
 
+/* Collapsed. `hidden` alone would lose to the flex display above. */
+.ws-side[hidden] {
+  display: none;
+}
+
+/* Sits at the head of the file tabs, which is the one strip that is there
+   whether or not a file is open. Pinned, because that strip scrolls once
+   enough files are open and the way back must not scroll away with it. */
+.ws-side-toggle {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  flex: none;
+  align-self: center;
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+  margin-right: 2px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  background: var(--surface-low);
+}
+
+.ws-side-toggle:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+  color: var(--on-surface);
+}
+
+.ws-side-toggle.off {
+  color: var(--primary);
+}
+
 .ws-side-head {
   display: flex;
   align-items: center;
@@ -3220,44 +3358,30 @@ small {
   font-size: 22px;
 }
 
-.panes {
-  flex: 1;
-  position: relative;
-  min-height: 0;
-  background: var(--surface-container);
-}
-
-/* Still mounted, just out of the layout, so the panes it holds keep their
-   scrollback while the user reads another panel. */
-.panes.hidden {
-  display: none;
-}
-
 .pane-empty {
-  position: absolute;
-  inset: 0;
+  flex: 1;
   display: grid;
   place-items: center;
   align-content: center;
   gap: 12px;
   color: var(--on-surface-variant);
+  background: var(--surface-container);
 }
 
 .pane-empty p {
   margin: 0;
 }
 
-/* Hidden rather than unmounted: an unmounted xterm loses its scrollback, and
-   the connection behind it would have to replay from scratch. */
+/* One terminal, filling the cell of whichever group holds its tab. Hidden by
+   the item wrapper rather than unmounted: an unmounted xterm loses its
+   scrollback, and the connection behind it cannot replay from scratch. */
 .pane {
-  position: absolute;
-  inset: 0;
-  display: none;
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
   padding: 10px 12px;
-}
-
-.pane.active {
-  display: block;
+  background: var(--surface-container);
 }
 
 .pane-term {

--- a/desktop/test/layout.test.ts
+++ b/desktop/test/layout.test.ts
@@ -1,0 +1,263 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  defaultLayout,
+  evenSizes,
+  groupOf,
+  isVisible,
+  moveItem,
+  panelItem,
+  panelOf,
+  PANEL_ITEMS,
+  parseLayout,
+  placedItems,
+  reconcile,
+  removeItem,
+  resize,
+  reveal,
+  splitInto,
+  sweep,
+  tabOf,
+  termItem,
+  totalSize,
+  visibleItems,
+  type Group,
+  type Layout,
+} from '../src/renderer/components/layout.ts'
+
+/** Indexing a group, with the check the type checker wants written once. */
+function g(layout: Layout, index: number): Group {
+  const group = layout.groups[index]
+  assert.ok(group, `no group at ${index}`)
+  return group
+}
+
+function sizes(layout: Layout): number[] {
+  return layout.groups.map((group) => group.size)
+}
+
+const CHAT = panelItem('chat')
+const TERMINAL = panelItem('terminal')
+const APPROVALS = panelItem('approvals')
+const FILES = panelItem('files')
+const GIT = panelItem('git')
+const TERM = termItem('h1:s1')
+const SHELL = termItem('h1:s1:sh2')
+
+/** The default, with `files` dragged out beside the transcript. */
+function split(): Layout {
+  return splitInto(defaultLayout(), FILES, 'g1', 'after')
+}
+
+/** What is left in the first group once `files` has been split out of it. */
+const REST = [CHAT, TERMINAL, APPROVALS, GIT]
+
+test('an item names either a panel or a terminal', () => {
+  assert.equal(panelOf(FILES), 'files')
+  assert.equal(panelOf(TERM), null)
+  assert.equal(tabOf(TERM), 'h1:s1')
+  assert.equal(tabOf(FILES), null)
+})
+
+test('a session starts as one group listing every panel, reading the transcript', () => {
+  const layout = defaultLayout()
+  assert.equal(layout.groups.length, 1)
+  assert.deepEqual(placedItems(layout), PANEL_ITEMS)
+  assert.equal(g(layout, 0).active, CHAT)
+  assert.equal(layout.focused, g(layout, 0).id)
+})
+
+test('revealing an unplaced item appends it to the focused group', () => {
+  const layout = reveal(defaultLayout(), TERM)
+  assert.deepEqual(placedItems(layout), [...PANEL_ITEMS, TERM])
+  assert.equal(g(layout, 0).active, TERM)
+})
+
+test('revealing a panel already in the strip only brings it forward', () => {
+  const layout = reveal(defaultLayout(), FILES)
+  assert.deepEqual(placedItems(layout), PANEL_ITEMS)
+  assert.equal(g(layout, 0).active, FILES)
+})
+
+test('revealing a placed item activates it where it is and focuses that group', () => {
+  const layout = split()
+  const left = g(layout, 0)
+  const right = g(layout, 1)
+  assert.deepEqual(left.items, REST)
+  assert.deepEqual(right.items, [FILES])
+
+  const back = reveal(layout, CHAT)
+  assert.equal(back.focused, left.id)
+  // The reveal must not drag files out of the group the user put it in.
+  assert.equal(groupOf(back, FILES)?.id, right.id)
+})
+
+test('a split makes a group beside the one it came from and halves its weight', () => {
+  const layout = split()
+  assert.equal(layout.groups.length, 2)
+  assert.deepEqual(sizes(layout), [0.5, 0.5])
+  assert.equal(layout.focused, g(layout, 1).id)
+  assert.equal(totalSize(layout), 1)
+})
+
+test('splitting before puts the new group on the left', () => {
+  const layout = splitInto(defaultLayout(), FILES, 'g1', 'before')
+  assert.deepEqual(g(layout, 0).items, [FILES])
+  assert.deepEqual(g(layout, 1).items, REST)
+})
+
+test('splitting a lone item off its own group does nothing', () => {
+  const layout = split()
+  const right = g(layout, 1)
+  assert.equal(splitInto(layout, FILES, right.id, 'after'), layout)
+})
+
+test('both groups are visible at once', () => {
+  const layout = split()
+  assert.deepEqual(visibleItems(layout).sort(), [CHAT, FILES].sort())
+  assert.equal(isVisible(layout, CHAT), true)
+  assert.equal(isVisible(layout, FILES), true)
+})
+
+test('moving the last item out of a group collapses it and returns its weight', () => {
+  const layout = split()
+  const left = g(layout, 0)
+  const right = g(layout, 1)
+  const merged = moveItem(layout, FILES, left.id, 1)
+
+  assert.equal(merged.groups.length, 1)
+  // Dropped at slot 1, which is where the pointer was — not appended.
+  assert.deepEqual(g(merged, 0).items, [CHAT, FILES, TERMINAL, APPROVALS, GIT])
+  assert.equal(g(merged, 0).size, 1)
+  assert.equal(groupOf(merged, FILES)?.id, left.id)
+  assert.equal(merged.groups.some((group) => group.id === right.id), false)
+})
+
+test('moving within a group reorders rather than collapsing', () => {
+  const moved = moveItem(defaultLayout(), GIT, 'g1', 0)
+  assert.deepEqual(g(moved, 0).items, [GIT, CHAT, TERMINAL, APPROVALS, FILES])
+  assert.equal(moved.groups.length, 1)
+})
+
+test('closing the middle of three shells activates the one before it', () => {
+  let layout = defaultLayout()
+  for (const tab of ['a', 'b', 'c']) layout = reveal(layout, termItem(tab))
+  layout = reveal(layout, termItem('b'))
+
+  const closed = removeItem(layout, termItem('b'))
+  assert.equal(g(closed, 0).active, termItem('a'))
+  assert.deepEqual(g(closed, 0).items, [...PANEL_ITEMS, termItem('a'), termItem('c')])
+})
+
+test('emptying the only group falls back to the transcript rather than nothing', () => {
+  const lone = parseLayout({ groups: [{ id: 'g1', items: [FILES], active: FILES, size: 1 }] })
+  const layout = removeItem(lone, FILES)
+  assert.deepEqual(g(layout, 0).items, [CHAT])
+  assert.equal(g(layout, 0).active, CHAT)
+})
+
+test('closing the last item of a split group collapses it', () => {
+  const layout = split()
+  const closed = removeItem(layout, FILES)
+  assert.equal(closed.groups.length, 1)
+  assert.deepEqual(g(closed, 0).items, REST)
+  assert.equal(g(closed, 0).size, 1)
+  assert.equal(closed.focused, g(closed, 0).id)
+})
+
+test('reconcile appends live tabs it has not placed', () => {
+  const layout = reconcile(defaultLayout(), ['h1:s1', 'h1:s1:sh2'])
+  assert.deepEqual(placedItems(layout), [...PANEL_ITEMS, TERM, SHELL])
+})
+
+test('reconcile never prunes: a saved terminal survives until its tab re-attaches', () => {
+  const saved = parseLayout({
+    axis: 'row',
+    focused: 'g1',
+    groups: [{ id: 'g1', items: [CHAT, SHELL], active: SHELL, size: 1 }],
+  })
+  // The shells have not been listed yet — this is the window syncShells awaits in.
+  const early = reconcile(saved, [])
+  assert.deepEqual(placedItems(early), [CHAT, SHELL])
+  assert.equal(g(early, 0).active, SHELL)
+})
+
+test('reconcile is idempotent for tabs already placed', () => {
+  const once = reconcile(defaultLayout(), ['h1:s1'])
+  assert.equal(reconcile(once, ['h1:s1']), once)
+})
+
+test('sweep spares an item that is visible in a group other than the focused one', () => {
+  const layout = split()
+  const old = Date.now() - 10 * 60 * 1000
+  const dead = sweep(layout, { [CHAT]: old, [FILES]: old, [GIT]: old }, Date.now(), 5 * 60 * 1000)
+  // chat and files are each in front of a group; only git is unseen.
+  assert.deepEqual(dead, [GIT])
+})
+
+test('sweep leaves items inside the window alone', () => {
+  const layout = split()
+  const now = Date.now()
+  assert.deepEqual(sweep(layout, { [GIT]: now - 1000 }, now, 5 * 60 * 1000), [])
+})
+
+test('a sash moves weight between its two groups and keeps the total', () => {
+  const layout = resize(split(), 0, 0.2)
+  assert.deepEqual(sizes(layout), [0.7, 0.3])
+  assert.equal(totalSize(layout), 1)
+})
+
+test('a sash cannot squeeze a group out of existence', () => {
+  const layout = resize(split(), 0, -5)
+  assert.ok(g(layout, 0).size >= 0.15)
+  assert.equal(totalSize(layout), 1)
+})
+
+test('a sash that names no pair is a no-op', () => {
+  const layout = split()
+  assert.equal(resize(layout, 1, 0.2), layout)
+})
+
+test('even sizes reset the weights', () => {
+  const layout = evenSizes(resize(split(), 0, 0.3))
+  assert.deepEqual(sizes(layout), [1, 1])
+})
+
+test('parseLayout falls back to the default for anything it cannot read', () => {
+  const chat = PANEL_ITEMS
+  for (const raw of [null, undefined, 'nope', 42, [], {}, { groups: [] }, { groups: 'x' }]) {
+    assert.deepEqual(g(parseLayout(raw), 0).items, chat, `for ${JSON.stringify(raw)}`)
+  }
+})
+
+test('parseLayout rejects a group with no id and one whose items are not strings', () => {
+  assert.equal(parseLayout({ groups: [{ items: [CHAT], active: CHAT, size: 1 }] }).groups.length, 1)
+  assert.deepEqual(g(parseLayout({ groups: [{ id: 'g1', items: [7] }] }), 0).items, PANEL_ITEMS)
+})
+
+test('parseLayout repairs a focus and an active that name nothing', () => {
+  const layout = parseLayout({
+    axis: 'row',
+    focused: 'gone',
+    groups: [{ id: 'g1', items: [CHAT], active: 'panel:vanished', size: 1 }],
+  })
+  assert.equal(layout.focused, 'g1')
+  assert.equal(g(layout, 0).active, CHAT)
+})
+
+test('parseLayout keeps a good layout as it was', () => {
+  const saved = split()
+  const read = parseLayout(JSON.parse(JSON.stringify(saved)))
+  assert.deepEqual(read, saved)
+})
+
+test('a group id restored from disk is never handed out twice', () => {
+  const saved = parseLayout({
+    axis: 'row',
+    focused: 'g9',
+    groups: [{ id: 'g9', items: [CHAT, FILES], active: CHAT, size: 1 }],
+  })
+  const after = splitInto(saved, FILES, 'g9', 'after')
+  assert.equal(new Set(after.groups.map((group) => group.id)).size, after.groups.length)
+})

--- a/docs/specs/50-desktop-split-layout.md
+++ b/docs/specs/50-desktop-split-layout.md
@@ -1,0 +1,502 @@
+# Editor Groups for the Desktop: Two Panels Side by Side, Remembered Per Session
+
+## The claim
+
+A session's panels should be arrangeable, not just switchable. The user should
+be able to drag the Files tab against the right edge of the transcript, get two
+groups side by side with a sash between them, and find that arrangement again
+the next time the session is opened — and the time after the app is restarted.
+
+Today the detail view shows exactly one panel. `detail.tsx` renders a single tab
+strip over a single body, and `state.panels[sessionKey]` holds the one name of
+the one panel in front. Reading the transcript while browsing the tree means
+alternating between two tabs, and the pairing the app is most used for —
+transcript or terminal on one side, Files on the other — cannot be expressed at
+all.
+
+This spec adds VS Code's editor-group mechanism: several groups along one axis,
+each with its own tab strip, tabs dragged between groups, a drop on a group's
+edge splitting off a new one, draggable sashes, and the whole arrangement stored
+per session.
+
+**Scope: `desktop/` only.** No daemon route changes shape, no wire format moves,
+and `mobile/` and `internal/tui` are untouched. A phone renders one panel at a
+time and should keep doing so; this is a change to how one renderer arranges
+what it already has.
+
+## Where we are
+
+| | Today |
+|---|---|
+| Tabs | one strip, `PANELS` = `chat \| terminal \| approvals \| git \| files` (`detail.tsx:23`) plus one per open shell (`detail.tsx:182`) |
+| Which is in front | `state.panels: Record<sessionKey, RightPanel>` (`store.ts:154`), read by `currentPanel` (`store.ts:1321`), written by `showPanel` (`store.ts:1332`) |
+| Which terminal is in front | `state.activeTabs: Record<sessionKey, string>` (`store.ts:160`), `currentTab` / `showTab` (`store.ts:1329,1337`) |
+| Persistence | none. Both maps are in memory; a restart forgets every session's panel |
+| Panel mounting | mount once, hide with `hidden` (`detail.tsx:219`), `.panel-keep[hidden]{display:none}` (`styles.css:1372`) |
+| Panel unmounting | an idle sweep after `PANEL_TTL` of 5 minutes (`detail.tsx:46,106-120`), except `NO_TTL = ['git','files']` (`detail.tsx:55`) |
+| Terminals | all mounted at once by `TerminalPanes` (`terminal.tsx:31`), one `.pane` each, `position:absolute; inset:0; display:none` and `.pane.active{display:block}` (`styles.css:3252-3261`) |
+| The one existing split | `.agent-split` — approvals docked beside the transcript, hard-coded, folding under it below 1240px (`styles.css:1586-1614`) |
+
+Two of those rows are the reason this is tractable. **Panels already stay
+mounted**, hidden by CSS rather than unmounted, and the comments say why
+(`detail.tsx:36-42`): a panel holds work as much as it displays it, and a tab
+switch that unmounts throws away the open file, the scrolled diff, the scrolled
+transcript. **Terminals already stay mounted** for a harder reason
+(`terminal.tsx:26-29`): an xterm that unmounts loses its scrollback, and neither
+the daemon nor the main process can replay it a second time.
+
+So the app is already rendering everything at once and choosing what to show.
+Showing two things is a layout change, not a lifecycle change — provided nothing
+about the arrangement causes a remount.
+
+## What it looks like
+
+Today. One strip, one body, and the only way to see the tree is to stop seeing
+the transcript:
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│ opal-app — rewrite the ingest worker            ● idle   default  │
+├───────────────────────────────────────────────────────────────────┤
+│ agent │ ●terminal ⟳ ⏻ │ approvals │ git │ files │ ●zsh ⟳ × │  +   │
+├───────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│   > the worker retries on a 429 but not on a 503 — want me to     │
+│     fold both into the same backoff?                              │
+│                                                                   │
+│                                                                   │
+├───────────────────────────────────────────────────────────────────┤
+│  ▌ask anything                                                    │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+After. Two groups, each with its own strip, a sash between them:
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│ opal-app — rewrite the ingest worker            ● idle   default  │
+├────────────────────────────────────────┬─┬────────────────────────┤
+│ agent │ ●terminal ⟳ ⏻ │ ●zsh ⟳ ×      │ │ files │ git │ approvals│
+├────────────────────────────────────────┤ ├────────────────────────┤
+│                                        │ │ ▾ internal/            │
+│  > the worker retries on a 429 but     │ │   ▾ ingest/            │
+│    not on a 503 — want me to fold      │ │       worker.go      ● │
+│    both into the same backoff?         │ │       backoff.go       │
+│                                        │ │   ▸ server/            │
+│                                        │ │ ──────────────────────  │
+│                                        │ │ func (w *Worker) run(  │
+├────────────────────────────────────────┤ │   for {                │
+│  ▌ask anything                         │ │     if err := w.step(  │
+└────────────────────────────────────────┴─┴────────────────────────┘
+     group A · 1.3fr                    sash    group B · 0.7fr
+     active: panel:chat                         active: panel:files
+     items:  panel:chat, panel:terminal,        items:  panel:files,
+             term:…:zsh                                 panel:git,
+                                                        panel:approvals
+```
+
+Both strips are live: clicking `git` in the right-hand group swaps that group's
+body and leaves the transcript alone. Nothing about the left group knows the
+right one exists.
+
+The grid underneath. Three column tracks, two row tracks, and every item a flat
+child placed into a cell — the strips into row 1, the bodies into row 2, the
+sash spanning both:
+
+```
+grid-template-columns: minmax(0,1.3fr)   6px   minmax(0,.7fr)
+grid-template-rows:    auto  /  1fr
+
+                col 1                col 2            col 3
+           ┌───────────────────┐    ┌─────┐    ┌──────────────────┐
+   row     │  strip A          │    │     │    │  strip B         │
+   auto    └───────────────────┘    │     │    └──────────────────┘
+           ┌───────────────────┐    │  s  │    ┌──────────────────┐
+           │  panel:chat       │    │  a  │    │  panel:files     │
+   row     │ ┄panel:terminal┄  │    │  s  │    │ ┄panel:git┄      │
+   1fr     │ ┄term:…:zsh┄      │    │  h  │    │ ┄panel:approvals┄│
+           └───────────────────┘    └─────┘    └──────────────────┘
+
+           ┄dashed┄ = the group's inactive items. Same cell, `hidden`,
+                      so they generate no box and size no track.
+```
+
+Dragging `files` from group B to group A changes one string —
+`gridColumn: 3` becomes `gridColumn: 1` — on a `<div>` that is not touched
+otherwise. That is the whole move.
+
+## The shape of the state
+
+A flat list of groups along one axis:
+
+```ts
+type ItemId = `panel:${RightPanel}` | `term:${string}`
+interface Group { id: string; items: ItemId[]; active: ItemId; size: number }
+interface Layout { axis: 'row' | 'column'; groups: Group[]; focused: string }
+```
+
+`size` is an `fr` weight, not a pixel count. A pixel width taken from today's
+window leaves gutters in a wider one, which is the bug `writeReadingWidth`
+already works around by hand for the markdown column (`files.tsx:731-736`).
+Weights need no such rule.
+
+Flat rather than a tree. VS Code has a full pane grid, but its common case — and
+the one this spec exists for — is a row of groups. A nested tree is several
+times the state and the drop logic for an arrangement nobody has asked for. The
+functions below take a `Layout` and return a `Layout`, so a tree can replace the
+representation later without touching a call site.
+
+Items, not panels. A shell tab and the Files panel are the same kind of thing
+once they can be dragged into different groups, and the current split — panels
+in one strip, terminals in a parallel `activeTabs` map — has no meaning under a
+layout. `detail.tsx:137` already argues the same point about the strip: a shell
+is a sibling of the transcript, not a mode of the terminal.
+
+## Rendering: one grid, and nothing ever moves in the DOM
+
+This is the load-bearing decision, so it is worth stating what it avoids.
+
+Dragging a tab from one group to another moves it in the DOM. In React, a
+re-parent is an unmount and a fresh mount — which runs `TerminalPane`'s cleanup
+and calls `term.dispose()` (`terminal.tsx:167`), losing the scrollback that
+cannot be replayed. The same move discards the CodeMirror state in Files and the
+scroll position in Git.
+
+The usual escape is a portal: hold a `div` created imperatively, `createPortal`
+the content into it once, and `appendChild` that `div` into whichever group
+should own it. The portal container object never changes, so React never
+unmounts. It works, and it costs three things. Child effects run before parent
+effects, so `term.open(container)` fires while the host is still detached —
+xterm 5.5 logs *"Terminal.open was called on an element that was not attached to
+the DOM"* and then measures character cells against a detached node, which can
+throw inside `WebglAddon`. Every move then needs a `proposeDimensions()` and
+`refresh()` kick to re-measure. And the browser clears focus when a node leaves
+the document, so CodeMirror sees a spurious selection change on every drag.
+
+None of that is necessary, because the DOM does not have to move.
+
+`.panel-body` becomes a **CSS Grid with flat children**:
+
+- `grid-template-rows: auto 1fr` — row 1 holds the tab strips, row 2 holds the
+  bodies.
+- `grid-template-columns` is computed inline from the group weights, interleaved
+  with fixed sash tracks: `minmax(0,1.3fr) 6px minmax(0,.7fr)`.
+- The children are three flat lists, rendered in an order that does not depend
+  on the layout: one strip per group, **one host per item** in canonical order
+  (`PANELS`, then `store.tabs`), and N−1 sashes at `grid-row: 1 / -1`.
+
+Several items share a cell. The inactive ones keep the `hidden` attribute they
+already carry (`detail.tsx:219`), generate no box, and contribute nothing to
+track sizing — so a hidden Files panel cannot widen the column its group sits
+in.
+
+Moving a tab between groups is then one inline `gridColumn` string changing on a
+node that stays exactly where it is. No remount, no re-parent, no re-measure, no
+focus loss. `minmax(0, …)` on every track because a grid item's default
+`min-width: auto` would let a wide diff refuse to shrink.
+
+`.panes` and `.pane` lose their absolute positioning (`styles.css:3223-3261`).
+That container existed to stack terminals on top of each other in one cell;
+under the grid each pane is a grid item in its group's cell, stacked by the same
+`hidden` rule as everything else.
+
+**Measured, not assumed.** The claim was tested against the running app over
+CDP, on a live agent terminal: `.panel-body` set to the grid above, `.panes` to
+`display: contents` so each `.pane` becomes a grid item, and the pane's
+`gridColumn` then moved between tracks.
+
+| | pane width | xterm | canvases |
+|---|---|---|---|
+| flex + absolute, as today | 1672px | 280 cols | 2 |
+| grid item, col 1 (1.3fr) | 1083px | 139 cols | 2 |
+| moved to col 3 (0.7fr) | 583px | 73 cols | 2 |
+| moved back to col 1 | 1083px | 139 cols | 2 |
+
+The node was identity-checked across the moves and never replaced, both WebGL
+canvases survived, and the terminal kept rendering. Changing one `gridColumn`
+string re-measured the pane, the proposal reached the host, and the host's
+answer resized the grid — the whole loop, with nothing re-parented.
+
+## The layout module
+
+`desktop/src/renderer/components/layout.ts`, pure, importing nothing from the
+store — the same shape as `components/grouping.ts`, and for the same reason:
+`bridge.ts` binds `window.helios` at module scope, so anything that reaches it
+cannot be loaded by the type-stripping test runner. A module that reaches
+nothing can be asserted directly.
+
+| Function | Does |
+|---|---|
+| `defaultLayout()` | one group, `['panel:chat']`, focused |
+| `reveal(layout, item)` | if the item is in a group, activate it there and focus that group; otherwise append it to the focused group and activate it |
+| `moveItem(layout, item, toGroup, index)` | move between strips, or reorder within one |
+| `splitInto(layout, item, atGroup, edge)` | new group before or after `atGroup`, taking half its weight |
+| `removeItem(layout, item)` | drop it, pick the neighbour as active, collapse an emptied group and give its weight back |
+| `resize(layout, sashIndex, delta)` | move weight across one sash, clamped |
+| `reconcile(layout, liveTermIds)` | **append-only** — add terminals that are not placed yet |
+| `sweep(layout, lastSeen, now)` | which items the idle sweep may unmount |
+| `parseLayout(unknown)` | a stored value, or the default |
+
+`removeItem` replaces the neighbour-picking written by hand inside `closeTab`
+(`store.ts:1256-1268`) — the rule it encodes, that closing the middle of three
+shells should land on the one before it rather than fall back to the agent's
+terminal, moves into the model and gets a test.
+
+## Seven things that will break if they are not designed for
+
+**1. Reconcile must never prune.** The layout is read from localStorage
+synchronously when a session is selected, but shells are re-attached over an
+`await` in `store.syncShells`, called from an effect (`detail.tsx:81-84`). A
+reconcile that dropped items with no live tab would delete every `term:` item in
+that window — the restored arrangement would be gone before it could be shown.
+Removal is event-driven only: `closeTab`, `killShell`, `terminal_closed`.
+
+**2. `applyShow` targets a session that may not be selected.** The agent's
+`helios_show` prepares another session's view and waits there
+(`store.ts:929-931`). Its layout may never have been loaded. Every mutation goes
+through a `layoutFor(state, key)` that materialises from localStorage on first
+touch and never re-reads once `state.layouts[key]` exists — otherwise the read
+that happens on select would clobber what the agent just did.
+
+**3. `openTerminal` reveals a tab that does not exist yet.** It sets the panel
+and the active tab, then `await`s `bridge.term.open` (`store.ts:1024-1054`).
+Under a layout, revealing `term:<id>` before the tab is in `state.tabs` places an
+item nothing renders. Create the tab and reveal it in the same `set`.
+
+**4. Two visible panes both grab focus.** `TerminalPane` calls `term.focus()`
+whenever it becomes active (`terminal.tsx:208`). With two groups on screen the
+last one to render wins, and every layout change steals the caret. Focus only
+when the item's group is `layout.focused`.
+
+**5. The idle sweep must look at every group.** `PANEL_TTL` unmounts a panel
+that has not been in front for five minutes. A panel sitting visible in a second
+group has not been "in front" by today's definition and would be swept out from
+under the user. The check becomes `groups.some(g => g.active === id)`.
+
+**6. A tab in a strip is not a mounted panel.** These have to be separate, and
+the first draft of this spec had them as one thing. If the layout only holds
+items that have been revealed, a panel you have never opened is in no strip and
+there is nothing to drag. If the layout holds everything and the layout drives
+mounting, opening a session mounts Git and Files and fires their fetches.
+
+So the default layout lists all five panels — the strip says what the session
+*has* — and mounting is a separate question the view answers: an item is mounted
+once it has been looked at, and terminals from the moment their tab exists,
+because output arrives on one channel for every tab and is dropped for a tab
+with no pane listening.
+
+**7. The terminal placeholder is not a pane.** "No terminal attached" and the
+Attach / Wake buttons live on the container today, alongside the effect that
+auto-attaches when the panel is first shown (`terminal.tsx:50-99`). Under the
+grid there is no container. `panel:terminal` becomes an item in its own right
+that renders the placeholder and holds that effect; `reconcile` swaps it for
+`term:<agentTabId>` in place once the agent's tab lands, so the split the user
+built survives the attach.
+
+**8. A pane has to outlive the session being selected.** The obvious shape —
+render the items of the selected session's layout — unmounts the previous
+session's terminals on every switch. That looks harmless, because switching back
+builds a new pane. It is not: the connection lives in the main process and keeps
+counting bytes, so the new xterm's re-attach asks the host to catch it up from a
+sequence the host has already passed, and gets a delta instead of a screen. The
+result is a live green dot over an empty grid with a cursor in it, until a
+reconnect. `TerminalPanes` avoided this by mapping over every tab in the store
+rather than the session's, and the replacement has to keep that: **one pane per
+tab, for every tab, mounted for as long as the tab is.** Which cell it sits in
+and whether it is hidden come from the selected session's layout; whether it
+exists does not.
+
+That splits the terminal in two: `panel:terminal` is the *slot* — the tab in the
+strip, and the attach button when there is nothing attached — while the pane
+itself is drawn from the deck of all tabs and placed into that slot's cell.
+
+**9. An xterm opened against a zero-size element is stranded for good.**
+`Terminal.open()` measures a character against the element it is given. A pane
+that mounts behind another tab has no layout, so the cell comes out zero wide —
+and nothing ever measures again: xterm carries no resize observer, and
+`FitAddon.proposeDimensions()` returns `undefined` on a zero cell, so the pane
+cannot even ask the host for a size. It draws an empty grid with a cursor in it
+until a reconnect builds a new terminal, which is exactly the "blinking cursor,
+fixed by refreshing" the shells already show today.
+
+The fix is to open the terminal the first time its container has a size rather
+than on mount. Writing before `open` is fine — the bytes land in the buffer — so
+the snapshot the host replays on attach is there when the pane is finally shown.
+This is a pre-existing bug that the split makes far easier to hit, because more
+panes now mount behind something.
+
+One more, adjacent rather than caused: every mounted terminal holds a WebGL
+context and Chrome evicts past roughly sixteen. `WebglAddon` is loaded at
+`terminal.tsx:148` and its `onContextLoss` is not handled. Two groups make more
+terminals visible at once and make the ceiling easier to hit, so dispose and
+reload the addon on loss. It loads after `open`, since the renderer needs the
+element.
+
+## What the split does *not* threaten
+
+Resizing a terminal by dragging a sash is safe, and it is worth writing down
+why, because it looks like the most dangerous thing in the feature.
+
+The host owns the grid. Since #118 the renderer sends `proposeDimensions()` and
+never resizes xterm itself; the only thing that moves the grid is a status
+broadcast from the host (`terminal.tsx:196-204, 227-233`). The host adopts the
+smallest interactive viewer (`internal/terminal/host.go:445-464`) and
+`applyNegotiatedSize` returns early when the negotiated size equals the current
+one (`host.go:471-474`). So a drag that moves less than one cell sends
+proposals the host discards, and a drag that does move a cell gets an answer
+back that both sides then agree on. The class of bug #118 fixed — a grid
+rendering at a width the PTY never adopted, which is what duplicated typing
+looks like — cannot come back through this door, because the renderer no longer
+has a way to set its own width.
+
+What remains is chatter: one IPC and one frame per `ResizeObserver` tick during
+a drag, most of them no-ops at the host. Worth a throttle if a drag ever feels
+heavy. Not a correctness risk, and not a reason to change the design.
+
+## What happens to the store
+
+`state.panels` and `state.activeTabs` are replaced by
+`state.layouts: Record<sessionKey, Layout>`. Every existing caller collapses to
+one operation — reveal an item — and `currentPanel` and `currentTab` survive as
+selectors derived from the focused group, so the call sites keep their shape:
+
+| Call site | Becomes |
+|---|---|
+| `setPanel` (`store.ts:897`) | `reveal('panel:' + name)` |
+| `openFile`, `findFile` (`store.ts:902,914`) | `reveal('panel:files')`, unchanged target |
+| `appendPrompt` (`store.ts:992`) | `reveal('panel:chat')` |
+| `applyShow` (`store.ts:933`) | `reveal` against the named session's layout, through `layoutFor` |
+| `openTerminal`, `showTerminal` (`store.ts:1019,1222`) | `reveal('term:' + id)`, in the same `set` as the tab |
+| `selectTab` (`store.ts:1279`) | `reveal('term:' + tabId)` |
+| `closeTab` (`store.ts:1242`) | `removeItem`, which now owns the neighbour rule |
+
+`showPanel` and `showTab` go.
+
+## Persistence
+
+`localStorage`, keyed `helios.layout.{hostId}.{sessionId}` — beside the Files
+panel's own per-session record at `helios.files.{hostId}.{sessionId}`
+(`files.tsx:199`), and written in the style every other reader in the codebase
+uses: a `try`/`catch` that falls back to the default, because a full or
+unavailable store should cost the arrangement and not the panel
+(`store.ts:206-276`, `files.tsx:940-966`).
+
+Per machine, deliberately. The daemon has no per-session metadata column —
+sessions are fixed columns in SQLite (`internal/store/sessions.go:11-60`) and the
+only key-value store is global (`internal/store/settings.go`) — so syncing the
+layout would mean a schema change and a new PATCH field, for a preference that a
+phone cannot honour and a 27-inch monitor and a laptop would disagree about
+anyway.
+
+Shell tab ids survive a restart: they are `terminalId(hostId, info.id)` over the
+daemon's own `terminals()` list, and the agent's tab keys on the session id.
+Both are server-side and stable, which is what makes a saved `term:` item
+meaningful on the next launch.
+
+## The gestures
+
+Drag and drop, following the conventions `sidebar.tsx` already sets for the
+group tree (`sidebar.tsx:140-160, 517-580`): a dedicated dataTransfer type so a
+drop target can refuse a payload it cannot hold, and both the payload and the
+drop mode read off the event rather than out of state — a drop can land in the
+same tick as the drag start, before a `setState` has committed.
+
+- `application/x-helios-tab` carries the `ItemId`.
+- Dropped on a tab strip: move into that group at the index under the pointer.
+- Dropped on a group body: the leading and trailing quarters **along the
+  layout's axis** split off a new group; everything else moves into the group
+  without splitting. That is `dropModeFor` (`sidebar.tsx:154`) turned sideways.
+  Only along the axis, because a flat list has nowhere to put a cross-axis
+  split — see below.
+
+```
+ a group body, while a tab is being dragged over it (axis: row)
+
+ ┌───────┬───────────────────────────────┬───────┐
+ │       │                               │       │
+ │  ←    │                               │   →   │
+ │ split │      move into this group     │ split │  leading / trailing
+ │ before│      (no split, just a tab)   │ after │  quarters
+ │       │                               │       │
+ │       │                               │       │
+ └───────┴───────────────────────────────┴───────┘
+   25%                  50%                 25%
+
+ axis: column turns the same three bands ninety degrees — split above,
+ move into, split below.
+
+ the drop, previewed: dragging `files` onto the right quarter
+
+ ┌────────────────────────────────────┬─┬────────┐
+ │ agent │ ●terminal │ ●zsh           │ │        │
+ ├────────────────────────────────────┤ ├────────┤
+ │                                    │ │▒▒▒▒▒▒▒▒│
+ │  > the worker retries on a 429…    │ │▒files▒▒│
+ │                                    │ │▒▒▒▒▒▒▒▒│
+ └────────────────────────────────────┴─┴────────┘
+       keeps 1fr… ── shrinks to make room ──→ 1fr
+```
+
+The highlight is drawn by the group under the pointer, at the size the new group
+would take — half the weight of the one it splits from.
+
+The sash is `onPointerDown` plus `pointermove`/`pointerup` on `window`, copying
+the markdown column's grip (`files.tsx:714-736`) and `.sidebar-grip`
+(`sidebar.tsx:806-816`). Double-click resets the weights, as the other two grips
+already do.
+
+Below the `.agent-split` breakpoint of 1240px (`styles.css:1612`) a row of
+groups is two unreadable columns. The axis flips to `column` at that width — the
+same answer the approvals dock already gives, and the reason `axis` is in the
+model rather than assumed.
+
+## What we are not doing
+
+- **A pane tree, and with it the cross-axis drop.** One axis, N groups. Dropping
+  a tab on the top edge of a group in a row layout would have to nest a column
+  inside that column, and there is nowhere in a flat list to put it — so those
+  two quarters are not drop zones, and the gesture is unavailable rather than
+  wrong. The API takes a `Layout` and returns one, so this is a representation
+  change if it is ever wanted.
+- **The same panel in two groups.** VS Code opens one file in two editors; here
+  a panel is a singleton with a live connection behind it, and two views of one
+  terminal have nothing to disagree about.
+- **Syncing to mobile.** Named above.
+- **Cross-session layouts.** A group holds one session's items. Two sessions
+  side by side is a different feature with a different state shape.
+- **Touching the daemon.** No route, payload or SSE event changes. If this spec
+  ever seems to need one, that is the signal it has drifted out of scope.
+
+## Tests
+
+The desktop suite is `node --test --experimental-strip-types test/*.test.ts` and
+does not mount React, so the tests go at the model, in
+`test/layout.test.ts`, mirroring `test/grouping.test.ts`:
+
+- A split makes a second group and halves the weight of the one it came from.
+- Removing the last item of a group collapses it and returns its weight to the
+  neighbour.
+- Closing the middle of three shells activates the one before it; closing the
+  last activates nothing and lets the fallback stand — the rule `closeTab`
+  encodes today.
+- `reconcile` leaves a saved `term:` item alone when its tab has not been
+  re-attached yet, and appends a live tab that is not placed anywhere.
+- `sweep` spares an item that is active in a group other than the focused one.
+- `reveal` on an item already placed focuses its group instead of moving it.
+- `parseLayout` returns the default for garbage, for a truncated object, and for
+  a layout whose `focused` names a group that is not there.
+
+Manual, against the running app over CDP, as with PRs #109 and #112: split Files
+out of the transcript and confirm the transcript keeps its scroll position; put
+a terminal in each group, type in both, drag the sash, and confirm neither loses
+scrollback; switch sessions and restart the app and confirm each layout returns.
+
+**A trap for whoever tests this.** A dev instance is a second interactive
+viewer, and the host adopts the smallest one. Narrowing a terminal in the dev
+window narrows the PTY for every other viewer, including the window the user is
+working in — measured during this spec's own testing: a session sitting at 218
+columns dropped to 139 when a dev pane was moved into a 0.7fr track. It is not
+damage and it is not sticky. `applyNegotiatedSize` runs again when the viewer
+disconnects (`internal/terminal/host.go:687-702`), so quitting the dev instance
+restores the size. But do the testing in a window at least as wide as the real
+one, or expect the user's terminal to reflow while you work.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -57,6 +57,7 @@ what is merged. Some are superseded and stay here for the history.
 | [48-mobile-provider-support.md](48-mobile-provider-support.md) | Mobile: Support a Second Provider |
 | [48-react-query-data-layer.md](48-react-query-data-layer.md) | React Query as the Desktop Data Layer |
 | [49-mobile-query-data-layer.md](49-mobile-query-data-layer.md) | A Query Data Layer for the Mobile App |
+| [50-desktop-split-layout.md](50-desktop-split-layout.md) | Editor Groups for the Desktop: Two Panels Side by Side, Remembered Per Session |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |
 | [desktop-notification-service.md](desktop-notification-service.md) | Desktop Notification Service |


### PR DESCRIPTION
## Summary

A session showed one panel at a time. Reading the transcript while browsing the tree meant alternating between two tabs, and the pairing the app is most used for — transcript or terminal on one side, Files on the other — could not be expressed at all.

Panels now live in **groups** laid along one axis, each with its own tab strip:

- Drag a tab onto another strip to move it there.
- Drop it on a group's leading or trailing quarter to split off a new group.
- Drag the sash between groups to move weight; double-click to even them out.
- The arrangement is stored **per session** in localStorage, so a session opens as it was left, across restarts.
- Below 1240px the groups stack instead of sitting side by side.

Design: [docs/specs/50-desktop-split-layout.md](docs/specs/50-desktop-split-layout.md).

### Two decisions worth reading

**A flat list of groups, not a pane tree.** Far less state for the case this exists for, and every function takes a `Layout` and returns one, so the representation can change later without touching a call site.

**One CSS grid with flat children.** Strips in one row, bodies in the next, sashes spanning both. Moving a tab between groups is then a change to one `grid-column` on a node that never moves in the DOM. A nested layout would re-parent the node, and a re-parent in React is an unmount — which disposes the xterm and takes the scrollback with it. This was measured against a live terminal over CDP before the code was written; the numbers are in the spec.

### Two fixes that fall out of it

- **A pane is mounted for as long as its tab is**, not for as long as its session is selected. The connection lives in the main process and keeps counting bytes, so a rebuilt xterm asks the host to catch it up from a sequence it has already passed and gets a delta instead of a screen.
- **The terminal opens against its element the first time that element has a size.** Opening against a hidden one measures a zero-wide cell, and nothing ever measures again: xterm carries no resize observer, and `FitAddon.proposeDimensions()` gives up on a zero cell, so the pane can no longer even ask the host for a size.

Both showed as a live green dot over an empty grid with a cursor in it, fixed by reconnecting. The second one predates this branch — shells re-listed at startup have always mounted hidden.

Also: the Files explorer can be collapsed, per session, from the file tab strip, with ⌘B, or by clicking the chip already showing. A Files pane sharing a window with a transcript has room for the tree or the editor, not both.

## Test plan

- [x] `npm run typecheck` and `npm test` — 221 pass, including 27 new tests for the layout model
- [x] Split Files out of the transcript: two groups, sash between them
- [x] Terminal in one group, Files in the other; scrollback intact, grid follows the sash (280 → 139 → 73 → 139 cols, canvases never rebuilt)
- [x] Drag a tab back onto the other strip: group collapses, weight returns
- [x] Switch sessions and back: each session keeps its own arrangement, terminal content intact
- [x] Quit and relaunch: same groups, same sash position
- [x] Shell re-attached at startup while hidden, then opened: renders at full width instead of a bare cursor
- [x] Explorer collapse: button, ⌘B, and the active chip; survives a restart; per session