### PR TITLE
docs: add a v-claw companion badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <img src="https://img.shields.io/badge/go-1.26%2B-00ADD8?logo=go&logoColor=white" alt="Go 1.26+" />
   <img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Android%20%7C%20iOS-6e7681" alt="Platforms: macOS, Linux, Android, iOS" />
   <img src="https://img.shields.io/badge/harnesses-Claude%20Code%20%7C%20Codex-8957e5" alt="Harnesses: Claude Code, Codex" />
+  <a href="https://github.com/kamrul1157024/v-claw"><img src="https://img.shields.io/badge/companion-v--claw-c9a227" alt="Companion app: v-claw" /></a>
 </p>
 
 <p align="center">
@@ -33,15 +34,6 @@
 </p>
 
 ---
-
-## Keeping the machine awake
-
-Sessions only run while the machine is awake. Close the lid on a laptop and every
-session you were watching from your phone stops with it.
-[v-claw](https://github.com/kamrul1157024/v-claw) is a companion menu bar app that
-blocks lid-close sleep, display sleep and the screen lock while the machine is on the
-power adapter, and releases it all when you unplug. Same author, and it is what makes a
-laptop usable as a helios host.
 
 ## What it is
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@
 
 ---
 
+## Keeping the machine awake
+
+Sessions only run while the machine is awake. Close the lid on a laptop and every
+session you were watching from your phone stops with it.
+[v-claw](https://github.com/kamrul1157024/v-claw) is a companion menu bar app that
+blocks lid-close sleep, display sleep and the screen lock while the machine is on the
+power adapter, and releases it all when you unplug. Same author, and it is what makes a
+laptop usable as a helios host.
+
 ## What it is
 
 You have five agent sessions open across three projects. One is blocked on a permission
@@ -169,16 +178,6 @@ the same SSE stream. Claude Code and Codex attach through the provider registry 
 `internal/provider`, which is also where the next harness will plug in.
 
 Diagrams, endpoints and the on-disk layout: [docs/architecture.md](docs/architecture.md).
-
-## Keeping the machine awake
-
-Sessions only run while the machine is awake. Close the lid on a laptop and every
-session you were watching from your phone stops with it.
-
-[v-claw](https://github.com/kamrul1157024/v-claw) is a companion menu bar app that
-blocks lid-close sleep, display sleep and the screen lock while the machine is on the
-power adapter, and releases it all when you unplug. Same author, and it is the thing
-that makes a laptop usable as a helios host.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ the same SSE stream. Claude Code and Codex attach through the provider registry 
 
 Diagrams, endpoints and the on-disk layout: [docs/architecture.md](docs/architecture.md).
 
+## Keeping the machine awake
+
+Sessions only run while the machine is awake. Close the lid on a laptop and every
+session you were watching from your phone stops with it.
+
+[v-claw](https://github.com/kamrul1157024/v-claw) is a companion menu bar app that
+blocks lid-close sleep, display sleep and the screen lock while the machine is on the
+power adapter, and releases it all when you unplug. Same author, and it is the thing
+that makes a laptop usable as a helios host.
+
 ## Requirements
 
 - Go 1.26+ (the version in `go.mod`)


### PR DESCRIPTION
## Summary
- Add a seventh badge to the header row linking [v-claw](https://github.com/kamrul1157024/v-claw), the companion menu bar app that stops a closed lid from sleeping the host and killing its sessions.
- No prose section: the badge is the whole mention, so the README stays at 199 lines.

## Test plan
- [ ] Read the rendered README and confirm the badge row wraps cleanly and the v-claw badge links to the repo.