### PR TITLE
fix: only run codesign/xattr on macOS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ DMG_PATH = helios.dmg
 
 build:
 	go build -o helios ./cmd/helios/
-	codesign -s - -f ./helios
+	@if [ "$$(uname)" = "Darwin" ]; then codesign -s - -f ./helios; fi
 
 install: build
 	sudo cp helios /usr/local/bin/helios
-	sudo codesign -s - -f /usr/local/bin/helios
-	sudo xattr -dr com.apple.quarantine /usr/local/bin/helios
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		sudo codesign -s - -f /usr/local/bin/helios; \
+		sudo xattr -dr com.apple.quarantine /usr/local/bin/helios; \
+	fi
 	@echo "helios installed to /usr/local/bin/helios"
 
 uninstall:


### PR DESCRIPTION
## Summary
- `build`/`install` targets called `codesign`/`sudo xattr` unconditionally, breaking `make install` on Linux (those tools don't exist there)
- Guard both calls behind a `uname` check so they only run on Darwin; macOS behavior is unchanged

Fixes #130

## Test plan
- [x] `make build` succeeds on Linux (skips codesign)
- [ ] `make build`/`make install` still work on macOS (codesign/xattr still run)