### PR TITLE
fix: surface a clear remedy for tailscale serve permission denials

### DIFF
--- a/internal/tailscale/serve.go
+++ b/internal/tailscale/serve.go
@@ -214,7 +214,7 @@ func (t *Tunnel) start(ctx context.Context, localPort int) error {
 	}
 
 	if _, err := run(ctx, t.binary, t.publishArgs()...); err != nil {
-		return err
+		return permissionHint(err)
 	}
 
 	if err := t.waitPublished(ctx); err != nil {

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"runtime"
 	"strings"
 	"time"
@@ -178,4 +179,21 @@ func run(ctx context.Context, binary string, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("tailscale %s: %w", strings.Join(args, " "), err)
 	}
 	return out, nil
+}
+
+// permissionHint rewrites tailscaled's "Access denied" response into a direct
+// remedy. On Linux, publishing a serve/funnel mapping requires either root or
+// a designated operator; the raw CLI message states this correctly but as two
+// lines of prose, which a cramped error panel (the TUI, the mobile app)
+// truncates before the fix is legible.
+func permissionHint(err error) error {
+	if err == nil || !strings.Contains(err.Error(), "Access denied") {
+		return err
+	}
+	username := "$USER"
+	if u, uerr := user.Current(); uerr == nil && u.Username != "" {
+		username = u.Username
+	}
+	return fmt.Errorf("tailscale needs elevated permission on this machine — "+
+		"run `sudo tailscale set --operator=%s` once, then retry", username)
 }

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -2,6 +2,7 @@ package tailscale
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -113,6 +114,29 @@ func TestStateProblemDistinguishesFailures(t *testing.T) {
 			t.Errorf("%s and %s produce the identical message %q", tt.name, prev, got)
 		}
 		seen[got] = tt.name
+	}
+}
+
+// TestPermissionHintRewritesAccessDenied pins the remedy surfaced when
+// tailscaled refuses a serve/funnel mutation for lacking permission — the raw
+// CLI message is correct but two lines of prose that a cramped error panel
+// truncates.
+func TestPermissionHintRewritesAccessDenied(t *testing.T) {
+	raw := fmt.Errorf("tailscale serve --bg --yes --http=7655 http://127.0.0.1:7655: " +
+		"sending serve config: Access denied: serve config denied")
+
+	got := permissionHint(raw)
+	if !strings.Contains(got.Error(), "sudo tailscale set --operator=") {
+		t.Errorf("permissionHint(%v) = %q, want it to name the operator remedy", raw, got)
+	}
+
+	other := fmt.Errorf("tailscale status: connection refused")
+	if got := permissionHint(other); got != other {
+		t.Errorf("permissionHint on an unrelated error = %q, want it unchanged", got)
+	}
+
+	if got := permissionHint(nil); got != nil {
+		t.Errorf("permissionHint(nil) = %v, want nil", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- On Linux, `tailscale serve`/`funnel` reject the mapping with an "Access denied" message unless the caller is root or the designated operator
- That raw two-line tailscaled message gets truncated in the TUI/mobile error panels, so the fix isn't visible where the error shows up
- `internal/tailscale.permissionHint` catches this specific case and rewrites it into one line naming the exact remedy (`sudo tailscale set --operator=<user>`), wired into `Tunnel.start`'s publish call

Fixes #132

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tailscale/...`
- [x] `go test ./internal/tailscale/...` (new `TestPermissionHintRewritesAccessDenied` covers the rewrite, an unrelated error passing through unchanged, and nil)