### PR TITLE
fix(mobile): re-read the transcript when a reader arrives

### DIFF
--- a/docs/specs/52-transcript-freshness.md
+++ b/docs/specs/52-transcript-freshness.md
@@ -1,0 +1,462 @@
+# Transcript Freshness: Heal a Missed Event Without a Spinner
+
+## The claim
+
+The mobile transcript should recover from a missed event on its own, and it must
+do so without ever putting the skeleton back over messages that are already on
+screen.
+
+Both halves matter, and today it does neither. The only thing that refreshes the
+transcript is a `session_status` event addressed to that exact session; if the
+one at the end of a turn is lost, the conversation stays frozen until the process
+restarts. And the mechanism that would otherwise fix it — invalidating the
+provider — is precisely the mechanism that wipes the list and throws away the
+reader's place, which is why `transcript.dart:61-63` forbids it.
+
+So this is not "add a refresh". Every heal below goes through `pullNew`, whose
+whole state transition is `AsyncData → AsyncData`. `isLoading` is never set.
+
+**Scope: `mobile/`, plus one change in `internal/transcript`.** The daemon change
+is a single additive response field. No route changes shape, no existing field
+changes meaning, no new event type, and `internal/server`, `desktop/`, `cmd/` and
+`internal/tui` are untouched. An older client talking to a newer daemon behaves
+exactly as it does today.
+
+Nearly all of the work is on the client, and that is the argument rather than an
+accident of scope — see *The daemon is not asked to notice the drop*.
+
+## Where we are
+
+| | Today |
+|---|---|
+| Transcript cache | `TranscriptNotifier`, a Riverpod `AsyncNotifierProvider.family` (`transcript.dart:137`) — **not** `autoDispose`, so it lives as long as the process |
+| Refresh triggers | one: a real `session_status` whose `session_id` matches (`session_detail_screen.dart:102-103`), debounced 500 ms (`:107-110`) |
+| Plus | a pull 500 ms after sending a prompt, and again at 5 s and 10 s (`:364,371-375`) |
+| Event-driven invalidation | none — `CacheTarget.transcript: break;` (`cache_invalidator.dart:58-59`) |
+| On SSE reconnect | the notification tray re-syncs (`daemon_api_service.dart:280`); the transcript does nothing |
+| On app resume | `resumeAll` reconnects each host (`host_manager.dart:414-424`); the transcript does nothing |
+| Gap detection | `epoch` + `after_seq`, already in the protocol (`api.go:451-461`) and already honoured by the client (`transcript.dart:33`) |
+| Loading render | `_loading = transcript.isLoading` (`session_detail_screen.dart:460`) → full `MessageListSkeleton` (`:502-506`) |
+
+The protocol is not the problem. Spec 38 built `seq`, `epoch` and `after_seq`
+exactly so a client could ask "what have I missed", and the client asks
+correctly. What is missing is every occasion on which it should ask.
+
+## What this costs today, stated plainly
+
+### The stream is lossy by construction, and says nothing about it
+
+`internal/server/sse.go:36-42`:
+
+```go
+for client := range b.clients {
+	select {
+	case client.ch <- event:
+	default:
+		// Client buffer full, skip
+	}
+}
+```
+
+Sixty-four slots per client (`sse.go:57`). A phone on a slow link overflows, and
+the drop is silent in both directions — no error to the daemon, no signal to the
+client. `session_status` is broadcast from fourteen sites including every
+`PreToolUse`, so a turn end is a burst, and a burst is exactly when a slow
+client's buffer is full.
+
+Disconnect is the same story with a different cause. `sse.go:65-70` deletes the
+client and keeps nothing; there is no `Last-Event-ID`, no replay buffer, no
+resume cursor. Whatever was broadcast during the gap is gone.
+
+None of that is changed by this spec. It is stated because it is the premise: the
+stream is best-effort by design, so a client that treats an event as its only
+cue to re-read has built on something that was never load-bearing.
+
+### One dropped event is survivable. The last one is not
+
+`pullNew` asks for everything after the newest `seq` it holds, so a single lost
+event heals on the next one. That makes the failure look intermittent and
+harmless, which is why it has survived.
+
+It is neither, because the burst that overflows the buffer is at the end of a
+turn. Drop the last `session_status` and the agent is now idle: no further event
+will ever be broadcast for that session. The transcript is frozen, and because
+the provider is not `autoDispose` (`transcript.dart:137`), leaving the screen and
+coming back re-reads the same held `Transcript`. Only a restart clears it.
+
+### The delta silently drops its middle
+
+`internal/transcript/store.go:134-137`:
+
+```go
+if limit > 0 && len(fresh) > limit {
+	fresh = fresh[len(fresh)-limit:]
+}
+```
+
+More than `limit` messages past `after_seq` — a backgrounded app, a long turn —
+and the daemon answers with the newest fifty and discards everything between.
+The client appends that run to a list ending at `after_seq` (`transcript.dart:41-48`),
+so the held conversation now has a hole and a `seq` jump across it.
+
+Nothing in the answer says so. `epoch` is unchanged, because the transcript did
+not fork. `HasMore` on this path is `start > 0` (`store.go:145`), which reports
+whether *older* pages exist — a different question, and the one the client
+already reads that way to drive `loadOlder`. So the hole is undetectable by the
+client and permanent.
+
+### `pullNew` reads its base before the await and writes it after
+
+`transcript.dart:95-112` captures `held` at `:96` and writes `appendDelta(held, …)`
+at `:111`, with a network round trip in between and no in-flight guard.
+`loadOlder` has one — `_loadingOlder`, `:118,121` — which makes the omission look
+accidental rather than considered.
+
+Overlap is reachable: the SSE debounce timer (`session_detail_screen.dart:108`)
+and the 5 s / 10 s resend timers (`:371-375`) are independent. Two pulls in
+flight from `seq 100`, the second answering 101–107 and the first answering
+101–105 but landing later, and the state regresses to 105. It heals on the next
+event — and at turn end there is no next event.
+
+### A failed fetch is indistinguishable from an empty one
+
+`fetchTranscript` catches everything and returns `null` (`daemon_api_service.dart:556-559`).
+`pullNew` then returns at `:110` without retrying and without recording anything.
+The event arrived, the pull fired, the request failed on a flaky link — and the
+outcome is identical to the dropped-event case.
+
+### The synthetic-event path does not reach the screens
+
+`_markStale` (`daemon_api_service.dart:80-81`) raises an event on `onSSEEvent`
+only. That reaches the cache invalidator through `HostManager` (`host_manager.dart:167`).
+It does **not** reach `_eventController`, which is what the three screens listen
+on (`session_detail_screen.dart:98`, `home_screen.dart:58`, `terminal_screen.dart:53`).
+Only `_handleEvent` (`:322-325`) feeds both.
+
+This is why "resume re-syncs the tray" does not imply "resume re-syncs anything a
+screen holds". Anything meant to reach a viewer has to go through `_handleEvent`.
+
+## The change
+
+### Healing goes through `pullNew`, never through invalidation
+
+`ref.invalidate(transcriptProvider(...))` does not appear anywhere in this
+design. It cannot: in Riverpod an invalidated notifier becomes
+`AsyncLoading.copyWithPrevious(old)`, which keeps `hasValue` but still reports
+`isLoading`, and `session_detail_screen.dart:460` reads exactly that field to
+decide whether to draw the skeleton. Invalidation blanks the conversation and
+loses the scroll position on every heal.
+
+`pullNew` assigns `AsyncData` directly (`transcript.dart:111`) and touches no
+loading state. Every trigger added below calls it.
+
+### The render guard stops lying
+
+`session_detail_screen.dart:460` becomes:
+
+```dart
+_loading = transcript.isLoading && !transcript.hasValue;
+```
+
+The skeleton is then a first-load affordance rather than a refresh one, which is
+what it was always meant to be.
+
+This is defence in depth rather than a load-bearing part of the heal, and it pays
+for itself immediately: it makes the `ref.invalidateSelf()` fallback at
+`transcript.dart:100` free. `build` returns `const Transcript()` rather than
+throwing when there is nothing to show (`:74,79`), so the provider always holds a
+value by the time that branch can run, and the refresh now keeps whatever is on
+screen while it re-reads.
+
+### `pullNew` becomes single-flight, re-reads after the await, and loops
+
+```dart
+Future<void>? _inFlight;
+bool _again = false;
+
+Future<void> pullNew() {
+  if (_inFlight != null) {
+    _again = true;
+    return _inFlight!;
+  }
+  _inFlight = _pull().whenComplete(() {
+    _inFlight = null;
+    if (_again) {
+      _again = false;
+      pullNew();
+    }
+  });
+  return _inFlight!;
+}
+```
+
+A trigger arriving mid-flight schedules a trailing re-run rather than being
+dropped. Dropping it would reintroduce the bug this spec exists to fix, one scale
+smaller: the whole failure mode is a signal that arrives and is not acted on. The
+guarantee wanted is that every trigger is followed by a pull that *started* after
+it, and the trailing flag is the cheapest thing that gives it.
+
+`_pull` re-reads the state on each iteration and keeps going while the daemon
+says there is more:
+
+```dart
+Future<void> _pull() async {
+  final service = _service;
+  if (service == null) return;
+  while (true) {
+    final held = state.valueOrNull;
+    if (held == null || held.messages.isEmpty || held.epoch.isEmpty) {
+      ref.invalidateSelf();
+      return;
+    }
+    final result = await service.fetchTranscript(
+      arg.$2,
+      limit: pageSize,
+      afterSeq: held.messages.last.seq,
+      epoch: held.epoch,
+    );
+    if (result == null) return;
+    state = AsyncData(appendDelta(state.valueOrNull ?? held, result));
+    if (!result.moreAfter) return;
+  }
+}
+```
+
+Reading `state` after the await is safe rather than merely better, and single
+flight is what makes it so: the only other writer to this notifier is `loadOlder`,
+which prepends and never touches the tail. Without the guard, re-reading would be
+the more dangerous of the two options.
+
+An `epoch` change mid-loop replaces the list and ends the loop, because
+`appendDelta` (`:33-40`) returns the fresh page and `more_after` is false on a
+page.
+
+### The states, and which one draws the skeleton
+
+```
+                   cold cell
+                       |
+                       v
+                +-------------+
+                |   Loading   |   the skeleton is drawn here, and nowhere else
+                +-------------+
+                       |
+                       |  page arrives — or the fetch fails and build()
+                       |  hands back an empty Transcript
+                       v
+                +-------------+
+        +------>|    Held     |
+        |       +-------------+
+        |              |
+        |              |  trigger: screen mount · foreground
+        |              |           · reconnect · session_status
+        |              v
+        |    +->+-------------+   trigger arrives    +-------------+
+        |    |  |   Pulling   |--------------------->|   Queued    |
+        |    |  |             |<---------------------|             |
+        |    |  +-------------+   flight ends:       +-------------+
+        |    |     |       |      run once more
+        |    +-----+       |
+        |   more_after:    |   delta appended and more_after false
+        |   advance the    |   epoch_changed: the list is replaced
+        |   cursor, ask    |   null answer: the list is untouched
+        |   again          |
+        +------------------+
+```
+
+Only **Loading** draws `MessageListSkeleton`. It is the one state with no value
+behind it, and after the guard change at `session_detail_screen.dart:460` it is
+the only state that reports `isLoading` without `hasValue`.
+
+**Pulling** and **Queued** are not loading states at all — the cell holds
+`AsyncData` for their whole duration, and the widget never rebuilds into the
+skeleton branch.
+
+The `invalidateSelf` fallback is the one edge left off the diagram, because it is
+the only one that does not fit the shape: it takes **Held** to an
+`AsyncLoading` carrying the previous value, and back to **Held** when the page
+arrives. It reports `isLoading`, so before the guard change it flashed the
+skeleton; after it, the conversation stays on screen while the page is re-read.
+
+The four triggers in the table below are the only edges into **Pulling**. Every
+one of them is a `pullNew` call, which is the entire reason this state machine
+has no path from **Held** back to **Loading**.
+
+### The delta stops dropping its middle
+
+`store.go:134-137` keeps the **oldest** `limit` and reports the truncation:
+
+```go
+moreAfter := false
+if limit > 0 && len(fresh) > limit {
+	fresh = fresh[:limit]
+	moreAfter = true
+}
+```
+
+Oldest rather than newest, because contiguity is what lets the client's loop
+terminate correctly. It appends a run starting at `afterSeq+1`, advances its
+cursor to the last `seq` it received, and asks again. Keeping the newest can
+never be made contiguous — there is no cursor that would fetch the skipped range,
+which is why the hole today is permanent.
+
+`TranscriptResult` gains `more_after`, false on the paging path and false when
+the delta fits. It is additive: a client that ignores it behaves as today.
+
+`HasMore` keeps its current meaning untouched. The two answer different
+questions — one about older pages, one about the tail — and collapsing them is
+what made the hole invisible in the first place.
+
+### The daemon is not asked to notice the drop
+
+The obvious server-side answer is to record the discard — a `dropped` bit on
+`sseClient`, flushed as a `resync` frame the next time anything is written to
+that client. It was the first draft of this section, and it is the wrong shape.
+
+The flush has to ride some frame, and on an idle session the only frame left is
+the 30 s heartbeat (`sse.go:76`). So the recovery time for the exact failure this
+spec is about — the last event of a turn, after which the agent goes quiet — is
+pinned to a heartbeat interval. Half a minute of a visibly wrong conversation, in
+exchange for a new atomic on the broadcaster, a new event type, a fan-out through
+`_handleEvent`, a new unfiltered branch in the screen, and a `cache_effects` row.
+
+**Staleness only matters when someone is looking at it.** That reframes the
+problem: the client does not need to be told it missed something, it needs to
+re-read whenever a viewer arrives. There are exactly three ways a viewer arrives
+at a transcript, all of them already observable on the client, none of them
+requiring the daemon to know anything:
+
+- the session screen is opened,
+- the app comes back to the foreground — unlock, app switcher, notification tap,
+- the stream reconnects after a drop.
+
+Cover those and the reader never *sees* a stale transcript, whatever the stream
+did. The heal latency stops mattering, because the heal always lands before the
+eye does.
+
+This also happens to match where drops come from. Overflowing 64 slots requires
+the client to stop draining for a while, and a foregrounded app on a live
+connection drains continuously. The buffer fills when the process is suspended or
+the link has stalled — and both of those end in a resume or a reconnect, which
+are two of the three triggers. The window the daemon would have reported is
+almost exactly the window the client can already detect on its own.
+
+So `sse.go` is left alone. The 64-slot buffer stays, the `default:` branch stays,
+and no new event type is introduced.
+
+### The triggers
+
+| When | Today | Becomes |
+|---|---|---|
+| `session_status` for this session | pull, 500 ms debounce (`session_detail_screen.dart:107-110`) | unchanged |
+| Detail screen mounts | nothing — `build` already ran on the live provider, so re-entering the session fetches nothing | pull |
+| App returns to the foreground | nothing for the transcript (`host_manager.dart:414-424` reconnects the stream) | pull |
+| SSE reconnects | the tray re-syncs (`daemon_api_service.dart:272-280`); the transcript does not | pull |
+
+The first three are pure client changes and need no new plumbing at all.
+
+**Mount** is one `pullNew()` in `initState`, beside the `_loadGitStatus()` that
+is already there (`session_detail_screen.dart:93`). This is the trigger that
+makes "go back and come back" work, which today it does not: the provider is not
+`autoDispose`, so re-entry re-reads the held `Transcript` and issues no request.
+
+**Foreground** is a `WidgetsBindingObserver` on the detail screen, resuming on
+`AppLifecycleState.resumed`. `terminal_screen.dart:73-84` already does exactly
+this for its shells, so the pattern is in the codebase. It has to be the detail
+screen's own observer rather than `home_screen`'s (`:71-77`), because home has no
+idea which transcript is on top of the navigator stack.
+
+One `resumed` covers unlock, returning from the app switcher, and tapping a
+notification — they are the same lifecycle edge. It also fires after a transient
+`inactive` that never reached `paused`, such as pulling down Control Center, so
+this will sometimes pull when nothing changed. That is deliberate: a delta that
+finds nothing is one small request against a cursor the client already holds, and
+single-flight collapses a burst of them. Trying to tell a real return from a
+spurious one would cost more than the requests it saves.
+
+**Reconnect** raises a synthetic event through `_handleEvent` (`:322-325`) rather
+than `_markStale` (`:80-81`), for the reason given above — `_markStale` reaches
+the invalidator and no screen. This is the one trigger that needs the event path,
+because the screen has no other way to learn the socket came back.
+
+## What we are not doing
+
+- **Anything in `internal/server/sse.go`** — no `dropped` bit, no `resync` event,
+  no larger buffer. Argued above: the client can already detect every window in
+  which the drop matters, and a server signal would have to wait for a frame to
+  ride out on.
+- **Sequence numbers on the SSE stream.** A cursor is a promise that the daemon
+  can serve the range behind it, which means a replay buffer — a second, weaker
+  copy of a transcript the daemon can already replay from disk by `after_seq`.
+- **A poll while the detail screen is open.** The residual gap is a reader
+  watching a live session who never leaves, never backgrounds, and never
+  reconnects. That is also the case where the buffer is least likely to overflow,
+  because a foregrounded app drains it continuously. A timer would fire mostly to
+  learn nothing, on a battery. If this gap shows up in practice, a slow poll
+  gated on *screen mounted **and** session active* is the answer — but the
+  evidence for it should come from use, not from this document.
+- **Making the transcript provider `autoDispose`.** It would refetch page one on
+  every re-entry and discard every older page the reader had scrolled back to,
+  which is the behaviour `transcript.dart:61-63` is written to prevent.
+- **Surfacing fetch failures in the UI.** `fetchTranscript` swallowing errors
+  (`daemon_api_service.dart:556-559`) is a real gap, but the trailing re-run and
+  the reconnect trigger already convert a transient failure into a later success.
+  An error affordance in the transcript is a design question, not a correctness
+  one, and it is not this spec.
+- **Desktop.** `chat.tsx` has the same shape and its own conversion in spec 48.
+- **The terminal.** A shell is a live byte stream and has nothing to re-read.
+
+## Tests
+
+Dart, in `test/transcript_test.dart`, which already asserts the reducers directly
+and needs no widget tree:
+
+- A delta with `more_after` appends and the loop asks again; the final list
+  equals what one unbounded fetch of the same range would have produced —
+  contiguous `seq`, no repeat.
+- Two overlapping `pullNew` calls put one request in flight and schedule exactly
+  one trailing re-run, and the state never regresses: the list after the second
+  is a superset of the list after the first.
+- A `null` answer leaves the held list and epoch untouched, clears `_inFlight`,
+  and leaves the next `pullNew` able to run.
+- An `epoch_changed` answer arriving mid-loop replaces the list rather than
+  appending, and ends the loop.
+- The render guard: `AsyncLoading` carrying a previous value reads as not
+  loading; a bare `AsyncLoading` reads as loading.
+
+Widget, in `test/` beside the existing screen tests — these three are the whole
+point of the spec and none of them can be asserted at the reducer:
+
+- Mounting the detail screen over a provider that already holds a transcript
+  issues a delta request. This fails today.
+- `didChangeAppLifecycleState(resumed)` issues a delta request, and does so
+  whether or not the state passed through `paused` first.
+- Neither of the above draws `MessageListSkeleton` while the request is in
+  flight; the messages already rendered stay rendered.
+
+Go:
+
+- `Delta` with more than `limit` messages past `afterSeq` returns the oldest
+  `limit`, starting at `afterSeq+1`, with `more_after` true.
+- Looping `Delta` with the cursor advanced by each answer reproduces the full
+  range exactly — no gap, no duplicate — over a fixture larger than several
+  pages.
+- `more_after` is false on the paging path and false when the delta fits.
+- `HasMore` keeps its current value on both paths.
+
+Manual, on a cabled phone, one per trigger:
+
+- Background the app mid-turn long enough to miss several hundred messages,
+  then foreground it. The conversation catches up with no gap and no skeleton.
+- Lock the phone with the session open, let a turn finish, unlock.
+- Leave the session for the list and come back.
+
+## Success criteria
+
+- A reader never sees a stale transcript: opening the session, foregrounding the
+  app, or reconnecting all bring it current before the screen is next looked at.
+- No path leaves a transcript stale until the process restarts.
+- An app that missed 300 messages catches up in `ceil(300/50)` delta requests
+  with no hole.
+- The skeleton appears once per session per process, on first open.
+- `internal/server/sse.go` is unchanged.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -59,6 +59,7 @@ what is merged. Some are superseded and stay here for the history.
 | [49-mobile-query-data-layer.md](49-mobile-query-data-layer.md) | A Query Data Layer for the Mobile App |
 | [50-desktop-split-layout.md](50-desktop-split-layout.md) | Editor Groups for the Desktop: Two Panels Side by Side, Remembered Per Session |
 | [51-file-previews.md](51-file-previews.md) | File Previews: Show the Image, Render the Page |
+| [52-transcript-freshness.md](52-transcript-freshness.md) | Transcript Freshness: Heal a Missed Event Without a Spinner |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |
 | [desktop-notification-service.md](desktop-notification-service.md) | Desktop Notification Service |

--- a/internal/transcript/reader.go
+++ b/internal/transcript/reader.go
@@ -55,6 +55,11 @@ type TranscriptResult struct {
 	// messages are then a fresh newest page rather than a delta, and the
 	// caller has to replace what it holds instead of appending.
 	EpochChanged bool `json:"epoch_changed,omitempty"`
+	// MoreAfter says the limit cut a delta short and more messages follow the
+	// last one returned. HasMore cannot carry this: on a delta it reports
+	// whether *older* pages exist, which is what a caller paging backwards
+	// asks, and the two answers disagree.
+	MoreAfter bool `json:"more_after,omitempty"`
 }
 
 // claudeEntry is the raw structure of a Claude .jsonl line.

--- a/internal/transcript/store.go
+++ b/internal/transcript/store.go
@@ -133,19 +133,27 @@ func (s *Store) Delta(parse LineParser, path, epoch string, afterSeq, limit int)
 		return e.messages[i].Seq > afterSeq
 	})
 	fresh := e.messages[start:]
+
+	// The oldest of what is left, not the newest. A caller appends a delta to a
+	// list ending at afterSeq, so only a run starting there can be appended
+	// without leaving a hole — and once it has been handed the newest instead,
+	// there is no cursor it could name to go back for what was skipped.
+	moreAfter := false
 	if limit > 0 && len(fresh) > limit {
-		fresh = fresh[len(fresh)-limit:]
+		fresh = fresh[:limit]
+		moreAfter = true
 	}
 	if fresh == nil {
 		fresh = []Message{}
 	}
 
 	return &TranscriptResult{
-		Messages: fresh,
-		Total:    len(e.messages),
-		Returned: len(fresh),
-		HasMore:  start > 0,
-		Epoch:    e.epoch,
+		Messages:  fresh,
+		Total:     len(e.messages),
+		Returned:  len(fresh),
+		HasMore:   start > 0,
+		MoreAfter: moreAfter,
+		Epoch:     e.epoch,
 	}, nil
 }
 

--- a/internal/transcript/store_test.go
+++ b/internal/transcript/store_test.go
@@ -263,6 +263,81 @@ func TestStoreDeltaReturnsOnlyWhatIsNew(t *testing.T) {
 	}
 }
 
+// A delta cut short by the limit must hand back the oldest of what is new.
+// Handing back the newest leaves the caller a hole it cannot name a cursor for:
+// its list ends at afterSeq, and the messages between there and what it was
+// given are unreachable.
+func TestStoreDeltaCutShortKeepsTheOldest(t *testing.T) {
+	path := writeTranscript(t, "one", "two")
+	s := NewStore()
+
+	first, err := s.Page(ParseClaudeLine, path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	newest := first.Messages[len(first.Messages)-1].Seq
+
+	appendTo(t, path, "three", "four", "five", "six")
+
+	delta, err := s.Delta(ParseClaudeLine, path, first.Epoch, newest, 2)
+	if err != nil {
+		t.Fatalf("Delta: %v", err)
+	}
+	if got := contents(delta.Messages); fmt.Sprint(got) != "[three four]" {
+		t.Fatalf("delta = %v, want the oldest two [three four]", got)
+	}
+	if !delta.MoreAfter {
+		t.Fatal("truncated delta did not report MoreAfter; the caller would stop two messages short and never learn of it")
+	}
+}
+
+func TestStoreDeltaLoopReproducesTheWholeRange(t *testing.T) {
+	path := writeTranscript(t, "one")
+	s := NewStore()
+
+	first, err := s.Page(ParseClaudeLine, path, 10, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	appendTo(t, path, "two", "three", "four", "five", "six", "seven")
+
+	// What a client does: ask, append, advance the cursor to the last seq it
+	// was given, ask again while the answer says more follows.
+	cursor := first.Messages[len(first.Messages)-1].Seq
+	var got []Message
+	for range 10 {
+		delta, err := s.Delta(ParseClaudeLine, path, first.Epoch, cursor, 2)
+		if err != nil {
+			t.Fatalf("Delta: %v", err)
+		}
+		got = append(got, delta.Messages...)
+		if !delta.MoreAfter {
+			break
+		}
+		cursor = delta.Messages[len(delta.Messages)-1].Seq
+	}
+
+	if want := "[two three four five six seven]"; fmt.Sprint(contents(got)) != want {
+		t.Fatalf("looped delta = %v, want %s", contents(got), want)
+	}
+}
+
+func TestStorePageNeverReportsMoreAfter(t *testing.T) {
+	path := writeTranscript(t, "one", "two", "three")
+	s := NewStore()
+
+	page, err := s.Page(ParseClaudeLine, path, 1, 0)
+	if err != nil {
+		t.Fatalf("Page: %v", err)
+	}
+	if page.MoreAfter {
+		t.Fatal("a page reported MoreAfter; it belongs to the delta path, and HasMore already answers this one")
+	}
+	if !page.HasMore {
+		t.Fatal("HasMore lost its meaning on the paging path")
+	}
+}
+
 func TestStoreDeltaOnAStaleEpochResets(t *testing.T) {
 	path := writeTranscript(t, "one", "two")
 	s := NewStore()

--- a/mobile/lib/models/message.dart
+++ b/mobile/lib/models/message.dart
@@ -71,6 +71,10 @@ class TranscriptResult {
   /// messages are a fresh newest page and replace what is held.
   final bool epochChanged;
 
+  /// Set when the limit cut a delta short and more messages follow the last
+  /// one here. Distinct from [hasMore], which is about older pages.
+  final bool moreAfter;
+
   TranscriptResult({
     required this.messages,
     required this.total,
@@ -79,6 +83,7 @@ class TranscriptResult {
     required this.hasMore,
     this.epoch = '',
     this.epochChanged = false,
+    this.moreAfter = false,
   });
 
   factory TranscriptResult.fromJson(Map<String, dynamic> json) {
@@ -91,6 +96,7 @@ class TranscriptResult {
       hasMore: json['has_more'] as bool? ?? false,
       epoch: json['epoch'] as String? ?? '',
       epochChanged: json['epoch_changed'] as bool? ?? false,
+      moreAfter: json['more_after'] as bool? ?? false,
     );
   }
 }

--- a/mobile/lib/providers/cache_effects.dart
+++ b/mobile/lib/providers/cache_effects.dart
@@ -151,6 +151,14 @@ List<CacheEffect> effectsFor(String hostId, String type, dynamic data) {
     case 'session_deleted':
       return [InvalidateTarget(CacheTarget.sessions, hostId)];
 
+    case 'stream_reconnected':
+      // The socket was down and the daemon keeps no replay buffer, so anything
+      // that changed in the gap was announced to nobody.
+      return [
+        InvalidateTarget(CacheTarget.sessions, hostId),
+        InvalidateTarget(CacheTarget.notifications, hostId),
+      ];
+
     case 'notification':
     case 'notification_resolved':
       // Sessions too: a permission request writes waiting_permission to the

--- a/mobile/lib/providers/transcript.dart
+++ b/mobile/lib/providers/transcript.dart
@@ -68,8 +68,23 @@ class TranscriptNotifier
   bool _loadingOlder = false;
   bool get loadingOlder => _loadingOlder;
 
+  /// The pull in flight, and whether a trigger arrived while it was running.
+  ///
+  /// A trigger that lands mid-flight is exactly the case this provider gets
+  /// wrong when it is dropped, so it schedules one more pull instead. What is
+  /// promised is that every trigger is followed by a pull that *started* after
+  /// it, which a single trailing flag is enough to give.
+  Future<void>? _pulling;
+  bool _pullAgain = false;
+
+  /// Set when the notifier is torn down or rebuilt. A pull is several awaits
+  /// long, and assigning `state` after that has happened throws.
+  bool _gone = false;
+
   @override
   Future<Transcript> build((String, String) arg) async {
+    _gone = false;
+    ref.onDispose(() => _gone = true);
     final (hostId, sessionId) = arg;
     if (sessionId.isEmpty) return const Transcript();
     final service = ref.watch(serviceProvider(hostId));
@@ -91,24 +106,57 @@ class TranscriptNotifier
   ///
   /// A status event fires several times a turn and the answer is usually one
   /// message, so asking for the page again would rebuild the list and lose the
-  /// reader's place.
-  Future<void> pullNew() async {
-    final held = state.valueOrNull;
+  /// reader's place. Nothing here touches the loading state: the whole
+  /// transition is `AsyncData` to `AsyncData`, so no caller can put the
+  /// skeleton back over a conversation the reader is looking at.
+  Future<void> pullNew() {
+    if (_pulling != null) {
+      _pullAgain = true;
+      return _pulling!;
+    }
+    return _pulling = _pull().whenComplete(() {
+      _pulling = null;
+      if (_pullAgain && !_gone) {
+        _pullAgain = false;
+        pullNew();
+      }
+    });
+  }
+
+  Future<void> _pull() async {
     final service = _service;
     if (service == null) return;
-    if (held == null || held.messages.isEmpty || held.epoch.isEmpty) {
-      ref.invalidateSelf();
-      return;
-    }
 
-    final result = await service.fetchTranscript(
-      arg.$2,
-      limit: pageSize,
-      afterSeq: held.messages.last.seq,
-      epoch: held.epoch,
-    );
-    if (result == null) return;
-    state = AsyncData(appendDelta(held, result));
+    // The daemon answers a delta up to a limit, so catching up after the app
+    // was away is several requests. Each one advances the cursor to the last
+    // seq it was given, which is only contiguous because the daemon hands back
+    // the oldest of what is new rather than the newest.
+    while (!_gone) {
+      final held = state.valueOrNull;
+      if (held == null || held.messages.isEmpty || held.epoch.isEmpty) {
+        // Nothing to quote an epoch from. This reads the first page again,
+        // which is a refresh rather than a delta — harmless, because there is
+        // nothing on screen to lose.
+        ref.invalidateSelf();
+        return;
+      }
+
+      final result = await service.fetchTranscript(
+        arg.$2,
+        limit: pageSize,
+        afterSeq: held.messages.last.seq,
+        epoch: held.epoch,
+      );
+      if (result == null || _gone) return;
+
+      // Read again rather than reusing `held`: the await is long enough for
+      // loadOlder to have prepended a page underneath.
+      state = AsyncData(appendDelta(state.valueOrNull ?? held, result));
+
+      // An empty answer cannot advance the cursor, so asking again would ask
+      // the same question forever.
+      if (!result.moreAfter || result.messages.isEmpty) return;
+    }
   }
 
   /// Reads the page before the oldest message held.

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -35,7 +35,7 @@ class SessionDetailScreen extends rp.ConsumerStatefulWidget {
 }
 
 class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   // Persisted across session switches (static = app-lifetime)
   static final _worktreeSelections =
       <String, String>{}; // sessionId → worktreePath
@@ -96,6 +96,12 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
     });
     final sse = context.read<HostManager>().serviceFor(widget.session.hostId);
     _eventSub = sse?.events.listen((event) {
+      // Addressed to every viewer rather than to a session: the socket came
+      // back and there is no telling what it missed while it was down.
+      if (event.type == 'stream_reconnected') {
+        _catchUp();
+        return;
+      }
       if (event.data is Map) {
         final data = event.data as Map;
         // Refresh on session status changes and notification events for this session
@@ -115,12 +121,44 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
         }
       }
     });
+    WidgetsBinding.instance.addObserver(this);
+    // Coming back to a session the app already holds: the provider outlives the
+    // screen, so build() does not run again and nothing would be read.
+    _catchUp();
     // Restore last sub-route after first frame
     _restoreSubRoute();
   }
 
+  /// Reads whatever arrived while nobody could see this screen.
+  ///
+  /// The event stream is best-effort — the daemon discards a broadcast to a
+  /// client whose buffer is full, and keeps nothing across a disconnect — so an
+  /// event is a hint that there is more to read, never the only cue. These are
+  /// the moments a reader arrives at the transcript, and re-reading at each of
+  /// them is what makes a lost event survivable.
+  ///
+  /// Only when something is already held: on a cold open the provider is still
+  /// building and will fetch the first page itself.
+  void _catchUp() {
+    if (!mounted) return;
+    if (!ref.read(transcriptProvider(_transcriptKey)).hasValue) return;
+    _loadNewMessages();
+  }
+
+  /// Unlock, the app switcher, a notification tap — one edge covers them all.
+  ///
+  /// This also fires after a transient `inactive` that never reached `paused`,
+  /// so it will sometimes read when nothing changed. A delta that finds nothing
+  /// is one small request against a cursor already held, and telling a real
+  /// return from a spurious one would cost more than the reads it saves.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _catchUp();
+  }
+
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _breathController.dispose();
     _promptController.dispose();
     _scrollController.dispose();
@@ -457,7 +495,11 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
         final sse = hm.serviceFor(widget.session.hostId);
         final transcript = ref.watch(transcriptProvider(_transcriptKey));
         _transcript = transcript.valueOrNull ?? const Transcript();
-        _loading = transcript.isLoading;
+        // Only a first load, never a refresh. A refreshing AsyncValue still
+        // reports isLoading while carrying the messages it already had, and
+        // reading that alone put the skeleton back over a conversation the
+        // reader was in the middle of.
+        _loading = transcript.isLoading && !transcript.hasValue;
         final held = ref
             .watch(sessionsProvider(allSessionsKey(widget.session.hostId)))
             .valueOrNull;

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -278,6 +278,10 @@ class DaemonAPIService extends ChangeNotifier {
       // so re-sync the tray against the daemon before trusting the stream
       // again. Resuming the app already does this; a network flap does not.
       _markStale('notification_resolved');
+      // Whatever was broadcast while the socket was down is gone: the daemon
+      // keeps no replay buffer. Anything holding data has to re-read, and
+      // _markStale cannot say so — it reaches the cache and no screen.
+      _handleEvent('stream_reconnected', const {});
       notifyListeners();
 
       String buffer = '';

--- a/mobile/test/cache_effects_test.dart
+++ b/mobile/test/cache_effects_test.dart
@@ -58,6 +58,18 @@ void main() {
     }
   });
 
+  // The socket was down and the daemon keeps no replay buffer, so anything that
+  // changed in the gap was announced to nobody.
+  test('a reconnect refetches what the stream could have missed', () {
+    expect(
+      effectsFor(host, 'stream_reconnected', const {}),
+      const [
+        InvalidateTarget(CacheTarget.sessions, host),
+        InvalidateTarget(CacheTarget.notifications, host),
+      ],
+    );
+  });
+
   // A permission request writes waiting_permission to the session and announces
   // only the notification, so the list is the one way the UI hears of it.
   test('a notification takes out the sessions as well as the notifications', () {

--- a/mobile/test/transcript_catchup_test.dart
+++ b/mobile/test/transcript_catchup_test.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:helios/providers/daemon_providers.dart';
+import 'package:helios/providers/transcript.dart';
+import 'package:helios/services/api_client.dart';
+import 'package:helios/services/daemon_api_service.dart';
+
+/// Catching up on a transcript after the event stream lost something.
+///
+/// The stream is best-effort — the daemon drops a broadcast to a client whose
+/// buffer is full and keeps nothing across a disconnect — so `pullNew` is the
+/// one path back to current, and every property it needs is asserted here:
+/// it walks a truncated delta to the end, it never runs twice at once, and it
+/// never puts the reader back on a loading state.
+
+const _host = 'h1';
+const _session = 's1';
+const _key = (_host, _session);
+
+Map<String, dynamic> msg(int seq) => {
+      'seq': seq,
+      'role': 'assistant',
+      'content': 'm$seq',
+      'timestamp': '2026-01-01T00:00:00Z',
+    };
+
+/// The daemon's answer: `seqs`, and whether the limit cut it short.
+String body(List<int> seqs, {String epoch = 'e1', bool moreAfter = false}) =>
+    jsonEncode({
+      'messages': seqs.map(msg).toList(),
+      'total': 99,
+      'returned': seqs.length,
+      'offset': 0,
+      'has_more': false,
+      'epoch': epoch,
+      'more_after': moreAfter,
+    });
+
+/// Records every transcript request, and answers from [answers] in order.
+class Daemon {
+  Daemon(this.answers);
+
+  final List<String> answers;
+  final List<Uri> asked = [];
+  int _next = 0;
+
+  /// Completed by the test to release the answer, when the test needs to
+  /// observe the state of a request that is still in flight.
+  List<Future<void>?> gates = [];
+
+  Future<http.Response> handle(http.Request req) async {
+    if (req.url.path.contains('/auth/')) {
+      return http.Response(
+        jsonEncode({
+          'token': 't',
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
+        }),
+        200,
+      );
+    }
+    asked.add(req.url);
+    final i = _next++;
+    if (i < gates.length && gates[i] != null) await gates[i];
+    return http.Response(answers[i.clamp(0, answers.length - 1)], 200);
+  }
+
+  List<Uri> get deltas =>
+      asked.where((u) => u.queryParameters.containsKey('after_seq')).toList();
+}
+
+ProviderContainer containerFor(Daemon daemon) {
+  final service = DaemonAPIService(
+    hostId: _host,
+    serverUrl: 'http://localhost:1',
+    api: ApiClient(
+      serverUrl: 'http://localhost:1',
+      deviceId: 'd1',
+      privateKeySeed: Uint8List(32),
+      client: MockClient(daemon.handle),
+    ),
+  );
+  final container = ProviderContainer(
+    overrides: [serviceProvider(_host).overrideWithValue(service)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+TranscriptNotifier notifierOf(ProviderContainer c) =>
+    c.read(transcriptProvider(_key).notifier);
+
+List<int> seqsOf(ProviderContainer c) => c
+    .read(transcriptProvider(_key))
+    .valueOrNull!
+    .messages
+    .map((m) => m.seq)
+    .toList();
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('walks a truncated delta to the end of the transcript', () async {
+    // Away long enough to miss more than one page: the daemon answers the
+    // oldest of what is new and says there is more behind it.
+    final daemon = Daemon([
+      body([1, 2]),
+      body([3, 4], moreAfter: true),
+      body([5, 6], moreAfter: true),
+      body([7]),
+    ]);
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    await notifierOf(c).pullNew();
+
+    expect(seqsOf(c), [1, 2, 3, 4, 5, 6, 7],
+        reason: 'a delta cut short must be followed to the end, not left as a hole');
+    expect(
+      daemon.deltas.map((u) => u.queryParameters['after_seq']),
+      ['2', '4', '6'],
+      reason: 'each request advances the cursor to the last seq it was given',
+    );
+  });
+
+  test('one delta is enough when nothing was cut short', () async {
+    final daemon = Daemon([
+      body([1, 2]),
+      body([3]),
+    ]);
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    await notifierOf(c).pullNew();
+
+    expect(seqsOf(c), [1, 2, 3]);
+    expect(daemon.deltas, hasLength(1));
+  });
+
+  test('a trigger arriving mid-flight is run once afterwards, not dropped',
+      () async {
+    final release = Completer<void>();
+    final daemon = Daemon([
+      body([1, 2]),
+      body([3]),
+      body([4]),
+    ])
+      ..gates = [null, release.future];
+
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    final first = notifierOf(c).pullNew();
+    await pumpEventQueue();
+    expect(daemon.deltas, hasLength(1), reason: 'the first read is out');
+
+    // A second event lands while that read is still waiting on the daemon.
+    notifierOf(c).pullNew();
+    await pumpEventQueue();
+    expect(daemon.deltas, hasLength(1),
+        reason: 'the second trigger must not open a second request');
+
+    release.complete();
+    await first;
+    await pumpEventQueue();
+
+    expect(daemon.deltas, hasLength(2),
+        reason: 'the trigger that arrived mid-flight is the one this provider '
+            'used to lose; it must produce a read that started after it');
+    expect(seqsOf(c), [1, 2, 3, 4]);
+  });
+
+  test('a failed read leaves the conversation alone and does not wedge the next',
+      () async {
+    final daemon = Daemon([body([1, 2])]);
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    // fetchTranscript swallows the failure and answers null.
+    daemon.answers.add('not json');
+    await notifierOf(c).pullNew();
+    expect(seqsOf(c), [1, 2]);
+
+    daemon.answers.add(body([3]));
+    await notifierOf(c).pullNew();
+    expect(seqsOf(c), [1, 2, 3], reason: 'the next pull must still run');
+  });
+
+  test('an epoch change replaces the conversation and stops the walk', () async {
+    final daemon = Daemon([
+      body([1, 2]),
+      jsonEncode({
+        'messages': [msg(9)],
+        'total': 1,
+        'returned': 1,
+        'offset': 0,
+        'has_more': false,
+        'epoch': 'e2',
+        'epoch_changed': true,
+      }),
+    ]);
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    await notifierOf(c).pullNew();
+
+    expect(seqsOf(c), [9],
+        reason: 'the seq numbers held counted against a parse that is gone');
+    expect(daemon.deltas, hasLength(1));
+  });
+
+  test('catching up never returns the cell to a loading state', () async {
+    final daemon = Daemon([
+      body([1, 2]),
+      body([3, 4], moreAfter: true),
+      body([5]),
+    ]);
+    final c = containerFor(daemon);
+    await c.read(transcriptProvider(_key).future);
+
+    final seen = <bool>[];
+    c.listen(transcriptProvider(_key), (_, next) => seen.add(next.isLoading));
+
+    await notifierOf(c).pullNew();
+
+    expect(seen, isNotEmpty);
+    expect(seen, everyElement(isFalse),
+        reason: 'a loading state here draws the skeleton over messages the '
+            'reader is looking at');
+  });
+}

--- a/mobile/test/transcript_triggers_test.dart
+++ b/mobile/test/transcript_triggers_test.dart
@@ -1,0 +1,248 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' as rp;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:helios/models/session.dart';
+import 'package:helios/providers/daemon_providers.dart';
+import 'package:helios/providers/theme_provider.dart';
+import 'package:helios/screens/session_detail_screen.dart';
+import 'package:helios/services/api_client.dart';
+import 'package:helios/services/daemon_api_service.dart';
+import 'package:helios/services/host_manager.dart';
+import 'package:helios/widgets/skeleton.dart';
+
+/// The two moments a reader arrives at a transcript.
+///
+/// An event is a hint that there is more to read, never the only cue: the
+/// daemon drops a broadcast to a client whose buffer is full and keeps nothing
+/// across a disconnect. So the screen reads again whenever someone can see it —
+/// on open, and on returning to the foreground. Neither can be asserted below
+/// the widget, because both are wiring rather than logic.
+
+const _host = 'h1';
+const _session = 's1';
+
+Session session() => Session(
+      hostId: _host,
+      sessionId: _session,
+      source: 'claude',
+      cwd: '/tmp/p',
+      project: 'p',
+      status: 'idle',
+      createdAt: '2026-01-01T00:00:00Z',
+    );
+
+/// Answers every transcript read with one more message than the last.
+class Daemon {
+  Daemon({this.empty = false, this.gateAfter});
+
+  /// Answer with no messages at all — a session opened before the agent has
+  /// written anything.
+  final bool empty;
+
+  /// Hold every read past this many, so a test can look at the screen while a
+  /// request is still out.
+  final int? gateAfter;
+  final _gate = Completer<void>();
+  void release() => _gate.complete();
+
+  final List<Uri> asked = [];
+  int _seq = 0;
+
+  Future<http.Response> handle(http.Request req) async {
+    final path = req.url.path;
+    if (path.contains('/auth/')) {
+      return http.Response(
+        jsonEncode({
+          'token': 't',
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
+        }),
+        200,
+      );
+    }
+    if (!path.endsWith('/transcript')) return http.Response('{}', 404);
+
+    asked.add(req.url);
+    if (gateAfter != null && asked.length > gateAfter!) await _gate.future;
+    if (empty) {
+      return http.Response(
+        jsonEncode({
+          'messages': [],
+          'total': 0,
+          'returned': 0,
+          'offset': 0,
+          'has_more': false,
+          'epoch': 'e1',
+        }),
+        200,
+      );
+    }
+    _seq++;
+    return http.Response(
+      jsonEncode({
+        'messages': [
+          {
+            'seq': _seq,
+            'role': 'assistant',
+            'content': 'm$_seq',
+            'timestamp': '2026-01-01T00:00:00Z',
+          }
+        ],
+        'total': _seq,
+        'returned': 1,
+        'offset': 0,
+        'has_more': false,
+        'epoch': 'e1',
+      }),
+      200,
+    );
+  }
+
+  List<Uri> get deltas =>
+      asked.where((u) => u.queryParameters.containsKey('after_seq')).toList();
+}
+
+/// One container for the whole test, so the transcript survives the screen
+/// being torn down — which is the situation these triggers exist for.
+class Harness {
+  Harness(this.tester, {bool empty = false, int? gateAfter})
+      : daemon = Daemon(empty: empty, gateAfter: gateAfter),
+        hosts = HostManager() {
+    final service = DaemonAPIService(
+      hostId: _host,
+      serverUrl: 'http://localhost:1',
+      api: ApiClient(
+        serverUrl: 'http://localhost:1',
+        deviceId: 'd1',
+        privateKeySeed: Uint8List(32),
+        client: MockClient(daemon.handle),
+      ),
+    );
+    container = rp.ProviderContainer(
+      overrides: [
+        hostManagerProvider.overrideWithValue(hosts),
+        serviceProvider(_host).overrideWithValue(service),
+      ],
+    );
+  }
+
+  final WidgetTester tester;
+  final Daemon daemon;
+  final HostManager hosts;
+  late final rp.ProviderContainer container;
+
+  Future<void> show(Widget child) async {
+    await tester.pumpWidget(
+      rp.UncontrolledProviderScope(
+        container: container,
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider.value(value: hosts),
+            ChangeNotifierProvider(create: (_) => ThemeProvider()),
+          ],
+          child: MaterialApp(home: child),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+
+  Future<void> openSession() => show(SessionDetailScreen(session: session()));
+
+  Future<void> leaveSession() => show(const Scaffold());
+
+  void dispose() {
+    container.dispose();
+    hosts.dispose();
+  }
+}
+
+Harness harnessFor(WidgetTester tester, {bool empty = false, int? gateAfter}) {
+  // The default 800x600 test surface is shorter than the composer plus the
+  // message list, and the overflow is reported as a test failure.
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 3.0;
+  addTearDown(tester.view.reset);
+
+  final h = Harness(tester, empty: empty, gateAfter: gateAfter);
+  addTearDown(h.dispose);
+  return h;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('coming back to a session reads what arrived while it was closed',
+      (tester) async {
+    final h = harnessFor(tester);
+
+    await h.openSession();
+    expect(h.daemon.asked, hasLength(1), reason: 'the first page, from build()');
+    expect(h.daemon.deltas, isEmpty,
+        reason: 'nothing held yet, so there is no cursor to quote');
+
+    await h.leaveSession();
+    await h.openSession();
+
+    expect(h.daemon.deltas, hasLength(1),
+        reason: 'the provider outlives the screen, so build() does not run '
+            'again — without this trigger, re-entering reads nothing');
+  });
+
+  testWidgets('coming back to the foreground reads the tail', (tester) async {
+    final h = harnessFor(tester);
+    await h.openSession();
+    final before = h.daemon.deltas.length;
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(h.daemon.deltas.length, before + 1,
+        reason: 'a turn can finish while the phone is locked, and the event '
+            'that announced it is gone by the time the screen is back');
+  });
+
+  testWidgets('neither read puts the skeleton back over the conversation',
+      (tester) async {
+    final h = harnessFor(tester);
+    await h.openSession();
+    await h.leaveSession();
+    await h.openSession();
+
+    // Mid-read: the delta is out, and the messages already held must still be
+    // the thing on screen.
+    expect(find.text('m1'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.text('m2'), findsOneWidget);
+  });
+
+  testWidgets('a session with nothing written yet re-reads without a skeleton',
+      (tester) async {
+    // Nothing is held, so there is no epoch to quote and the catch-up falls
+    // back to reading the page again. That is a refresh, and a refreshing
+    // AsyncValue still reports isLoading while carrying its previous value.
+    // The catch-up read is held open, so the screen is observed while the
+    // refresh is still out rather than after it has landed.
+    final h = harnessFor(tester, empty: true, gateAfter: 1);
+    await h.openSession();
+    await h.leaveSession();
+    await h.openSession();
+
+    expect(find.byType(MessageListSkeleton), findsNothing,
+        reason: 'the skeleton belongs to a first load; drawing it on a refresh '
+            'is what threw away the reader place this whole change protects');
+  });
+}


### PR DESCRIPTION
Closes the stale-transcript bug where the only way back to a current conversation was restarting the app.

Design: [docs/specs/52-transcript-freshness.md](docs/specs/52-transcript-freshness.md).

## The problem

The transcript had one refresh trigger — a `session_status` event naming that session (`session_detail_screen.dart:102`). The SSE stream is best-effort: the broadcaster discards an event when a client's 64-slot buffer is full (`sse.go:36-42`), and keeps no replay buffer across a disconnect (`sse.go:65-70`).

A single lost event heals on the next one. The problem is *which* event gets lost: `session_status` fires in a burst at the end of a turn, which is exactly when a slow client's buffer overflows — and after that burst the agent is idle, so no further event is ever broadcast. The conversation freezes. Because the provider is not `autoDispose`, leaving the session and coming back re-reads the same held `Transcript`, so only a process restart cleared it.

## The change

Staleness only matters when someone is looking at it. So rather than have the daemon report the drop, the client re-reads whenever a reader arrives:

| Trigger | Before | After |
|---|---|---|
| `session_status` for this session | pull | unchanged |
| Session screen opens | nothing — `build()` already ran on the live provider | pull |
| App returns to the foreground | nothing | pull |
| SSE reconnects | tray re-sync only | pull |

All four go through `pullNew`, whose entire transition is `AsyncData → AsyncData`. No trigger can draw the skeleton over a conversation in progress, which is what ruled out invalidation as the mechanism.

`internal/server/sse.go` is deliberately untouched. The server-side alternative — a `dropped` bit flushed as a `resync` frame — has to ride some frame, and on an idle session the only one left is the 30 s heartbeat. That pins recovery to a heartbeat interval for the exact case this fixes. Foregrounding and reconnecting are also where buffer overflows actually come from, so the client can already see every window that matters.

## Supporting fixes

- **`Delta` dropped the middle of a truncated answer.** It kept the newest `limit` and discarded everything between, so the client appended a run that did not start at its cursor — a permanent hole with no way to name what was skipped. It now keeps the oldest and reports `more_after`, and the client walks the range. This is the only daemon change: one additive response field, no route or existing field changes meaning.
- **`pullNew` read its base before the await and wrote it after**, with no in-flight guard (`loadOlder` has one). A late-landing response could regress the list. Now single-flight with a trailing re-run, re-reading state after each await, and it stops writing once the notifier is disposed.
- **`_loading` read `isLoading`**, which is true during a refresh as well as a first load, so any invalidation blanked the list to a skeleton. Now `isLoading && !hasValue`.

## Test plan

- [x] `go test ./...` — all packages pass, including 3 new `Delta` tests (oldest-first truncation, cursor loop reproduces the full range, `MoreAfter` stays off the paging path)
- [x] `flutter test` — 170 pass, including 6 new notifier tests and 4 new widget tests
- [x] `flutter analyze` — clean
- [x] Each new test checked against the unpatched code. All four widget tests go red without their fix. The skeleton test initially passed either way because the refetch completed inside the pump, so the response is now gated to observe the in-flight frame.
- [x] **Verified on device** (Android, debug build installed as `com.helios.helios.dev`, against a live daemon with 15 real sessions):
  - Open a session cold: 1 read, the first page.
  - Back to the list, re-enter: **1 read**. This was 0 before the change, and is the bug.
  - Home, then foreground: 0 reads while backgrounded, **1 on resume**.
  - Lock, then unlock: 0 reads while off, **2 on unlock** — the socket had genuinely died during screen-off, so `stream_reconnected` and `resumed` both fired, 82 ms apart. That exercised the reconnect path against a real network drop, which no test can do.
  - Transcript kept its scroll position throughout. No skeleton at any point.
- [ ] Two things the device run could **not** show. `fetchTranscript` logs only the status and the daemon keeps no access log, so the device proves the trigger fires, not that the request carries `after_seq` — that is asserted in `transcript_catchup_test.dart`. And the `more_after` loop is unit-tested on both sides but not across the seam, because the daemon on the test machine predates this change.
