### PR TITLE
feat: tell viewers when a file changes under them

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -18,8 +18,23 @@ export const BETA = 's-beta'
 
 export interface StubDaemon {
   url: string
+  /** Pushes one SSE frame to every connected client, as the daemon would. */
+  emit(type: string, data: unknown): void
+  /** Replaces what `/api/file` answers for a path, and its mod time with it. */
+  setFile(path: string, content: string): void
+  /**
+   * How many times `/api/file` has been asked for a path.
+   *
+   * The way to wait for the app to have *finished* thinking about an event when
+   * the right outcome is that nothing changes. Asserting an absence on its own
+   * passes before the event has even crossed the socket.
+   */
+  reads(path: string): number
   close(): Promise<void>
 }
+
+/** What `/api/file` answers before a test has said otherwise. */
+const DEFAULT_CONTENT = 'package main\n'
 
 function session(id: string, title: string): Session {
   return {
@@ -91,6 +106,22 @@ export async function startDaemon(): Promise<StubDaemon> {
   // Held open so the process can be shut down without waiting for the event
   // stream, which by design never ends on its own.
   const streams = new Set<http.ServerResponse>()
+  // What each path currently holds. A test writes here and then emits, which is
+  // the order the real daemon works in: the sweep reads the disk, then speaks.
+  const contents = new Map<string, string>()
+  // Bumped on every write so a changed file reports a changed mod time, as a
+  // real one would. The app must not need it — it compares bytes — and that is
+  // worth having true here so the test cannot pass for the wrong reason.
+  let revision = 0
+  const readCount = new Map<string, number>()
+
+  const held = (target: string): FileAnswer => {
+    readCount.set(target, (readCount.get(target) ?? 0) + 1)
+    return {
+      content: contents.get(target) ?? DEFAULT_CONTENT,
+      modTime: `2026-01-01T00:00:${String(revision).padStart(2, '0')}Z`,
+    }
+  }
 
   const server = http.createServer((req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1')
@@ -106,7 +137,7 @@ export async function startDaemon(): Promise<StubDaemon> {
     }
 
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(answer(path, q)))
+    res.end(JSON.stringify(answer(path, q, held)))
   })
 
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
@@ -114,6 +145,15 @@ export async function startDaemon(): Promise<StubDaemon> {
 
   return {
     url: `http://127.0.0.1:${port}`,
+    emit: (type, data) => {
+      const frame = `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`
+      for (const stream of streams) stream.write(frame)
+    },
+    reads: (target) => readCount.get(target) ?? 0,
+    setFile: (target, content) => {
+      contents.set(target, content)
+      revision += 1
+    },
     close: () =>
       new Promise<void>((resolve) => {
         for (const stream of streams) stream.end()
@@ -129,7 +169,16 @@ export async function startDaemon(): Promise<StubDaemon> {
  * about — settings, providers, notifications — and an empty answer is enough
  * for all of it. A 404 would put an error where a panel should be.
  */
-function answer(path: string, q: (name: string) => string): unknown {
+interface FileAnswer {
+  content: string
+  modTime: string
+}
+
+function answer(
+  path: string,
+  q: (name: string) => string,
+  held: (target: string) => FileAnswer,
+): unknown {
   switch (path) {
     case '/api/health':
       return { ok: true }
@@ -159,8 +208,10 @@ function answer(path: string, q: (name: string) => string): unknown {
       return { root: q('path'), branch: 'main', base: '', scope: 'all', commits: [], has_more: false }
     case '/api/files':
       return { path: q('path'), entries: TREES[q('path')] ?? [] }
-    case '/api/file':
-      return { path: q('path'), size: 12, mod_time: '2026-01-01T00:00:00Z', content: 'package main\n' }
+    case '/api/file': {
+      const { content, modTime } = held(q('path'))
+      return { path: q('path'), size: content.length, mod_time: modTime, content }
+    }
     case '/api/files/grep':
       return { root: q('path'), matches: grepMatches(q('path'), q('q')), scanned: 2, truncated: false }
     case '/api/files/search':

--- a/desktop/e2e/file-changes.spec.ts
+++ b/desktop/e2e/file-changes.spec.ts
@@ -1,0 +1,125 @@
+// A file moving under an open tab.
+//
+// The rule these drive is the one with no unit test behind it, because it lives
+// in a component and there is no component test framework here: a clean tab
+// takes what is on disk, a dirty tab keeps every character and says so, and an
+// event carrying the bytes already on screen does nothing at all.
+//
+// See docs/specs/53-file-change-events.md.
+import type { Locator, Page } from '@playwright/test'
+
+import { REPO } from './daemon.ts'
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+const MAIN = `${REPO}/main.go`
+
+function shown(window: Page): Locator {
+  return window.locator('.panel-keep:not([hidden])')
+}
+
+/** Opens Alpha's files panel with main.go in front, in the editor. */
+async function openFile(window: Page): Promise<Locator> {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await window.locator('.panel-tabs button', { hasText: 'files' }).first().click()
+  await expect(shown(window)).toBeVisible()
+  await shown(window).locator('.tree-row', { hasText: 'main.go' }).click()
+  const editor = shown(window).locator('.cm-content')
+  await expect(editor).toContainText('package main')
+  return editor
+}
+
+/** What the daemon broadcasts once its sweep has found the file changed. */
+function moved(path: string): [string, unknown] {
+  return ['file_changed', { paths: [{ path, kind: 'file', mod_time: '2026-01-01T00:00:09Z' }] }]
+}
+
+test.beforeEach(async ({ window }) => {
+  await expect(window.locator('.session-row', { hasText: ALPHA })).toBeVisible()
+})
+
+test('an agent edit lands in an open tab with nobody clicking anything', async ({ window, daemon }) => {
+  const editor = await openFile(window)
+
+  daemon.setFile(MAIN, 'package main // edited by the agent\n')
+  daemon.emit(...moved(MAIN))
+
+  await expect(editor).toContainText('edited by the agent')
+  // A clean tab is replaced outright: no bar, nothing to answer.
+  await expect(shown(window).locator('.ws-stale-bar')).toHaveCount(0)
+})
+
+test('an unsaved buffer survives an edit, and the bar says so', async ({ window, daemon }) => {
+  const editor = await openFile(window)
+
+  await editor.click()
+  await window.keyboard.type('// mine')
+  await expect(shown(window).locator('.ws-tab-close')).toHaveText('●')
+
+  daemon.setFile(MAIN, 'package main // theirs\n')
+  daemon.emit(...moved(MAIN))
+
+  await expect(shown(window).locator('.ws-stale-bar')).toBeVisible()
+  // Every character still there, and not a word of theirs in the buffer.
+  await expect(editor).toContainText('// mine')
+  await expect(editor).not.toContainText('// theirs')
+  await expect(shown(window).locator('.ws-tab-close')).toHaveText('●')
+})
+
+test('reload takes what is on disk, and only when asked', async ({ window, daemon }) => {
+  const editor = await openFile(window)
+
+  await editor.click()
+  await window.keyboard.type('// mine')
+  daemon.setFile(MAIN, 'package main // theirs\n')
+  daemon.emit(...moved(MAIN))
+  await expect(shown(window).locator('.ws-stale-bar')).toBeVisible()
+
+  await shown(window).locator('.ws-stale-bar button', { hasText: 'Reload' }).click()
+
+  await expect(editor).toContainText('// theirs')
+  await expect(editor).not.toContainText('// mine')
+  await expect(shown(window).locator('.ws-stale-bar')).toHaveCount(0)
+  await expect(shown(window).locator('.ws-tab-close')).toHaveText('✕')
+})
+
+// The daemon compares digests before it speaks, but the client compares bytes
+// too: this is the echo of a save, which the broadcaster cannot skip because it
+// has no addressing. Acting on it would remount the editor under whoever typed.
+//
+// Waits on the re-read rather than on the absence of a bar. A bar that has not
+// appeared yet and a bar that is never going to appear look identical, so
+// asserting the absence on its own passes before the event has crossed the
+// socket — which it did, until this test was checked against a mutation.
+test('an event carrying the bytes already on screen changes nothing', async ({ window, daemon }) => {
+  const editor = await openFile(window)
+
+  await editor.click()
+  await window.keyboard.type('// mine')
+  await expect(shown(window).locator('.ws-tab-close')).toHaveText('●')
+
+  // Content untouched: the same answer the tab already holds.
+  const before = daemon.reads(MAIN)
+  daemon.emit(...moved(MAIN))
+  await expect.poll(() => daemon.reads(MAIN)).toBeGreaterThan(before)
+
+  // Re-read, compared, and nothing done: no bar over a file that did not move.
+  await expect(shown(window).locator('.ws-stale-bar')).toHaveCount(0)
+  await expect(editor).toContainText('// mine')
+})
+
+test('an event about another file leaves this tab alone', async ({ window, daemon }) => {
+  const editor = await openFile(window)
+
+  daemon.setFile(`${REPO}/README.md`, '# elsewhere\n')
+  daemon.emit(...moved(`${REPO}/README.md`))
+
+  // A second event, for a file that really is open, is what proves the first
+  // has been dealt with: the stream is ordered, so this cannot land first.
+  daemon.setFile(MAIN, 'package main // later\n')
+  daemon.emit(...moved(MAIN))
+  await expect(editor).toContainText('// later')
+
+  await expect(editor).not.toContainText('elsewhere')
+  await expect(shown(window).locator('.ws-stale-bar')).toHaveCount(0)
+})

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -135,7 +135,12 @@ export function registerIpc(deps: IpcDeps): void {
   hosts.on('hosts', (list) => send('hosts:changed', list))
   hosts.on('status', (status: { id: string; state: string }) => {
     send('hosts:status', status)
-    if (status.state === 'online') void reconcile(status.id)
+    if (status.state !== 'online') return
+    void reconcile(status.id)
+    // The renderer's cache missed the same window the tray did, and it hears
+    // nothing from `reconcile`. A synthetic event is how it learns the socket
+    // came back — there is no replay buffer to ask (spec 54).
+    send('hosts:event', { hostId: status.id, event: { type: 'stream_reconnected', data: {} } })
   })
   hosts.on('event', ({ hostId, event }: { hostId: string; event: { type: string; data: Record<string, unknown> } }) => {
     notifier.handleEvent(hostId, event.type, event.data)

--- a/desktop/src/renderer/components/editor.tsx
+++ b/desktop/src/renderer/components/editor.tsx
@@ -52,6 +52,14 @@ interface Props {
   onChange: (text: string) => void
   onSave: () => void
   cursor?: Cursor | null
+  /**
+   * Whether to take the keyboard when the buffer is built. Default true.
+   *
+   * False when the remount was not asked for by a person: a file event
+   * replacing the text of a tab that happens to be in front must not pull the
+   * caret out of whatever the user is typing into elsewhere.
+   */
+  autoFocus?: boolean
   /** Where the file was left last time. Applied once, as the buffer is built. */
   restore?: ReadingPosition | null
   onViewChange?: (at: ReadingPosition) => void
@@ -73,6 +81,7 @@ export function CodeEditor({
   onChange,
   onSave,
   cursor,
+  autoFocus = true,
   restore,
   onViewChange,
   onContextMenu,
@@ -86,6 +95,10 @@ export function CodeEditor({
   // every time the position it describes changed, which is every keystroke.
   const restoreRef = useRef(restore)
   restoreRef.current = restore
+  // Read at mount for the same reason as restore: as a dependency it would
+  // rebuild the editor whenever the panel changed its mind about focus.
+  const focusRef = useRef(autoFocus)
+  focusRef.current = autoFocus
 
   const report = (editor: EditorView): void => {
     const handle = handlers.current.onViewChange
@@ -146,7 +159,7 @@ export function CodeEditor({
     })
     const created = new EditorView({ state, parent: host.current })
     view.current = created
-    created.focus()
+    if (focusRef.current) created.focus()
 
     const start = restoreRef.current
     if (start) {

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { api, statusOf } from '../bridge.ts'
+import { api, bridge, statusOf } from '../bridge.ts'
 import { dataUrl, extensionOf, kindOf, type FileKind } from '../filetype.ts'
-import { keys } from '../keys.ts'
+import { fileEffectFor, keys } from '../keys.ts'
 import { isMarkdownPath, languageForPath, renderMarkdownBlocks } from '../markdown.ts'
 import { useMermaid } from '../mermaid.ts'
 import { fileContentQuery, worktreesQuery } from '../queries.ts'
@@ -48,6 +48,13 @@ interface OpenTab {
    *  on that would throw away the cursor of whoever pressed ⌘S. */
   version: number
   cursor: Cursor | null
+  /** The file changed under an unsaved buffer. Raises the bar; changes nothing
+   *  else. Cleared by a reload or by a save that lands. */
+  staleOnDisk: boolean
+  /** This version came from an event rather than from a person, so the editor
+   *  must not take focus when it remounts — the user may be typing somewhere
+   *  else entirely. Cleared by the effect that follows the render using it. */
+  quiet: boolean
 }
 
 /** What the file is, as opposed to what the window is doing with it. */
@@ -193,6 +200,8 @@ export function FilesPanel({
             mode: kindOf(path) !== 'text' || isMarkdownPath(path) ? 'preview' : 'edit',
             version: 0,
             cursor: at ? { ...at, seq: 1 } : null,
+            staleOnDisk: false,
+            quiet: false,
           },
         ])
         if (activate) setActivePath(path)
@@ -282,7 +291,7 @@ export function FilesPanel({
   }, [memory, loadedFor, rootOverride, tabs, activePath, expanded, side, viewTick])
 
   const save = useCallback(
-    async (path: string): Promise<void> => {
+    async (path: string, quiet = true): Promise<void> => {
       const tab = tabsRef.current.find((t) => t.path === path)
       const onDisk = client.getQueryData(fileContentQuery(hostId, path).queryKey)
       if (!tab || !tab.dirty || !onDisk || shapeOf(onDisk).readOnly) return
@@ -295,7 +304,11 @@ export function FilesPanel({
         client.setQueryData(fileContentQuery(hostId, path).queryKey, (current) =>
           current ? { ...current, content: text, mod_time: result.mod_time } : current,
         )
-        setTabs((current) => current.map((t) => (t.path === path ? { ...t, dirty: false } : t)))
+        // The bar goes with the save: what is on disk is now what is in the
+        // buffer, whoever else had written to it in between.
+        setTabs((current) =>
+          current.map((t) => (t.path === path ? { ...t, dirty: false, staleOnDisk: false } : t)),
+        )
       } catch (err) {
         // The agent edits the same files, so this is a real outcome rather than
         // an edge case: reload, then decide what to keep.
@@ -306,6 +319,18 @@ export function FilesPanel({
     [hostId, client],
   )
 
+  /** Replaces the buffer from disk. `quiet` keeps the editor from taking focus. */
+  const adopt = useCallback((path: string, quiet: boolean): void => {
+    delete drafts.current[path]
+    setTabs((current) =>
+      current.map((tab) =>
+        tab.path === path
+          ? { ...tab, dirty: false, staleOnDisk: false, quiet, version: tab.version + 1 }
+          : tab,
+      ),
+    )
+  }, [])
+
   const reload = useCallback(
     async (path: string): Promise<void> => {
       try {
@@ -313,32 +338,103 @@ export function FilesPanel({
         // its own, precisely so nothing but this and the effect below can move
         // it under an open buffer.
         await client.fetchQuery({ ...fileContentQuery(hostId, path), staleTime: 0 })
-        delete drafts.current[path]
-        setTabs((current) =>
-          current.map((tab) =>
-            tab.path === path ? { ...tab, dirty: false, version: tab.version + 1 } : tab,
-          ),
-        )
+        adopt(path, false)
       } catch (err) {
         store.fail(err)
       }
     },
-    [hostId, client],
+    [hostId, client, adopt],
   )
 
+  /**
+   * Brings one tab in line with the disk after something said the file moved.
+   *
+   * Reads around the cache on purpose. `fetchQuery` would write the answer into
+   * the entry `ActiveFile` derives `saved` from, and under a dirty tab that
+   * moves two things at once: the text the unsaved marker is decided against,
+   * and the `mod_time` a later save sends as its base — which would turn the
+   * 409 that protects the other writer into a silent overwrite.
+   */
+  const syncFromDisk = useCallback(
+    async (path: string, quiet = true): Promise<void> => {
+      const tab = tabsRef.current.find((t) => t.path === path)
+      const held = client.getQueryData(fileContentQuery(hostId, path).queryKey)
+      if (!tab || !held) return
+
+      let fresh: FileContent | null = null
+      try {
+        fresh = await api(hostId).readFile(path)
+      } catch (err) {
+        // Gone is a real answer and the bar reports it. Anything else is a
+        // transient, and the next event or the next arrival tries again.
+        if (statusOf(err) !== 404) return
+      }
+
+      switch (fileEffectFor(tab, held.content, fresh?.content ?? null)) {
+        case 'ignore':
+          return
+        case 'mark':
+          setTabs((current) =>
+            current.map((t) => (t.path === path ? { ...t, staleOnDisk: true } : t)),
+          )
+          return
+        case 'reload':
+          // The answer is already in hand, so this writes it rather than
+          // fetching the same bytes a second time.
+          if (fresh) client.setQueryData(fileContentQuery(hostId, path).queryKey, fresh)
+          adopt(path, quiet)
+      }
+    },
+    [hostId, client, adopt],
+  )
+
+  /**
+   * The daemon says a path it was asked to watch has changed content.
+   *
+   * Every open tab, not just the one in front: a background tab holds no query,
+   * but it holds a draft and an unsaved marker, and its cache entry is what the
+   * user sees the moment they click it.
+   */
+  useEffect(() => {
+    return bridge.hosts.onEvent(({ hostId: from, event }) => {
+      if (from !== hostId || event.type !== 'file_changed') return
+      const named = event.data.paths
+      if (!Array.isArray(named)) return
+      const moved = new Set(
+        named.map((entry) => (entry as { path?: unknown }).path).filter((p): p is string => typeof p === 'string'),
+      )
+      for (const tab of tabsRef.current) {
+        if (moved.has(tab.path)) void syncFromDisk(tab.path)
+      }
+    })
+  }, [hostId, syncFromDisk])
+
+  /**
+   * Clears the quiet flag once the render that used it has happened.
+   *
+   * It is read on mount only, so leaving it set would suppress the focus a
+   * later tab switch is right to take. Clearing does not bump the version, so
+   * nothing remounts.
+   */
+  const activeTab = tabs.find((tab) => tab.path === activePath) ?? null
+  useEffect(() => {
+    if (!activeTab?.quiet) return
+    setTabs((current) => current.map((t) => (t.quiet ? { ...t, quiet: false } : t)))
+  }, [activeTab?.path, activeTab?.version, activeTab?.quiet])
+
   // The agent edits the tree while the user is elsewhere, so the buffer that
-  // was accurate on the way out is stale on the way back. Unsaved edits
-  // outrank what is on disk and are left alone; the file keeps its unsaved
-  // marker and the user can revert deliberately.
+  // was accurate on the way out is stale on the way back. Every clean tab, not
+  // just the one in front — and a read is also what re-registers the path with
+  // the daemon's watcher after its TTL expired. Unsaved edits outrank what is
+  // on disk and are left alone; the file keeps its unsaved marker, and the bar
+  // appears if what is on disk really did move.
   const wasVisible = useRef(visible)
   useEffect(() => {
     const returning = visible && !wasVisible.current
     wasVisible.current = visible
-    if (!returning || !activePath) return
-    const tab = tabsRef.current.find((t) => t.path === activePath)
-    if (!tab || tab.dirty) return
-    void reload(activePath)
-  }, [visible, activePath, reload])
+    if (!returning) return
+    for (const tab of tabsRef.current) void syncFromDisk(tab.path, tab.path !== activePath)
+  }, [visible, activePath, syncFromDisk])
 
   const close = (path: string): void => {
     const tab = tabsRef.current.find((t) => t.path === path)
@@ -568,6 +664,11 @@ export function FilesPanel({
             }}
             onSave={() => void save(active.path)}
             onReload={() => void reload(active.path)}
+            onDismissStale={() =>
+              setTabs((current) =>
+                current.map((t) => (t.path === active.path ? { ...t, staleOnDisk: false } : t)),
+              )
+            }
             onMode={(mode) =>
               setTabs((current) => current.map((t) => (t.path === active.path ? { ...t, mode } : t)))
             }
@@ -629,6 +730,7 @@ function ActiveFile({
   onChange,
   onSave,
   onReload,
+  onDismissStale,
   onMode,
   restore,
   onPositionChange,
@@ -642,6 +744,7 @@ function ActiveFile({
   onChange: (text: string, dirty: boolean) => void
   onSave: () => void
   onReload: () => void
+  onDismissStale: () => void
   onMode: (mode: 'edit' | 'preview') => void
   restore: ReadingPosition | null
   onPositionChange: (at: ReadingPosition) => void
@@ -671,6 +774,7 @@ function ActiveFile({
       onChange={(text) => onChange(text, text !== data.content)}
       onSave={onSave}
       onReload={onReload}
+      onDismissStale={onDismissStale}
       onMode={onMode}
       restore={restore}
       onPositionChange={onPositionChange}
@@ -687,6 +791,7 @@ function FileView({
   onChange,
   onSave,
   onReload,
+  onDismissStale,
   onMode,
   restore,
   onPositionChange,
@@ -699,6 +804,9 @@ function FileView({
   onChange: (text: string) => void
   onSave: () => void
   onReload: () => void
+  /** Keep the buffer and put the bar away. The save still 409s, which is right:
+   *  the other writer's change is still on disk and the user chose theirs. */
+  onDismissStale: () => void
   onMode: (mode: 'edit' | 'preview') => void
   /** Where this file was last left, or null if it has not been opened before. */
   restore: ReadingPosition | null
@@ -881,6 +989,22 @@ function FileView({
         )}
       </header>
 
+      {/* The file moved under an unsaved buffer. Nothing has been touched: the
+          reader decides whether to take what is on disk or keep what they
+          typed. No merge, and no dialog in the way of either answer. */}
+      {file.staleOnDisk && (
+        <div className="ws-stale-bar" role="status">
+          <span>Changed on disk. Your unsaved edits are still here.</span>
+          <span className="grow" />
+          <button className="filled tiny" onClick={onReload}>
+            Reload
+          </button>
+          <button className="icon-btn tiny" title="Keep my version" onClick={onDismissStale}>
+            ✕
+          </button>
+        </div>
+      )}
+
       {source ? (
         <div className={`ws-image ${natural ? 'natural' : ''}`}>
           <img
@@ -965,6 +1089,7 @@ function FileView({
           onChange={onChange}
           onSave={onSave}
           cursor={file.cursor}
+          autoFocus={!file.quiet}
           restore={restore}
           onViewChange={onPositionChange}
           onContextMenu={(at) => setMenu({ x: at.x, y: at.y, range: { start: at.startLine, end: at.endLine } })}

--- a/desktop/src/renderer/keys.ts
+++ b/desktop/src/renderer/keys.ts
@@ -214,6 +214,35 @@ export function effectsFor(hostId: string, event: SSEEvent): CacheEffect[] {
     case 'session_evicted':
       return [{ kind: 'invalidate', queryKey: keys.host(hostId) }]
 
+    // Every path named has changed *content*, not merely a changed mtime: the
+    // daemon compares digests before it says anything (spec 54). Which paths
+    // they are does not change the answer here — both prefixes go, and React
+    // Query refetches only what has an observer, so naming one costs the same
+    // as naming all of them.
+    //
+    // Git comes too. A working-tree write moves `git status`, and a repo entry
+    // is a commit or a checkout.
+    case 'file_changed': {
+      const named = event.data.paths
+      if (!Array.isArray(named) || named.length === 0) return []
+      return [
+        { kind: 'invalidate', queryKey: keys.files(hostId) },
+        { kind: 'invalidate', queryKey: keys.git(hostId) },
+      ]
+    }
+
+    // The socket was down and the daemon keeps no replay buffer, so anything
+    // that moved in the gap was announced to nobody. Files and git for a second
+    // reason: a path whose watch expired while a tab sat open is not being
+    // swept, and re-reading is what registers it again.
+    case 'stream_reconnected':
+      return [
+        { kind: 'invalidate', queryKey: keys.allSessions(hostId) },
+        { kind: 'invalidate', queryKey: keys.notifications(hostId) },
+        { kind: 'invalidate', queryKey: keys.files(hostId) },
+        { kind: 'invalidate', queryKey: keys.git(hostId) },
+      ]
+
     // 'show' instructs the window, and the terminal events move connections:
     // 'terminal_opened' re-lists a session's shells and attaches the ones this
     // client is missing, 'terminal_closed' tears a tab down. The store handles
@@ -225,4 +254,44 @@ export function effectsFor(hostId: string, event: SSEEvent): CacheEffect[] {
 
 function text(value: unknown): string {
   return typeof value === 'string' ? value : ''
+}
+
+// ─── What a file event does to one open tab ─────────────────────────────────
+
+/**
+ * What to do with a tab once its file has been re-read.
+ *
+ * `reload` replaces the buffer, `mark` raises the changed-on-disk bar, and
+ * `ignore` does nothing at all.
+ */
+export type FileEffect = 'reload' | 'mark' | 'ignore'
+
+/**
+ * Whether an event means anything for one open tab, decided by comparing bytes.
+ *
+ * Kept out of the component so the rule that protects unsaved work can be
+ * asserted: there is no component test framework here, and this is the half
+ * that must never be wrong.
+ *
+ * Bytes rather than mod times, for two reasons. It drops the echo of this
+ * window's own save — the broadcaster has no addressing, so a writer hears
+ * itself — without which every save would remount the editor of whoever pressed
+ * ⌘S. And it is the second line of defence behind the daemon's own hash: the
+ * daemon compares digests so it does not broadcast noise, and this compares
+ * text so a false alarm never reaches a dirty buffer.
+ *
+ * Comparing `mod_time` would not survive the API anyway: the read route formats
+ * it with RFC3339 and the write route with RFC3339Nano, so a tab's cached value
+ * changes precision depending on how it was last filled.
+ */
+export function fileEffectFor(
+  tab: { dirty: boolean },
+  saved: string,
+  fetched: string | null,
+): FileEffect {
+  // A file that has gone leaves the buffer alone and says so. Closing the tab
+  // would discard work that saving could still put back on disk.
+  if (fetched === null) return 'mark'
+  if (fetched === saved) return 'ignore'
+  return tab.dirty ? 'mark' : 'reload'
 }

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2683,6 +2683,20 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
+/* Somebody else wrote the file while this buffer had unsaved edits. A strip
+   rather than a dialog: the buffer is untouched either way, so nothing needs
+   answering before the reader can carry on typing. */
+.ws-stale-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  background: var(--surface-container-high);
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+  font-size: 12px;
+  color: var(--on-surface);
+}
+
 .preview-path {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/desktop/test/cache-keys.test.ts
+++ b/desktop/test/cache-keys.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   appendDelta,
   effectsFor,
+  fileEffectFor,
   keys,
   mergeSettings,
   patchSessionInPage,
@@ -173,6 +174,71 @@ test('session_evicted takes out the whole host', () => {
   assert.deepEqual(effectsFor(HOST, { type: 'session_evicted', data: {} }), [
     { kind: 'invalidate', queryKey: keys.host(HOST) },
   ])
+})
+
+// ─── Files ──────────────────────────────────────────────────────────────────
+
+// Every path named has changed *content*: the daemon compares digests before it
+// says anything, so a formatter that rewrites a file with the bytes already in
+// it never reaches here. See docs/specs/54-file-change-events.md.
+test('file_changed takes out the files and the git reads', () => {
+  const named = { paths: [{ path: '/repo/a.go', kind: 'file', mod_time: '2026-09-01T04:03:11.204Z' }] }
+  assert.deepEqual(effectsFor(HOST, { type: 'file_changed', data: named }), [
+    { kind: 'invalidate', queryKey: keys.files(HOST) },
+    { kind: 'invalidate', queryKey: keys.git(HOST) },
+  ])
+})
+
+// A working-tree write moves `git status`, and a repo entry is a commit or a
+// checkout, so both kinds reach git the same way.
+test('a repo entry and a deletion take out the same keys', () => {
+  for (const entry of [{ path: '/repo', kind: 'repo' }, { path: '/repo/x.go', kind: 'file', gone: true }]) {
+    assert.equal(effectsFor(HOST, { type: 'file_changed', data: { paths: [entry] } }).length, 2)
+  }
+})
+
+test('a file_changed naming nothing does nothing', () => {
+  assert.deepEqual(effectsFor(HOST, { type: 'file_changed', data: {} }), [])
+  assert.deepEqual(effectsFor(HOST, { type: 'file_changed', data: { paths: [] } }), [])
+  assert.deepEqual(effectsFor(HOST, { type: 'file_changed', data: { paths: 'nonsense' } }), [])
+})
+
+// The socket was down and there is no replay buffer, so the gap was announced
+// to nobody. Files and git for a second reason: a watch that expired while a
+// tab sat open is not being swept, and re-reading registers it again.
+test('a reconnect refetches what the stream could have missed', () => {
+  assert.deepEqual(effectsFor(HOST, { type: 'stream_reconnected', data: {} }), [
+    { kind: 'invalidate', queryKey: keys.allSessions(HOST) },
+    { kind: 'invalidate', queryKey: keys.notifications(HOST) },
+    { kind: 'invalidate', queryKey: keys.files(HOST) },
+    { kind: 'invalidate', queryKey: keys.git(HOST) },
+  ])
+})
+
+// ─── What a file event does to one open tab ─────────────────────────────────
+//
+// The rule that protects unsaved work. It lives outside the component so it can
+// be asserted at all: there is no component test framework here.
+
+test('a clean tab whose file really moved is reloaded', () => {
+  assert.equal(fileEffectFor({ dirty: false }, 'old', 'new'), 'reload')
+})
+
+test('a dirty tab is marked and never reloaded', () => {
+  assert.equal(fileEffectFor({ dirty: true }, 'old', 'new'), 'mark')
+})
+
+// This window's own save comes back to it: the broadcaster has no addressing.
+// Without this the editor of whoever pressed the save key remounts under them.
+test('text equal to what is held is ignored, dirty or not', () => {
+  assert.equal(fileEffectFor({ dirty: false }, 'same', 'same'), 'ignore')
+  // The false-alarm case: no bar over a file that did not change.
+  assert.equal(fileEffectFor({ dirty: true }, 'same', 'same'), 'ignore')
+})
+
+test('a file that has gone is marked, never closed', () => {
+  assert.equal(fileEffectFor({ dirty: false }, 'old', null), 'mark')
+  assert.equal(fileEffectFor({ dirty: true }, 'old', null), 'mark')
 })
 
 test('events that are not about data touch no keys', () => {

--- a/docs/specs/54-file-change-events.md
+++ b/docs/specs/54-file-change-events.md
@@ -1,0 +1,571 @@
+# File Change Events: Watch What Someone Is Looking At
+
+## The claim
+
+The daemon must tell a viewer when a file changes. Today it never does.
+
+Helios exists to watch an agent work. The agent's main output is a file edit.
+That edit reaches no screen. A desktop tab keeps the old text. A phone keeps the
+old listing.
+
+Both clients are already built for the event. `CacheTarget.files` and
+`CacheTarget.git` each have a switch arm in `cache_invalidator.dart:60-72`.
+Neither arm can run, because `effectsFor` never returns those targets. The
+desktop holds file and git query keys (`keys.ts:47,63-72`) and maps no event to
+them. The consumers exist. The producer does not.
+
+The producer watches **metadata for the paths a viewer holds**. Not the tree, and
+not the tool call. A read registers a path; a sweep re-stats what is registered;
+anything that moved goes out on the stream. So the work the daemon does is
+proportional to what people are looking at, rather than to what changed on disk.
+That one property is the whole design. See *Why not a tree watcher* and *Why not
+the tool payload*.
+
+**Scope:** `internal/server` (a registry, a digest, one broadcast),
+`internal/daemon` (a sweep), one line in each provider's `PostToolUse`,
+`mobile/`, `desktop/`. One new SSE event type. No route changes shape. No
+existing field changes meaning. Both clients return an empty effect list for an
+unknown event type (`cache_effects.dart:190-191`, `keys.ts:221-222`), so an older
+client talking to a newer daemon behaves exactly as it does today. `internal/tui`
+is untouched, and `go.mod` gains no dependency.
+
+## Where we are
+
+| | Today |
+|---|---|
+| File change event | none. The stream carries 10 types, and none names a path |
+| Filesystem watcher | none. `trust_watcher.go` watches sessions, not files |
+| Mobile files cache | `CacheTarget.files` invalidates `listFilesProvider` (`cache_invalidator.dart:68-72`) — unreachable |
+| Mobile git cache | `CacheTarget.git` invalidates five providers (`cache_invalidator.dart:60-67`) — unreachable |
+| Mobile refresh today | one button (`file_browser_screen.dart:271`) |
+| Mobile writes | none. `api_client.dart` has no `PUT`. The mobile file view is read-only |
+| Desktop files cache | `keys.fileDir`, `keys.fileContent`, `keys.fileAsset`, two search keys (`keys.ts:63-72`); `effectsFor` (`keys.ts:178`) returns no file effect |
+| Desktop refresh today | one trigger. A hide/show reloads the **active** tab, and only when it is clean (`files.tsx:332-339`) |
+| Desktop write conflict | `base_mod_time` compare, 409, a toast that says "reload first" (`filesearch.go:197`, `files.tsx:301`) |
+| Desktop reconnect | the tray reconciles on `status === 'online'` (`ipc.ts:138`); no event reaches `effectsFor` |
+| Mobile reconnect | `stream_reconnected` reaches `effectsFor` (`daemon_api_service.dart:284`) and takes out sessions and notifications only |
+| Read handlers | `handleListFiles` (`files.go:26`) does a readdir plus one `Info()` per entry; `handleReadFile` (`files.go:87`) stats one path |
+| Periodic work | `internal/daemon` already runs sweeps — `reaper.go`, `evict.go` |
+
+## What this costs today, stated plainly
+
+### The product's main case is the one that is invisible
+
+The agent writes a file. Every open viewer keeps the old bytes. Nothing on any
+screen moves.
+
+On the desktop the user must hide the files panel and show it again, and that
+reloads one tab. On the phone the user must press a button. Neither client has
+any way to learn that the file moved.
+
+### Stale content is worse than a stale list
+
+A directory listing that misses a new file is a small error. The user sees fewer
+rows than exist.
+
+A file view that shows text the agent replaced is a large error. The user reads
+it, reasons about it, and asks the agent about code that is gone. The screen is
+not incomplete. It is wrong, and it looks correct.
+
+### The dead branches make the bug look fixed
+
+A reader of `cache_invalidator.dart:68` sees `CacheTarget.files` handled, with a
+careful comment about why `readFile` is left alone. The reader concludes the path
+works. It does not. `effectsFor` (`cache_effects.dart:128-193`) has no case that
+returns that target, so the arm cannot run.
+
+`CacheTarget.git` is dead in the same way, and its comment is equally careful.
+Two enum members, one switch arm each, zero producers.
+
+### The desktop reload rule is right, and has no event behind it
+
+`files.tsx:332-339` reloads the active tab when the panel becomes visible, and
+skips a dirty one. That is the correct rule. It runs on the wrong trigger.
+
+A background tab therefore stays stale for as long as it is open. A file the user
+watches without leaving the panel stays stale forever. The effect covers the case
+where the user was not looking, and misses the case where the user is.
+
+### A save can only find out by failing
+
+The 409 at `files.tsx:301` is the only path by which the desktop learns a file
+moved under it. The user types for a minute, presses save, and is then told to
+reload and redo the work by hand. The information existed a minute earlier.
+
+## The change
+
+### The event
+
+```json
+{
+  "type": "file_changed",
+  "data": {
+    "paths": [
+      { "path": "/home/u/repo/internal/server/api.go", "kind": "file", "mod_time": "2026-09-01T04:03:11.204Z" },
+      { "path": "/home/u/repo/internal/server", "kind": "dir" },
+      { "path": "/home/u/repo/docs/old.md", "kind": "file", "gone": true },
+      { "path": "/home/u/repo", "kind": "repo" }
+    ]
+  }
+}
+```
+
+Every entry names something a client asked for. There is no coarse "something
+changed" flag, because the daemon never has to guess: it knows exactly which of
+the paths it was asked about have moved.
+
+Every entry named has **changed content**, not merely changed metadata. That is
+the daemon's promise, and *Metadata gates the check* is how it keeps it.
+
+`mod_time` is informational — for logs and for a listing row. No client decides
+anything from it. `gone` marks a path that no longer exists.
+
+### The watch set comes from the reads
+
+A read is the subscription. There is no subscribe call and no unsubscribe call.
+
+| Handler | Registers | Kind |
+|---|---|---|
+| `GET /api/file` (`files.go:87`) | the file | `file` |
+| `GET /api/files` (`files.go:26`) | the directory | `dir` |
+| `GET /api/git/status` (`server.go:206`) | the repo root | `repo` |
+
+Each read refreshes the entry's TTL. An entry not read for ten minutes leaves the
+set and stops costing anything. The set is capped, and the least recently read
+entry is dropped first, so a script hammering the read routes cannot grow it
+without limit.
+
+This is what makes the design safe. The cost of watching is bounded by the number
+of things a human has open, which is tens. It is not bounded by the size of the
+working tree, which is hundreds of thousands.
+
+Registering also digests immediately, and a first digest never broadcasts.
+Otherwise every read would announce itself.
+
+### Metadata gates the check. Content decides it
+
+**Changed metadata does not mean changed content.** A formatter rewrites a file
+with identical output. `go generate` and codegen rewrite unconditionally. `git
+checkout` restores bytes that were already there. An editor saves with no edit.
+An agent retries an `Edit` and produces the same text. Every one of those moves
+`mtime` and changes nothing.
+
+Acting on `mtime` alone would be wrong on the one path that touches the user's
+work: a dirty tab would raise *Changed on disk* over a file that did not change,
+and invite the user to discard their edits for nothing. A false alarm there is
+worse than a slow update.
+
+So the sweep is two stages. Metadata is the cheap filter. Content is the answer.
+
+```
+     sweep
+       |
+       v
+  stat the entry
+       |
+       +-- mtime and size unchanged --> done. No read, no hash, no event.
+       |
+       +-- mtime or size moved
+                |
+                v
+          read and hash
+                |
+                +-- hash equals the stored hash --> store the new mtime. No event.
+                |
+                +-- hash differs --> store both. Name it in the event.
+```
+
+In the steady state the sweep does one stat per entry and nothing else. A hash
+only runs on an entry whose metadata already moved, which is rare, and the file
+is at most 10 MB (`files.go:15`). The bytes are warm: the client read them
+moments earlier.
+
+| Kind | Gate | Digest | Steady-state cost |
+|---|---|---|---|
+| `file` | `mtime`, `size` | SHA-256 of the contents | one stat |
+| `dir` | none | a hash of the `[]fileEntry` slice `handleListFiles` builds (`files.go:56-70`) | one readdir, one `Info()` per entry |
+| `repo` | none | the contents of `.git/HEAD` and of the ref it names | two small reads |
+
+A directory needs no second stage, because for a listing the metadata **is** the
+content. The client's screen shows each entry's name, size and `ModTime`
+(`files.go:56-70`), so an entry whose mtime moved is a row that changed. The
+digest is computed by the same code that produces the answer the client holds, so
+it cannot disagree with the screen.
+
+A repo needs no second stage either. `.git/HEAD` is a few bytes and a ref file is
+41, so reading them outright is cheaper than deciding whether to. Comparing their
+contents rather than their mtimes catches a commit, a checkout, a branch switch
+and a reset, with no false positive at all.
+
+**`.git/index` is deliberately not watched.** `git status` refreshes the index as
+a side effect, so watching it would make the daemon's own answer change the thing
+it watches: a status read moves the index, the sweep sees it, the clients refetch
+status, and the loop never settles. The cost of leaving it out is that a bare
+`git add` does not announce itself. That is a staged/unstaged split lagging by one
+real change, and it is worth the loop it avoids.
+
+The residual gap is a file rewritten twice inside one filesystem timestamp tick
+with the same size. The registry keeps full-precision `mtime` internally rather
+than the truncated form the API reports, which makes this reachable only on a
+filesystem with one-second granularity. Viewer arrival covers it, as it covers
+every other miss.
+
+### The sweep, and the poke
+
+One sweep, every second, in `internal/daemon` beside the existing ones. It
+re-digests the whole set and broadcasts one `file_changed` naming everything that
+moved. One event per sweep, however many paths changed.
+
+`PostToolUse` runs a sweep at once rather than waiting for the tick. For both
+providers this is one line beside the status write (`claude/hooks.go:1045`,
+`codex/hooks.go:325`):
+
+```go
+ctx.Files.Poke()
+```
+
+It passes no path and reads no `tool_input`. The hook is a hint that now is a good
+time to look, not a description of what happened. `PUT /api/file`
+(`filesearch.go:162`) pokes for the same reason: the writer already has its
+answer, but the other clients do not.
+
+Pokes are debounced to one sweep per 250 ms, so a burst of tool calls does not
+sweep repeatedly.
+
+Cost when nothing is open: one timer, zero syscalls. The set is empty.
+
+### Why not a tree watcher
+
+`fsnotify` on each session CWD is the obvious answer, and it fails on the
+property this design is built around.
+
+`sse.go:36-42` drops an event when a client's 64 slots are full. Spec 52 exists
+because of that drop. A recursive watch reports every write under the tree.
+`npm install` writes tens of thousands of files. `go build` fills a cache. `git
+checkout` rewrites the index and the working tree. Each write would become a
+broadcast, and would evict `session_status` and `notification` from every
+connected client's buffer at exactly the moment a build runs. A file event that
+silences approval notifications is a bad trade at any latency.
+
+The metadata sweep has the inverse behaviour. A build touching ten thousand files
+produces one event naming the two paths somebody has open. The output is
+proportional to the watch set, and the watch set is what a human is looking at.
+
+The cost arrives before the damage as well. A recursive inotify watch takes one
+descriptor per directory, `fs.inotify.max_user_watches` is 8192 by default on
+several distributions, and one `node_modules` tree passes that alone. macOS
+FSEvents coalesces differently and reports renames differently, so the two
+platforms would need separate correctness arguments for one feature. A stat is a
+stat on both.
+
+### Why not the tool payload
+
+The other obvious answer is to read the paths out of the hook: Claude's `Write`
+and `Edit` carry `file_path`, which `internal/transcript/reader.go:317-330`
+already extracts. It is precise, it is instant, and it was the first draft of
+this section.
+
+It is the wrong shape, for three reasons.
+
+It is provider-coupled. Every tool that writes needs a rule, in every provider,
+for as long as both exist. Codex puts `apply_patch` in a `command` string
+(`codex/hooks.go:646-649`), so reading it back means parsing a patch envelope out
+of a shell command.
+
+It misses most writers. A `Bash` call that runs `sed -i`, a build, a `git
+checkout`, and the user's own editor are all invisible to it. Each of those
+needed a coarse "something under this root changed" fallback, which meant a
+second event shape, a coalescer to stop a build flooding the stream, and a client
+path that refetches everything because it cannot be told what moved.
+
+It is a second source of truth. The tool input says what the agent *asked* for.
+The digest says what is *there*. When those disagree, the digest is right.
+
+The metadata sweep needs none of it. The hook survives as one line that carries
+nothing, which is exactly as much provider coupling as this feature deserves.
+
+### The client's answer differs by target
+
+**Directory listings are always safe.** A listing holds no user state. Invalidate
+the whole family rather than the named path: both Riverpod and React Query
+refetch only entries that have an observer, so a family with one open directory
+costs one request, and a family nobody is watching costs nothing.
+
+**File content is not always safe.** This is the rule that matters.
+
+*Mobile: invalidate it.* The mobile file view is read-only. `api_client.dart` has
+no `PUT`, so no buffer on that client can be dirty. The comment at
+`cache_invalidator.dart:69-71` guards a case that does not exist there yet.
+Replace it with the invalidation, and keep a note that a future mobile editor
+must take the desktop rule below.
+
+*Desktop: reload the clean, mark the dirty.*
+
+- **Clean tab** → refetch, then compare. Text equal to `saved` → stop. Text
+  different → `reload(path)` (`files.tsx:308`), which already exists. This is the
+  whole feature: the text on screen becomes the text on disk while the user
+  watches.
+- **Dirty tab** → refetch and compare, and never write to the buffer. Text equal
+  to `saved` → stop, and show nothing. Text different → set `staleOnDisk`
+  and show a bar over the editor: *Changed on disk*, with a **Reload** action.
+  `reload` clears the flag, and so does a successful save. Dismissing hides the
+  bar and leaves the tab's unsaved pill in place. No merge, no prompt, no
+  character lost.
+- **`gone: true`** → mark the tab, and do not close it. An unsaved buffer over a
+  deleted file is still the user's work, and saving it recreates the file.
+
+**The reading position already survives, and the keyboard does not.** `reload`
+bumps `version`, which remounts the editor. The position is fine: `CodeEditor`
+reads `restoreRef.current` on mount, sets the selection, and applies `scrollTop`
+after a frame (`editor.tsx:151-160`), and the panel hands it `views[path]` from
+a ref at render time. Nothing to build.
+
+Focus is the problem. `editor.tsx:149` calls `created.focus()` on every mount.
+Under the hide/show trigger that is right — the panel just appeared. Under a
+live event it is not: the user can be typing in the transcript composer when the
+agent saves a file, and the caret jumps into the editor mid-sentence. So the
+editor takes an `autoFocus` prop, and a remount the user did not ask for passes
+false.
+
+This is the one requirement in this spec that only exists because the trigger
+changed. It is invisible until the reload stops being something a person asked
+for.
+
+**Compare against what you hold, not against a timestamp.** An event naming a
+path means *refetch*, not *replace*. Compare the fetched text with the tab's
+`saved` string. If they are equal, do nothing at all: no remount, no bar, no
+cursor moved.
+
+That one rule covers two separate problems.
+
+It covers the echo. A desktop save writes its own answer into the cache
+(`files.tsx:294-296`) and then receives its own `file_changed` back, because the
+broadcaster has no addressing and cannot skip the writer. Without the compare,
+every save would remount the editor of whoever pressed ⌘S — which is exactly the
+loss the `version` comment at `files.tsx:44-46` was written to prevent.
+
+It also covers anything the daemon's hash missed. The daemon compares hashes so
+it does not broadcast noise; the client compares text so it does not act on noise
+that got through. The check that protects unsaved work is the one closest to the
+work.
+
+Comparing `mod_time` would have been the obvious alternative and it does not
+survive contact with the API: `GET /api/file` formats `mod_time` with
+`time.RFC3339` (`files.go:129`) and `PUT /api/file` formats it with
+`time.RFC3339Nano` (`filesearch.go:226`). A tab's cached value therefore changes
+precision depending on how it was last filled. `filesearch.go:240` already
+truncates both sides to seconds to paper over this. Comparing bytes needs no such
+rule.
+
+**Git.** A `repo` entry invalidates the git family, and so does any file or
+directory change, because a working-tree write moves `git status`. Mobile:
+`CacheTarget.git` already does this (`cache_invalidator.dart:60-67`) and now gets
+its first producer. Desktop: `keys.git(hostId)` takes every git read out in one
+call (`keys.ts:47`). Neither narrows by cwd; the observer rule above makes the
+wide invalidation cheap.
+
+### Viewer arrival closes the rest
+
+Spec 52 argued that staleness matters only when someone looks at it. That holds
+here, and it covers the two gaps the sweep leaves.
+
+A `file_changed` broadcast during a disconnect is gone — `sse.go:65-70` keeps no
+replay buffer and there is no `Last-Event-ID`. And a path whose TTL expired while
+a tab sat open is no longer watched at all.
+
+Both heal the same way: arriving at a viewer re-reads, and a re-read
+re-registers. The watch set repairs itself as a side effect of the thing that
+needed it.
+
+| Trigger | Today | Becomes |
+|---|---|---|
+| Desktop panel becomes visible | reloads the active clean tab (`files.tsx:332-339`) | reloads every clean tab, and the listing |
+| Mobile file screen mounts | nothing | invalidate the listing |
+| Mobile app returns to the foreground | nothing for files | invalidate the listing |
+| SSE reconnects, mobile | `stream_reconnected` takes out sessions and notifications (`cache_effects.dart:154-160`) | add the files and git targets |
+| SSE reconnects, desktop | the tray reconciles (`ipc.ts:138`); nothing reaches `effectsFor` | raise `stream_reconnected` into the renderer's event path, and map it |
+
+The desktop reconnect row is the only one that needs new plumbing, and it is one
+line beside the reconcile that is already there.
+
+### The state, per open file
+
+```
+                  file opened
+                       |
+                       v
+                +-------------+
+        +------>|    Clean    |<---------------------+
+        |       +-------------+                      |
+        |          |       ^                         |
+        |  user    |       | save succeeds           | reload lands
+        |  types   |       |                         |
+        |          v       |                         |
+        |       +-------------+                      |
+        |       |    Dirty    |                      |
+        |       +-------------+                      |
+        |             |                              |
+        |             | file_changed names this path |
+        |             v                              |
+        |       +---------------+   Reload pressed   |
+        |       | Dirty + stale |--------------------+
+        |       +---------------+
+        |             |
+        |             | save pressed -> 409, buffer unchanged
+        |             v
+        |          stays Dirty + stale
+        |
+        +-- file_changed names this path, tab is Clean:
+            reload at once. No bar, no prompt, no keystroke lost.
+```
+
+The only edge that shows a bar is the one into **Dirty + stale**. Every other
+heal is silent, which is the point: a user reading a file should see it change,
+not be asked about it.
+
+## What we are not doing
+
+- **A recursive tree watcher.** Argued above. Its output is proportional to what
+  changed rather than to what is watched, and that floods a lossy 64-slot
+  broadcaster during any build.
+- **Reading paths out of the tool input.** Argued above. It is provider-coupled,
+  it misses every writer that is not a named file tool, and the digest is a
+  better source of truth than the tool's own request.
+- **Watching `.git/index`.** `git status` moves it, so watching it would make the
+  daemon's answer change what the daemon watches.
+- **Fixing the `mod_time` precision split.** `GET /api/file` and `GET /api/files`
+  format with `time.RFC3339` (`files.go:67,129`); `PUT /api/file` formats with
+  `time.RFC3339Nano` (`filesearch.go:201,226`); the write-conflict check
+  truncates both to seconds to cope (`filesearch.go:240`). It is a real wart and
+  it is not this spec's to fix. This design routes around it by comparing bytes
+  rather than timestamps, which is why nothing here depends on the answer.
+- **Sending file contents in the event.** The event says what moved. A client
+  fetches the bytes only when it holds that file. A content payload would push
+  bytes to every client, including the ones holding nothing, through the same 64
+  slots.
+- **A replay buffer, or `Last-Event-ID`.** Same argument as spec 52. Re-reading
+  on viewer arrival is a smaller promise, and it repairs the watch set at the
+  same time.
+- **Merging a change into a dirty buffer.** No three-way merge, no diff view. The
+  user reloads or keeps their text.
+- **Making `readFileProvider` refresh on its own.** No `staleTime`, no poll. The
+  comment at `daemon_providers.dart:505-509` is right about why, and this spec
+  gives it the explicit trigger it was waiting for.
+- **Per-client watch sets.** `sse.go` broadcasts to every client and has no
+  addressing. Adding it would buy nothing: a client already ignores a path it
+  does not hold, and the set is the union of a handful of open files.
+- **Tuning the sweep for a large watched directory.** A directory digest costs a
+  readdir plus one stat per entry, so a watched `node_modules` would be
+  expensive. The set cap bounds the damage. If a real directory shows up as a
+  cost, digest the large ones less often — but build that when there is evidence,
+  not now.
+- **Changing `internal/server/sse.go`.** The buffer size stays, the `default:`
+  branch stays, and this spec is careful not to need them changed.
+- **The TUI.** It reads the session store, not the file tree.
+
+## Tests
+
+Go, the registry in `internal/server`:
+
+- Registering a path digests it and broadcasts nothing.
+- A file whose content changes is named in the next sweep, with its new
+  `mod_time`.
+- A file read again with no change broadcasts nothing.
+- **A file rewritten with identical bytes broadcasts nothing**, and the sweep
+  stores the new `mtime` so it does not hash the same file twice.
+- A file whose `mtime` and `size` are both unchanged is never read or hashed —
+  asserted by counting reads, not by the absence of an event.
+- A file whose content changes to the same length is named. Size alone is not the
+  gate.
+- A file that grows and shrinks back between two sweeps, ending with different
+  bytes and the same size, is named.
+- A deleted file is named once with `gone:true`, and then leaves the set.
+- A directory is named when an entry is added, when one is removed, when one is
+  renamed, and when a child's own content changes.
+- An entry not read for the TTL leaves the set. A read inside the TTL extends it.
+- The set is capped, and the least recently read entry is evicted first.
+- A commit on the watched branch names the repo. A `git status` read on its own
+  names nothing — the loop guard.
+- One sweep produces one event, however many paths moved.
+- Two pokes inside the debounce window run one sweep.
+
+Go, the providers:
+
+- `PostToolUse` pokes, for Claude and for Codex.
+- The poke reads no `tool_input` — asserted by poking from a hook payload with
+  none, and getting a sweep.
+- `PUT /api/file` pokes, and the resulting event carries the `mod_time` the route
+  returned.
+
+Dart, `mobile/test/cache_effects_test.dart`, which asserts the mapping without a
+container:
+
+- `file_changed` naming a file returns the files target and the git target.
+- `file_changed` naming only a repo returns the git target.
+- `stream_reconnected` returns four targets, not two.
+- A payload with no `paths` returns no effects.
+
+Desktop, `desktop/test/cache-keys.test.ts`:
+
+- `effectsFor` maps `file_changed` to `keys.files(hostId)` and `keys.git(hostId)`.
+- `effectsFor` maps `stream_reconnected` to the same two.
+
+Desktop, the per-tab decision. **There is no component test framework** —
+`desktop/package.json` has no testing-library and no jsdom, and every test under
+`desktop/test/` is a node-level logic test. So the rule that protects unsaved
+work must not live inside the component. Extract it:
+
+```ts
+fileEffectFor(tab, saved, fetched): 'reload' | 'mark' | 'ignore'
+```
+
+It takes the two texts rather than the event, because the decision is a
+comparison and nothing else. It lives in `keys.ts` beside `effectsFor`, for the
+same reason: that file is the one place the renderer keeps pure decisions.
+`fetched` is null when the file has gone. Test it in the same style as
+`cache-keys.test.ts`:
+
+- A clean tab whose fetched text differs returns `reload`.
+- A dirty tab whose fetched text differs returns `mark`, never `reload`.
+- A clean tab whose fetched text equals `saved` returns `ignore` — the save echo.
+- A **dirty** tab whose fetched text equals `saved` returns `ignore`. This is the
+  false-alarm case: no bar over a file that did not change.
+- `gone` returns `mark` for a dirty tab and for a clean one, never a close.
+
+What is left in the component is the bar and the remount, and those are checked
+by hand below.
+
+Manual:
+
+- Open a file on the desktop. Ask the agent to edit it. The text updates while
+  you watch, with no click and no scroll jump.
+- Type into that file first, then ask the agent to edit it. Your text survives,
+  the bar appears, and Reload replaces the buffer.
+- Open a directory on the phone. Ask the agent to add a file. The row appears.
+- Edit a file in your own editor, outside Helios, with no agent running. The
+  desktop tab updates within a second. This is the case no hook could ever cover.
+- Run `git checkout` in a plain terminal. The open tabs and the git panel follow.
+- Ask the agent to run `npm install`. The stream stays usable, approvals keep
+  arriving, and the panel refreshes only the paths that are open.
+- Start typing into a file, then run the project's formatter over the whole tree
+  so it rewrites that file with identical bytes. No bar appears, and your text is
+  untouched. Then run a formatter that really does reformat it. The bar appears.
+
+## Success criteria
+
+- An agent edit reaches every open viewer of that file in under a second, with no
+  user action.
+- An edit made outside Helios does the same. No writer is privileged.
+- No unsaved character is ever lost to an event.
+- **A rewrite with identical bytes produces no event and no bar.** A touch, a
+  no-op formatter run, and a checkout that restores the same content are all
+  silent.
+- In the steady state the sweep does one stat per watched file and reads nothing.
+- A build touching ten thousand files produces events naming only the paths a
+  client has open.
+- With nothing open, the sweep does no filesystem work.
+- The daemon holds no provider-specific knowledge of which tools write.
+- `internal/server/sse.go` is unchanged, no tree watcher is added, and `go.mod`
+  gains no dependency.
+- No member of `CacheTarget` is unreachable, and no file or git query key in
+  `keys.ts` is without a producer.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -61,6 +61,7 @@ what is merged. Some are superseded and stay here for the history.
 | [51-file-previews.md](51-file-previews.md) | File Previews: Show the Image, Render the Page |
 | [52-transcript-freshness.md](52-transcript-freshness.md) | Transcript Freshness: Heal a Missed Event Without a Spinner |
 | [53-mermaid-diagrams.md](53-mermaid-diagrams.md) | Mermaid Diagrams: Draw the Fence Instead of Printing It |
+| [54-file-change-events.md](54-file-change-events.md) | File Change Events: Watch What Someone Is Looking At |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |
 | [desktop-notification-service.md](desktop-notification-service.md) | Desktop Notification Service |

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -314,6 +314,11 @@ func startDaemon(cfg *Config) error {
 		}
 	}()
 
+	// Reports files moving under the clients that are reading them. Its own
+	// loop rather than a tick here: most sweeps come from a tool hook poking
+	// it, and only the fallback is on a clock.
+	go shared.Files.Run(ctx)
+
 	// Start both servers
 	errCh := make(chan error, 2)
 

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -1044,6 +1044,7 @@ func handleToolPost(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 
 	ctx.DB.UpdateSessionStatus(input.SessionID, "active", "PostToolUse:"+input.ToolName)
 	updateSessionTranscript(ctx, &input)
+	pokeFiles(ctx)
 
 	// The tool finished, so the question is answered. Retract the notification
 	// on every other surface. Which side answered does not matter.
@@ -1075,6 +1076,9 @@ func handleToolPostFailure(ctx *provider.HookContext, w http.ResponseWriter, r *
 
 	ctx.DB.UpdateSessionStatus(input.SessionID, "active", "PostToolUseFailure:"+input.ToolName)
 	updateSessionTranscript(ctx, &input)
+	// A command that failed at step nine still wrote at steps one to eight, and
+	// the watcher decides for itself whether anything actually moved.
+	pokeFiles(ctx)
 	// A tool that ran and failed was still permitted by somebody.
 	resolveToolPermissions(ctx, input.SessionID, input.ToolName)
 
@@ -1272,6 +1276,16 @@ func killSessionWindow(ctx *provider.HookContext, sessionID string) {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+// pokeFiles tells the daemon a tool just ran, so now is a good time to check
+// the paths clients are watching. No path is passed and no tool input is read:
+// working out which tools write, in which provider, is exactly the coupling the
+// digest exists to avoid. See docs/specs/54-file-change-events.md.
+func pokeFiles(ctx *provider.HookContext) {
+	if ctx.FilesTouched != nil {
+		ctx.FilesTouched()
+	}
 }
 
 func summarizeToolInput(raw json.RawMessage) string {

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -2097,3 +2097,47 @@ func TestElicitation_ThePhoneStillFillsInTheForm(t *testing.T) {
 	awaitCleared(t, overlays)
 	assertStatus(t, db, "sess-1", "waiting_permission")
 }
+
+// The hook is a hint that now is a good time to look, not a description of
+// what happened. It must not depend on the tool name or on the tool input:
+// working out which tools write, per provider, is the coupling the daemon's
+// digest exists to avoid. See docs/specs/54-file-change-events.md.
+func TestToolPostPokesTheFileWatcher(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler func(*provider.HookContext, http.ResponseWriter, *http.Request, json.RawMessage)
+		tool    string
+		input   string
+	}{
+		{"write", handleToolPost, "Write", `{"file_path":"/tmp/a.txt"}`},
+		{"bash", handleToolPost, "Bash", `{"command":"sed -i s/a/b/ x"}`},
+		{"no tool input", handleToolPost, "Bash", ""},
+		// A command that failed at step nine still wrote at steps one to eight.
+		{"failure", handleToolPostFailure, "Bash", `{"command":"make"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _, _ := setupCtx(t)
+			pokes := 0
+			ctx.FilesTouched = func() { pokes++ }
+
+			in := hookInput{SessionID: "s1", ToolName: tc.tool}
+			if tc.input != "" {
+				in.ToolInput = json.RawMessage(tc.input)
+			}
+			callHook(tc.handler, ctx, in)
+
+			if pokes != 1 {
+				t.Errorf("poked %d times, want 1", pokes)
+			}
+		})
+	}
+}
+
+// A provider built without a watcher — every context in these tests before
+// this change — must not panic.
+func TestToolPostWithoutAWatcher(t *testing.T) {
+	ctx, _, _ := setupCtx(t)
+	ctx.FilesTouched = nil
+	callHook(handleToolPost, ctx, hookInput{SessionID: "s1", ToolName: "Write"})
+}

--- a/internal/provider/codex/codex_test.go
+++ b/internal/provider/codex/codex_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/provider"
 	"github.com/kamrul1157024/helios/internal/store"
 	"github.com/kamrul1157024/helios/internal/transcript"
@@ -670,4 +671,65 @@ func TestBothTrustDialogsAreRecognised(t *testing.T) {
 	if p.MatchScreen("just an ordinary prompt") != nil {
 		t.Error("matched a screen with no dialog on it")
 	}
+}
+
+// The poke carries no path and reads no tool input. apply_patch puts its patch
+// in a shell command string (see summarize), and parsing that back out is
+// exactly what the daemon's digest exists to avoid.
+// See docs/specs/54-file-change-events.md.
+func TestToolPostPokesTheFileWatcher(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	for _, tool := range []string{"apply_patch", "shell", "read"} {
+		t.Run(tool, func(t *testing.T) {
+			pokes := 0
+			ctx := &provider.HookContext{
+				DB:             db,
+				Mgr:            notifications.NewManager(db),
+				Notify:         func(string, interface{}) {},
+				Report:         func(provider.ReportEvent) {},
+				SessionStarted: func(string) {},
+				FilesTouched:   func() { pokes++ },
+			}
+			body, _ := json.Marshal(map[string]interface{}{
+				"session_id": "01a04dee-183a-7461-9bef-5f05c0aa510a",
+				"cwd":        "/tmp",
+				"tool_name":  tool,
+				"tool_input": map[string]string{"command": "anything"},
+			})
+			w := httptest.NewRecorder()
+			handleToolPost(ctx, w, httptest.NewRequest("POST", "/hooks/codex/tool/post", nil), body)
+
+			if pokes != 1 {
+				t.Errorf("poked %d times, want 1", pokes)
+			}
+		})
+	}
+}
+
+func TestToolPostWithoutAWatcher(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	ctx := &provider.HookContext{
+		DB:             db,
+		Mgr:            notifications.NewManager(db),
+		Notify:         func(string, interface{}) {},
+		Report:         func(provider.ReportEvent) {},
+		SessionStarted: func(string) {},
+	}
+	body, _ := json.Marshal(map[string]interface{}{
+		"session_id": "01a04dee-183a-7461-9bef-5f05c0aa510a",
+		"cwd":        "/tmp",
+		"tool_name":  "shell",
+	})
+	w := httptest.NewRecorder()
+	handleToolPost(ctx, w, httptest.NewRequest("POST", "/hooks/codex/tool/post", nil), body)
 }

--- a/internal/provider/codex/hooks.go
+++ b/internal/provider/codex/hooks.go
@@ -324,6 +324,12 @@ func handleToolPost(ctx *provider.HookContext, w http.ResponseWriter, r *http.Re
 	key := sessionKey(ctx, r, in)
 	ctx.DB.UpdateSessionStatus(key, "active", "PostToolUse:"+in.ToolName)
 	updateTranscript(ctx, key, in)
+	// A tool ran, so the paths clients are watching may have moved. No path is
+	// passed: the daemon works out what changed from its own digests, which is
+	// why apply_patch needs no parsing here. See spec 54.
+	if ctx.FilesTouched != nil {
+		ctx.FilesTouched()
+	}
 	// The tool ran, so any permission card for it is settled whichever surface
 	// answered. Matched by tool name because PermissionRequest carries no
 	// tool_use_id to match on — measured, see spec 46.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -325,4 +325,9 @@ type HookContext struct {
 	PromptSubmitted func(sessionID string)
 	// Report pushes an event to the Reporter for narration.
 	Report func(event ReportEvent)
+	// FilesTouched says a tool just ran, so now is a good time to look at the
+	// paths clients are watching. It carries no path and reads no tool input:
+	// the daemon compares digests and works out what moved for itself. See
+	// docs/specs/54-file-change-events.md.
+	FilesTouched func()
 }

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -47,10 +47,30 @@ func (s *PublicServer) handleListFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries, err := os.ReadDir(clean)
+	result, err := listDir(clean)
 	if err != nil {
 		jsonError(w, "failed to read directory", http.StatusInternalServerError)
 		return
+	}
+
+	// Reading a directory is what subscribes to it. See filewatch.go.
+	s.files().Watch(clean, WatchDir)
+
+	jsonResponse(w, http.StatusOK, map[string]interface{}{
+		"path":    clean,
+		"entries": result,
+	})
+}
+
+// listDir reads one directory into the shape the API returns.
+//
+// Shared with the file watcher's digest (filewatch.go) on purpose: a digest
+// built from the same entries as the answer cannot disagree with what the
+// client has on screen.
+func listDir(clean string) ([]fileEntry, error) {
+	entries, err := os.ReadDir(clean)
+	if err != nil {
+		return nil, err
 	}
 
 	result := make([]fileEntry, 0, len(entries))
@@ -75,11 +95,7 @@ func (s *PublicServer) handleListFiles(w http.ResponseWriter, r *http.Request) {
 		}
 		return strings.ToLower(result[i].Name) < strings.ToLower(result[j].Name)
 	})
-
-	jsonResponse(w, http.StatusOK, map[string]interface{}{
-		"path":    clean,
-		"entries": result,
-	})
+	return result, nil
 }
 
 // handleReadFile returns the content of the file at the given path query param.
@@ -122,6 +138,9 @@ func (s *PublicServer) handleReadFile(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to read file", http.StatusInternalServerError)
 		return
 	}
+
+	// Reading a file is what subscribes to it. See filewatch.go.
+	s.files().Watch(clean, WatchFile)
 
 	body := map[string]interface{}{
 		"path":     clean,

--- a/internal/server/filesearch.go
+++ b/internal/server/filesearch.go
@@ -220,6 +220,11 @@ func (s *PublicServer) handleWriteFile(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to stat file", http.StatusInternalServerError)
 		return
 	}
+	// The writer already has its answer, but the other clients do not. The
+	// broadcaster has no addressing, so this goes out to the writer as well;
+	// each client compares against what it holds and ignores its own echo.
+	s.files().Poke()
+
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
 		"path":     clean,
 		"size":     written.Size(),

--- a/internal/server/filewatch.go
+++ b/internal/server/filewatch.go
@@ -67,8 +67,8 @@ type watchEntry struct {
 	lastRead time.Time
 	// mtime and size gate the hash for a file. A directory and a repo have no
 	// gate: their digests are cheap enough to take every sweep.
-	mtime time.Time
-	size  int64
+	mtime  time.Time
+	size   int64
 	digest string
 	gone   bool
 	// seen is false until the first look. It is what makes a new entry compute

--- a/internal/server/filewatch.go
+++ b/internal/server/filewatch.go
@@ -1,0 +1,388 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// See docs/specs/54-file-change-events.md.
+//
+// The daemon tells viewers which file moved by watching metadata for the paths
+// somebody asked for, rather than by watching the tree. A read registers a
+// path; a sweep re-checks what is registered; anything whose *content* changed
+// goes out on the stream. So the work is proportional to what people are
+// looking at, not to what changed on disk — which is what keeps a build from
+// spending every client's 64-slot buffer (sse.go:36) on events nobody wants.
+
+const (
+	// watchTTL is how long a path stays watched after its last read. Long
+	// enough to cover a reader who leaves a tab open and goes to lunch; short
+	// enough that a directory walked once is not stat'd forever.
+	watchTTL = 10 * time.Minute
+	// maxWatched bounds the set so a client walking a tree cannot grow it
+	// without limit. The least recently read entry goes first.
+	maxWatched = 512
+	// sweepEvery is the fallback clock. Most sweeps come from a poke.
+	sweepEvery = time.Second
+	// pokeSettle collapses a burst of tool calls into one sweep.
+	pokeSettle = 250 * time.Millisecond
+)
+
+// WatchKind is what a watched path is, which decides how it is digested.
+type WatchKind string
+
+const (
+	// WatchFile is a single file. Its digest is a hash of its contents, gated
+	// by mtime and size so the common case costs one stat.
+	WatchFile WatchKind = "file"
+	// WatchDir is a directory listing. Its digest is built from the same
+	// entries handleListFiles returns, so it cannot disagree with the screen.
+	WatchDir WatchKind = "dir"
+	// WatchRepo is a git checkout. Its digest is HEAD and the ref HEAD names.
+	WatchRepo WatchKind = "repo"
+)
+
+// FileChange is one path whose content moved, as it appears in the event.
+type FileChange struct {
+	Path string    `json:"path"`
+	Kind WatchKind `json:"kind"`
+	// ModTime is informational — for a listing row and for logs. No client
+	// decides anything from it, because the two read routes disagree about its
+	// precision (files.go:129 seconds, filesearch.go:226 nanoseconds).
+	ModTime string `json:"mod_time,omitempty"`
+	Gone    bool   `json:"gone,omitempty"`
+}
+
+type watchEntry struct {
+	kind     WatchKind
+	lastRead time.Time
+	// mtime and size gate the hash for a file. A directory and a repo have no
+	// gate: their digests are cheap enough to take every sweep.
+	mtime time.Time
+	size  int64
+	digest string
+	gone   bool
+	// seen is false until the first look. It is what makes a new entry compute
+	// and stay quiet, and it is kept apart from an empty digest on purpose: a
+	// path that disappears clears its digest, and a file restored with the
+	// bytes it went away with must still count as news.
+	seen bool
+}
+
+// FileWatcher holds the paths clients have read and reports the ones whose
+// content changes.
+type FileWatcher struct {
+	mu      sync.Mutex
+	entries map[string]*watchEntry
+	sse     *SSEBroadcaster
+	poke    chan struct{}
+	// now is swapped in tests so TTL and eviction can be driven without
+	// sleeping.
+	now func() time.Time
+}
+
+// files returns the watcher, or nil when the server has no shared state at all
+// — the shape several handler tests construct, because these routes touch
+// nothing else on it. Every method below tolerates a nil receiver, so callers
+// need no guard of their own.
+func (s *PublicServer) files() *FileWatcher {
+	if s.shared == nil {
+		return nil
+	}
+	return s.shared.Files
+}
+
+func NewFileWatcher(sse *SSEBroadcaster) *FileWatcher {
+	return &FileWatcher{
+		entries: make(map[string]*watchEntry),
+		sse:     sse,
+		poke:    make(chan struct{}, 1),
+		now:     time.Now,
+	}
+}
+
+// Watch registers a path, or refreshes one already registered.
+//
+// A path new to the set is digested here and announces nothing. Otherwise every
+// read would report itself as a change.
+func (w *FileWatcher) Watch(path string, kind WatchKind) {
+	if w == nil || path == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if entry, ok := w.entries[path]; ok {
+		entry.lastRead = w.now()
+		return
+	}
+	entry := &watchEntry{kind: kind, lastRead: w.now()}
+	w.entries[path] = entry
+	w.refresh(path, entry)
+	w.evictLocked()
+}
+
+// Poke asks for a sweep now rather than on the next tick. It never blocks: a
+// sweep is already pending if the buffer is full, and that is the same answer.
+func (w *FileWatcher) Poke() {
+	if w == nil {
+		return
+	}
+	select {
+	case w.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Run sweeps until the context ends. A poke sweeps after pokeSettle, so a run
+// of tool calls costs one sweep rather than one each.
+func (w *FileWatcher) Run(ctx context.Context) {
+	ticker := time.NewTicker(sweepEvery)
+	defer ticker.Stop()
+	var settle <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.Sweep()
+		case <-w.poke:
+			// Restarting the timer on each poke is deliberate: the last call in
+			// a burst is the one whose writes we want to have landed.
+			settle = time.After(pokeSettle)
+		case <-settle:
+			settle = nil
+			w.Sweep()
+		}
+	}
+}
+
+// Sweep re-digests the set and broadcasts one event naming everything that
+// changed. Exported for tests, which drive it directly rather than by clock.
+func (w *FileWatcher) Sweep() []FileChange {
+	changes := w.collect()
+	if len(changes) > 0 && w.sse != nil {
+		w.sse.Broadcast(SSEEvent{
+			Type: "file_changed",
+			Data: map[string]interface{}{"paths": changes},
+		})
+	}
+	return changes
+}
+
+func (w *FileWatcher) collect() []FileChange {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	cutoff := w.now().Add(-watchTTL)
+	var changes []FileChange
+	for path, entry := range w.entries {
+		if entry.lastRead.Before(cutoff) {
+			delete(w.entries, path)
+			continue
+		}
+		if changed, change := w.refresh(path, entry); changed {
+			changes = append(changes, change)
+		}
+	}
+	// Stable order so a test can assert one, and so a log reads the same twice.
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Path < changes[j].Path })
+	return changes
+}
+
+// refresh brings one entry up to date and says whether its content moved.
+// Callers hold the lock.
+func (w *FileWatcher) refresh(path string, entry *watchEntry) (bool, FileChange) {
+	switch entry.kind {
+	case WatchDir:
+		return w.refreshDigest(path, entry, dirDigest)
+	case WatchRepo:
+		return w.refreshDigest(path, entry, repoDigest)
+	default:
+		return w.refreshFile(path, entry)
+	}
+}
+
+// refreshFile gates on metadata and decides on content.
+//
+// Changed metadata does not mean changed content: a formatter rewrites a file
+// with identical output, codegen rewrites unconditionally, a checkout restores
+// bytes that were already there. Announcing those would raise "changed on disk"
+// over a dirty buffer that did not need it, which is the one false alarm that
+// costs the user work.
+func (w *FileWatcher) refreshFile(path string, entry *watchEntry) (bool, FileChange) {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return w.markGone(path, entry, WatchFile)
+	}
+	wasGone := entry.gone
+	if entry.seen && !wasGone && info.ModTime().Equal(entry.mtime) && info.Size() == entry.size {
+		// The cheap answer, and the one taken on almost every sweep: no read,
+		// no hash, nothing to say.
+		return false, FileChange{}
+	}
+
+	sum, err := hashFile(path)
+	if err != nil {
+		return w.markGone(path, entry, WatchFile)
+	}
+	// A file that came back is news even with the bytes it went away with,
+	// because the client dropped it when it heard "gone". Otherwise: metadata
+	// moved and content did not, so keep the new mtime — which stops the same
+	// file being hashed again on the next sweep — and say nothing.
+	moved := entry.seen && (sum != entry.digest || wasGone)
+	entry.seen, entry.gone = true, false
+	entry.mtime, entry.size, entry.digest = info.ModTime(), info.Size(), sum
+	return moved, changeOf(path, WatchFile, info)
+}
+
+// refreshDigest handles the kinds whose digest is cheap enough to take whole.
+func (w *FileWatcher) refreshDigest(
+	path string,
+	entry *watchEntry,
+	digest func(string) (string, error),
+) (bool, FileChange) {
+	sum, err := digest(path)
+	if err != nil {
+		return w.markGone(path, entry, entry.kind)
+	}
+	moved := entry.seen && (sum != entry.digest || entry.gone)
+	entry.seen, entry.gone = true, false
+	entry.digest = sum
+	return moved, FileChange{Path: path, Kind: entry.kind}
+}
+
+// markGone reports a disappearance once, and stays quiet after it. A path
+// registered while already missing announces nothing, and announces its arrival
+// when it turns up.
+func (w *FileWatcher) markGone(path string, entry *watchEntry, kind WatchKind) (bool, FileChange) {
+	if entry.gone {
+		return false, FileChange{}
+	}
+	moved := entry.seen
+	entry.seen, entry.gone = true, true
+	entry.digest = ""
+	entry.mtime, entry.size = time.Time{}, 0
+	return moved, FileChange{Path: path, Kind: kind, Gone: true}
+}
+
+func changeOf(path string, kind WatchKind, info os.FileInfo) FileChange {
+	return FileChange{
+		Path:    path,
+		Kind:    kind,
+		ModTime: info.ModTime().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+// evictLocked drops the least recently read entry while the set is over its
+// cap. Callers hold the lock.
+func (w *FileWatcher) evictLocked() {
+	for len(w.entries) > maxWatched {
+		var oldest string
+		var at time.Time
+		for path, entry := range w.entries {
+			if oldest == "" || entry.lastRead.Before(at) {
+				oldest, at = path, entry.lastRead
+			}
+		}
+		delete(w.entries, oldest)
+	}
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	sum := sha256.New()
+	// Bounded by the same limit the read route enforces (files.go:110), so a
+	// file nobody can open cannot be hashed either.
+	if _, err := io.Copy(sum, io.LimitReader(f, maxFileSize+1)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), nil
+}
+
+// dirDigest hashes the listing handleListFiles would return.
+//
+// Built from the same entries as the answer, so the digest cannot disagree with
+// what is on the screen. For a listing the metadata *is* the content: the client
+// draws each entry's size and mod time, so an entry whose mtime moved is a row
+// that changed.
+func dirDigest(path string) (string, error) {
+	entries, err := listDir(path)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&b, "%s\x00%s\x00%d\x00%t\n", e.Name, e.ModTime, e.Size, e.IsDir)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// repoDigest reads HEAD and the ref it names.
+//
+// Deliberately not .git/index: `git status` refreshes the index as a side
+// effect, so watching it would make the daemon's own answer change the thing it
+// watches — a status read moves the index, the sweep sees it, clients refetch
+// status, and the loop never settles. The cost is that a bare `git add` does
+// not announce itself, which is a staged/unstaged split lagging by one real
+// change.
+func repoDigest(root string) (string, error) {
+	dir, err := gitDir(root)
+	if err != nil {
+		return "", err
+	}
+	head, err := os.ReadFile(filepath.Join(dir, "HEAD"))
+	if err != nil {
+		return "", err
+	}
+	body := string(head)
+	if ref, ok := strings.CutPrefix(strings.TrimSpace(body), "ref: "); ok {
+		// A packed ref has no file, and a branch with no commits has neither.
+		// Both are stable states, and HEAD alone already distinguishes them.
+		if target, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(ref))); err == nil {
+			body += string(target)
+		}
+	}
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// gitDir finds the real git directory for a checkout. A linked worktree has a
+// .git file pointing at one, which is how the worktree view (spec 35) leaves
+// them on disk.
+func gitDir(root string) (string, error) {
+	path := filepath.Join(root, ".git")
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return path, nil
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(string(body)), "gitdir: ")
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	if filepath.IsAbs(target) {
+		return target, nil
+	}
+	return filepath.Join(root, target), nil
+}

--- a/internal/server/filewatch_test.go
+++ b/internal/server/filewatch_test.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// touch rewrites a file with the given content and forces its mtime forward.
+//
+// Forced rather than left to the clock: a test writes twice inside one
+// filesystem tick, and the gate would then see no metadata movement and skip
+// the hash — which is the real behaviour, but not the one under test here.
+func touch(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	later := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, later, later); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+func newWatcher(t *testing.T) *FileWatcher {
+	t.Helper()
+	return NewFileWatcher(nil)
+}
+
+func paths(changes []FileChange) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.Path)
+	}
+	return out
+}
+
+func TestWatchDigestsWithoutAnnouncing(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("registering announced %v, want nothing", paths(got))
+	}
+}
+
+func TestSweepNamesAChangedFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	touch(t, file, "two")
+
+	got := w.Sweep()
+	if len(got) != 1 || got[0].Path != file {
+		t.Fatalf("got %v, want just %s", paths(got), file)
+	}
+	if got[0].Kind != WatchFile {
+		t.Errorf("kind = %q, want %q", got[0].Kind, WatchFile)
+	}
+	if got[0].ModTime == "" {
+		t.Error("mod_time is empty")
+	}
+	if len(w.Sweep()) != 0 {
+		t.Error("the same change was announced twice")
+	}
+}
+
+// The point of the whole two-stage design: a formatter that rewrites a file
+// with the bytes already in it must not raise "changed on disk" over a buffer
+// somebody is typing into.
+func TestIdenticalRewriteIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "same")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	touch(t, file, "same")
+
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("identical rewrite announced %v, want nothing", paths(got))
+	}
+}
+
+// Having decided the content is unchanged, the sweep must remember the new
+// mtime — otherwise the same file is read and hashed on every tick forever.
+func TestIdenticalRewriteStoresTheNewMtime(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "same")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	touch(t, file, "same")
+	w.Sweep()
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.mu.Lock()
+	stored := w.entries[file].mtime
+	w.mu.Unlock()
+	if !stored.Equal(info.ModTime()) {
+		t.Errorf("stored mtime %v, want %v", stored, info.ModTime())
+	}
+}
+
+func TestUnchangedFileIsNeverRead(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+
+	// Made unreadable after registering: a sweep that opens it would fail and
+	// report the file gone, so silence proves the gate skipped the read.
+	if err := os.Chmod(file, 0o000); err != nil {
+		t.Skipf("cannot drop read permission here: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(file, 0o644) })
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, where a mode of 000 is still readable")
+	}
+
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("sweep read a file whose metadata had not moved: %v", paths(got))
+	}
+}
+
+// Size alone is not the gate, and neither is it the digest.
+func TestSameLengthChangeIsNamed(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "aaa")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	touch(t, file, "bbb")
+
+	if got := w.Sweep(); len(got) != 1 {
+		t.Fatalf("got %v, want the file named", paths(got))
+	}
+}
+
+func TestDeletedFileIsNamedOnce(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+
+	got := w.Sweep()
+	if len(got) != 1 || !got[0].Gone {
+		t.Fatalf("got %+v, want one gone entry", got)
+	}
+	if len(w.Sweep()) != 0 {
+		t.Error("a file that stayed deleted was announced twice")
+	}
+}
+
+func TestRestoredFileIsNamedAgain(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	w.Watch(file, WatchFile)
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+	w.Sweep()
+	// Put back with exactly the bytes it had: the client dropped it when it
+	// heard "gone", so this is still news even though the content matches.
+	touch(t, file, "one")
+
+	got := w.Sweep()
+	if len(got) != 1 || got[0].Gone {
+		t.Fatalf("got %+v, want the file named as present", got)
+	}
+}
+
+func TestDirectoryNamedOnEveryStructuralChange(t *testing.T) {
+	cases := []struct {
+		name string
+		act  func(t *testing.T, dir string)
+	}{
+		{"added", func(t *testing.T, dir string) { touch(t, filepath.Join(dir, "new.txt"), "x") }},
+		{"removed", func(t *testing.T, dir string) {
+			if err := os.Remove(filepath.Join(dir, "a.txt")); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"renamed", func(t *testing.T, dir string) {
+			if err := os.Rename(filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt")); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		// The listing carries each entry's size and mod time, so a child's own
+		// content moving is a row that changed.
+		{"child content", func(t *testing.T, dir string) { touch(t, filepath.Join(dir, "a.txt"), "much longer") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			touch(t, filepath.Join(dir, "a.txt"), "one")
+
+			w := newWatcher(t)
+			w.Watch(dir, WatchDir)
+			tc.act(t, dir)
+
+			got := w.Sweep()
+			if len(got) != 1 || got[0].Path != dir || got[0].Kind != WatchDir {
+				t.Fatalf("got %+v, want the directory named", got)
+			}
+		})
+	}
+}
+
+func TestDirectoryUnchangedIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	touch(t, filepath.Join(dir, "a.txt"), "one")
+
+	w := newWatcher(t)
+	w.Watch(dir, WatchDir)
+
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("got %v, want nothing", paths(got))
+	}
+}
+
+func TestEntryLeavesTheSetAfterTheTTL(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	now := time.Now()
+	w.now = func() time.Time { return now }
+	w.Watch(file, WatchFile)
+
+	now = now.Add(watchTTL + time.Minute)
+	touch(t, file, "two")
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("an expired entry still reported %v", paths(got))
+	}
+	w.mu.Lock()
+	remaining := len(w.entries)
+	w.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("%d entries left, want 0", remaining)
+	}
+}
+
+func TestReadingAgainExtendsTheTTL(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	touch(t, file, "one")
+
+	w := newWatcher(t)
+	now := time.Now()
+	w.now = func() time.Time { return now }
+	w.Watch(file, WatchFile)
+
+	now = now.Add(watchTTL - time.Minute)
+	w.Watch(file, WatchFile)
+	now = now.Add(2 * time.Minute)
+	touch(t, file, "two")
+
+	if got := w.Sweep(); len(got) != 1 {
+		t.Fatalf("got %v, want the file still watched", paths(got))
+	}
+}
+
+func TestSetIsCappedOldestFirst(t *testing.T) {
+	dir := t.TempDir()
+	w := newWatcher(t)
+	now := time.Now()
+	w.now = func() time.Time { return now }
+
+	first := filepath.Join(dir, "first.txt")
+	touch(t, first, "x")
+	w.Watch(first, WatchFile)
+
+	for i := 0; i < maxWatched; i++ {
+		now = now.Add(time.Second)
+		path := filepath.Join(dir, "f"+itoa(i)+".txt")
+		touch(t, path, "x")
+		w.Watch(path, WatchFile)
+	}
+
+	w.mu.Lock()
+	_, stillThere := w.entries[first]
+	size := len(w.entries)
+	w.mu.Unlock()
+	if stillThere {
+		t.Error("the least recently read entry survived the cap")
+	}
+	if size > maxWatched {
+		t.Errorf("%d entries, want at most %d", size, maxWatched)
+	}
+}
+
+func TestOneSweepIsOneEvent(t *testing.T) {
+	dir := t.TempDir()
+	sse := NewSSEBroadcaster()
+	w := NewFileWatcher(sse)
+
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	touch(t, a, "one")
+	touch(t, b, "one")
+	w.Watch(a, WatchFile)
+	w.Watch(b, WatchFile)
+	touch(t, a, "two")
+	touch(t, b, "two")
+
+	got := w.Sweep()
+	if len(got) != 2 {
+		t.Fatalf("got %v, want both files in one answer", paths(got))
+	}
+	if got[0].Path > got[1].Path {
+		t.Error("changes are not in a stable order")
+	}
+}
+
+func TestRepoNamedOnCommitAndSilentOnStatus(t *testing.T) {
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	touch(t, filepath.Join(dir, "a.txt"), "one")
+	git("add", ".")
+	git("commit", "-qm", "first")
+
+	w := newWatcher(t)
+	w.Watch(dir, WatchRepo)
+
+	// A status read refreshes .git/index. Watching the index would make this
+	// look like a change, and the refetch it triggers would refresh it again.
+	git("status", "--porcelain")
+	if got := w.Sweep(); len(got) != 0 {
+		t.Fatalf("git status announced %v — the index loop is back", paths(got))
+	}
+
+	touch(t, filepath.Join(dir, "b.txt"), "two")
+	git("add", ".")
+	git("commit", "-qm", "second")
+
+	got := w.Sweep()
+	if len(got) != 1 || got[0].Path != dir || got[0].Kind != WatchRepo {
+		t.Fatalf("got %+v, want the repo named after a commit", got)
+	}
+}
+
+func TestNilWatcherTolerates(t *testing.T) {
+	var w *FileWatcher
+	w.Watch("/tmp/whatever", WatchFile)
+	w.Poke()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/server/git.go
+++ b/internal/server/git.go
@@ -50,6 +50,9 @@ func (s *PublicServer) handleGitStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reading a repo's status is what subscribes to it. See filewatch.go.
+	s.files().Watch(root, WatchRepo)
+
 	// Branch name.
 	branch, err := gitCmd(root, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -88,6 +88,7 @@ func (s *InternalServer) hookContext() *provider.HookContext {
 		PromptSubmitted: func(sessionID string) {
 			s.shared.Signals.Fire(SignalPromptSubmitted, sessionID)
 		},
+		FilesTouched: s.shared.Files.Poke,
 		Report: func(event provider.ReportEvent) {
 			s.shared.Reporter.AddEvent(reporter.Event{
 				Type:      event.Type,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,9 @@ type Shared struct {
 	// HITL renders helios's own prompts over session terminals. See
 	// docs/specs/36-helios-owned-hitl.md.
 	HITL *hitl.Controller
+	// Files reports when a path a client has read changes underneath it. See
+	// docs/specs/54-file-change-events.md.
+	Files *FileWatcher
 }
 
 // overlayNotifier is implemented by backends that can report the keystrokes an
@@ -107,6 +110,7 @@ func NewShared(db *store.Store, mgr *notifications.Manager, be backend.Backend) 
 		// its own provider when that provider has a cheap model.
 		Reporter: reporter.New("claude", db),
 	}
+	sh.Files = NewFileWatcher(sh.SSE)
 	// The manager owns notification state, so it announces its own writes. No
 	// caller has to remember to, and none can resolve one silently.
 	mgr.SetBroadcaster(func(eventType string, data interface{}) {

--- a/mobile/lib/providers/cache_effects.dart
+++ b/mobile/lib/providers/cache_effects.dart
@@ -151,12 +151,32 @@ List<CacheEffect> effectsFor(String hostId, String type, dynamic data) {
     case 'session_deleted':
       return [InvalidateTarget(CacheTarget.sessions, hostId)];
 
+    case 'file_changed':
+      // Every path named has changed *content*, not merely a changed mtime —
+      // the daemon compares digests before it says anything (spec 54). Which
+      // paths they are does not change the answer here: both families are
+      // invalidated whole, and Riverpod refetches only the entries something is
+      // watching, so naming one costs the same as naming all of them.
+      //
+      // Git comes too. A working-tree write moves `git status`, and a repo
+      // entry is a commit or a checkout.
+      final named = map['paths'];
+      if (named is! List || named.isEmpty) return const [];
+      return [
+        InvalidateTarget(CacheTarget.files, hostId),
+        InvalidateTarget(CacheTarget.git, hostId),
+      ];
+
     case 'stream_reconnected':
       // The socket was down and the daemon keeps no replay buffer, so anything
-      // that changed in the gap was announced to nobody.
+      // that changed in the gap was announced to nobody. Files and git are here
+      // for a second reason: a path whose watch expired while a screen sat open
+      // is no longer being swept, and re-reading is what registers it again.
       return [
         InvalidateTarget(CacheTarget.sessions, hostId),
         InvalidateTarget(CacheTarget.notifications, hostId),
+        InvalidateTarget(CacheTarget.files, hostId),
+        InvalidateTarget(CacheTarget.git, hostId),
       ];
 
     case 'notification':

--- a/mobile/lib/providers/cache_invalidator.dart
+++ b/mobile/lib/providers/cache_invalidator.dart
@@ -58,8 +58,9 @@ void _invalidate(Ref ref, InvalidateTarget effect) {
     case CacheTarget.transcript:
       break;
     case CacheTarget.git:
-      // No git event names a path, and a commit moves status, log, diff and
-      // worktrees together, so the whole family goes.
+      // The whole family: a commit moves status, log, diff and worktrees
+      // together, and `file_changed` names a working-tree path rather than the
+      // cwd these are keyed by.
       ref.invalidate(gitStatusProvider);
       ref.invalidate(gitLogProvider);
       ref.invalidate(gitDiffProvider);
@@ -67,9 +68,12 @@ void _invalidate(Ref ref, InvalidateTarget effect) {
       ref.invalidate(gitWorktreesProvider);
     case CacheTarget.files:
       ref.invalidate(listFilesProvider);
-      // readFile is deliberately left alone: a viewer may hold an edited
-      // buffer, and dropping the entry under it would mark a dirty file clean.
-      break;
+      // Content too, which the desktop cannot do: this client has no PUT at
+      // all (`api_client.dart`), so no buffer here can be dirty and there is
+      // nothing to lose. An editor on this side would have to take the
+      // desktop's rule instead — refetch, compare, and leave a dirty buffer
+      // alone. See docs/specs/54-file-change-events.md.
+      ref.invalidate(readFileProvider);
   }
 }
 

--- a/mobile/lib/screens/file_browser_screen.dart
+++ b/mobile/lib/screens/file_browser_screen.dart
@@ -37,7 +37,8 @@ class FileBrowserScreen extends rp.ConsumerStatefulWidget {
   rp.ConsumerState<FileBrowserScreen> createState() => _FileBrowserScreenState();
 }
 
-class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen> {
+class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
+    with WidgetsBindingObserver {
   late String _currentPath;
   late String _rootPath;
   final List<String> _history = [];
@@ -47,7 +48,34 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen> {
     super.initState();
     _currentPath = widget.startPath ?? widget.rootPath;
     _rootPath = widget.rootPath;
+    WidgetsBinding.instance.addObserver(this);
+    _reread();
   }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  /// Coming back to the app is a reason to look again.
+  ///
+  /// The daemon announces what it is asked to watch, and it was not being
+  /// watched while this was suspended. Covers the writer no hook can see, too:
+  /// somebody's own editor.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _reread();
+  }
+
+  /// Drops the held listing so the next build fetches.
+  ///
+  /// Before the first build on purpose. The provider is not autoDispose, so
+  /// returning to a directory otherwise serves what it held on the way out —
+  /// and the read is also what re-registers the path with the daemon after its
+  /// watch expired. A cold key has no entry to drop, so this costs one fetch
+  /// rather than two either way. See docs/specs/54-file-change-events.md.
+  void _reread() => ref.invalidate(listFilesProvider(_listingKey));
 
   /// The listing for wherever the browser currently is.
   ///
@@ -253,7 +281,12 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen> {
   Widget _buildBody(ThemeData theme) {
     final listing = ref.watch(listFilesProvider(_listingKey));
 
-    if (listing.isLoading) return const _FileListSkeleton();
+    // Not a bare isLoading: an invalidation keeps the previous value and still
+    // reports loading, so a file_changed event would blank the listing the
+    // reader is looking at and redraw it. The skeleton is a first-load
+    // affordance. Same guard as the transcript's (spec 52,
+    // session_detail_screen.dart:460).
+    if (listing.isLoading && !listing.hasValue) return const _FileListSkeleton();
 
     final failed = listing.hasError || listing.valueOrNull == null;
     if (failed) {
@@ -443,7 +476,8 @@ class FileViewerScreen extends rp.ConsumerStatefulWidget {
   rp.ConsumerState<FileViewerScreen> createState() => _FileViewerScreenState();
 }
 
-class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen> {
+class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
+    with WidgetsBindingObserver {
   /// The last value `build` saw.
   ///
   /// Held in a field so the callbacks below — copy, ask-AI — read the same
@@ -462,9 +496,35 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen> {
   bool _runScripts = false;
 
   FileReadResult? get _result => _file.valueOrNull;
-  bool get _loading => _file.isLoading;
+  /// Whether there is nothing to show yet.
+  ///
+  /// Not a bare `isLoading`: an agent editing this file invalidates the entry,
+  /// which reports loading while still holding the previous value. Drawing the
+  /// skeleton then would replace the text the reader is part-way through with
+  /// grey bars, and put it back a moment later. Same guard as the transcript's
+  /// (spec 52, `session_detail_screen.dart:460`).
+  bool get _loading => _file.isLoading && !_file.hasValue;
 
   (String, String) get _fileKey => (widget.hostId, widget.path);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Same reasoning as the listing's: see _FileBrowserScreenState._reread.
+    ref.invalidate(readFileProvider(_fileKey));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) ref.invalidate(readFileProvider(_fileKey));
+  }
 
   /// What a preview may read from, and what "show in folder" browses.
   String get _root => widget.rootPath ?? _directory;

--- a/mobile/test/cache_effects_test.dart
+++ b/mobile/test/cache_effects_test.dart
@@ -66,8 +66,73 @@ void main() {
       const [
         InvalidateTarget(CacheTarget.sessions, host),
         InvalidateTarget(CacheTarget.notifications, host),
+        // Files and git for a second reason: a path whose watch expired while
+        // a screen sat open is not being swept, and re-reading re-registers it.
+        InvalidateTarget(CacheTarget.files, host),
+        InvalidateTarget(CacheTarget.git, host),
       ],
     );
+  });
+
+  // Every path the daemon names has changed *content*, not merely a changed
+  // mtime — it compares digests before it says anything. See spec 54.
+  group('file_changed', () {
+    const named = {
+      'paths': [
+        {'path': '/repo/a.go', 'kind': 'file', 'mod_time': '2026-09-01T04:03:11.204Z'},
+      ],
+    };
+
+    test('takes out the files and the git reads', () {
+      expect(
+        effectsFor(host, 'file_changed', named),
+        const [
+          InvalidateTarget(CacheTarget.files, host),
+          InvalidateTarget(CacheTarget.git, host),
+        ],
+      );
+    });
+
+    // A working-tree write moves `git status`, and a repo entry is a commit or
+    // a checkout, so both kinds reach git the same way.
+    test('a repo entry takes out the same targets', () {
+      expect(
+        effectsFor(host, 'file_changed', const {
+          'paths': [
+            {'path': '/repo', 'kind': 'repo'},
+          ],
+        }),
+        hasLength(2),
+      );
+    });
+
+    test('a deletion is a change like any other', () {
+      expect(
+        effectsFor(host, 'file_changed', const {
+          'paths': [
+            {'path': '/repo/gone.go', 'kind': 'file', 'gone': true},
+          ],
+        }),
+        hasLength(2),
+      );
+    });
+
+    test('another host is not answered for', () {
+      expect(
+        effectsFor(other, 'file_changed', named),
+        const [
+          InvalidateTarget(CacheTarget.files, other),
+          InvalidateTarget(CacheTarget.git, other),
+        ],
+      );
+    });
+
+    test('an event naming nothing does nothing', () {
+      expect(effectsFor(host, 'file_changed', const {}), isEmpty);
+      expect(effectsFor(host, 'file_changed', const {'paths': []}), isEmpty);
+      expect(effectsFor(host, 'file_changed', const {'paths': 'nonsense'}), isEmpty);
+      expect(effectsFor(host, 'file_changed', null), isEmpty);
+    });
   });
 
   // A permission request writes waiting_permission to the session and announces


### PR DESCRIPTION
Closes the gap where an agent edit reached no screen.

`CacheTarget.files` and `CacheTarget.git` already had switch arms in the mobile cache (`cache_invalidator.dart:60-72`), and the desktop already held file and git query keys. Neither could ever run — there was no producer. A desktop tab kept the old text until the panel was hidden and shown; the phone kept the old listing until someone pressed refresh.

## The producer

Metadata for **the paths a viewer holds**, not the tree.

- A read is the subscription. `GET /api/file`, `GET /api/files` and `GET /api/git/status` register a path with a TTL; the set is capped and evicts least-recently-read.
- A sweep re-checks what is registered and broadcasts one `file_changed` naming what moved.
- `PostToolUse` pokes the sweep and **passes nothing** — no `file_path`, no `apply_patch` parsing, no per-provider rules about which tools write.

The work is proportional to the watch set, not to what changed on disk. A build touching ten thousand files produces one event naming the two paths somebody has open. A recursive `fsnotify` watch has the inverse property, and would have evicted `session_status` and `notification` from every client's 64-slot buffer (`sse.go:36-42`) during any build — reopening the bug spec 52 just closed.

Because the hook carries no payload, every writer is covered, including the ones no hook can see: Bash, a build, `git checkout`, and the user's own editor.

## Metadata gates the check, content decides it

Changed metadata is not changed content. A formatter rewriting identical output, codegen, a checkout restoring the same bytes, an agent retrying an `Edit` — all move `mtime` and change nothing.

So: stat as the cheap gate, then SHA-256 only when metadata moved, and broadcast only when the hash differs. Steady state is one stat per watched file and zero reads.

This matters most on a **dirty** tab, where a false positive raises "changed on disk" over a file that did not change and invites the user to discard their edits for nothing.

`.git/index` is deliberately not watched: `git status` refreshes it, so the daemon's own answer would change what it watches and the loop would never settle. `.git/HEAD` plus its ref catches commit, checkout, branch switch and reset.

## The clients compare bytes

An event means *refetch*, not *replace*.

- **Clean desktop tab** → reload.
- **Dirty desktop tab** → refetch, never write to the buffer; raise a bar with Reload. No merge, no dialog, no character lost.
- **Equal to what is held** → nothing. This drops the echo of this window's own save, which the broadcaster cannot skip since it has no addressing.
- **Mobile** → invalidates content outright. It has no `PUT`, so no buffer there can be dirty.

Comparing `mod_time` would not have worked: `GET /api/file` formats it with `RFC3339` and `PUT` with `RFC3339Nano`, so a tab's cached value changes precision depending on how it was last filled.

`syncFromDisk` reads around the React Query cache on purpose. `fetchQuery` would move the entry `saved` is derived from *and* the `mod_time` a later save sends as its base — turning the 409 that protects the other writer into a silent overwrite.

## Two things reading the code turned up

**The editor took keyboard focus on every remount** (`editor.tsx:149`). Harmless on a hide/show; not harmless when the caret is in the transcript composer and the agent saves a file. `CodeEditor` gains `autoFocus`, and a remount nobody asked for passes false.

**Both mobile render guards read a bare `isLoading`.** Riverpod's `invalidate` keeps the previous value and still reports loading, so every agent edit would have blanked the file under the reader and redrawn it. Now the spec 52 guard (`isLoading && !hasValue`).

## Tests

- **Go**: 16 watcher tests — the gate, the hash, identical-rewrite silence, deletion and restore, directory digests for add/remove/rename/child-content, TTL, eviction, one-sweep-one-event, and the `git status` loop guard. Plus poke tests for both providers asserting the hook reads no tool input.
- **Desktop**: `effectsFor` mapping and `fileEffectFor` — the rule protecting unsaved work is extracted out of the component so it can be asserted at all (there is no component test framework here).
- **Mobile**: `file_changed` and the widened `stream_reconnected` in `cache_effects_test.dart`.

`go vet` and `go test ./...` pass; desktop typecheck, 241 tests and build pass.

## Not verified locally

No Dart toolchain on this machine, so `flutter analyze` and `flutter test` have not run — CI will be the first check on the mobile changes.

The desktop bar, the remount and the focus behaviour have no automated coverage and want a manual pass: open a file, have an agent edit it, then repeat with unsaved text in the buffer.

Spec: [`docs/specs/54-file-change-events.md`](docs/specs/54-file-change-events.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)