### PR TITLE
docs: put the install line above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
   <a href="https://github.com/kamrul1157024/v-claw"><img src="https://img.shields.io/badge/companion-v--claw-c9a227" alt="Companion app: v-claw" /></a>
 </p>
 
+```sh
+curl -fsSL https://raw.githubusercontent.com/kamrul1157024/helios/main/scripts/install.sh | sh
+```
+
 <p align="center">
   <img src="docs/assets/desktop/chat.png" width="700" alt="Helios desktop app — session transcript" />
 </p>


### PR DESCRIPTION
## Summary

The one-liner sat under three screenshots and a page of prose. It now runs directly under the badges, where someone deciding whether to try this can copy it without scrolling. The Install section keeps it too, with the explanation of what it does.

## Test plan

- [x] Rendered check of the README top: badges, install line, screenshots