### PR TITLE
fix(hitl): accept SS3 arrow keys in the question overlay

### DIFF
--- a/internal/hitl/keys.go
+++ b/internal/hitl/keys.go
@@ -65,8 +65,14 @@ func decodeKeys(p []byte) []event {
 
 // decodeEscape reads one escape sequence from the front of p, which begins with
 // ESC, and reports how many bytes it consumed.
+//
+// Cursor keys arrive two ways. In the default mode a terminal sends them as CSI
+// — "ESC [ A". A full-screen application switches the terminal into application
+// cursor keys mode (DECCKM, "ESC [ ? 1 h"), after which the same keys arrive as
+// SS3 — "ESC O A". Both have to move the highlight, or the prompt is unanswerable
+// with the arrow keys the moment an alt-screen agent is on screen.
 func decodeEscape(p []byte) (event, int) {
-	if len(p) < 3 || p[1] != '[' {
+	if len(p) < 3 || (p[1] != '[' && p[1] != 'O') {
 		return event{kind: keyCancel}, 1
 	}
 	switch p[2] {
@@ -75,7 +81,7 @@ func decodeEscape(p []byte) (event, int) {
 	case 'B':
 		return event{kind: keyNext}, 3
 	}
-	// Some other CSI — a mouse report, a bracketed-paste marker, a function
+	// Some other CSI/SS3 — a mouse report, a bracketed-paste marker, a function
 	// key. Skip to its final byte rather than reading its parameters as
 	// keystrokes: an unread "\x1b[3~" would otherwise select choice three.
 	i := 2

--- a/internal/hitl/keys_test.go
+++ b/internal/hitl/keys_test.go
@@ -10,6 +10,17 @@ func TestDecodeKeys(t *testing.T) {
 	}{
 		{"down arrow", "\x1b[B", []event{{kind: keyNext}}},
 		{"up arrow", "\x1b[A", []event{{kind: keyPrev}}},
+		// SS3 cursor keys: what a full-screen app in application cursor keys
+		// mode (DECCKM) makes the terminal send. Before this was handled they
+		// decoded as a cancel, so arrows dismissed the prompt instead of moving.
+		{"ss3 down arrow", "\x1bOB", []event{{kind: keyNext}}},
+		{"ss3 up arrow", "\x1bOA", []event{{kind: keyPrev}}},
+		{"ss3 coalesced", "\x1bOB\x1bOB\r", []event{
+			{kind: keyNext}, {kind: keyNext}, {kind: keyConfirm},
+		}},
+		// An SS3 function key (F1 is "ESC O P") is not a cursor key: skip it
+		// whole rather than reading 'P' as anything.
+		{"ss3 function key is skipped", "\x1bOP", nil},
 		{"vi keys", "jk", []event{{kind: keyNext}, {kind: keyPrev}}},
 		{"enter", "\r", []event{{kind: keyConfirm}}},
 		{"newline", "\n", []event{{kind: keyConfirm}}},


### PR DESCRIPTION
## Summary

Fixes #140.

When a Helios session is running a **full-screen (alternate-screen) application** and Claude asks a question (`AskUserQuestion`), the HITL overlay appears but its arrow keys don't work — pressing ↑/↓ dismisses the prompt and, because the overlay swallows every other key, the session looks frozen.

## Root cause

A full-screen app switches the terminal into **application cursor keys mode** (DECCKM, `ESC [ ? 1 h`). After that the arrow keys arrive as **SS3** (`ESC O A` / `ESC O B`) instead of CSI (`ESC [ A` / `ESC [ B`). `decodeEscape` in `internal/hitl/keys.go` only knew the CSI form; anything whose second byte wasn't `[` fell through to `keyCancel`. So an arrow keypress decoded as a cancel.

Verified end-to-end:
- **Terminfo** (`xterm-256color`): `smkx=\E[?1h`, `kcuu1=\EOA`, `kcud1=\EOB` — a full-screen app really does make arrows SS3.
- **The decoder**: running the real `decodeKeys`, both `"\x1bOA"` and `"\x1bOB"` returned `keyCancel` before this change.
- **Symptom match**: default-mode arrows (`\E[A`) already worked; only application/full-screen-mode arrows (`\EOA`) broke — exactly "works normally, breaks only in fullscreen".

## Change

`decodeEscape` now accepts the `ESC O` (SS3) form of the cursor keys alongside `ESC [`. Non-cursor SS3 sequences (e.g. F1 = `ESC O P`) are skipped whole, same as unknown CSI. No other decoding behaviour changes.

`captureInput`'s swallow-by-design behaviour is intentionally left untouched: letting raw bytes through to a hook-blocked CLI is what its comment warns against.

## Testing

- `go test ./internal/hitl/...` — all pass, including new SS3 cases (`ss3 up/down arrow`, `ss3 coalesced`, `ss3 function key is skipped`) and every pre-existing case.
- `go build ./...` — clean.

Note: `internal/terminal` has two failing tests on `main` (`TestE2EClaudeSnapshotCatchesUpLateViewer` and an emulator panic); confirmed pre-existing (they fail with this change stashed) and out of scope here.
