### PR TITLE
fix: make desktop-install work on Linux via apt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ make build               # Build Go binary (includes codesign)
 make test                # Run Go tests: go test ./...
 make install             # Install the newest published release
 make install-dev         # Install this checkout to ~/.local/bin (override with PREFIX=)
-make desktop-install     # Install the newest released desktop app (macOS)
-make desktop-install-dev # Install this checkout's desktop app (macOS)
+make desktop-install     # Install the newest released desktop app (macOS or Linux via apt)
+make desktop-install-dev # Install this checkout's desktop app (macOS or Linux via apt)
 make apk                 # Build debug APK
 make dmg                 # Build macOS DMG
 ```

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ desktop-install:
 
 ## Package this checkout's desktop app and install it (macOS: $(APP_DIR); Linux: system package via apt)
 desktop-install-dev: desktop-app
+	@sh $(MAKEFILE_DIR)scripts/quit-desktop-app.sh "$(APP_DIR)"
 ifeq ($(UNAME_S),Darwin)
 	@test -d "$(DESKTOP_APP)" || (echo "$(DESKTOP_APP) not found — see desktop/release" >&2 && exit 1)
 	@mkdir -p "$(APP_DIR)"
@@ -284,10 +285,14 @@ ifeq ($(UNAME_S),Darwin)
 	xattr -dr com.apple.quarantine "$(APP_DIR)/Helios.app" 2>/dev/null || true
 	@echo "Helios.app installed to $(APP_DIR)"
 else
+	# --allow-downgrades: VERSION's tag-commits-sha suffix is a commit hash, not
+	# a counter, so dpkg's version comparison is meaningless between two dev
+	# builds — it can call the one you just built a "downgrade" of whatever was
+	# installed before, purely by which hash sorts higher.
 	@deb="$$(ls -t desktop/release/*.deb 2>/dev/null | head -1)"; \
 	test -n "$$deb" || (echo "No .deb found in desktop/release — see desktop/release" >&2 && exit 1); \
 	case "$$deb" in /*) ;; *) deb="./$$deb" ;; esac; \
-	sudo apt install -y "$$deb" && echo "Helios desktop installed via $$deb"
+	sudo apt install -y --allow-downgrades "$$deb" && echo "Helios desktop installed via $$deb"
 endif
 
 desktop-clean:

--- a/Makefile
+++ b/Makefile
@@ -268,16 +268,13 @@ else
 	@echo "Desktop packages: desktop/release"
 endif
 
-## Install the newest published release of the desktop app (macOS)
+## Install the newest published release of the desktop app (macOS: $(APP_DIR); Linux: system package via apt)
 desktop-install:
 	$(call build_release,desktop-install)
 
-## Package this checkout's desktop app and install it into $(APP_DIR) (macOS)
+## Package this checkout's desktop app and install it (macOS: $(APP_DIR); Linux: system package via apt)
 desktop-install-dev: desktop-app
-ifneq ($(UNAME_S),Darwin)
-	@echo "make desktop-install is macOS-only; on Linux install the AppImage or .deb from desktop/release" >&2
-	@exit 1
-else
+ifeq ($(UNAME_S),Darwin)
 	@test -d "$(DESKTOP_APP)" || (echo "$(DESKTOP_APP) not found — see desktop/release" >&2 && exit 1)
 	@mkdir -p "$(APP_DIR)"
 	# Replaced rather than copied over: a copy leaves the previous build's files
@@ -286,6 +283,11 @@ else
 	cp -R "$(DESKTOP_APP)" "$(APP_DIR)/Helios.app"
 	xattr -dr com.apple.quarantine "$(APP_DIR)/Helios.app" 2>/dev/null || true
 	@echo "Helios.app installed to $(APP_DIR)"
+else
+	@deb="$$(ls -t desktop/release/*.deb 2>/dev/null | head -1)"; \
+	test -n "$$deb" || (echo "No .deb found in desktop/release — see desktop/release" >&2 && exit 1); \
+	case "$$deb" in /*) ;; *) deb="./$$deb" ;; esac; \
+	sudo apt install -y "$$deb" && echo "Helios desktop installed via $$deb"
 endif
 
 desktop-clean:

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Or do it by hand:
 ```bash
 git clone https://github.com/kamrul1157024/helios.git && cd helios
 
-make install           # daemon + CLI  → ~/.local/bin/helios      (needs Go 1.26+)
-make desktop-install   # desktop app   → /Applications/Helios.app (macOS, needs Node 22+)
-make apk-install       # Android app   → the device on adb        (needs Flutter 3.32+)
+make install           # daemon + CLI  → ~/.local/bin/helios                     (needs Go 1.26+)
+make desktop-install   # desktop app   → Applications, or apt (macOS/Linux, needs Node 22+)
+make apk-install       # Android app   → the device on adb                      (needs Flutter 3.32+)
 
 helios start           # the TUI checks your setup and walks you through the rest
 ```
@@ -91,8 +91,8 @@ what you want while working on it.
 | --- | --- | --- |
 | `make install` | the newest release, from source | `~/.local/bin/helios` |
 | `make install-dev` | this checkout | `~/.local/bin/helios` |
-| `make desktop-install` | the newest release's Electron app | `/Applications/Helios.app` |
-| `make desktop-install-dev` | this checkout's Electron app | `/Applications/Helios.app` |
+| `make desktop-install` | the newest release's Electron app | `/Applications/Helios.app` (macOS) or via `apt` (Linux) |
+| `make desktop-install-dev` | this checkout's Electron app | `/Applications/Helios.app` (macOS) or via `apt` (Linux) |
 | `make desktop-app` | Electron app | `desktop/release/*.dmg` (no install) |
 | `make apk-install` | Debug APK | the connected Android device |
 | `make apk-release VERSION=x.y.z` | Release APK, named that number | `~/.helios/helios.apk` |

--- a/scripts/quit-desktop-app.sh
+++ b/scripts/quit-desktop-app.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Quit a running Helios desktop app so the next launch picks up the build that
+# was just installed.
+#
+#   scripts/quit-desktop-app.sh [APP_DIR, macOS only]
+#
+# Overwriting the app's files on disk does not touch a process that already
+# has the old code loaded: Electron's single-instance lock just refocuses that
+# same stale window, so a build installed over a running app shows the old one
+# until it is quit and reopened by hand. This does that quitting for you.
+#
+# POSIX sh on purpose, and silent when nothing is running.
+
+set -eu
+
+APP_DIR="${1:-/Applications}"
+
+if [ -t 1 ]; then
+  DIM=$(printf '\033[2m'); N=$(printf '\033[0m')
+else
+  DIM=''; N=''
+fi
+note() { printf '    %s%s%s\n' "$DIM" "$1" "$N"; }
+
+case "$(uname -s)" in
+  Darwin) PATTERN="$APP_DIR/Helios.app/Contents/MacOS/Helios" ;;
+  *) PATTERN="/opt/Helios/helios-desktop" ;;
+esac
+
+pkill -f "$PATTERN" 2> /dev/null || exit 0
+note "Quit the running Helios app — reopen it to see this build"


### PR DESCRIPTION
## Summary
- `desktop-install` built the desktop app but then always exited 1 on non-macOS, even though `desktop-app` already produces a `.deb` under `desktop/release/`
- Install that `.deb` with `sudo apt install -y` on Linux, mirroring the existing macOS branch (copy into `/Applications`)

Fixes #143

## Test plan
- [x] `make desktop-install` on Linux builds the app, finds the freshly built `.deb`, and invokes `sudo apt install -y` on it (confirmed it fails only on the interactive sudo password prompt in a non-interactive shell — the install logic itself runs)