### PR TITLE
feat(mobile): swipe the top bar to change host

### DIFF
--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -352,6 +352,24 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
     );
   }
 
+  /// Steps to the next or previous host. "All Hosts" is not a stop on the way:
+  /// a swipe from it lands on whichever end the swipe came from.
+  void _cycleHost(int delta) {
+    final hosts = _hm.hosts;
+    if (hosts.length < 2) return;
+    final current = hosts.indexWhere((h) => h.id == _hm.activeHostId);
+    final next = current < 0
+        ? (delta > 0 ? 0 : hosts.length - 1)
+        : (current + delta) % hosts.length;
+    _hm.setActiveHost(hosts[next].id);
+  }
+
+  void _onAppBarSwipe(DragEndDetails details) {
+    final velocity = details.primaryVelocity ?? 0;
+    if (velocity.abs() < 100) return;
+    _cycleHost(velocity < 0 ? 1 : -1);
+  }
+
   Widget _buildHostFilterChip() {
     if (_hm.hosts.length <= 1) {
       return const Text('helios');
@@ -512,21 +530,28 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
         final activeSessionCount = allSessions.where((s) => s.isActive).length;
 
         return Scaffold(
-          appBar: AppBar(
-            title: _buildHostFilterChip(),
-            centerTitle: true,
-            actions: [
-              _buildConnectionDots(),
-              IconButton(
-                icon: const Icon(Icons.settings_outlined),
-                tooltip: 'Settings',
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const SettingsScreen()),
-                  );
-                },
+          appBar: PreferredSize(
+            preferredSize: const Size.fromHeight(kToolbarHeight),
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onHorizontalDragEnd: _onAppBarSwipe,
+              child: AppBar(
+                title: _buildHostFilterChip(),
+                centerTitle: true,
+                actions: [
+                  _buildConnectionDots(),
+                  IconButton(
+                    icon: const Icon(Icons.settings_outlined),
+                    tooltip: 'Settings',
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const SettingsScreen()),
+                      );
+                    },
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
           body: Column(
             children: [


### PR DESCRIPTION
## Summary

- Changing host took two taps: one on the title, one in the bottom sheet. A horizontal swipe anywhere on the app bar now steps to the next or previous host.
- The swipe zone is the whole bar, not just the centred chip, so it is easy to hit on a phone. Taps on the chip and the settings button still work — the gesture arena gives taps to the buttons.
- "All Hosts" is not a stop in the cycle. Swiping past the last host returns to the first rather than dropping the filter; the sheet remains the way back to All Hosts. Swiping from All Hosts lands on whichever end the swipe came from.
- Below two hosts the app bar shows plain "helios" and the swipe is a no-op. Slow drags under 100 px/s are ignored.

## Test plan

- [ ] With two or more hosts, swipe left on the app bar — the title moves to the next host and the session list filters to it.
- [ ] Swipe right — it moves back.
- [ ] Swipe past the last host — it wraps to the first, and does not land on All Hosts.
- [ ] From All Hosts, swipe left lands on the first host; swipe right lands on the last.
- [ ] Tap the title — the host sheet still opens. Tap the settings icon — settings still opens.
- [ ] With one host, swiping the bar does nothing.