### PR TITLE
Answer a question properly from the terminal

### DIFF
--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -78,6 +78,22 @@ export function NotificationCard({
   )
 }
 
+// readableInput lays a tool's input out as one field per block, with any
+// multi-line value — a file's contents, a patch — printed as the lines it is
+// rather than as one escaped string.
+function readableInput(fields: Record<string, unknown> | null): string | null {
+  if (!fields) return null
+  const entries = Object.entries(fields)
+  if (entries.length === 0) return null
+  return entries
+    .map(([key, value]) =>
+      typeof value === 'string' && value.includes('\n')
+        ? `${key}:\n${value}`
+        : `${key}: ${typeof value === 'string' ? value : JSON.stringify(value)}`,
+    )
+    .join('\n\n')
+}
+
 function PermissionCard({
   payload,
   busy,
@@ -88,7 +104,14 @@ function PermissionCard({
   act: (body: Record<string, unknown>) => Promise<void>
 }): JSX.Element {
   const toolInput = payload.tool_input
-  const original = typeof toolInput === 'string' ? toolInput : JSON.stringify(toolInput ?? {}, null, 2)
+  // The field the tool actually runs, when there is one. A command goes through
+  // JSON.stringify as a single line of \n escapes, which is unreadable exactly
+  // when it matters most: a heredoc writing a file is the thing you most want
+  // to read before approving it.
+  const fields = toolInput && typeof toolInput === 'object' ? (toolInput as Record<string, unknown>) : null
+  const command = typeof fields?.command === 'string' ? fields.command : null
+  const original =
+    typeof toolInput === 'string' ? toolInput : (command ?? readableInput(fields) ?? '{}')
   const suggestions = Array.isArray(payload.permission_suggestions) ? payload.permission_suggestions : []
 
   const [editing, setEditing] = useState(false)
@@ -98,12 +121,18 @@ function PermissionCard({
   const approve = (): void => {
     const body: Record<string, unknown> = { action: 'approve' }
     if (editing && edited !== original) {
-      try {
-        body.updated_input = JSON.parse(edited)
-      } catch {
-        // Not JSON: the common edit is a shell command, and that is the field
-        // the tool reads. Matches the mobile client's fallback.
-        body.updated_input = { command: edited }
+      if (command !== null) {
+        // Editing the command edits that one field: the rest of the input —
+        // a description, a timeout — is not the user's to lose.
+        body.updated_input = { ...fields, command: edited }
+      } else {
+        try {
+          body.updated_input = JSON.parse(edited)
+        } catch {
+          // Not JSON: the common edit is a shell command, and that is the field
+          // the tool reads. Matches the mobile client's fallback.
+          body.updated_input = { command: edited }
+        }
       }
     }
     if (rule !== null) body.apply_permission = rule

--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -164,18 +164,48 @@ function QuestionCard({
   act: (body: Record<string, unknown>) => Promise<void>
 }): JSX.Element {
   const questions = (Array.isArray(payload.questions) ? payload.questions : []) as Question[]
-  // Question index → option index. Indices rather than labels: the daemon
+  // Question index → option indices. Indices rather than labels: the daemon
   // answers by moving the CLI's own highlight, so position is what it needs.
-  const [chosen, setChosen] = useState<Record<number, number>>({})
+  // A multi-select question keeps several; the rest replace the one they hold.
+  const [chosen, setChosen] = useState<Record<number, number[]>>({})
+  // Question index → what was typed instead of picking.
+  const [typed, setTyped] = useState<Record<number, string>>({})
+
+  const pick = (question: Question, questionIndex: number, optionIndex: number): void =>
+    setChosen((current) => {
+      const held = current[questionIndex] ?? []
+      if (!question.multiSelect) {
+        return { ...current, [questionIndex]: [optionIndex] }
+      }
+      const next = held.includes(optionIndex)
+        ? held.filter((i) => i !== optionIndex)
+        : [...held, optionIndex].sort((a, b) => a - b)
+      return { ...current, [questionIndex]: next }
+    })
+
+  const answered = (index: number): boolean =>
+    (chosen[index] ?? []).length > 0 || (typed[index] ?? '').trim() !== ''
 
   const submit = (): void => {
     const selections = Object.entries(chosen)
-      .map(([questionIndex, optionIndex]) => ({
-        question_index: Number(questionIndex),
-        option_index: optionIndex,
-      }))
+      .flatMap(([questionIndex, optionIndexes]) =>
+        optionIndexes.map((optionIndex) => ({
+          question_index: Number(questionIndex),
+          option_index: optionIndex,
+        })),
+      )
       .sort((a, b) => a.question_index - b.question_index)
-    void act({ action: 'answer', selections })
+
+    // One text field on the wire for the whole set, so an answer past the
+    // first says which question it belongs to.
+    const written = questions
+      .map((question, index) => [question, (typed[index] ?? '').trim()] as const)
+      .filter(([, text]) => text !== '')
+      .map(([question, text]) =>
+        questions.length === 1 ? text : `${question.header ?? question.question}: ${text}`,
+      )
+
+    void act({ action: 'answer', selections, text: written.join('\n') })
   }
 
   return (
@@ -187,25 +217,34 @@ function QuestionCard({
           {(question.options ?? []).map((option, optionIndex) => (
             <button
               key={optionIndex}
-              className={`option ${chosen[questionIndex] === optionIndex ? 'chosen' : ''}`}
-              onClick={() => setChosen((current) => ({ ...current, [questionIndex]: optionIndex }))}
+              className={`option ${(chosen[questionIndex] ?? []).includes(optionIndex) ? 'chosen' : ''}`}
+              onClick={() => pick(question, questionIndex, optionIndex)}
             >
-              <span className="option-label">{option.label}</span>
+              <span className="option-label">
+                {question.multiSelect &&
+                  ((chosen[questionIndex] ?? []).includes(optionIndex) ? '☑ ' : '☐ ')}
+                {option.label}
+              </span>
               {option.description && <span className="option-desc">{option.description}</span>}
             </button>
           ))}
-          {/* Answering drives the CLI's own list, which takes one highlighted
-              option per question. Picking several needs the terminal. */}
-          {question.multiSelect && (
-            <small className="option-desc">Pick one here, or answer in the terminal to choose several.</small>
-          )}
+          <label className="field">
+            <span>Other</span>
+            <input
+              value={typed[questionIndex] ?? ''}
+              placeholder="Answer in your own words"
+              onChange={(event) =>
+                setTyped((current) => ({ ...current, [questionIndex]: event.target.value }))
+              }
+            />
+          </label>
         </div>
       ))}
 
       <Actions busy={busy}>
         {/* Every question, not just one: the daemon walks the CLI through them
             in order and a gap would leave it stranded. */}
-        <button disabled={Object.keys(chosen).length !== questions.length} onClick={submit}>
+        <button disabled={!questions.every((_, index) => answered(index))} onClick={submit}>
           Submit
         </button>
         <button className="ghost" onClick={() => void act({ action: 'skip' })}>

--- a/docs/specs/36-helios-owned-hitl.md
+++ b/docs/specs/36-helios-owned-hitl.md
@@ -313,6 +313,11 @@ type Overlay struct {
 func RenderOverlay(o Overlay, cols, rows int) []byte
 ```
 
+[Spec 55](55-answering-a-question-from-the-terminal.md) adds three fields to this — the
+per-option descriptions, the checkboxes of a multi-select question, and the row that
+collects a typed answer — and with them the rule that a question with no options is
+answered in the terminal rather than left to the phone.
+
 `RenderOverlay` is bracketed by `\x1b7` / `\x1b8` and hides the cursor, so it can
 be re-stamped after any PTY output without disturbing the application
 underneath. It anchors to the bottom of the viewport — where a CLI puts its own

--- a/docs/specs/55-answering-a-question-from-the-terminal.md
+++ b/docs/specs/55-answering-a-question-from-the-terminal.md
@@ -1,0 +1,293 @@
+# Answering a Question From the Terminal
+
+## The claim
+
+The terminal should answer any question the desktop can answer. Today it answers the
+easiest third of them: it shows the option labels and nothing else, it cannot take a typed
+answer when none of the options fit, and it cannot select two options when the question
+asks for two. Every one of those is a rendering gap, not a protocol gap — the daemon
+already carries the data and already accepts the answers.
+
+## Where we are
+
+| | Option descriptions | Typed answer | Multi-select |
+| --- | --- | --- | --- |
+| Terminal overlay | dropped in `optionLabels()`, `claude/question.go:183` | none | none |
+| Desktop | drawn, `desktop/src/renderer/components/notification-card.tsx:194` | none | none |
+| Flutter | dropped, reads `opt['label']` only, `mobile/lib/providers/cards.dart:400` | none | reads `multiSelect` at `cards.dart:384`, then ignores it |
+
+What already exists on the daemon side, unused:
+
+- `questionOption.Description` is parsed (`claude/question.go:20`) and never read again.
+- `questionAnswer.Text` is defined (`claude/question.go:47`) and rendered into the reason
+  Claude reads (`claude/question.go:230`). No surface ever sets it.
+- `Selections` is a flat list of `{question_index, option_index}` (`claude/question.go:46`),
+  so two entries sharing a question index already *is* a multi-select answer. Nothing needs
+  to change in the answer payload.
+
+What is genuinely missing: `questionSpec` (`claude/question.go:24-28`) does not parse
+`multiSelect` at all.
+
+## What it looks like
+
+Single-select, every description drawn:
+
+```
+┌─ Next step ────────────────────────────────────────────────────────┐
+│ Unit repro done. What next on PR 141?                              │
+│                                                                    │
+│ ❯ Live repro in TUI                                                │
+│      Start a real session with an alt-screen agent, trigger        │
+│      AskUserQuestion, press arrows. Confirms end-to-end.           │
+│   Code review the PR                                               │
+│      Read the full diff and report issues: SS3 edge cases,         │
+│      skip-to-final-byte logic, test coverage gaps.                 │
+│   Other…                                                           │
+│                                                                    │
+│ ↑↓ select · enter confirm · esc cancel                             │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Multi-select:
+
+```
+┌─ Which checks to run  (2/3) ───────────────────────────────────────┐
+│ Pick every check that must pass before merge.                      │
+│                                                                    │
+│   [x] Unit tests                                                   │
+│       go test ./... across the daemon. Two failures are            │
+│       already present on main and stay expected.                   │
+│ ❯ [x] Race detector                                                │
+│       go test -race on internal/terminal. Slow, but the            │
+│       overlay redraw path is where the races have been.            │
+│   [ ] Flutter analyze                                              │
+│       dart analyze on mobile/. Nothing here touches Dart.          │
+│   [ ] Other…                                                       │
+│                                                                    │
+│ space toggle · ↑↓ move · enter confirm · esc cancel                │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Editing a typed answer:
+
+```
+┌─ Next step ────────────────────────────────────────────────────────┐
+│ Unit repro done. What next on PR 141?                              │
+│                                                                    │
+│   Live repro in TUI                                                │
+│   Code review the PR                                               │
+│ ❯ Other…                                                           │
+│   ┌──────────────────────────────────────────────────────┐         │
+│   │ rebase onto main first, then re-run the SS3 test█    │         │
+│   └──────────────────────────────────────────────────────┘         │
+│                                                                    │
+│ enter send · esc back to the list                                  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Descriptions indent four columns, not two. At two they sit in the same column as an
+unselected label and the list reads as one paragraph. They are dim and capped at two
+wrapped lines: the box is anchored to the bottom and clips from the *top*
+(`terminal/overlay.go:80`), so an uncapped description pushes the question itself off
+screen. Four options with two lines each is 19 rows, which fits an 80×24 terminal.
+
+Every option keeps its description at all times. Expanding only the highlighted row halves
+the height but makes the box grow and shrink under the cursor, and because it is
+bottom-anchored the top edge would walk up and down the screen while the user arrows.
+
+## The change
+
+### The overlay gains three optional fields
+
+`terminal.Overlay` (`terminal/overlay.go:16-27`) is marshalled by the daemon
+(`terminal/client.go:95-99`) and unmarshalled by `helios ptyhost`
+(`terminal/host.go:820-825`). A ptyhost from an earlier build can still be running after an
+upgrade. So every field is additive and `omitempty`, and `Options []string` keeps its exact
+shape and meaning:
+
+```go
+Details []string      `json:"details,omitempty"` // index-aligned with Options
+Checked []bool        `json:"checked,omitempty"` // non-nil renders checkboxes
+Input   *OverlayInput `json:"input,omitempty"`   // the typed-answer row
+```
+
+```go
+type OverlayInput struct {
+    Label  string `json:"label"`  // the row that opens the field, e.g. "Other…"
+    Value  string `json:"value"`  // what has been typed so far
+    Active bool   `json:"active"` // the field has the keyboard
+}
+```
+
+An old ptyhost ignores all three and paints today's list from `Options`.
+
+### Capability, because two of the three do not degrade
+
+Descriptions degrade silently and correctly. The other two do not. An old host that ignores
+`Checked` draws a multi-select question as a single-select list, and Enter answers with one
+option — silently wrong. An old host that ignores `Input` leaves the user typing into a
+buffer they cannot see.
+
+So the daemon asks before it offers. `hitl.Overlays` (`hitl/hitl.go:51-54`) gains a third
+method, defined at the consumer as the other two are:
+
+```go
+OverlayProtocol(sessionID string) int
+```
+
+It reads through to the mirror's cached sidecar protocol (`terminal/mirror.go:244-253`),
+the same value `SendText` already gates `FramePaste` on (`terminal/mirror.go:232-242`).
+`HostProtocol` goes to 2 (`terminal/paths.go:39`).
+
+The three do not fail the same way, so they are not gated the same way.
+
+| On a host reporting protocol 1 | |
+| --- | --- |
+| Descriptions | Drawn as labels alone. Nothing is lost that the user needed. |
+| The answer field | Dropped. The choices are still answerable, and what the user wanted to write is still answerable on the phone. |
+| Checkboxes | The whole question goes to the phone. Drawn as a single-select list it would collect an answer the user did not give. |
+| A question with no choices | The whole question goes to the phone. There is no reduced version of a prompt that was only ever a field. |
+
+Suppressing every question on an old host would be the easy rule and the wrong one: since
+questions always offer the field, it would leave a terminal that used to show the options
+showing nothing at all. Sending the whole set to the phone is what a free-text question
+already did (`claude/question.go:72`), and it stays reserved for the cases with no
+smaller thing to draw.
+
+### The prompt gains the state, and the state machine gains a mode
+
+`hitl.Prompt` (`hitl/hitl.go:32-39`):
+
+```go
+Details   []string // index-aligned with Choices, optional
+Multi     bool     // space toggles, enter submits the set
+AllowText bool     // append the Other… row
+TextLabel string   // defaults to "Other…"
+```
+
+`live` (`hitl/hitl.go:66-79`) gains `checked []bool`, `text string` and `editing bool`
+under the same mutex that guards `selected`.
+
+`hitl.Answer` (`hitl/hitl.go:42-45`) gains two fields beside `Index`:
+
+```go
+Indexes []int  // set when Prompt.Multi
+Text    string // set when the user typed instead of choosing
+```
+
+`Index` keeps its meaning for the single-choice case, so the three prompt builders that do
+not opt in (`claude/hooks.go:232`, `claude/hooks.go:522`, `codex/hooks.go:428`) are
+untouched. `Cancelled()` becomes "nothing was chosen and nothing was typed" rather than
+`Index < 0` alone, because a typed answer legitimately carries no index.
+
+### Two key modes
+
+`decodeKeys` (`hitl/keys.go:33`) today treats every printable byte as a command: `j` and
+`k` move, `1`-`9` jump the highlight, ESC cancels. A text buffer needs those same bytes as
+literal characters, so the decoder takes the mode:
+
+| | List mode | Edit mode |
+| --- | --- | --- |
+| `↑ ↓ j k` | move | move (leaves the field first) |
+| `1`-`9` | jump the highlight; toggle when `Multi` | literal digits |
+| space | toggle when `Multi` | literal space |
+| printable | ignored | appended |
+| backspace / DEL | ignored | delete one rune |
+| Ctrl-U / Ctrl-W | ignored | clear the line / delete a word |
+| Enter | confirm | send the typed answer |
+| ESC | cancel the prompt | leave the field, stay in the prompt |
+| Ctrl-C | cancel | cancel |
+| bracketed paste | skipped whole | inserted literally |
+
+ESC is deliberately overloaded rather than spending a second key on the exit. The footer
+carries it: it reads `enter send · esc back to the list` while the field is active, so the
+user is told the first ESC does not throw the question away. Bracketed paste stops being
+skipped as an unknown CSI (`hitl/keys.go:84-93`) and becomes an insert while editing.
+
+The buffer lives in the daemon, not the host. `HandleInput` already re-sends the whole
+overlay on every highlight move (`hitl/hitl.go:177-181`), so a redraw per keystroke is the
+existing path. It follows that every viewer of the session watches the answer being typed,
+which is correct for a surface where the first answer wins.
+
+### The question provider fills it in
+
+In `claude/question.go`:
+
+- `questionSpec` gains `MultiSelect bool \`json:"multiSelect"\``.
+- `optionDescriptions(q)` beside `optionLabels()` (`:183`), returning nil when every
+  description is blank so `details` stays out of the JSON.
+- `ask()` (`:101`) sets `Details`, `Multi: q.MultiSelect` and `AllowText: true`. The CLI
+  always permits a free-text answer, so the `Other…` row is not conditional.
+- `answered()` (`:125`) writes one `selection` per chosen index and puts a typed answer in
+  `questionAnswer.Text`. A set shares one text field on the wire, so an answer past the
+  first is prefixed with the question it belongs to.
+- The bail-out for optionless questions (`:72`) goes away. It is no longer a special case:
+  a question with no choices is one whose only row is the field, and the capability gate
+  already sends it to the phone when the host cannot draw that. `Ask` opens the field for
+  it immediately, since there is nothing else on the row to pick.
+
+### The other two surfaces
+
+Desktop (`desktop/src/renderer/components/notification-card.tsx`) already draws
+descriptions. It gains checkboxes when `multiSelect` is set, and an "Other" field that
+posts `text`.
+
+Flutter (`mobile/lib/providers/cards.dart`) gains all three. `_selections` becomes a set
+per question rather than `Map<int, int>` (`:313`); the submit body at `:322-323` still
+emits a flat `{question_index, option_index}` list, one entry per checked option.
+
+## What we are not doing
+
+- **Elicitation forms.** `claude/hooks.go:522` still sends the user to the app. One line of
+  text is not a JSON schema, and pretending otherwise collects the wrong answer.
+- **Permission suggestions in the overlay.** `PermissionSuggestions` stays desktop-only.
+- **All four questions at once.** They still paint one at a time, titled `Header (i/N)`
+  (`claude/question.go:112`).
+- **Wrapping long labels.** `ansi.Truncate(opt, width-2, "…")` (`terminal/overlay.go:131`)
+  stays. Descriptions wrap; labels are meant to be short.
+- **Multi-line typed answers.** One line. Enter sends, so there is no key left to mean
+  newline without stealing another.
+- **Readline.** Backspace, Ctrl-U and Ctrl-W. No cursor movement inside the line, no
+  history, no completion.
+
+## Tests
+
+`internal/terminal/overlay_test.go`, in the style of
+`TestRenderOverlayDrawsTitleBodyAndOptions`:
+
+- A description is drawn under its own option, indented four, dim, after the label it
+  belongs to.
+- A description longer than two wrapped lines is cut to two and ends in `…`.
+- `Checked` renders `[x]` and `[ ]` and leaves the highlight bar intact on a checked row.
+- `Input` renders the label, the framed value, and swaps the footer when `Active`.
+- An `Overlay` carrying none of the three marshals to JSON with no `details`, `checked` or
+  `input` key. This is the promise made to an older ptyhost, so it is asserted on the bytes,
+  not on the render.
+- Rows stay uniform width with all three present, extending
+  `TestOverlayBoxRowsAreUniformWidth`.
+- `TestOverlayFrameRoundTrip` carries all three through the frame.
+
+`internal/hitl/keys_test.go`:
+
+- Every row of the mode table above, both modes.
+- ESC in edit mode does not produce a cancel; ESC in list mode still does.
+- A bracketed paste inserts its payload in edit mode and is skipped whole in list mode.
+- Coalesced input mixing a paste and an Enter is decoded in order.
+
+`internal/hitl/hitl_test.go`:
+
+- Space toggles under `Multi` and does nothing without it.
+- Enter under `Multi` answers with every checked index; with none checked it is a cancel.
+- Typing and Enter answers with `Text` set and no index.
+- A prompt whose host reports protocol 1 and which needs text or checkboxes never calls
+  `SetOverlay`.
+- A prompt with none of the new fields paints an overlay with all three fields nil, so the
+  permission and elicitation prompts are byte-identical to today.
+
+`internal/provider/claude/question_test.go`:
+
+- Descriptions reach `Prompt.Details`; a question with none produces nil.
+- `multiSelect: true` reaches `Prompt.Multi`.
+- Two checked options on one question produce two `selection` entries sharing a question
+  index, and `questionReason` names both.
+- A typed answer reaches `questionAnswer.Text` and appears in the reason.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -62,6 +62,7 @@ what is merged. Some are superseded and stay here for the history.
 | [52-transcript-freshness.md](52-transcript-freshness.md) | Transcript Freshness: Heal a Missed Event Without a Spinner |
 | [53-mermaid-diagrams.md](53-mermaid-diagrams.md) | Mermaid Diagrams: Draw the Fence Instead of Printing It |
 | [54-file-change-events.md](54-file-change-events.md) | File Change Events: Watch What Someone Is Looking At |
+| [55-answering-a-question-from-the-terminal.md](55-answering-a-question-from-the-terminal.md) | Answering a Question From the Terminal |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |
 | [desktop-notification-service.md](desktop-notification-service.md) | Desktop Notification Service |

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -133,6 +133,17 @@ func (h *Host) SetOverlay(sessionID string, o terminal.Overlay) error {
 	return m.SetOverlay(o)
 }
 
+// OverlayProtocol reports what the host behind a session can draw. A session
+// with no host reports 0, the oldest protocol: a prompt that needs more than
+// that belongs on the phone rather than half-painted here.
+func (h *Host) OverlayProtocol(sessionID string) int {
+	m, err := h.Mirror(sessionID)
+	if err != nil {
+		return 0
+	}
+	return m.Protocol()
+}
+
 // ClearOverlay takes the modal down and hands the keyboard back to the agent.
 func (h *Host) ClearOverlay(sessionID string) error {
 	m, err := h.Mirror(sessionID)

--- a/internal/hitl/hitl.go
+++ b/internal/hitl/hitl.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/kamrul1157024/helios/internal/terminal"
@@ -24,9 +25,22 @@ import (
 // package existed.
 var ErrNoTerminal = errors.New("hitl: session has no terminal")
 
-// footer is the key hint under every prompt. Short on purpose: it is drawn on
-// terminals as narrow as the box allows.
-const footer = "↑↓ select · enter confirm · esc cancel"
+// The key hints under a prompt. Short on purpose: they are drawn on terminals
+// as narrow as the box allows.
+const (
+	footer      = "↑↓ select · enter confirm · esc cancel"
+	footerMulti = "space toggle · ↑↓ move · enter confirm · esc cancel"
+	// footerTyping says what the first Escape does, which is the one thing a
+	// user cannot guess: it closes the field and leaves the question standing.
+	footerTyping = "enter send · esc back to the list"
+)
+
+// defaultTextLabel names the row that opens the answer field.
+const defaultTextLabel = "Other…"
+
+// richOverlayProtocol is the first host build that draws checkboxes and the
+// answer field. See terminal.HostProtocol.
+const richOverlayProtocol = 2
 
 // Prompt is one question helios is waiting on a human to answer.
 type Prompt struct {
@@ -36,21 +50,42 @@ type Prompt struct {
 	Body []string
 	// Choices are the answers, in the order they are shown.
 	Choices []string
+	// Details are descriptions of the choices, index-aligned with them. A short
+	// slice or a blank entry means that choice has none.
+	Details []string
+	// Multi lets the user tick more than one choice and answer with the set.
+	Multi bool
+	// AllowText adds a row that opens a field for an answer none of the choices
+	// carry.
+	AllowText bool
+	// TextLabel names that row. Empty means "Other…".
+	TextLabel string
 }
 
 // Answer is how a terminal user resolved a prompt.
 type Answer struct {
-	// Index selects Prompt.Choices, or is negative when the user cancelled.
+	// Index selects Prompt.Choices for a single-choice prompt, and is negative
+	// when the user chose nothing.
 	Index int
+	// Indexes selects them for a Multi prompt.
+	Indexes []int
+	// Text is what the user typed instead of choosing.
+	Text string
 }
 
-// Cancelled reports whether the user dismissed the prompt instead of choosing.
-func (a Answer) Cancelled() bool { return a.Index < 0 }
+// Cancelled reports whether the user dismissed the prompt instead of answering.
+// A typed answer carries no index, so an index alone cannot decide this.
+func (a Answer) Cancelled() bool {
+	return a.Index < 0 && len(a.Indexes) == 0 && a.Text == ""
+}
 
 // Overlays is the part of the terminal backend a Controller drives.
 type Overlays interface {
 	SetOverlay(sessionID string, o terminal.Overlay) error
 	ClearOverlay(sessionID string) error
+	// OverlayProtocol reports what the host behind a session can draw. A
+	// session with no host reports 0.
+	OverlayProtocol(sessionID string) int
 }
 
 // Controller holds the prompt each session is waiting on and turns keystrokes
@@ -67,11 +102,14 @@ type live struct {
 	prompt   Prompt
 	onAnswer func(Answer)
 
-	// mu guards selected alone. Input arrives on the mirror's read goroutine
-	// while the hook's goroutine may be releasing the prompt, and the highlight
-	// is the one field both can touch.
+	// mu guards the answer being assembled. Input arrives on the mirror's read
+	// goroutine while the hook's goroutine may be releasing the prompt, and
+	// these are the fields both can touch.
 	mu       sync.Mutex
 	selected int
+	checked  []bool
+	text     string
+	editing  bool
 
 	// answered guards the callback: two Enters, or an Enter racing an Escape,
 	// must still produce exactly one answer.
@@ -96,11 +134,32 @@ func (c *Controller) Ask(sessionID string, p Prompt, onAnswer func(Answer)) (rel
 	if c == nil || c.terms == nil {
 		return func() {}, ErrNoTerminal
 	}
-	if len(p.Choices) == 0 {
+	if len(p.Choices) == 0 && !p.AllowText {
 		return func() {}, errors.New("hitl: prompt has no choices")
+	}
+	// An older host ignores the fields it has never heard of. A description is
+	// no loss that way, but the other two are: checkboxes would draw a
+	// multi-select question as a single-select list, and the answer field would
+	// hide the line the user is typing into.
+	//
+	// So the answer field is dropped rather than mourned — the choices are still
+	// answerable, and anything the user wants to write is still on the phone.
+	// Checkboxes have no such half measure, and neither does a question whose
+	// only row was the field, so those go to the phone whole.
+	if c.terms.OverlayProtocol(sessionID) < richOverlayProtocol {
+		if p.Multi || len(p.Choices) == 0 {
+			return func() {}, fmt.Errorf("hitl: host cannot draw this prompt: %w", ErrNoTerminal)
+		}
+		p.AllowText = false
 	}
 
 	l := &live{prompt: p, onAnswer: onAnswer}
+	if p.Multi {
+		l.checked = make([]bool, len(p.Choices))
+	}
+	// A question with no choices is asking to be typed into. Opening the field
+	// saves an Enter whose only purpose would be to open it.
+	l.editing = len(p.Choices) == 0
 
 	c.mu.Lock()
 	// Last prompt wins. Two blocking hooks for one session at once is not a
@@ -154,8 +213,11 @@ func (c *Controller) HandleInput(sessionID string, keys []byte) {
 		return
 	}
 
+	// The mode is read once for the whole frame. A frame that both opens the
+	// answer field and types into it would be decoded under the old mode, which
+	// no terminal produces: it sends what the user pressed, as they press it.
 	moved := false
-	for _, ev := range decodeKeys(keys) {
+	for _, ev := range decodeKeys(keys, l.isEditing()) {
 		switch ev.kind {
 		case keyPrev:
 			moved = l.move(-1) || moved
@@ -165,9 +227,20 @@ func (c *Controller) HandleInput(sessionID string, keys []byte) {
 			if ev.n < len(l.prompt.Choices) {
 				moved = l.jump(ev.n) || moved
 			}
+		case keyToggle:
+			moved = l.toggle() || moved
+		case keyText:
+			moved = l.insert(ev.s) || moved
+		case keyErase, keyEraseWord, keyEraseLine:
+			moved = l.erase(ev.kind) || moved
+		case keyLeaveField:
+			moved = l.leaveField() || moved
 		case keyConfirm:
-			l.answer(Answer{Index: l.at()})
-			return
+			if a, done := l.confirm(); done {
+				l.answer(a)
+				return
+			}
+			moved = true
 		case keyCancel:
 			l.answer(Answer{Index: -1})
 			return
@@ -188,17 +261,31 @@ func (c *Controller) Pending(sessionID string) bool {
 	return c.pending[sessionID] != nil
 }
 
+// rows is how many places the highlight can land: the choices, and the row that
+// opens the answer field.
+func (l *live) rows() int {
+	n := len(l.prompt.Choices)
+	if l.prompt.AllowText {
+		n++
+	}
+	return n
+}
+
 // move shifts the highlight and reports whether it actually went anywhere.
 // Movement stops at the ends rather than wrapping, so holding an arrow key
-// cannot roll past "Deny" onto "Allow".
+// cannot roll past "Deny" onto "Allow". Moving also closes the answer field:
+// the arrow was aimed at the list.
 func (l *live) move(delta int) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	next := l.selected + delta
-	if next < 0 || next >= len(l.prompt.Choices) || next == l.selected {
+	if next < 0 || next >= l.rows() {
 		return false
 	}
-	l.selected = next
+	if next == l.selected && !l.editing {
+		return false
+	}
+	l.selected, l.editing = next, false
 	return true
 }
 
@@ -212,10 +299,105 @@ func (l *live) jump(to int) bool {
 	return true
 }
 
-func (l *live) at() int {
+// toggle ticks the highlighted choice on a multi-select prompt. The row that
+// opens the answer field has nothing to tick.
+func (l *live) toggle() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.selected
+	if !l.prompt.Multi || l.selected < 0 || l.selected >= len(l.checked) {
+		return false
+	}
+	l.checked[l.selected] = !l.checked[l.selected]
+	return true
+}
+
+// insert adds typed or pasted characters to the answer. Newlines become spaces:
+// the field is one line, and Enter is how it is sent.
+func (l *live) insert(s string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.editing || s == "" {
+		return false
+	}
+	l.text += strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' {
+			return ' '
+		}
+		return r
+	}, s)
+	return true
+}
+
+// erase removes the rune, the word or the line behind the caret.
+func (l *live) erase(k key) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.editing || l.text == "" {
+		return false
+	}
+	switch k {
+	case keyEraseLine:
+		l.text = ""
+	case keyEraseWord:
+		trimmed := strings.TrimRight(l.text, " ")
+		if i := strings.LastIndex(trimmed, " "); i >= 0 {
+			l.text = trimmed[:i+1]
+		} else {
+			l.text = ""
+		}
+	default:
+		r := []rune(l.text)
+		l.text = string(r[:len(r)-1])
+	}
+	return true
+}
+
+// leaveField closes the answer field, keeping what was typed. The prompt stays
+// on screen: only a second Escape takes it down.
+func (l *live) leaveField() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.editing {
+		return false
+	}
+	l.editing = false
+	return true
+}
+
+// confirm decides what Enter meant. It reports the answer, and whether the
+// prompt is over: on the answer-field row Enter opens the field instead, and an
+// empty field closes it rather than sending nothing.
+func (l *live) confirm() (Answer, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.editing {
+		if text := strings.TrimSpace(l.text); text != "" {
+			return Answer{Index: -1, Text: text}, true
+		}
+		l.editing = false
+		return Answer{}, false
+	}
+	if l.prompt.AllowText && l.selected == len(l.prompt.Choices) {
+		l.editing = true
+		return Answer{}, false
+	}
+	if l.prompt.Multi {
+		var picked []int
+		for i, on := range l.checked {
+			if on {
+				picked = append(picked, i)
+			}
+		}
+		return Answer{Index: -1, Indexes: picked}, true
+	}
+	return Answer{Index: l.selected}, true
+}
+
+func (l *live) isEditing() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.editing
 }
 
 // answer delivers the user's choice exactly once, off the read goroutine.
@@ -228,11 +410,30 @@ func (l *live) answer(a Answer) {
 }
 
 func (l *live) overlay() terminal.Overlay {
-	return terminal.Overlay{
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	o := terminal.Overlay{
 		Title:    l.prompt.Title,
 		Body:     l.prompt.Body,
 		Options:  l.prompt.Choices,
-		Selected: l.at(),
+		Details:  l.prompt.Details,
+		Selected: l.selected,
 		Footer:   footer,
 	}
+	if l.prompt.Multi {
+		o.Checked = append([]bool(nil), l.checked...)
+		o.Footer = footerMulti
+	}
+	if l.prompt.AllowText {
+		label := l.prompt.TextLabel
+		if label == "" {
+			label = defaultTextLabel
+		}
+		o.Input = &terminal.OverlayInput{Label: label, Value: l.text, Active: l.editing}
+	}
+	if l.editing {
+		o.Footer = footerTyping
+	}
+	return o
 }

--- a/internal/hitl/hitl_test.go
+++ b/internal/hitl/hitl_test.go
@@ -12,10 +12,11 @@ import (
 // fakeOverlays records what a controller painted, standing in for the terminal
 // backend.
 type fakeOverlays struct {
-	mu      sync.Mutex
-	painted []terminal.Overlay
-	cleared []string
-	setErr  error
+	mu       sync.Mutex
+	painted  []terminal.Overlay
+	cleared  []string
+	setErr   error
+	protocol int
 }
 
 func (f *fakeOverlays) SetOverlay(sessionID string, o terminal.Overlay) error {
@@ -35,6 +36,17 @@ func (f *fakeOverlays) ClearOverlay(sessionID string) error {
 	return nil
 }
 
+// OverlayProtocol reports a current host unless a test says otherwise, so the
+// zero value of fakeOverlays is not an ancient terminal.
+func (f *fakeOverlays) OverlayProtocol(sessionID string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.protocol == 0 {
+		return terminal.HostProtocol
+	}
+	return f.protocol
+}
+
 func (f *fakeOverlays) last() (terminal.Overlay, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -42,6 +54,12 @@ func (f *fakeOverlays) last() (terminal.Overlay, bool) {
 		return terminal.Overlay{}, false
 	}
 	return f.painted[len(f.painted)-1], true
+}
+
+func (f *fakeOverlays) paints() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.painted)
 }
 
 func (f *fakeOverlays) clears() int {
@@ -59,10 +77,15 @@ var testPrompt = Prompt{
 // ask wires a controller to a fake terminal and a channel of answers.
 func ask(t *testing.T) (*Controller, *fakeOverlays, chan Answer, func()) {
 	t.Helper()
+	return askPrompt(t, testPrompt)
+}
+
+func askPrompt(t *testing.T, p Prompt) (*Controller, *fakeOverlays, chan Answer, func()) {
+	t.Helper()
 	terms := &fakeOverlays{}
 	c := NewController(terms)
 	answers := make(chan Answer, 4)
-	release, err := c.Ask("s1", testPrompt, func(a Answer) { answers <- a })
+	release, err := c.Ask("s1", p, func(a Answer) { answers <- a })
 	if err != nil {
 		t.Fatalf("Ask: %v", err)
 	}
@@ -249,5 +272,245 @@ func TestAPromptWithNoChoicesIsRejected(t *testing.T) {
 	c := NewController(&fakeOverlays{})
 	if _, err := c.Ask("s1", Prompt{Title: "empty"}, nil); err == nil {
 		t.Error("expected an error for a prompt with nothing to choose")
+	}
+}
+
+var multiPrompt = Prompt{
+	Title:   "Which checks to run",
+	Choices: []string{"Unit tests", "Race detector", "Flutter analyze"},
+	Multi:   true,
+}
+
+var typedPrompt = Prompt{
+	Title:     "Next step",
+	Choices:   []string{"Live repro", "Code review"},
+	AllowText: true,
+}
+
+func TestDescriptionsReachTheOverlay(t *testing.T) {
+	_, terms, _, _ := askPrompt(t, Prompt{
+		Title:   "Next step",
+		Choices: []string{"Live repro", "Code review"},
+		Details: []string{"Drive the real TUI.", "Read the diff."},
+	})
+
+	o, _ := terms.last()
+	if len(o.Details) != 2 || o.Details[0] != "Drive the real TUI." {
+		t.Errorf("details = %v, want both descriptions", o.Details)
+	}
+}
+
+// A permission prompt asks for none of this, and has to paint exactly what it
+// painted before the fields existed — an older host is reading the same bytes.
+func TestAPlainPromptCarriesNoneOfTheNewFields(t *testing.T) {
+	_, terms, _, _ := ask(t)
+
+	o, _ := terms.last()
+	if o.Details != nil || o.Checked != nil || o.Input != nil {
+		t.Errorf("overlay = %+v, want no details, checkboxes or field", o)
+	}
+}
+
+func TestSpaceTicksAChoice(t *testing.T) {
+	c, terms, _, _ := askPrompt(t, multiPrompt)
+
+	c.HandleInput("s1", []byte(" "))
+	o, _ := terms.last()
+	if len(o.Checked) != 3 || !o.Checked[0] {
+		t.Errorf("checked = %v, want the first choice ticked", o.Checked)
+	}
+
+	c.HandleInput("s1", []byte(" "))
+	o, _ = terms.last()
+	if o.Checked[0] {
+		t.Error("a second space did not untick the choice")
+	}
+}
+
+func TestSpaceDoesNothingOnASingleChoicePrompt(t *testing.T) {
+	c, terms, answers, _ := ask(t)
+
+	c.HandleInput("s1", []byte(" "))
+	o, _ := terms.last()
+	if o.Checked != nil {
+		t.Errorf("checked = %v, want none on a single-choice prompt", o.Checked)
+	}
+	select {
+	case a := <-answers:
+		t.Fatalf("space answered the prompt: %+v", a)
+	default:
+	}
+}
+
+func TestEnterAnswersWithEveryTickedChoice(t *testing.T) {
+	c, _, answers, _ := askPrompt(t, multiPrompt)
+
+	c.HandleInput("s1", []byte(" "))      // tick the first
+	c.HandleInput("s1", []byte("\x1b[B")) // move down
+	c.HandleInput("s1", []byte(" "))      // tick the second
+	c.HandleInput("s1", []byte("\r"))
+
+	a := awaitAnswer(t, answers)
+	if a.Cancelled() {
+		t.Fatalf("answer = %+v, want two choices", a)
+	}
+	if len(a.Indexes) != 2 || a.Indexes[0] != 0 || a.Indexes[1] != 1 {
+		t.Errorf("indexes = %v, want [0 1]", a.Indexes)
+	}
+}
+
+// Answering a multi-select question with nothing ticked is not an answer.
+func TestEnterWithNothingTickedIsACancel(t *testing.T) {
+	c, _, answers, _ := askPrompt(t, multiPrompt)
+
+	c.HandleInput("s1", []byte("\r"))
+	if a := awaitAnswer(t, answers); !a.Cancelled() {
+		t.Errorf("answer = %+v, want a cancel", a)
+	}
+}
+
+func TestTypingAnAnswer(t *testing.T) {
+	c, terms, answers, _ := askPrompt(t, typedPrompt)
+
+	// Down twice lands on the row past the two choices: the answer field.
+	c.HandleInput("s1", []byte("\x1b[B\x1b[B"))
+	c.HandleInput("s1", []byte("\r"))
+	o, _ := terms.last()
+	if o.Input == nil || !o.Input.Active {
+		t.Fatalf("input = %+v, want an open field", o.Input)
+	}
+	if o.Footer != footerTyping {
+		t.Errorf("footer = %q, want the typing hint", o.Footer)
+	}
+
+	c.HandleInput("s1", []byte("rebase first"))
+	o, _ = terms.last()
+	if o.Input.Value != "rebase first" {
+		t.Errorf("value = %q, want what was typed", o.Input.Value)
+	}
+
+	c.HandleInput("s1", []byte("\r"))
+	a := awaitAnswer(t, answers)
+	if a.Text != "rebase first" || a.Cancelled() {
+		t.Errorf("answer = %+v, want the typed text", a)
+	}
+}
+
+func TestBackspaceEditsTheAnswer(t *testing.T) {
+	c, terms, _, _ := askPrompt(t, typedPrompt)
+
+	c.HandleInput("s1", []byte("\x1b[B\x1b[B\r"))
+	c.HandleInput("s1", []byte("one two"))
+	c.HandleInput("s1", []byte("\x7f"))
+	if o, _ := terms.last(); o.Input.Value != "one tw" {
+		t.Errorf("value = %q, want one rune gone", o.Input.Value)
+	}
+	c.HandleInput("s1", []byte("\x17"))
+	if o, _ := terms.last(); o.Input.Value != "one " {
+		t.Errorf("value = %q, want the word gone", o.Input.Value)
+	}
+	c.HandleInput("s1", []byte("\x15"))
+	if o, _ := terms.last(); o.Input.Value != "" {
+		t.Errorf("value = %q, want the line cleared", o.Input.Value)
+	}
+}
+
+// The first Escape closes the field and leaves the question standing. Only the
+// second one throws it away.
+func TestEscapeLeavesTheFieldBeforeItCancels(t *testing.T) {
+	c, terms, answers, _ := askPrompt(t, typedPrompt)
+
+	c.HandleInput("s1", []byte("\x1b[B\x1b[B\r"))
+	c.HandleInput("s1", []byte("draft"))
+	c.HandleInput("s1", []byte("\x1b"))
+
+	o, _ := terms.last()
+	if o.Input.Active {
+		t.Error("the field is still open after Escape")
+	}
+	if o.Input.Value != "draft" {
+		t.Errorf("value = %q, want what was typed to survive", o.Input.Value)
+	}
+	select {
+	case a := <-answers:
+		t.Fatalf("the first Escape answered the prompt: %+v", a)
+	default:
+	}
+
+	c.HandleInput("s1", []byte("\x1b"))
+	if a := awaitAnswer(t, answers); !a.Cancelled() {
+		t.Errorf("answer = %+v, want a cancel", a)
+	}
+}
+
+func TestAnEmptyFieldIsNotAnAnswer(t *testing.T) {
+	c, terms, answers, _ := askPrompt(t, typedPrompt)
+
+	c.HandleInput("s1", []byte("\x1b[B\x1b[B\r"))
+	c.HandleInput("s1", []byte("\r"))
+
+	if o, _ := terms.last(); o.Input.Active {
+		t.Error("Enter on an empty field left it open")
+	}
+	select {
+	case a := <-answers:
+		t.Fatalf("an empty field answered the prompt: %+v", a)
+	default:
+	}
+}
+
+// An older host would draw a multi-select question as a single-select list,
+// which is an answer the user did not give. That one goes to the phone whole.
+func TestAnOldHostIsNotOfferedCheckboxes(t *testing.T) {
+	terms := &fakeOverlays{protocol: 1}
+	c := NewController(terms)
+
+	if _, err := c.Ask("s1", multiPrompt, nil); !errors.Is(err, ErrNoTerminal) {
+		t.Errorf("err = %v, want ErrNoTerminal", err)
+	}
+	if terms.paints() != 0 {
+		t.Error("painted a multi-select prompt on a host that cannot draw one")
+	}
+}
+
+// The answer field is the one that degrades: an older host still gets the
+// choices, and what the user wanted to write is still answerable on the phone.
+// Suppressing the whole prompt instead would leave that terminal with nothing.
+func TestAnOldHostStillGetsTheChoices(t *testing.T) {
+	terms := &fakeOverlays{protocol: 1}
+	c := NewController(terms)
+
+	if _, err := c.Ask("s1", typedPrompt, nil); err != nil {
+		t.Fatalf("err = %v, want the choices painted", err)
+	}
+	o, ok := terms.last()
+	if !ok {
+		t.Fatal("nothing was painted")
+	}
+	if o.Input != nil {
+		t.Errorf("input = %+v, want no field on a host that cannot draw one", o.Input)
+	}
+	if len(o.Options) != len(typedPrompt.Choices) {
+		t.Errorf("options = %v, want all the choices", o.Options)
+	}
+}
+
+// A question with no choices is nothing but the field, so there is no reduced
+// version of it to draw.
+func TestAnOldHostGetsNoFieldOnlyPrompt(t *testing.T) {
+	terms := &fakeOverlays{protocol: 1}
+	c := NewController(terms)
+
+	_, err := c.Ask("s1", Prompt{Title: "Name", AllowText: true}, nil)
+	if !errors.Is(err, ErrNoTerminal) {
+		t.Errorf("err = %v, want ErrNoTerminal", err)
+	}
+}
+
+// A prompt that asks for none of it is painted on any host.
+func TestAnOldHostStillGetsAPlainPrompt(t *testing.T) {
+	c := NewController(&fakeOverlays{protocol: 1})
+	if _, err := c.Ask("s1", testPrompt, nil); err != nil {
+		t.Errorf("err = %v, want it painted", err)
 	}
 }

--- a/internal/hitl/keys.go
+++ b/internal/hitl/keys.go
@@ -1,7 +1,9 @@
 package hitl
 
-// key is one thing a prompt understands. Terminal input is bytes; a prompt
-// only ever reacts to these five.
+import "bytes"
+
+// key is one thing a prompt understands. Terminal input is bytes; a prompt only
+// ever reacts to these.
 type key int
 
 const (
@@ -12,13 +14,32 @@ const (
 	keyCancel
 	// keySelect picks a choice by number, the way the CLI's own dialogs do.
 	keySelect
+	// keyToggle ticks a choice without answering, on a multi-select prompt.
+	keyToggle
+	// keyText carries characters typed into the answer field, in s.
+	keyText
+	// keyErase, keyEraseWord and keyEraseLine edit that field backwards from
+	// the caret: one rune, one word, the whole line.
+	keyErase
+	keyEraseWord
+	keyEraseLine
+	// keyLeaveField closes the answer field and leaves the prompt standing.
+	keyLeaveField
 )
 
-// event is a decoded keystroke. n carries the 0-based choice for keySelect.
+// event is a decoded keystroke. n carries the 0-based choice for keySelect, and
+// s the characters for keyText.
 type event struct {
 	kind key
 	n    int
+	s    string
 }
+
+// A terminal brackets a paste so an application can tell it from typing.
+const (
+	pasteStart = "\x1b[200~"
+	pasteEnd   = "\x1b[201~"
+)
 
 // decodeKeys turns a chunk of terminal input into prompt keys.
 //
@@ -26,17 +47,33 @@ type event struct {
 // paste delivers several keystrokes in one frame, and dropping all but the
 // first would lose moves the user made.
 //
-// A lone ESC is a cancel. That is correct for a real keypress, which arrives as
-// one byte, but a terminal that split an escape sequence across two writes
-// would read as a cancel followed by junk. No terminal in practice does, and
-// the alternative — waiting to see whether more bytes follow — would make every
-// real Escape feel slow.
-func decodeKeys(p []byte) []event {
+// The same bytes mean different things depending on whether the answer field
+// has the keyboard, so editing selects between two vocabularies. In the list
+// the digits jump the highlight and "j" moves down; in the field both are
+// characters the user meant to type.
+//
+// A lone ESC is a cancel in the list, and only closes the field while editing.
+// That is correct for a real keypress, which arrives as one byte, but a
+// terminal that split an escape sequence across two writes would read as a
+// cancel followed by junk. No terminal in practice does, and the alternative —
+// waiting to see whether more bytes follow — would make every real Escape feel
+// slow.
+func decodeKeys(p []byte, editing bool) []event {
 	var out []event
 	for i := 0; i < len(p); {
+		if text, width, ok := decodePaste(p[i:]); ok {
+			// Pasted text is only ever text. Read as keystrokes it would arrive
+			// as a burst of jumps and confirms and answer the prompt by itself.
+			if editing && text != "" {
+				out = append(out, event{kind: keyText, s: text})
+			}
+			i += width
+			continue
+		}
+
 		switch b := p[i]; {
 		case b == 0x1b:
-			ev, width := decodeEscape(p[i:])
+			ev, width := decodeEscape(p[i:], editing)
 			if ev.kind != keyIgnored {
 				out = append(out, ev)
 			}
@@ -47,11 +84,20 @@ func decodeKeys(p []byte) []event {
 		case b == 0x03: // Ctrl-C
 			out = append(out, event{kind: keyCancel})
 			i++
+		case editing:
+			ev, width := decodeEdit(p[i:])
+			if ev.kind != keyIgnored {
+				out = append(out, ev)
+			}
+			i += width
 		case b == 'k':
 			out = append(out, event{kind: keyPrev})
 			i++
 		case b == 'j':
 			out = append(out, event{kind: keyNext})
+			i++
+		case b == ' ':
+			out = append(out, event{kind: keyToggle})
 			i++
 		case b >= '1' && b <= '9':
 			out = append(out, event{kind: keySelect, n: int(b - '1')})
@@ -63,6 +109,45 @@ func decodeKeys(p []byte) []event {
 	return out
 }
 
+// decodeEdit reads one editing keystroke from the front of p, which is neither
+// an escape sequence, a newline nor a Ctrl-C.
+func decodeEdit(p []byte) (event, int) {
+	switch b := p[0]; {
+	case b == 0x7f || b == 0x08:
+		return event{kind: keyErase}, 1
+	case b == 0x15: // Ctrl-U
+		return event{kind: keyEraseLine}, 1
+	case b == 0x17: // Ctrl-W
+		return event{kind: keyEraseWord}, 1
+	case b >= 0x20:
+		// Take the whole printable run, so a fast typist or a bracket-less
+		// paste becomes one insert rather than one event per byte. Runs stop at
+		// any control byte, which keeps multi-byte UTF-8 intact.
+		i := 0
+		for i < len(p) && p[i] >= 0x20 && p[i] != 0x7f {
+			i++
+		}
+		return event{kind: keyText, s: string(p[:i])}, i
+	default:
+		return event{kind: keyIgnored}, 1
+	}
+}
+
+// decodePaste reads a bracketed paste from the front of p and reports whether
+// one was there.
+func decodePaste(p []byte) (string, int, bool) {
+	if !bytes.HasPrefix(p, []byte(pasteStart)) {
+		return "", 0, false
+	}
+	body := p[len(pasteStart):]
+	if end := bytes.Index(body, []byte(pasteEnd)); end >= 0 {
+		return string(body[:end]), len(pasteStart) + end + len(pasteEnd), true
+	}
+	// A paste whose end marker has not arrived yet. Take what is here: the rest
+	// lands as ordinary input, which is what an unbracketed paste does anyway.
+	return string(body), len(p), true
+}
+
 // decodeEscape reads one escape sequence from the front of p, which begins with
 // ESC, and reports how many bytes it consumed.
 //
@@ -71,9 +156,13 @@ func decodeKeys(p []byte) []event {
 // cursor keys mode (DECCKM, "ESC [ ? 1 h"), after which the same keys arrive as
 // SS3 — "ESC O A". Both have to move the highlight, or the prompt is unanswerable
 // with the arrow keys the moment an alt-screen agent is on screen.
-func decodeEscape(p []byte) (event, int) {
+func decodeEscape(p []byte, editing bool) (event, int) {
+	lone := event{kind: keyCancel}
+	if editing {
+		lone = event{kind: keyLeaveField}
+	}
 	if len(p) < 3 || (p[1] != '[' && p[1] != 'O') {
-		return event{kind: keyCancel}, 1
+		return lone, 1
 	}
 	switch p[2] {
 	case 'A':

--- a/internal/hitl/keys_test.go
+++ b/internal/hitl/keys_test.go
@@ -41,11 +41,59 @@ func TestDecodeKeys(t *testing.T) {
 		{"empty", "", nil},
 		// A truncated sequence must not run off the end of the buffer.
 		{"bare csi", "\x1b[", []event{{kind: keyCancel}}},
+		{"space toggles", " ", []event{{kind: keyToggle}}},
+		// Pasted text read as keystrokes would jump and confirm its way to an
+		// answer nobody chose.
+		{"paste is skipped whole", "\x1b[200~2 j\x1b[201~", nil},
+		{"paste then enter", "\x1b[200~x\x1b[201~\r", []event{{kind: keyConfirm}}},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := decodeKeys([]byte(c.in))
+			got := decodeKeys([]byte(c.in), false)
+			if len(got) != len(c.want) {
+				t.Fatalf("decodeKeys(%q) = %v, want %v", c.in, got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("key %d = %v, want %v", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeKeysWhileEditing pins the other vocabulary. The same bytes that
+// drive the list are characters once the answer field has the keyboard.
+func TestDecodeKeysWhileEditing(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []event
+	}{
+		{"letters are text", "hello", []event{{kind: keyText, s: "hello"}}},
+		{"digits are text", "13", []event{{kind: keyText, s: "13"}}},
+		{"vi keys are text", "jk", []event{{kind: keyText, s: "jk"}}},
+		{"space is text", "a b", []event{{kind: keyText, s: "a b"}}},
+		{"utf-8 survives", "héllo…", []event{{kind: keyText, s: "héllo…"}}},
+		{"backspace", "\x7f", []event{{kind: keyErase}}},
+		{"ctrl-u clears the line", "\x15", []event{{kind: keyEraseLine}}},
+		{"ctrl-w deletes a word", "\x17", []event{{kind: keyEraseWord}}},
+		// The first Escape closes the field. Only the second cancels, and the
+		// footer says so while the field is open.
+		{"escape leaves the field", "\x1b", []event{{kind: keyLeaveField}}},
+		{"ctrl-c still cancels", "\x03", []event{{kind: keyCancel}}},
+		{"enter sends", "\r", []event{{kind: keyConfirm}}},
+		{"arrows still move", "\x1b[B", []event{{kind: keyNext}}},
+		{"paste is inserted", "\x1b[200~2 j\x1b[201~", []event{{kind: keyText, s: "2 j"}}},
+		{"typing then enter", "ok\r", []event{{kind: keyText, s: "ok"}, {kind: keyConfirm}}},
+		// A paste whose end marker has not arrived yet still has to land as text.
+		{"unterminated paste", "\x1b[200~half", []event{{kind: keyText, s: "half"}}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := decodeKeys([]byte(c.in), true)
 			if len(got) != len(c.want) {
 				t.Fatalf("decodeKeys(%q) = %v, want %v", c.in, got, c.want)
 			}

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -1235,7 +1235,10 @@ func TestQuestion_SkippedFromTheTerminal(t *testing.T) {
 // A free-text question has no options to list, so the overlay stays away and
 // the phone keeps it. Painting a choice-less box would block the terminal on a
 // prompt it cannot answer.
-func TestQuestion_FreeTextIsLeftToThePhone(t *testing.T) {
+// A question with no options wants free text. The overlay opens the field for
+// it rather than sending the whole set to the phone, which is what it did
+// before the field existed.
+func TestQuestion_FreeTextOpensTheFieldInTheTerminal(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 	overlays, _ := withTerminal(ctx)
@@ -1245,10 +1248,9 @@ func TestQuestion_FreeTextIsLeftToThePhone(t *testing.T) {
 		ToolInput: questionInput(t, oneQuestion("What should it be called?", "Name")),
 	})
 
-	select {
-	case o := <-overlays.painted:
-		t.Fatalf("painted %+v, want nothing the terminal cannot answer", o)
-	case <-time.After(200 * time.Millisecond):
+	o := awaitOverlay(t, overlays)
+	if o.Input == nil || !o.Input.Active {
+		t.Fatalf("painted %+v, want an open answer field", o)
 	}
 
 	ctx.Mgr.Resolve(notifID, notifications.Decision{
@@ -1693,6 +1695,12 @@ func (p *paintedOverlays) SetOverlay(sessionID string, o terminal.Overlay) error
 func (p *paintedOverlays) ClearOverlay(sessionID string) error {
 	p.cleared <- sessionID
 	return nil
+}
+
+// OverlayProtocol reports a host of this build, so a prompt that needs
+// checkboxes or the answer field is painted rather than left to the phone.
+func (p *paintedOverlays) OverlayProtocol(sessionID string) int {
+	return terminal.HostProtocol
 }
 
 // withTerminal gives a context a terminal that can be painted on, as a live

--- a/internal/provider/claude/question.go
+++ b/internal/provider/claude/question.go
@@ -22,9 +22,10 @@ type questionOption struct {
 
 // questionSpec is one entry of the AskUserQuestion tool input.
 type questionSpec struct {
-	Question string           `json:"question"`
-	Header   string           `json:"header"`
-	Options  []questionOption `json:"options"`
+	Question    string           `json:"question"`
+	Header      string           `json:"header"`
+	Options     []questionOption `json:"options"`
+	MultiSelect bool             `json:"multiSelect"`
 }
 
 // questionPayload is the tool input as the notification stores it: the CLI's
@@ -65,14 +66,6 @@ func showQuestionPrompt(ctx *provider.HookContext, sessionID, notifID string, qu
 	if len(questions) == 0 {
 		return func() {}
 	}
-	for _, q := range questions {
-		// A question with no options wants free text, which a list of choices
-		// cannot collect. Leaving the whole set to the phone beats answering
-		// half of it from the terminal.
-		if len(q.Options) == 0 {
-			return func() {}
-		}
-	}
 
 	a := &questionAsker{ctx: ctx, sessionID: sessionID, notifID: notifID, questions: questions}
 	a.ask(0)
@@ -92,6 +85,7 @@ type questionAsker struct {
 	// this may be taking the prompt down.
 	mu      sync.Mutex
 	chosen  []selection
+	typed   map[int]string
 	release func()
 	stopped bool
 }
@@ -104,6 +98,11 @@ func (a *questionAsker) ask(i int) {
 		Title:   a.title(i),
 		Body:    nonEmpty([]string{q.Question}),
 		Choices: optionLabels(q),
+		Details: optionDescriptions(q),
+		Multi:   q.MultiSelect,
+		// The CLI always takes an answer none of its options carry, so the row
+		// that collects one is not conditional.
+		AllowText: true,
 	}, func(ans hitl.Answer) { a.answered(i, ans) }))
 }
 
@@ -129,8 +128,21 @@ func (a *questionAsker) answered(i int, ans hitl.Answer) {
 	}
 
 	a.mu.Lock()
-	a.chosen = append(a.chosen, selection{QuestionIndex: i, OptionIndex: ans.Index})
+	switch {
+	case ans.Text != "":
+		if a.typed == nil {
+			a.typed = make(map[int]string)
+		}
+		a.typed[i] = ans.Text
+	case len(ans.Indexes) > 0:
+		for _, idx := range ans.Indexes {
+			a.chosen = append(a.chosen, selection{QuestionIndex: i, OptionIndex: idx})
+		}
+	default:
+		a.chosen = append(a.chosen, selection{QuestionIndex: i, OptionIndex: ans.Index})
+	}
 	chosen := append([]selection(nil), a.chosen...)
+	text := a.typedText()
 	a.mu.Unlock()
 
 	if i+1 < len(a.questions) {
@@ -138,12 +150,31 @@ func (a *questionAsker) answered(i int, ans hitl.Answer) {
 		return
 	}
 
-	response, err := json.Marshal(questionAnswer{Selections: chosen})
+	response, err := json.Marshal(questionAnswer{Selections: chosen, Text: text})
 	if err != nil {
 		log.Printf("hook: encode question answer for %s: %v", a.notifID, err)
 		return
 	}
 	a.resolve(notifications.Decision{Status: "answered", Response: response})
+}
+
+// typedText renders the answers the user wrote rather than picked. A set of
+// questions shares one text field on the wire, so each answer past the first
+// says which question it belongs to. The caller holds mu.
+func (a *questionAsker) typedText() string {
+	if len(a.typed) == 0 {
+		return ""
+	}
+	if len(a.questions) == 1 {
+		return a.typed[0]
+	}
+	lines := make([]string, 0, len(a.typed))
+	for i := range a.questions {
+		if text, ok := a.typed[i]; ok {
+			lines = append(lines, fmt.Sprintf("%s: %s", a.title(i), text))
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // resolve settles the one notification both surfaces share, so the first answer
@@ -190,6 +221,23 @@ func optionLabels(q questionSpec) []string {
 		labels = append(labels, o.Label)
 	}
 	return labels
+}
+
+// optionDescriptions returns the reasoning under each label, or nil when the
+// question carries none — the overlay leaves the field out entirely then, and
+// an older host sees the JSON it has always seen.
+func optionDescriptions(q questionSpec) []string {
+	found := false
+	details := make([]string, 0, len(q.Options))
+	for _, o := range q.Options {
+		d := strings.TrimSpace(o.Description)
+		found = found || d != ""
+		details = append(details, d)
+	}
+	if !found {
+		return nil
+	}
+	return details
 }
 
 func skipResponse() json.RawMessage {

--- a/internal/provider/claude/question_test.go
+++ b/internal/provider/claude/question_test.go
@@ -136,3 +136,49 @@ func TestParseQuestions(t *testing.T) {
 		t.Errorf("questions = %+v, want nil for input that cannot be read", got)
 	}
 }
+
+func TestOptionDescriptions(t *testing.T) {
+	got := optionDescriptions(questionSpec{Options: []questionOption{
+		{Label: "Yes", Description: "  Ship it.  "},
+		{Label: "No"},
+	}})
+	if len(got) != 2 || got[0] != "Ship it." || got[1] != "" {
+		t.Errorf("descriptions = %q, want the first trimmed and the second blank", got)
+	}
+
+	// A question with nothing to explain leaves the field out of the overlay
+	// JSON entirely, which is what an older host has always received.
+	none := optionDescriptions(questionSpec{Options: []questionOption{{Label: "Yes"}, {Label: "No"}}})
+	if none != nil {
+		t.Errorf("descriptions = %q, want nil when no option carries one", none)
+	}
+}
+
+func TestParseQuestionsReadsMultiSelect(t *testing.T) {
+	qs := parseQuestions(json.RawMessage(
+		`{"questions":[{"question":"Which?","header":"Checks","multiSelect":true,` +
+			`"options":[{"label":"Unit","description":"go test ./..."},{"label":"Race"}]}]}`))
+	if len(qs) != 1 {
+		t.Fatalf("questions = %+v, want one", qs)
+	}
+	if !qs[0].MultiSelect {
+		t.Error("multiSelect was dropped")
+	}
+	if qs[0].Options[0].Description != "go test ./..." {
+		t.Errorf("description = %q, want the option's own words", qs[0].Options[0].Description)
+	}
+}
+
+// Two options ticked on one question are two selections sharing a question
+// index. The wire shape already allowed this; nothing about it is new.
+func TestQuestionReason_TwoOptionsOnOneQuestion(t *testing.T) {
+	d := &notifications.Decision{Response: json.RawMessage(
+		`{"selections":[{"question_index":0,"option_index":0},{"question_index":0,"option_index":1}]}`)}
+
+	got := questionReason(threeQuestions[:1], d)
+	for _, want := range []string{"Every host", "Only the active host"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reason is missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/terminal/mirror.go
+++ b/internal/terminal/mirror.go
@@ -198,6 +198,11 @@ func (m *Mirror) SetOverlay(o Overlay) error { return m.client.SetOverlay(o) }
 // ClearOverlay takes the modal down and hands input back to the PTY.
 func (m *Mirror) ClearOverlay() error { return m.client.ClearOverlay() }
 
+// Protocol reports the frame vocabulary the host on the other end understands.
+// It is read from the sidecar when the mirror connects and never changes: the
+// host would have to restart to speak anything else.
+func (m *Mirror) Protocol() int { return m.protocol }
+
 // SessionID returns the session this mirror follows.
 func (m *Mirror) SessionID() string { return m.sessionID }
 

--- a/internal/terminal/overlay.go
+++ b/internal/terminal/overlay.go
@@ -20,10 +20,33 @@ type Overlay struct {
 	Body []string `json:"body,omitempty"`
 	// Options are the choices. An empty list renders an informational box.
 	Options []string `json:"options,omitempty"`
-	// Selected indexes Options. Out-of-range values highlight nothing.
+	// Details are per-option descriptions, index-aligned with Options. A short
+	// slice or a blank entry means that option has none.
+	Details []string `json:"details,omitempty"`
+	// Checked ticks the options of a multi-select prompt, index-aligned with
+	// Options. A nil slice renders a single-select list with no checkboxes.
+	Checked []bool `json:"checked,omitempty"`
+	// Input is the typed-answer row, drawn after the options. Nil leaves it off.
+	Input *OverlayInput `json:"input,omitempty"`
+	// Selected indexes Options, or equals len(Options) to mean the Input row.
+	// Out-of-range values highlight nothing.
 	Selected int `json:"selected"`
 	// Footer is the key hint line.
 	Footer string `json:"footer,omitempty"`
+}
+
+// OverlayInput is the row that collects an answer none of the options carry.
+//
+// Details, Checked and Input are all additive and omitted when empty: a host
+// from an older build ignores them and paints the option labels alone, which is
+// what it did before they existed.
+type OverlayInput struct {
+	// Label is the row that opens the field, e.g. "Other…".
+	Label string `json:"label"`
+	// Value is what has been typed so far.
+	Value string `json:"value"`
+	// Active reports that the field holds the keyboard.
+	Active bool `json:"active"`
 }
 
 // ParseOverlay decodes a FrameOverlaySet payload.
@@ -123,23 +146,15 @@ func overlayBox(o Overlay, width int) []string {
 		}
 	}
 
-	if len(o.Options) > 0 {
+	if len(o.Options) > 0 || o.Input != nil {
 		if len(o.Body) > 0 {
 			lines = append(lines, boxRow("", "", width))
 		}
-		for i, opt := range o.Options {
-			text := ansi.Truncate(opt, width-2, "…")
-			raw := "  " + text
-			styled := "  " + text
-			if i == o.Selected {
-				raw = "❯ " + text
-				styled = sgrReverse + "❯ " + text + strings.Repeat(" ", max(width-2-ansi.StringWidth(text), 0)) + sgrReset
-				// Already padded to the full width so the highlight is a bar,
-				// not a ragged block ending at the label.
-				lines = append(lines, "│ "+styled+" │")
-				continue
-			}
-			lines = append(lines, boxRow(raw, styled, width))
+		for i := range o.Options {
+			lines = append(lines, optionRows(o, i, width)...)
+		}
+		if o.Input != nil {
+			lines = append(lines, inputRows(o, width)...)
 		}
 	}
 
@@ -150,6 +165,107 @@ func overlayBox(o Overlay, width int) []string {
 	}
 
 	return append(lines, "└"+strings.Repeat("─", inner)+"┘")
+}
+
+// optionRows draws one choice and the description under it.
+func optionRows(o Overlay, i, width int) []string {
+	mark := ""
+	if i < len(o.Checked) {
+		mark = "[ ] "
+		if o.Checked[i] {
+			mark = "[x] "
+		}
+	}
+	text := ansi.Truncate(o.Options[i], width-2-ansi.StringWidth(mark), "…")
+
+	rows := []string{selectableRow(mark+text, i == o.Selected, width)}
+	if i < len(o.Details) {
+		// Indented past the checkbox as well, so the description keeps sitting
+		// under the label rather than under the box.
+		rows = append(rows, detailRows(o.Details[i], detailIndent+ansi.StringWidth(mark), width)...)
+	}
+	return rows
+}
+
+// selectableRow draws a row that the highlight can land on.
+func selectableRow(text string, selected bool, width int) string {
+	if !selected {
+		raw := "  " + text
+		return boxRow(raw, raw, width)
+	}
+	// Padded to the full width so the highlight is a bar, not a ragged block
+	// ending at the label.
+	body := "❯ " + text
+	pad := strings.Repeat(" ", max(width-ansi.StringWidth(body), 0))
+	return "│ " + sgrReverse + body + pad + sgrReset + " │"
+}
+
+// detailMaxLines caps a description. The box is anchored to the bottom and
+// clips from the top, so an uncapped description pushes the question itself off
+// the screen.
+const detailMaxLines = 2
+
+// detailIndent sets a description in from its label. Two columns would leave it
+// in the same column as an unselected label, and the list would read as one
+// paragraph.
+const detailIndent = 4
+
+// detailRows wraps one option's description, dim and indented under the label.
+func detailRows(detail string, at, width int) []string {
+	if strings.TrimSpace(detail) == "" {
+		return nil
+	}
+	avail := width - at
+	if avail < 1 {
+		return nil
+	}
+	wrapped := wrapLine(detail, avail)
+	if len(wrapped) > detailMaxLines {
+		wrapped = wrapped[:detailMaxLines]
+		last := detailMaxLines - 1
+		wrapped[last] = ansi.Truncate(wrapped[last], avail-1, "") + "…"
+	}
+
+	indent := strings.Repeat(" ", at)
+	rows := make([]string, 0, len(wrapped))
+	for _, line := range wrapped {
+		rows = append(rows, boxRow(indent+line, indent+sgrDim+line+sgrReset, width))
+	}
+	return rows
+}
+
+// inputRows draws the typed-answer row, and the field itself once it is active.
+func inputRows(o Overlay, width int) []string {
+	in := o.Input
+	label := ansi.Truncate(in.Label, width-2, "…")
+	rows := []string{selectableRow(label, o.Selected == len(o.Options), width)}
+	if !in.Active {
+		return rows
+	}
+
+	frame := width - detailIndent
+	text := frame - 2
+	if text < 1 {
+		return rows
+	}
+
+	// The caret rides at the end of the value, and a value longer than the
+	// field scrolls: the tail is where the typing is happening.
+	field := in.Value + "█"
+	if w := ansi.StringWidth(field); w > text {
+		field = ansi.TruncateLeft(field, w-text+1, "…")
+	}
+
+	pad := strings.Repeat(" ", 2)
+	edge := strings.Repeat("─", frame)
+	top := pad + "┌" + edge + "┐"
+	mid := pad + "│ " + field + strings.Repeat(" ", max(text-ansi.StringWidth(field), 0)) + " │"
+	bottom := pad + "└" + edge + "┘"
+	return append(rows,
+		boxRow(top, top, width),
+		boxRow(mid, mid, width),
+		boxRow(bottom, bottom, width),
+	)
 }
 
 // boxRow pads styled to width using raw's display width, so SGR bytes do not

--- a/internal/terminal/overlay_host_test.go
+++ b/internal/terminal/overlay_host_test.go
@@ -260,3 +260,34 @@ func TestHostIgnoresOverlayFromANonControlViewer(t *testing.T) {
 		t.Error("a non-control viewer set an overlay")
 	}
 }
+
+// The new fields have to survive the socket, not just the renderer: the daemon
+// marshals them here and a separate ptyhost process is what draws them.
+func TestHostOverlayCarriesDescriptionsCheckboxesAndTheField(t *testing.T) {
+	h, _, ctl, view := overlaidHost(t, "ov-rich")
+
+	setOverlayAndWait(t, h, ctl, Overlay{
+		Title:    "Which checks to run",
+		Options:  []string{"Unit tests", "Race detector"},
+		Details:  []string{"go test across the daemon.", "Slow, but it finds the races."},
+		Checked:  []bool{true, false},
+		Input:    &OverlayInput{Label: "Other…", Value: "just the linter", Active: true},
+		Selected: 2,
+	})
+
+	// One frame carries the whole box, so it is waited for once and then read.
+	f, ok := nextFrameMatching(t, view, 3*time.Second, carries("Which checks to run"))
+	if !ok {
+		t.Fatal("the interactive viewer never received the overlay")
+	}
+	for _, want := range []string{
+		"go test across the daemon.", // a description
+		"[x] Unit tests",             // a ticked choice
+		"[ ] Race detector",          // an unticked one
+		"just the linter█",           // the open field, caret and all
+	} {
+		if !strings.Contains(string(f.Payload), want) {
+			t.Errorf("the painted overlay is missing %q", want)
+		}
+	}
+}

--- a/internal/terminal/overlay_test.go
+++ b/internal/terminal/overlay_test.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"bytes"
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -15,6 +16,9 @@ func TestOverlayFrameRoundTrip(t *testing.T) {
 		Title:    "Bash",
 		Body:     []string{"rm -rf build/", "Run this command?"},
 		Options:  []string{"Yes", "Yes, and don't ask again", "No"},
+		Details:  []string{"Once.", "And write the rule.", ""},
+		Checked:  []bool{false, false, true},
+		Input:    &OverlayInput{Label: "Other…", Value: "half typed", Active: true},
 		Selected: 2,
 		Footer:   "↑↓ select · enter confirm",
 	}
@@ -42,6 +46,15 @@ func TestOverlayFrameRoundTrip(t *testing.T) {
 	}
 	if strings.Join(got.Body, "|") != strings.Join(want.Body, "|") {
 		t.Errorf("body = %v, want %v", got.Body, want.Body)
+	}
+	if strings.Join(got.Details, "|") != strings.Join(want.Details, "|") {
+		t.Errorf("details = %v, want %v", got.Details, want.Details)
+	}
+	if len(got.Checked) != len(want.Checked) || !got.Checked[2] {
+		t.Errorf("checked = %v, want %v", got.Checked, want.Checked)
+	}
+	if got.Input == nil || *got.Input != *want.Input {
+		t.Errorf("input = %+v, want %+v", got.Input, want.Input)
 	}
 }
 
@@ -150,6 +163,9 @@ func TestOverlayBoxRowsAreUniformWidth(t *testing.T) {
 		Title:    "A rather long title that keeps going",
 		Body:     []string{"", "short", strings.Repeat("wrap me ", 12)},
 		Options:  []string{"yes", strings.Repeat("verbose-", 10), "no"},
+		Details:  []string{"a short reason", strings.Repeat("a long reason ", 8), ""},
+		Checked:  []bool{true, false, true},
+		Input:    &OverlayInput{Label: "Other…", Value: strings.Repeat("typed ", 12), Active: true},
 		Selected: 1,
 		Footer:   "↑↓ select · enter confirm · esc cancel",
 	}, width)
@@ -173,6 +189,119 @@ func TestWrapLineCutsAnOverlongWord(t *testing.T) {
 	for _, line := range wrapLine(strings.Repeat("x", 40), 10) {
 		if ansi.StringWidth(line) > 10 {
 			t.Errorf("wrapped line too wide: %q", line)
+		}
+	}
+}
+
+func TestRenderOverlayDrawsDescriptionsUnderTheirOptions(t *testing.T) {
+	out := string(RenderOverlay(Overlay{
+		Title:   "Next step",
+		Options: []string{"Live repro", "Code review"},
+		Details: []string{"Drive the real TUI.", "Read the whole diff."},
+	}, 80, 24))
+
+	first := strings.Index(out, "Live repro")
+	reason := strings.Index(out, "Drive the real TUI.")
+	second := strings.Index(out, "Code review")
+	if first < 0 || reason < 0 || second < 0 {
+		t.Fatalf("render is missing a label or a description:\n%s", out)
+	}
+	if !(first < reason && reason < second) {
+		t.Errorf("the description is not between its own label and the next:\n%s", out)
+	}
+	if !strings.Contains(out, sgrDim+"Drive the real TUI.") {
+		t.Errorf("the description is not dim:\n%s", out)
+	}
+}
+
+// A description is capped rather than wrapped forever: the box is anchored to
+// the bottom and clips from the top, so a long one would push the question off
+// the screen.
+func TestRenderOverlayCapsALongDescription(t *testing.T) {
+	lines := overlayBox(Overlay{
+		Options: []string{"only"},
+		Details: []string{strings.Repeat("reason ", 60)},
+	}, 40)
+
+	body := 0
+	for _, line := range lines {
+		if strings.Contains(line, "reason") {
+			body++
+		}
+	}
+	if body != detailMaxLines {
+		t.Errorf("description drew %d lines, want %d", body, detailMaxLines)
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "…") {
+		t.Error("a cut description does not say it was cut")
+	}
+}
+
+func TestRenderOverlayDrawsCheckboxes(t *testing.T) {
+	out := string(RenderOverlay(Overlay{
+		Options: []string{"Unit tests", "Race detector"},
+		Checked: []bool{true, false},
+	}, 80, 24))
+
+	if !strings.Contains(out, "[x] Unit tests") {
+		t.Errorf("a ticked option is not drawn ticked:\n%s", out)
+	}
+	if !strings.Contains(out, "[ ] Race detector") {
+		t.Errorf("an unticked option is not drawn empty:\n%s", out)
+	}
+}
+
+func TestRenderOverlayDrawsTheAnswerField(t *testing.T) {
+	closed := string(RenderOverlay(Overlay{
+		Options: []string{"Live repro"},
+		Input:   &OverlayInput{Label: "Other…"},
+	}, 80, 24))
+	if !strings.Contains(closed, "Other…") {
+		t.Errorf("the row that opens the field is missing:\n%s", closed)
+	}
+	if strings.Contains(closed, "█") {
+		t.Errorf("a closed field drew a caret:\n%s", closed)
+	}
+
+	open := string(RenderOverlay(Overlay{
+		Options:  []string{"Live repro"},
+		Input:    &OverlayInput{Label: "Other…", Value: "rebase first", Active: true},
+		Selected: 1,
+	}, 80, 24))
+	if !strings.Contains(open, "rebase first█") {
+		t.Errorf("the open field does not show the value and caret:\n%s", open)
+	}
+}
+
+// A value longer than the field scrolls: the tail is where the typing is.
+func TestRenderOverlayScrollsALongValue(t *testing.T) {
+	lines := overlayBox(Overlay{
+		Options: []string{"only"},
+		Input:   &OverlayInput{Label: "Other…", Value: strings.Repeat("x", 200) + "tail", Active: true},
+	}, 40)
+
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "tail█") {
+		t.Errorf("the end of the value is not visible:\n%s", joined)
+	}
+	if !strings.Contains(joined, "…") {
+		t.Error("a scrolled value does not say it was scrolled")
+	}
+}
+
+// The promise to a host from an older build: an overlay that uses none of the
+// new fields marshals to the bytes it always did, so that host keeps painting.
+func TestAPlainOverlayMarshalsWithoutTheNewKeys(t *testing.T) {
+	b, err := json.Marshal(Overlay{
+		Title:   "Bash",
+		Options: []string{"Allow", "Deny"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	for _, key := range []string{"details", "checked", "input"} {
+		if bytes.Contains(b, []byte(key)) {
+			t.Errorf("plain overlay carries %q: %s", key, b)
 		}
 	}
 }

--- a/internal/terminal/paths.go
+++ b/internal/terminal/paths.go
@@ -36,7 +36,11 @@ func SidecarPath(heliosDir, sessionID string) string {
 // the host on the other end of the socket will do with it.
 //
 // 1 adds FramePaste.
-const HostProtocol = 1
+// 2 renders Overlay.Details, .Checked and .Input. A host below it ignores them,
+// which is right for a description and wrong for the other two: it would draw a
+// multi-select question as a single-select list, and hide the field the user is
+// typing into. So the daemon asks before it offers either.
+const HostProtocol = 2
 
 // Sidecar is the durable session→terminal mapping. It replaces the
 // @helios_session_id tmux pane option, so the mapping survives without a

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -48,10 +48,7 @@ class _PermissionCardState extends State<PermissionCard> {
       margin: const EdgeInsets.only(bottom: 8),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.orange.withValues(alpha: 0.3),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.orange.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -72,19 +69,30 @@ class _PermissionCardState extends State<PermissionCard> {
                   },
                 ),
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.orange.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
-                    border: Border.all(color: Colors.orange.withValues(alpha: 0.3)),
+                    border: Border.all(
+                      color: Colors.orange.withValues(alpha: 0.3),
+                    ),
                   ),
-                  child: const Text('permission', style: TextStyle(fontSize: 11, color: Colors.orange)),
+                  child: const Text(
+                    'permission',
+                    style: TextStyle(fontSize: 11, color: Colors.orange),
+                  ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     n.displayTitle,
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -98,10 +106,10 @@ class _PermissionCardState extends State<PermissionCard> {
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(8),
               ),
-              constraints: const BoxConstraints(maxHeight: 100),
+              constraints: const BoxConstraints(maxHeight: 160),
               child: SingleChildScrollView(
                 child: Text(
-                  n.displayDetail,
+                  _displayInput(),
                   style: TextStyle(
                     fontFamily: 'monospace',
                     fontSize: 12,
@@ -140,17 +148,22 @@ class _PermissionCardState extends State<PermissionCard> {
                 width: double.infinity,
                 padding: const EdgeInsets.all(10),
                 decoration: BoxDecoration(
-                  border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text('Quick rules', style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    )),
+                    Text(
+                      'Quick rules',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
                     const SizedBox(height: 4),
                     ...List.generate(suggestions.length, (i) {
                       final sug = suggestions[i];
@@ -167,13 +180,18 @@ class _PermissionCardState extends State<PermissionCard> {
                           child: Row(
                             children: [
                               Icon(
-                                selected ? Icons.check_box : Icons.check_box_outline_blank,
+                                selected
+                                    ? Icons.check_box
+                                    : Icons.check_box_outline_blank,
                                 size: 18,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                               const SizedBox(width: 6),
                               Expanded(
-                                child: Text(label, style: const TextStyle(fontSize: 12)),
+                                child: Text(
+                                  label,
+                                  style: const TextStyle(fontSize: 12),
+                                ),
                               ),
                             ],
                           ),
@@ -196,7 +214,9 @@ class _PermissionCardState extends State<PermissionCard> {
                 style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
                 decoration: InputDecoration(
                   labelText: 'Edit command',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                   isDense: true,
                 ),
               ),
@@ -213,7 +233,8 @@ class _PermissionCardState extends State<PermissionCard> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: FilledButton(
-                    onPressed: () => widget.sse.sendAction(n.id, {'action': 'deny'}),
+                    onPressed: () =>
+                        widget.sse.sendAction(n.id, {'action': 'deny'}),
                     style: FilledButton.styleFrom(
                       backgroundColor: Theme.of(context).colorScheme.error,
                       foregroundColor: Theme.of(context).colorScheme.onError,
@@ -263,6 +284,32 @@ class _PermissionCardState extends State<PermissionCard> {
     }
 
     widget.sse.sendAction(n.id, body);
+  }
+
+  /// What the tool will actually do, laid out to be read.
+  ///
+  /// The notification's own detail is the command cut to 100 characters, which
+  /// hides the end of the very thing being approved. Encoding the input as JSON
+  /// instead is worse: a heredoc becomes one line of \n escapes. So the command
+  /// is shown as it is, and any other input as one field per block with its
+  /// multi-line values printed as the lines they are.
+  String _displayInput() {
+    final ti = n.payload?['tool_input'];
+    if (ti is String && ti.isNotEmpty) return ti;
+    if (ti is Map) {
+      final cmd = ti['command'];
+      if (cmd is String) return cmd;
+      if (ti.isNotEmpty) {
+        return ti.entries
+            .map((e) {
+              final v = e.value;
+              if (v is String && v.contains('\n')) return '${e.key}:\n$v';
+              return '${e.key}: ${v is String ? v : jsonEncode(v)}';
+            })
+            .join('\n\n');
+      }
+    }
+    return n.displayDetail;
   }
 
   String _getEditableInput() {
@@ -349,7 +396,9 @@ class _QuestionCardState extends State<QuestionCard> {
       if (text.isEmpty) continue;
       if (questions.length == 1) return text;
       final q = questions[i];
-      final header = (q is Map ? (q['header'] ?? q['question']) : null)?.toString() ?? 'Question ${i + 1}';
+      final header =
+          (q is Map ? (q['header'] ?? q['question']) : null)?.toString() ??
+          'Question ${i + 1}';
       lines.add('$header: $text');
     }
     return lines.join('\n');
@@ -360,11 +409,16 @@ class _QuestionCardState extends State<QuestionCard> {
     final selections = <Map<String, int>>[];
     for (final entry in _selections.entries) {
       for (final optionIndex in entry.value.toList()..sort()) {
-        selections.add({'question_index': entry.key, 'option_index': optionIndex});
+        selections.add({
+          'question_index': entry.key,
+          'option_index': optionIndex,
+        });
       }
     }
-    selections.sort((a, b) =>
-        (a['question_index'] as int).compareTo(b['question_index'] as int));
+    selections.sort(
+      (a, b) =>
+          (a['question_index'] as int).compareTo(b['question_index'] as int),
+    );
 
     final error = await widget.sse.sendActionError(n.id, {
       'action': 'answer',
@@ -374,9 +428,9 @@ class _QuestionCardState extends State<QuestionCard> {
     if (!mounted) return;
     setState(() => _submitting = false);
     if (error != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Couldn't answer: $error")),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Couldn't answer: $error")));
     }
   }
 
@@ -388,10 +442,7 @@ class _QuestionCardState extends State<QuestionCard> {
       margin: const EdgeInsets.only(bottom: 8),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.blue.withValues(alpha: 0.3),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.blue.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -401,19 +452,30 @@ class _QuestionCardState extends State<QuestionCard> {
             Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.blue.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
-                    border: Border.all(color: Colors.blue.withValues(alpha: 0.3)),
+                    border: Border.all(
+                      color: Colors.blue.withValues(alpha: 0.3),
+                    ),
                   ),
-                  child: const Text('question', style: TextStyle(fontSize: 11, color: Colors.blue)),
+                  child: const Text(
+                    'question',
+                    style: TextStyle(fontSize: 11, color: Colors.blue),
+                  ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     n.displayTitle,
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -435,7 +497,13 @@ class _QuestionCardState extends State<QuestionCard> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     if (header != null) ...[
-                      Text(header, style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 13)),
+                      Text(
+                        header,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 13,
+                        ),
+                      ),
                       const SizedBox(height: 2),
                     ],
                     Text(question, style: const TextStyle(fontSize: 13)),
@@ -443,16 +511,21 @@ class _QuestionCardState extends State<QuestionCard> {
                     ...options.asMap().entries.map((oe) {
                       final optionIndex = oe.key;
                       final opt = oe.value;
-                      final label = (opt is Map ? opt['label'] : opt)?.toString() ?? '';
-                      final description = opt is Map ? opt['description']?.toString() : null;
+                      final label =
+                          (opt is Map ? opt['label'] : opt)?.toString() ?? '';
+                      final description = opt is Map
+                          ? opt['description']?.toString()
+                          : null;
                       final isSelected =
-                          _selections[questionIndex]?.contains(optionIndex) ?? false;
+                          _selections[questionIndex]?.contains(optionIndex) ??
+                          false;
                       return InkWell(
                         onTap: _submitting
                             ? null
                             : () {
                                 setState(() {
-                                  final held = _selections[questionIndex] ?? <int>{};
+                                  final held =
+                                      _selections[questionIndex] ?? <int>{};
                                   if (!multiSelect) {
                                     _selections[questionIndex] = {optionIndex};
                                   } else if (!held.remove(optionIndex)) {
@@ -470,10 +543,12 @@ class _QuestionCardState extends State<QuestionCard> {
                             children: [
                               Icon(
                                 multiSelect
-                                    ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                                    ? (isSelected
+                                          ? Icons.check_box
+                                          : Icons.check_box_outline_blank)
                                     : (isSelected
-                                        ? Icons.radio_button_checked
-                                        : Icons.radio_button_unchecked),
+                                          ? Icons.radio_button_checked
+                                          : Icons.radio_button_unchecked),
                                 size: 20,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
@@ -482,13 +557,19 @@ class _QuestionCardState extends State<QuestionCard> {
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    Text(label, style: const TextStyle(fontSize: 13)),
-                                    if (description != null && description.isNotEmpty)
+                                    Text(
+                                      label,
+                                      style: const TextStyle(fontSize: 13),
+                                    ),
+                                    if (description != null &&
+                                        description.isNotEmpty)
                                       Text(
                                         description,
                                         style: TextStyle(
                                           fontSize: 11.5,
-                                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onSurfaceVariant,
                                         ),
                                       ),
                                   ],
@@ -542,11 +623,17 @@ class _QuestionCardState extends State<QuestionCard> {
               child: FilledButton(
                 // Every question, not just one: a gap comes back to Claude as
                 // a question nobody answered.
-                onPressed: _submitting ||
-                        !List.generate(questions.length, _answered).every((ok) => ok)
+                onPressed:
+                    _submitting ||
+                        !List.generate(
+                          questions.length,
+                          _answered,
+                        ).every((ok) => ok)
                     ? null
                     : () => _submit(questions),
-                child: Text(questions.length > 1 ? 'Submit Answers' : 'Submit Answer'),
+                child: Text(
+                  questions.length > 1 ? 'Submit Answers' : 'Submit Answer',
+                ),
               ),
             ),
           ],
@@ -575,10 +662,7 @@ class ElicitationFormCard extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.purple.withValues(alpha: 0.3),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.purple.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -588,19 +672,30 @@ class ElicitationFormCard extends StatelessWidget {
             Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.purple.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
-                    border: Border.all(color: Colors.purple.withValues(alpha: 0.3)),
+                    border: Border.all(
+                      color: Colors.purple.withValues(alpha: 0.3),
+                    ),
                   ),
-                  child: const Text('input', style: TextStyle(fontSize: 11, color: Colors.purple)),
+                  child: const Text(
+                    'input',
+                    style: TextStyle(fontSize: 11, color: Colors.purple),
+                  ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     n.mcpServerName ?? 'MCP Server',
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -678,11 +773,7 @@ class TrustCard extends StatelessWidget {
   final HeliosNotification notification;
   final DaemonAPIService sse;
 
-  const TrustCard({
-    super.key,
-    required this.notification,
-    required this.sse,
-  });
+  const TrustCard({super.key, required this.notification, required this.sse});
 
   @override
   Widget build(BuildContext context) {
@@ -693,10 +784,7 @@ class TrustCard extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.teal.withValues(alpha: 0.3),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.teal.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -706,13 +794,21 @@ class TrustCard extends StatelessWidget {
             Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.teal.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
-                    border: Border.all(color: Colors.teal.withValues(alpha: 0.3)),
+                    border: Border.all(
+                      color: Colors.teal.withValues(alpha: 0.3),
+                    ),
                   ),
-                  child: const Text('trust', style: TextStyle(fontSize: 11, color: Colors.teal)),
+                  child: const Text(
+                    'trust',
+                    style: TextStyle(fontSize: 11, color: Colors.teal),
+                  ),
                 ),
                 const SizedBox(width: 8),
                 const Expanded(
@@ -807,10 +903,7 @@ class ElicitationUrlCard extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: Colors.purple.withValues(alpha: 0.3),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.purple.withValues(alpha: 0.3), width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -820,19 +913,30 @@ class ElicitationUrlCard extends StatelessWidget {
             Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.purple.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
-                    border: Border.all(color: Colors.purple.withValues(alpha: 0.3)),
+                    border: Border.all(
+                      color: Colors.purple.withValues(alpha: 0.3),
+                    ),
                   ),
-                  child: const Text('auth', style: TextStyle(fontSize: 11, color: Colors.purple)),
+                  child: const Text(
+                    'auth',
+                    style: TextStyle(fontSize: 11, color: Colors.purple),
+                  ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     n.mcpServerName ?? 'MCP Server',
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -898,7 +1002,8 @@ class ElicitationUrlCard extends StatelessWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: FilledButton(
-                    onPressed: () => sse.sendAction(n.id, {'action': 'decline'}),
+                    onPressed: () =>
+                        sse.sendAction(n.id, {'action': 'decline'}),
                     style: FilledButton.styleFrom(
                       backgroundColor: Theme.of(context).colorScheme.error,
                       foregroundColor: Theme.of(context).colorScheme.onError,
@@ -923,11 +1028,7 @@ class ErrorCard extends StatefulWidget {
   final HeliosNotification notification;
   final DaemonAPIService sse;
 
-  const ErrorCard({
-    super.key,
-    required this.notification,
-    required this.sse,
-  });
+  const ErrorCard({super.key, required this.notification, required this.sse});
 
   @override
   State<ErrorCard> createState() => _ErrorCardState();
@@ -971,7 +1072,9 @@ class _ErrorCardState extends State<ErrorCard> {
     final reset = widget.notification.rateLimitResetAt;
     if (reset == null) return '';
     final left = reset.difference(DateTime.now().toUtc());
-    if (left.inHours >= 1) return 'Retry in ${left.inHours}h ${left.inMinutes % 60}m';
+    if (left.inHours >= 1) {
+      return 'Retry in ${left.inHours}h ${left.inMinutes % 60}m';
+    }
     if (left.inMinutes >= 1) return 'Retry in ${left.inMinutes}m';
     return 'Retry in ${left.inSeconds}s';
   }
@@ -1013,7 +1116,10 @@ class _ErrorCardState extends State<ErrorCard> {
             Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: accent.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(4),
@@ -1028,7 +1134,10 @@ class _ErrorCardState extends State<ErrorCard> {
                 Expanded(
                   child: Text(
                     n.displayTitle,
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -1043,7 +1152,9 @@ class _ErrorCardState extends State<ErrorCard> {
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(
-                n.errorText?.isNotEmpty == true ? n.errorText! : n.displayDetail,
+                n.errorText?.isNotEmpty == true
+                    ? n.errorText!
+                    : n.displayDetail,
                 style: TextStyle(
                   fontFamily: 'monospace',
                   fontSize: 12,
@@ -1078,8 +1189,9 @@ class _ErrorCardState extends State<ErrorCard> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: OutlinedButton(
-                    onPressed:
-                        _sending ? null : () => _send({'action': 'dismiss'}),
+                    onPressed: _sending
+                        ? null
+                        : () => _send({'action': 'dismiss'}),
                     child: const Text('Dismiss'),
                   ),
                 ),

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -307,23 +307,69 @@ class QuestionCard extends StatefulWidget {
 }
 
 class _QuestionCardState extends State<QuestionCard> {
-  /// Question index → chosen option index. Indices rather than labels: the
+  /// Question index → chosen option indices. Indices rather than labels: the
   /// daemon resolves them against the question it raised, and two options can
-  /// share a label.
-  final Map<int, int> _selections = {};
+  /// share a label. A multi-select question keeps several; the rest hold one.
+  final Map<int, Set<int>> _selections = {};
+
+  /// Question index → what the user typed instead of picking.
+  final Map<int, TextEditingController> _typed = {};
   bool _submitting = false;
 
   HeliosNotification get n => widget.notification;
 
-  Future<void> _submit() async {
+  @override
+  void dispose() {
+    for (final controller in _typed.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  TextEditingController _controllerFor(int questionIndex) =>
+      _typed.putIfAbsent(questionIndex, () {
+        final c = TextEditingController();
+        c.addListener(() => setState(() {}));
+        return c;
+      });
+
+  String _textFor(int questionIndex) =>
+      _typed[questionIndex]?.text.trim() ?? '';
+
+  bool _answered(int questionIndex) =>
+      (_selections[questionIndex]?.isNotEmpty ?? false) ||
+      _textFor(questionIndex).isNotEmpty;
+
+  /// The wire carries one text field for the whole set, so an answer past the
+  /// first says which question it belongs to.
+  String _writtenAnswers(List<dynamic> questions) {
+    final lines = <String>[];
+    for (var i = 0; i < questions.length; i++) {
+      final text = _textFor(i);
+      if (text.isEmpty) continue;
+      if (questions.length == 1) return text;
+      final q = questions[i];
+      final header = (q is Map ? (q['header'] ?? q['question']) : null)?.toString() ?? 'Question ${i + 1}';
+      lines.add('$header: $text');
+    }
+    return lines.join('\n');
+  }
+
+  Future<void> _submit(List<dynamic> questions) async {
     setState(() => _submitting = true);
+    final selections = <Map<String, int>>[];
+    for (final entry in _selections.entries) {
+      for (final optionIndex in entry.value.toList()..sort()) {
+        selections.add({'question_index': entry.key, 'option_index': optionIndex});
+      }
+    }
+    selections.sort((a, b) =>
+        (a['question_index'] as int).compareTo(b['question_index'] as int));
+
     final error = await widget.sse.sendActionError(n.id, {
       'action': 'answer',
-      'selections': _selections.entries
-          .map((e) => {'question_index': e.key, 'option_index': e.value})
-          .toList()
-        ..sort((a, b) =>
-            (a['question_index'] as int).compareTo(b['question_index'] as int)),
+      'selections': selections,
+      'text': _writtenAnswers(questions),
     });
     if (!mounted) return;
     setState(() => _submitting = false);
@@ -398,43 +444,72 @@ class _QuestionCardState extends State<QuestionCard> {
                       final optionIndex = oe.key;
                       final opt = oe.value;
                       final label = (opt is Map ? opt['label'] : opt)?.toString() ?? '';
-                      final isSelected = _selections[questionIndex] == optionIndex;
+                      final description = opt is Map ? opt['description']?.toString() : null;
+                      final isSelected =
+                          _selections[questionIndex]?.contains(optionIndex) ?? false;
                       return InkWell(
                         onTap: _submitting
                             ? null
                             : () {
                                 setState(() {
-                                  _selections[questionIndex] = optionIndex;
+                                  final held = _selections[questionIndex] ?? <int>{};
+                                  if (!multiSelect) {
+                                    _selections[questionIndex] = {optionIndex};
+                                  } else if (!held.remove(optionIndex)) {
+                                    held.add(optionIndex);
+                                    _selections[questionIndex] = held;
+                                  } else {
+                                    _selections[questionIndex] = held;
+                                  }
                                 });
                               },
                         child: Padding(
                           padding: const EdgeInsets.symmetric(vertical: 2),
                           child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Icon(
-                                isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                                multiSelect
+                                    ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                                    : (isSelected
+                                        ? Icons.radio_button_checked
+                                        : Icons.radio_button_unchecked),
                                 size: 20,
                                 color: Theme.of(context).colorScheme.primary,
                               ),
                               const SizedBox(width: 8),
-                              Expanded(child: Text(label, style: const TextStyle(fontSize: 13))),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(label, style: const TextStyle(fontSize: 13)),
+                                    if (description != null && description.isNotEmpty)
+                                      Text(
+                                        description,
+                                        style: TextStyle(
+                                          fontSize: 11.5,
+                                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
                             ],
                           ),
                         ),
                       );
                     }),
-                    // Helios answers with one choice per question on every
-                    // surface, the terminal overlay included.
-                    if (multiSelect) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        'Claude will take several answers here, but helios sends one.',
-                        style: TextStyle(
-                          fontSize: 11,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
+                    const SizedBox(height: 4),
+                    TextField(
+                      controller: _controllerFor(questionIndex),
+                      enabled: !_submitting,
+                      style: const TextStyle(fontSize: 13),
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        labelText: 'Other',
+                        hintText: 'Answer in your own words',
                       ),
-                    ],
+                    ),
                   ],
                 ),
               );
@@ -467,9 +542,10 @@ class _QuestionCardState extends State<QuestionCard> {
               child: FilledButton(
                 // Every question, not just one: a gap comes back to Claude as
                 // a question nobody answered.
-                onPressed: _submitting || _selections.length != questions.length
+                onPressed: _submitting ||
+                        !List.generate(questions.length, _answered).every((ok) => ok)
                     ? null
-                    : _submit,
+                    : () => _submit(questions),
                 child: Text(questions.length > 1 ? 'Submit Answers' : 'Submit Answer'),
               ),
             ),

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -31,7 +31,8 @@ class SessionDetailScreen extends rp.ConsumerStatefulWidget {
   const SessionDetailScreen({super.key, required this.session});
 
   @override
-  rp.ConsumerState<SessionDetailScreen> createState() => _SessionDetailScreenState();
+  rp.ConsumerState<SessionDetailScreen> createState() =>
+      _SessionDetailScreenState();
 }
 
 class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
@@ -44,6 +45,7 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
 
   final _promptController = TextEditingController();
   final List<UploadFile> _attachments = [];
+
   /// The block just pasted into the composer, while the offer to file it is up.
   String? _pastedBlock;
   String _lastPrompt = '';
@@ -225,26 +227,34 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
     final hostId = widget.session.hostId;
     if (_sse == null) return;
 
-    final status = await ref.read(gitStatusProvider((hostId, _effectiveCwd)).future);
+    final status = await ref.read(
+      gitStatusProvider((hostId, _effectiveCwd)).future,
+    );
     if (!mounted) return;
     setState(() => _gitStatus = status);
 
     // The server resolves a git root from any subdirectory, so the worktree
     // listing uses the resolved root rather than the session's cwd.
     final gitRoot = status?.root ?? widget.session.cwd;
-    final worktrees = await ref.read(gitWorktreesProvider((hostId, gitRoot)).future);
+    final worktrees = await ref.read(
+      gitWorktreesProvider((hostId, gitRoot)).future,
+    );
     if (!mounted) return;
     setState(() => _worktrees = worktrees);
 
     if (worktrees.length <= 1) return;
     final statuses = await Future.wait(
-      worktrees.map((wt) => ref.read(gitStatusProvider((hostId, wt.path)).future)),
+      worktrees.map(
+        (wt) => ref.read(gitStatusProvider((hostId, wt.path)).future),
+      ),
     );
     if (!mounted) return;
-    setState(() => _worktreeStatuses = {
-          for (var i = 0; i < worktrees.length; i++)
-            if (statuses[i] != null) worktrees[i].path: statuses[i]!,
-        });
+    setState(
+      () => _worktreeStatuses = {
+        for (var i = 0; i < worktrees.length; i++)
+          if (statuses[i] != null) worktrees[i].path: statuses[i]!,
+      },
+    );
   }
 
   /// Picks attachments, from the gallery, the camera, or the file browser.
@@ -407,9 +417,11 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
         timer.cancel();
       }
       _resendReads = [5, 10]
-          .map((seconds) => Timer(Duration(seconds: seconds), () {
-                if (mounted) _loadNewMessages();
-              }))
+          .map(
+            (seconds) => Timer(Duration(seconds: seconds), () {
+              if (mounted) _loadNewMessages();
+            }),
+          )
           .toList();
     } else if (mounted) {
       // The prompt stays in the box: it never reached the session, so the
@@ -441,7 +453,11 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
               Navigator.pop(ctx);
               final title = controller.text.trim();
               ref
-                  .read(sessionsProvider(allSessionsKey(widget.session.hostId)).notifier)
+                  .read(
+                    sessionsProvider(
+                      allSessionsKey(widget.session.hostId),
+                    ).notifier,
+                  )
                   .patch(widget.session.sessionId, title: title);
             },
           ),
@@ -455,8 +471,12 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
                 Navigator.pop(ctx);
                 final title = controller.text.trim();
                 ref
-                  .read(sessionsProvider(allSessionsKey(widget.session.hostId)).notifier)
-                  .patch(widget.session.sessionId, title: title);
+                    .read(
+                      sessionsProvider(
+                        allSessionsKey(widget.session.hostId),
+                      ).notifier,
+                    )
+                    .patch(widget.session.sessionId, title: title);
               },
               child: const Text('Save'),
             ),
@@ -480,11 +500,14 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
 
   /// Get pending notifications for this session.
   List<HeliosNotification> _pendingNotifications() {
-    final held =
-        ref.watch(notificationsProvider(widget.session.hostId)).valueOrNull;
+    final held = ref
+        .watch(notificationsProvider(widget.session.hostId))
+        .valueOrNull;
     if (held == null) return const [];
     return held
-        .where((n) => n.sourceSession == widget.session.sessionId && n.isPending)
+        .where(
+          (n) => n.sourceSession == widget.session.sessionId && n.isPending,
+        )
         .toList();
   }
 
@@ -503,7 +526,8 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
         final held = ref
             .watch(sessionsProvider(allSessionsKey(widget.session.hostId)))
             .valueOrNull;
-        final session = held?.firstWhere(
+        final session =
+            held?.firstWhere(
               (s) => s.sessionId == widget.session.sessionId,
               orElse: () => widget.session,
             ) ??
@@ -573,32 +597,42 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
           top: BorderSide(color: Colors.orange.withValues(alpha: 0.5)),
         ),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Batch approve all button
-          if (notifs.length > 1)
-            Padding(
-              padding: const EdgeInsets.only(left: 12, right: 12, top: 8),
-              child: SizedBox(
-                width: double.infinity,
-                child: FilledButton.tonal(
-                  onPressed: () {
-                    final ids = notifs
-                        .where((n) => n.isPermission)
-                        .map((n) => n.id)
-                        .toList();
-                    if (ids.isNotEmpty) {
-                      sse.batchAction(ids, {'action': 'approve'});
-                    }
-                  },
-                  child: Text('Approve All (${notifs.length})'),
+      // A question with descriptions and an Other field is taller than the
+      // room under the transcript. Cap it and let it scroll, or the buttons at
+      // its foot are unreachable.
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.55,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Batch approve all button
+              if (notifs.length > 1)
+                Padding(
+                  padding: const EdgeInsets.only(left: 12, right: 12, top: 8),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.tonal(
+                      onPressed: () {
+                        final ids = notifs
+                            .where((n) => n.isPermission)
+                            .map((n) => n.id)
+                            .toList();
+                        if (ids.isNotEmpty) {
+                          sse.batchAction(ids, {'action': 'approve'});
+                        }
+                      },
+                      child: Text('Approve All (${notifs.length})'),
+                    ),
+                  ),
                 ),
-              ),
-            ),
-          // Individual notification cards
-          ...notifs.map((n) => _buildInlineNotifCard(n, sse)),
-        ],
+              // Individual notification cards
+              ...notifs.map((n) => _buildInlineNotifCard(n, sse)),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -938,8 +972,9 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
   /// then: a button that appears a moment later is better than one that opens
   /// an empty sheet.
   bool _providerHasModes(Session session) {
-    final providers =
-        ref.watch(readyProvidersProvider(widget.session.hostId)).valueOrNull;
+    final providers = ref
+        .watch(readyProvidersProvider(widget.session.hostId))
+        .valueOrNull;
     if (providers == null) return false;
     for (final p in providers) {
       if (p.id == session.source) return p.permissionModes.isNotEmpty;


### PR DESCRIPTION
## Summary

The terminal could answer the easiest third of a question: it showed the option
labels and nothing else, could not take a typed answer when none of them fit, and
could not select two options when the question asked for two. Closes #146.

Almost none of this was a protocol gap. The CLI already sends each option's
description and `questionOption.Description` already parsed it; `questionAnswer.Text`
already existed and `questionReason` already rendered it; `Selections` is already a
flat list, so two entries sharing a question index already *was* a multi-select
answer. Three surfaces simply never produced any of it.

Design is written up in [docs/specs/55](docs/specs/55-answering-a-question-from-the-terminal.md).

## What changed

- **Overlay** gains `Details`, `Checked` and `Input`, all additive and `omitempty`.
  Descriptions are dim, indented past the label and the checkbox, and capped at two
  wrapped lines — the box is bottom-anchored and clips from the *top*, so an
  uncapped description would push the question itself off screen.
- **Two key vocabularies.** In the list, digits jump the highlight and `j` moves
  down; in the answer field both are characters the user meant. Escape closes the
  field and only cancels from the list, which the footer says while the field is
  open. A bracketed paste is now one insert rather than a burst of jumps and
  confirms read out of its payload.
- **Multi-select** with `space`, and `questionSpec` finally parses `multiSelect`.
- **A question with no options** is answered in the terminal instead of being
  handed to the phone whole.
- **Desktop and Flutter** get the same three, and both permission cards now show
  the command as it is rather than as `\n` escapes or a 100-character stub.

## Compatibility

`HostProtocol` goes to 2. The three fields do not fail the same way, so they are not
gated the same way: a description is no loss on an old host, the answer field is
dropped so the choices stay answerable, and checkboxes go to the phone whole because
a multi-select question drawn as a single-select list collects an answer the user
did not give.

This matters in practice — every running ptyhost keeps the renderer it launched
with, so existing sessions stay on protocol 1 until they are recreated.

## Testing

- `go test ./...` and `-race` on `internal/hitl` and `internal/terminal`.
- New: the full key table in both modes, toggle/submit/typing behaviour, the
  capability gate, overlay rendering and the promise that a plain overlay marshals
  without the new keys, and a host round-trip proving the fields survive the socket.
- `tsc` clean, 243 desktop tests pass, `dart analyze` clean, APK installed and
  exercised on a device.

Not verified: a live `AskUserQuestion` against a session started from this build.