### PR TITLE
fix(desktop): a background refetch emptied the panel it was refreshing

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -30,6 +30,14 @@ export interface StubDaemon {
    * passes before the event has even crossed the socket.
    */
   reads(path: string): number
+  /**
+   * How many times the content search has been run.
+   *
+   * A refetch of a search nobody re-typed asks the same question and gets the
+   * same answer, so it leaves no mark on the results. Counting the asking is
+   * how a test knows the refetch it provoked has happened at all.
+   */
+  greps(): number
   close(): Promise<void>
 }
 
@@ -232,6 +240,7 @@ export async function startDaemon(): Promise<StubDaemon> {
   // worth having true here so the test cannot pass for the wrong reason.
   let revision = 0
   const readCount = new Map<string, number>()
+  let grepCount = 0
 
   const held = (target: string): FileAnswer => {
     readCount.set(target, (readCount.get(target) ?? 0) + 1)
@@ -254,6 +263,7 @@ export async function startDaemon(): Promise<StubDaemon> {
       return
     }
 
+    if (path === '/api/files/grep') grepCount += 1
     res.setHeader('Content-Type', 'application/json')
     res.end(JSON.stringify(answer(path, q, held)))
   })
@@ -268,6 +278,7 @@ export async function startDaemon(): Promise<StubDaemon> {
       for (const stream of streams) stream.write(frame)
     },
     reads: (target) => readCount.get(target) ?? 0,
+    greps: () => grepCount,
     setFile: (target, content) => {
       contents.set(target, content)
       revision += 1

--- a/desktop/e2e/file-changes.spec.ts
+++ b/desktop/e2e/file-changes.spec.ts
@@ -123,3 +123,38 @@ test('an event about another file leaves this tab alone', async ({ window, daemo
   await expect(editor).not.toContainText('elsewhere')
   await expect(shown(window).locator('.ws-stale-bar')).toHaveCount(0)
 })
+
+test('search results are replaced rather than emptied and filled', async ({ window, daemon }) => {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await window.locator('.panel-tabs button', { hasText: 'files' }).first().click()
+  await shown(window).locator('.ws-view', { hasText: 'Search' }).click()
+  await shown(window).locator('.find-input').fill('needle')
+  await shown(window).locator('.find-input').press('Enter')
+  await expect(shown(window).locator('.find-hit')).toHaveCount(2)
+
+  // The count as React commits it, not as the test happens to look: a panel
+  // that empties and fills within one turn of the event loop is back before
+  // any assertion could catch it, and is exactly the flicker under test.
+  await window.evaluate(() => {
+    const results = document.querySelector('.find-results')
+    if (!results) throw new Error('no results container')
+    const count = (): number => results.querySelectorAll('.find-hit').length
+    const seen = { low: count() }
+    Object.assign(window, { __hits: seen })
+    new MutationObserver(() => {
+      seen.low = Math.min(seen.low, count())
+    }).observe(results, { childList: true, subtree: true })
+  })
+
+  const before = daemon.greps()
+  daemon.setFile(MAIN, 'package main // edited by the agent\n')
+  daemon.emit(...moved(MAIN))
+
+  // The search is under the same `files` key the edit invalidates, so it is
+  // asked again. Waiting for that is what makes the assertion below mean
+  // something: before the refetch there is nothing it could have caught.
+  await expect.poll(() => daemon.greps()).toBeGreaterThan(before)
+
+  const low = await window.evaluate(() => (window as unknown as { __hits: { low: number } }).__hits.low)
+  expect(low).toBe(2)
+})

--- a/desktop/src/renderer/components/commits.tsx
+++ b/desktop/src/renderer/components/commits.tsx
@@ -155,10 +155,19 @@ function ScopeMenu({
   onClose: () => void
 }): JSX.Element {
   const [all, setAll] = useState(false)
-  const { data, error, isFetching, hasNextPage, fetchNextPage } = useInfiniteQuery(
+  const { data, error, isFetching, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteQuery(
     gitLogPagesQuery(hostId, root, all),
   )
   const commits = useMemo(() => data?.pages.flatMap((page) => page.commits) ?? [], [data])
+  /**
+   * A fetch the reader is waiting on: the first page, or the next one.
+   *
+   * Not every fetch is. A working-tree write invalidates the whole `git`
+   * prefix, so this log refetches whenever the agent touches a file — and
+   * saying so pulled "Load more" out from under the pointer and put a
+   * "Loading…" line in its place, for an answer nobody had asked for.
+   */
+  const loading = isFetchingNextPage || (isFetching && commits.length === 0)
   // The newest page answers for the branch: base and scope do not move between
   // pages, and has_more is the last page's to report.
   const log = data?.pages[data.pages.length - 1] ?? null
@@ -282,9 +291,9 @@ function ScopeMenu({
             </button>
           ))}
 
-          {isFetching && <p className="empty-note">Loading…</p>}
-          {!isFetching && !error && commits.length === 0 && <p className="empty-note">No commits.</p>}
-          {hasNextPage && !isFetching && (
+          {loading && <p className="empty-note">Loading…</p>}
+          {!loading && !error && commits.length === 0 && <p className="empty-note">No commits.</p>}
+          {hasNextPage && !loading && (
             <button className="commit-more" onClick={() => void fetchNextPage()}>
               Load more
             </button>

--- a/desktop/src/renderer/components/find-in-files.tsx
+++ b/desktop/src/renderer/components/find-in-files.tsx
@@ -56,7 +56,7 @@ export function FindInFiles({
    */
   const [submitted, setSubmitted] = useState<Submitted | null>(null)
 
-  const { data, error, isFetching } = useQuery({
+  const { data, error, isFetching, isPlaceholderData } = useQuery({
     ...grepQuery(hostId, root, submitted?.q ?? '', {
       regex: submitted?.regex ?? false,
       caseSensitive: submitted?.caseSensitive ?? false,
@@ -68,6 +68,20 @@ export function FindInFiles({
   const matches = submitted ? (data?.matches ?? null) : null
   const truncated = data?.truncated ?? false
   const groups = groupByFile(matches ?? [])
+
+  /**
+   * A fetch worth saying anything about, which is not every fetch.
+   *
+   * An agent writing a file invalidates every read under `files`, this one
+   * included, so a background refetch arrives whenever the session is busy.
+   * Announcing those emptied the panel and filled it again a moment later,
+   * under a reader who had asked for nothing — which is what `keepPreviousData`
+   * above was already holding the results to prevent.
+   *
+   * What is left is the two cases the reader is waiting on: a first search with
+   * nothing on screen yet, and a new one running behind the last one's results.
+   */
+  const searching = isFetching && (matches === null || isPlaceholderData)
 
   return (
     <div className="find">
@@ -101,33 +115,32 @@ export function FindInFiles({
       </div>
 
       <div className="find-results">
-        {isFetching && <p className="empty-note">Searching…</p>}
+        {searching && <p className="empty-note">Searching…</p>}
         {error && <p className="empty-note">{error.message}</p>}
-        {!isFetching && !error && matches !== null && matches.length === 0 && (
+        {!searching && !error && matches !== null && matches.length === 0 && (
           <>
             <p className="empty-note">No results under {root}.</p>
             {onPickRoot && <RootSuggestions root={root} worktrees={worktrees} onPick={onPickRoot} />}
           </>
         )}
-        {!isFetching &&
-          groups.map(([rel, hits]) => (
-            <div key={rel} className="find-group">
-              <span className="find-file" title={rel}>
-                {rel}
-                <span className="find-count">{hits.length}</span>
-              </span>
-              {hits.map((hit) => (
-                <button
-                  key={`${hit.line}:${hit.column}`}
-                  className="find-hit"
-                  onClick={() => onOpen(hit.path, hit.line, hit.column)}
-                >
-                  <span className="find-line">{hit.line}</span>
-                  <span className="find-text">{hit.text.trim()}</span>
-                </button>
-              ))}
-            </div>
-          ))}
+        {groups.map(([rel, hits]) => (
+          <div key={rel} className="find-group">
+            <span className="find-file" title={rel}>
+              {rel}
+              <span className="find-count">{hits.length}</span>
+            </span>
+            {hits.map((hit) => (
+              <button
+                key={`${hit.line}:${hit.column}`}
+                className="find-hit"
+                onClick={() => onOpen(hit.path, hit.line, hit.column)}
+              >
+                <span className="find-line">{hit.line}</span>
+                <span className="find-text">{hit.text.trim()}</span>
+              </button>
+            ))}
+          </div>
+        ))}
         {truncated && matches !== null && matches.length > 0 && (
           <p className="empty-note">Showing the first {matches.length} results.</p>
         )}


### PR DESCRIPTION
## What was wrong

The main window's content flickered while a session was busy.

An agent writing a file makes the daemon emit `file_changed`, and `effectsFor` turns that into an invalidation of two whole key prefixes:

```ts
{ kind: 'invalidate', queryKey: keys.files(hostId) },
{ kind: 'invalidate', queryKey: keys.git(hostId) },
```

`fileGrep` and `gitLogPages` sit under those prefixes, so the content search and the commit log refetch whenever the agent touches anything. That part is correct — the results really did go stale.

What was wrong is that both panels gated their rendered content on `isFetching`, which is true for a background revalidation as much as for a first load. So the panel emptied and refilled for an answer nobody had asked for.

Find-in-files was the visible one: `placeholderData: keepPreviousData` was already there to hold the results across a fetch, and `{!isFetching && groups.map(...)}` threw them away again.

## What changed

- `find-in-files.tsx` renders its results unconditionally. "Searching…" now appears only when there is nothing to show yet, or when a newly typed search is running behind the previous one's results.
- `commits.tsx` distinguishes the next page — which the reader asked for — from a revalidation they did not, so "Load more" no longer goes out from under the pointer.

## Behaviour change worth a look

Typing a *new* search now keeps the previous search's hits on screen with a "Searching…" note, rather than blanking. That is what `keepPreviousData` was already asking for, but it does mean hits for the old term are briefly clickable. Happy to hide them on a user-typed search and keep them only for background refetches, if that reads better.

## Test plan

- [x] New e2e test in `file-changes.spec.ts`: a MutationObserver watches `.find-results` across the `file_changed` refetch and records the low-water hit count. Added `daemon.greps()` to the stub daemon so the test can tell the refetch actually happened.
- [x] Confirmed the test catches the bug — reverting `find-in-files.tsx` fails it with `Expected: 2, Received: 0`.
- [x] `npm run typecheck` clean
- [x] `npm test` — 243 passed
- [x] `npx playwright test` — 21 passed