### PR TITLE
Drop a file on a terminal and get a path the agent can read

### DIFF
--- a/desktop/src/renderer/attachments.ts
+++ b/desktop/src/renderer/attachments.ts
@@ -103,3 +103,29 @@ export function promptWithAttachments(attachments: Attachment[], text: string): 
   if (lines.length === 0) return text
   return [...lines, '', text].join('\n').trim()
 }
+
+/** A pasted image has no name of its own, and the name becomes the path. */
+export function pastedName(type: string): string {
+  const ext = type.split('/')[1]?.split('+')[0] ?? 'bin'
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, '')
+  return `pasted-${stamp}.${ext}`
+}
+
+/**
+ * The paths of files dropped on a terminal, as the shell should read them.
+ *
+ * Typed rather than pasted into a composer, so this is going to a command line:
+ * a path with a space in it is quoted, and a single quote inside one is closed,
+ * escaped and reopened the way a shell requires. Ends with a space so what the
+ * user types next is a separate word.
+ */
+export function terminalPaths(paths: string[]): string {
+  const kept = paths.filter((path) => path !== '')
+  if (kept.length === 0) return ''
+  return kept.map(shellQuote).join(' ') + ' '
+}
+
+function shellQuote(path: string): string {
+  if (!/[\s'"\\$`*?()[\]{}|&;<>#~!]/.test(path)) return path
+  return `'${path.replaceAll("'", `'\\''`)}'`
+}

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -8,6 +8,7 @@ import { appendDelta, transcriptMessages, transcriptQuery } from '../queries.ts'
 import {
   isLargePaste,
   needingUpload,
+  pastedName,
   pastedTextAttachment,
   promptWithAttachments,
   removeFirst,
@@ -507,13 +508,6 @@ export function ChatPanel({
       )}
     </div>
   )
-}
-
-/** A pasted image has no name of its own, and the name becomes the path. */
-function pastedName(type: string): string {
-  const ext = type.split('/')[1]?.split('+')[0] ?? 'bin'
-  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, '')
-  return `pasted-${stamp}.${ext}`
 }
 
 function fileSize(bytes: number): string {

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -70,11 +70,12 @@ const MODES: { value: AppearancePrefs['mode']; label: string; detail: string }[]
  * theme pickers pushed the notification toggles out of sight — and the two have
  * nothing to do with each other.
  */
-type SectionId = 'appearance' | 'sessions' | 'notifications'
+type SectionId = 'appearance' | 'sessions' | 'terminal' | 'notifications'
 
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'sessions', label: 'Sessions' },
+  { id: 'terminal', label: 'Terminal' },
   { id: 'notifications', label: 'Notifications' },
 ]
 
@@ -203,6 +204,8 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
 
           {section === 'sessions' && <SessionsPane />}
 
+          {section === 'terminal' && <TerminalPane />}
+
           {section === 'notifications' && !prefs && <Loading title="Notifications" />}
 
           {section === 'notifications' && prefs && (
@@ -267,6 +270,36 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
  * stacking all of them meant scrolling past three copies of the same four
  * toggles to reach the one machine you meant.
  */
+function TerminalPane(): JSX.Element {
+  const uploads = useStore((s) => s.terminalUploads)
+
+  return (
+    <section className="settings-group">
+      <h3>
+        Dropped and pasted files
+        <Info>
+          A file dropped on a terminal is on this machine, and the agent reading it is on the
+          daemon&apos;s. Uploading it and typing back the path it landed at is the only reading
+          that works when those are different machines.
+        </Info>
+      </h3>
+
+      <label className="check">
+        <input
+          type="checkbox"
+          checked={uploads}
+          onChange={(event) => store.setTerminalUploads(event.target.checked)}
+        />
+        <span>Upload to the daemon and type the path</span>
+        <Info>
+          Off leaves the terminal to the CLI, which is what you want when the daemon runs on this
+          machine and the CLI can read the clipboard itself.
+        </Info>
+      </label>
+    </section>
+  )
+}
+
 function SessionsPane(): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const [hostId, setHostId] = useState<string | null>(null)

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
@@ -6,7 +6,8 @@ import { WebglAddon } from '@xterm/addon-webgl'
 
 import { silenceDeviceReports } from './deviceReports.ts'
 import { linkHandler, webLinkActivate } from './links.ts'
-import { bridge } from '../bridge.ts'
+import { isLargePaste, pastedName, pastedTextAttachment, terminalPaths } from '../attachments.ts'
+import { api, bridge } from '../bridge.ts'
 import { store, terminalId, useStore, type Tab } from '../store.ts'
 import { canResume, hasTerminal, needsRecovery, type Session } from '../../shared/models.ts'
 
@@ -117,6 +118,83 @@ export function TerminalPane({
   /** Whether the terminal has met the DOM yet; see `apply` below. */
   const opened = useRef(false)
   const theme = useStore((s) => s.terminalTheme)
+  const uploads = useStore((s) => s.terminalUploads)
+  /** A pasted block big enough to ask about, held until the reader chooses. */
+  const [pasted, setPasted] = useState<string | null>(null)
+
+  /**
+   * Puts dropped or pasted files where the agent can reach them, and types the
+   * paths in.
+   *
+   * The file is on this machine and the agent is on the daemon's, so the local
+   * path names nothing it can open. Uploading the bytes and writing back the
+   * path they landed at is what makes this work against a remote host — and
+   * against a local one it is the same path either way.
+   *
+   * The text is typed, not run: the reader decides what to do with it.
+   */
+  const insertUploads = async (files: File[]): Promise<void> => {
+    if (files.length === 0) return
+    try {
+      const parts = await Promise.all(
+        files.map(async (file) => ({
+          // A pasted screenshot arrives unnamed, and the name becomes the path.
+          name: file.name || pastedName(file.type),
+          type: file.type,
+          bytes: new Uint8Array(await file.arrayBuffer()),
+        })),
+      )
+      const stored = await api(tab.hostId).uploadFiles(tab.sessionId, parts)
+      const text = terminalPaths(stored.map((file) => file.path))
+      if (text) await bridge.term.input(tab.id, encoder.encode(text))
+    } catch (err) {
+      store.notify(`Could not attach to the terminal: ${String(err)}`, 'error')
+    }
+  }
+
+  /** Types a held block into the terminal after all, bracketing as xterm does. */
+  const pasteAnyway = (text: string): void => {
+    setPasted(null)
+    termRef.current?.paste(text)
+    termRef.current?.focus()
+  }
+
+  /** Puts a held block in a file and types its path instead. */
+  const pasteAsFile = async (text: string): Promise<void> => {
+    setPasted(null)
+    const { name, type, bytes } = pastedTextAttachment(0, text)
+    await insertUploads([new File([bytes as BlobPart], name, { type })])
+    termRef.current?.focus()
+  }
+
+  // xterm takes paste on a hidden textarea of its own, so this listens in the
+  // capture phase to see the paste first.
+  //
+  // A big block is held rather than offered the way the composer offers it: a
+  // composer can take its text back, and a terminal cannot — the bytes are with
+  // the agent the moment they are sent. So the choice is made before anything
+  // is forwarded. Everything else pastes as it always did.
+  useEffect(() => {
+    const container = hostRef.current
+    if (!container || !uploads) return
+
+    const onPaste = (event: ClipboardEvent): void => {
+      const files = [...(event.clipboardData?.files ?? [])]
+      if (files.length > 0) {
+        event.preventDefault()
+        event.stopPropagation()
+        void insertUploads(files)
+        return
+      }
+      const text = event.clipboardData?.getData('text') ?? ''
+      if (!isLargePaste(text)) return
+      event.preventDefault()
+      event.stopPropagation()
+      setPasted(text)
+    }
+    container.addEventListener('paste', onPaste, true)
+    return () => container.removeEventListener('paste', onPaste, true)
+  }, [uploads, tab.id, tab.hostId, tab.sessionId])
 
   // Assigned rather than passed on construction: rebuilding the terminal to
   // recolour it would throw away the scrollback, which the host cannot replay
@@ -290,7 +368,38 @@ export function TerminalPane({
   // wrapper carries `hidden`, and a pane that is up fills the cell it is in.
   return (
     <div className="pane">
-      <div className="pane-term" ref={hostRef} />
+      <div
+        className="pane-term"
+        ref={hostRef}
+        // Always swallowed, uploads on or off: a file dropped on a window
+        // Electron has not claimed navigates it to that file, replacing the app.
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => {
+          event.preventDefault()
+          if (!uploads) return
+          void insertUploads([...event.dataTransfer.files])
+        }}
+      />
+      {pasted !== null && (
+        <div
+          className="paste-offer paste-offer-term"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') pasteAnyway(pasted)
+          }}
+        >
+          <span className="paste-offer-text">
+            Pasted {new Blob([pasted]).size.toLocaleString()} bytes of text
+          </span>
+          <button className="ghost" onClick={() => void pasteAsFile(pasted)}>
+            Paste as file
+          </button>
+          {/* The default, and what Escape does: a paste nobody chose about is
+              still a paste the reader asked for. */}
+          <button className="ghost" onClick={() => pasteAnyway(pasted)} autoFocus>
+            Paste text
+          </button>
+        </div>
+      )}
       {tab.status.state !== 'live' && (
         <div className="pane-overlay">
           {/* No spinner once it is closed: nothing is being waited for, and a

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -235,6 +235,8 @@ export interface State {
   pairingLink: string | null
   /** The palette xterm draws with; the CSS side is set on <html>, not here. */
   terminalTheme: XtermTheme
+  /** Whether a file dropped or pasted on a terminal is uploaded to its daemon. */
+  terminalUploads: boolean
   /**
    * How much of a session the sidebar shows. Kept here as well as on <html>
    * because the control that changes it lives in the sidebar and has to show
@@ -286,6 +288,31 @@ function readGroupMode(): GroupMode {
 function writeGroupMode(mode: GroupMode): void {
   try {
     localStorage.setItem(GROUPING_KEY, mode)
+  } catch {
+    // A full or unavailable store costs the preference, not the setting.
+  }
+}
+
+const TERMINAL_UPLOADS_KEY = 'helios.terminalUploads'
+
+/**
+ * On unless it has been turned off. A file dropped on the terminal is on this
+ * machine, and the agent reading it is on the daemon's — so uploading it and
+ * writing back the path it landed at is the only reading that works when the
+ * two are not the same box. Off leaves the terminal to the CLI, which is what
+ * someone running the daemon locally may prefer.
+ */
+function readTerminalUploads(): boolean {
+  try {
+    return localStorage.getItem(TERMINAL_UPLOADS_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
+function writeTerminalUploads(on: boolean): void {
+  try {
+    localStorage.setItem(TERMINAL_UPLOADS_KEY, on ? '1' : '0')
   } catch {
     // A full or unavailable store costs the preference, not the setting.
   }
@@ -374,6 +401,7 @@ const initial: State = {
   query: '',
   loading: true,
   terminalTheme: bridge.theme.boot().terminal,
+  terminalUploads: readTerminalUploads(),
   density: bridge.theme.boot().density,
   toast: null,
   pairingLink: null,
@@ -641,6 +669,12 @@ class Store {
       for (const [key, page] of before) queryClient.setQueryData(key, page)
       this.fail(err)
     }
+  }
+
+  /** Turns uploading a file dropped or pasted on a terminal on or off. */
+  setTerminalUploads(on: boolean): void {
+    this.set({ terminalUploads: on })
+    writeTerminalUploads(on)
   }
 
   /**

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2395,6 +2395,18 @@ figure.mermaid svg {
   font-size: 12px;
 }
 
+/* Over the terminal rather than above it: the pane is full of xterm, and a row
+   that pushed it up would resize the grid for a question about a paste. */
+.paste-offer-term {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 2;
+  margin-bottom: 0;
+  box-shadow: 0 6px 24px rgb(0 0 0 / 35%);
+}
+
 .paste-offer-text {
   flex: 1;
   color: var(--on-surface-variant);

--- a/desktop/test/attachments.test.ts
+++ b/desktop/test/attachments.test.ts
@@ -8,6 +8,7 @@ import {
   needingUpload,
   pastedTextAttachment,
   removeFirst,
+  terminalPaths,
   promptWithAttachments,
   withStoredPaths,
   type Attachment,
@@ -104,4 +105,33 @@ test('an earlier identical block survives', () => {
 
 test('a draft the paste is no longer in is untouched', () => {
   assert.equal(removeFirst('user deleted it', 'LOG'), 'user deleted it')
+})
+
+// What goes into a terminal is going to a command line, not a composer: a path
+// the shell would split or glob has to survive being typed.
+test('a plain path is typed into the terminal as it is', () => {
+  assert.equal(terminalPaths(['/uploads/s1/a.png']), '/uploads/s1/a.png ')
+})
+
+test('several paths are separated, and the last one still ends the word', () => {
+  assert.equal(terminalPaths(['/a.png', '/b.png']), '/a.png /b.png ')
+})
+
+test('a path with a space is quoted', () => {
+  assert.equal(terminalPaths(['/uploads/s1/Screen Shot.png']), "'/uploads/s1/Screen Shot.png' ")
+})
+
+test("a quote inside a path is closed, escaped and reopened", () => {
+  assert.equal(terminalPaths(["/uploads/s1/it's.png"]), "'/uploads/s1/it'\\''s.png' ")
+})
+
+test('a path the shell would glob or expand is quoted', () => {
+  for (const path of ['/a*.png', '/a$b.png', '/a`b`.png', '/a;rm -rf.png', '/a(1).png']) {
+    assert.equal(terminalPaths([path]).startsWith("'"), true, path)
+  }
+})
+
+test('nothing to attach types nothing', () => {
+  assert.equal(terminalPaths([]), '')
+  assert.equal(terminalPaths(['']), '')
 })


### PR DESCRIPTION
## Summary

Dropping a file on a terminal pane did nothing, and dragging one onto the window
navigated the app to that file. Pasting a screenshot did nothing either.

Inserting the local path would not have fixed it: the file is on the machine
running the desktop app, and the agent reading it is on the daemon's. So the
bytes go up through the upload endpoint the composer already uses, and the path
they landed at is typed into the terminal — the same path either way when the
daemon is local.

Typed, not run. What to do with the path is the reader's call.

## Large pastes

A block over 2,000 characters or 50 lines is held, and a bar over the pane offers
**Paste as file** or **Paste text** (focused by default; Escape does the same).

The composer offers to file a block *after* it lands, because a textarea's text
can be taken back. A terminal's cannot — once forwarded the bytes are with the
agent — so the terminal has to ask first. That is the one intrusive part of this,
and there is no way around it.

Same thresholds and same `pasted-<stamp>` naming as the composer and the phone.

## Settings

A Terminal tab, on by default, turns the whole thing off — for a daemon on this
machine, where the CLI can read the clipboard itself and may do it better.

A drop is swallowed even when it is off: without `preventDefault` Electron
replaces the app with the dropped file, so off means "insert nothing", not "let
the browser have it".

## Testing

`tsc` clean; desktop suite 243 → 249, the new cases covering `terminalPaths`
quoting — a path with a space, an embedded single quote, and the glob and
expansion characters a shell would otherwise act on.

Not covered: the drop, paste and offer handlers are DOM-level, and the suite
never mounts React. I have not exercised them in a running app.