### PR TITLE
feat(desktop): a status line at the foot, in place of the header above

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -23,6 +23,15 @@ export interface StubDaemon {
   /** Replaces what `/api/file` answers for a path, and its mod time with it. */
   setFile(path: string, content: string): void
   /**
+   * Changes a session's status in the list this daemon serves.
+   *
+   * A `session_status` event alone is not enough: the client patches the cache
+   * from the payload and then refetches behind it, so a list still answering
+   * "idle" puts the old status straight back. The event says it moved; this is
+   * what makes it stay moved.
+   */
+  setStatus(sessionId: string, status: string): void
+  /**
    * How many times `/api/file` has been asked for a path.
    *
    * The way to wait for the app to have *finished* thinking about an event when
@@ -246,6 +255,14 @@ export async function startDaemon(): Promise<StubDaemon> {
   let revision = 0
   const readCount = new Map<string, number>()
   let grepCount = 0
+  // Per daemon, not on the fixtures: SESSIONS is a module constant shared by
+  // every test in the worker, and one test leaving a session busy would be the
+  // next test's starting state.
+  const statuses = new Map<string, string>()
+  const statusOf = (one: Session): Session => {
+    const status = statuses.get(one.session_id)
+    return status === undefined ? one : { ...one, status: status as Session['status'] }
+  }
 
   const held = (target: string): FileAnswer => {
     readCount.set(target, (readCount.get(target) ?? 0) + 1)
@@ -270,7 +287,7 @@ export async function startDaemon(): Promise<StubDaemon> {
 
     if (path === '/api/files/grep') grepCount += 1
     res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(answer(path, q, held)))
+    res.end(JSON.stringify(answer(path, q, held, statusOf)))
   })
 
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
@@ -288,6 +305,7 @@ export async function startDaemon(): Promise<StubDaemon> {
       contents.set(target, content)
       revision += 1
     },
+    setStatus: (sessionId, status) => statuses.set(sessionId, status),
     close: () =>
       new Promise<void>((resolve) => {
         for (const stream of streams) stream.end()
@@ -312,6 +330,7 @@ function answer(
   path: string,
   q: (name: string) => string,
   held: (target: string) => FileAnswer,
+  statusOf: (session: Session) => Session,
 ): unknown {
   switch (path) {
     case '/api/health':
@@ -321,7 +340,7 @@ function answer(
       // everything a schedule started, and one schedule's runs.
       const jobs = q('filter') === 'jobs' || q('schedule_id') !== ''
       return {
-        sessions: jobs ? RUNS : SESSIONS,
+        sessions: (jobs ? RUNS : SESSIONS).map(statusOf),
         host: { warm: 2, warm_rss: 0, budget: 8, load: 0.1, memory_used: 1, memory_total: 8 },
       }
     }
@@ -377,7 +396,7 @@ function answer(
       {
         const id = path.slice('/api/sessions/'.length)
         const one = [...SESSIONS, ...RUNS].find((s) => s.session_id === id)
-        if (path.startsWith('/api/sessions/') && one) return { session: one, pending_permissions: 0 }
+        if (path.startsWith('/api/sessions/') && one) return { session: statusOf(one), pending_permissions: 0 }
       }
       if (path.endsWith('/transcript')) {
         const id = path.slice('/api/sessions/'.length, -'/transcript'.length)

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -53,6 +53,11 @@ function session(id: string, title: string): Session {
     title,
     status: 'idle',
     pinned: false,
+    // Both are optional on the wire and absent on a session the daemon has not
+    // heard from yet. Set here because the status line draws them, and a bar
+    // with two empty slots proves nothing.
+    model: 'opus',
+    permission_mode: 'default',
     created_at: '2026-01-01T00:00:00Z',
     last_event_at: '2026-01-01T00:00:00Z',
     supports_prompt_queue: true,

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -6,6 +6,7 @@
 // components, and there is no component test framework here.
 import type { Page } from '@playwright/test'
 
+import { ALPHA as ALPHA_ID } from './daemon.ts'
 import { expect, test } from './fixtures.ts'
 
 const ALPHA = 'Alpha'
@@ -105,6 +106,26 @@ async function openSettings(window: Page): Promise<void> {
 function segment(window: Page, label: string) {
   return window.locator('.seg-row', { has: window.getByText(label, { exact: true }) })
 }
+
+// The modes grey out mid-turn, and a disabled button fires no pointer events —
+// so a tooltip on them is unreadable by construction. The way out has to be a
+// row of its own.
+test('a busy session says what to do before the modes will take', async ({ window, daemon }) => {
+  await open(window, ALPHA)
+
+  // Both halves: the event is what the client hears, and the list behind it has
+  // to agree or the refetch puts "idle" straight back.
+  daemon.setStatus(ALPHA_ID, 'active')
+  daemon.emit('session_status', { session_id: ALPHA_ID, status: 'active' })
+  await expect(bar(window)).toContainText('Active')
+
+  await window.locator('.tab-menu').click()
+  await window.locator('.line-menu').first().getByText('Permission mode').hover()
+
+  const submenu = window.locator('.line-sub-menu')
+  await expect(submenu.getByText('Stop the agent to change this')).toBeVisible()
+  await expect(submenu.getByRole('button', { name: 'bypassPermissions' })).toBeDisabled()
+})
 
 // Two ways into one list. They are built from the same function, and this is
 // what would catch a second list being grown beside it.

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -1,0 +1,110 @@
+// The bar at the foot of a session, and the menu that replaced the header.
+//
+// A 67px header used to carry the session's directory, status and permission
+// mode. It is gone; this checks that what it carried is still reachable — from
+// an 18px bar, and from the row's own context menu. Those rules live in
+// components, and there is no component test framework here.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+function bar(window: Page) {
+  return window.locator('.status-line')
+}
+
+async function open(window: Page, title: string): Promise<void> {
+  await window.locator('.session-row', { hasText: title }).click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+}
+
+test.beforeEach(async ({ window }) => {
+  await expect(window.locator('.session-row', { hasText: ALPHA })).toBeVisible()
+})
+
+test('the header is gone and the status line carries what it held', async ({ window }) => {
+  await open(window, ALPHA)
+
+  await expect(window.locator('.detail-head')).toHaveCount(0)
+
+  // The five defaults: directory, branch, model, mode, status. The branch is
+  // the one that was not on the header at all — reading it meant opening the
+  // Git panel.
+  await expect(bar(window)).toContainText('/repo')
+  await expect(bar(window)).toContainText('main')
+  await expect(bar(window)).toContainText('opus')
+  await expect(bar(window)).toContainText('default')
+  await expect(bar(window)).toContainText('Idle')
+})
+
+// The whole point of the change. Measured rather than eyeballed, because a
+// later padding tweak would put the height back without anyone noticing.
+test('the bar is no taller than the text it holds', async ({ window }) => {
+  await open(window, ALPHA)
+  const box = await bar(window).boundingBox()
+  expect(box?.height).toBe(18)
+})
+
+test('the permission mode is on the row menu, ticked on the one in force', async ({ window }) => {
+  await window.locator('.session-row', { hasText: ALPHA }).click({ button: 'right' })
+
+  const menu = window.locator('.line-menu').first()
+  await expect(menu).toBeVisible()
+  await expect(menu.getByText('Rename…')).toBeVisible()
+
+  // Hovering the parent row opens the child beside it. The parent is one row
+  // tall whether or not the provider list has arrived, which is why the modes
+  // live in a child rather than being appended to the menu.
+  await menu.getByText('Permission mode').hover()
+  const submenu = window.locator('.line-sub-menu')
+  await expect(submenu).toBeVisible()
+  await expect(submenu.getByText('✓ default')).toBeVisible()
+  await expect(submenu.getByText('bypassPermissions')).toBeVisible()
+})
+
+async function openSettings(window: Page): Promise<void> {
+  await window.locator('.sidebar-foot .menu summary').click()
+  await window.getByRole('button', { name: 'Settings' }).click()
+  await expect(window.locator('.seg-list')).toBeVisible()
+}
+
+function segment(window: Page, label: string) {
+  return window.locator('.seg-row', { has: window.getByText(label, { exact: true }) })
+}
+
+test('a segment dragged up the list moves left along the bar', async ({ window }) => {
+  await open(window, ALPHA)
+  // Directory first, status last: the default order, and what the drag changes.
+  await expect(bar(window).locator('> *').first()).toContainText('/repo')
+
+  await openSettings(window)
+  await segment(window, 'Status').dragTo(segment(window, 'Working directory'))
+
+  await expect(window.locator('.seg-row:not(.off) .seg-label').first()).toHaveText('Status')
+
+  await window.keyboard.press('Escape')
+  await expect(bar(window).locator('> *').first()).toContainText('Idle')
+})
+
+test('turning every segment off hides the bar', async ({ window }) => {
+  await open(window, ALPHA)
+  await expect(bar(window)).toBeVisible()
+
+  await openSettings(window)
+  await expect(window.locator('.seg-list .seg-row:not(.off)')).toHaveCount(5)
+
+  // By name rather than by position. Unticking one drops it below the divider
+  // and the next takes its place, so a locator that keeps asking for the first
+  // row is asking about a different segment each time.
+  for (const label of ['Working directory', 'Git branch', 'Model', 'Permission mode', 'Status']) {
+    await segment(window, label).locator('input').click()
+  }
+
+  await expect(window.locator('.seg-list .seg-row:not(.off)')).toHaveCount(0)
+  await window.keyboard.press('Escape')
+
+  // The preference went to the main process and came back over theme:changed —
+  // no reload anywhere, which is the part worth asserting.
+  await expect(bar(window)).toHaveCount(0)
+})

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -54,7 +54,7 @@ test('the bar is no taller than the text it holds', async ({ window }) => {
   // this strip was trimmed.
   const tabs = await window.locator('.panel-tabs').boundingBox()
   const modes = await window.locator('.sidebar-modes').boundingBox()
-  expect(tabs?.height).toBe(28)
+  expect(tabs?.height).toBe(34)
   expect(modes?.height).toBe(tabs?.height)
   expect(modes?.y).toBe(tabs?.y)
 })

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -44,6 +44,27 @@ test('the bar is no taller than the text it holds', async ({ window }) => {
   await open(window, ALPHA)
   const box = await bar(window).boundingBox()
   expect(box?.height).toBe(18)
+
+  // The strip above it is the other half of the saving, and the buttons a
+  // terminal tab brings with it used to be what set its height.
+  const tabs = await window.locator('.panel-tabs').boundingBox()
+  expect(tabs?.height).toBe(28)
+})
+
+test('the bar grows with the text size rather than clipping it', async ({ window }) => {
+  await open(window, ALPHA)
+  expect((await bar(window).boundingBox())?.height).toBe(18)
+
+  await openSettings(window)
+  const field = window.locator('.setting-row', { hasText: 'Status line size' }).locator('input')
+  await field.fill('16')
+  await field.blur()
+  await window.keyboard.press('Escape')
+
+  // Height is derived from the size, not set beside it: 16 + 7.
+  await expect
+    .poll(async () => (await bar(window).boundingBox())?.height)
+    .toBe(23)
 })
 
 test('the permission mode is on the row menu, ticked on the one in force', async ({ window }) => {
@@ -72,6 +93,22 @@ async function openSettings(window: Page): Promise<void> {
 function segment(window: Page, label: string) {
   return window.locator('.seg-row', { has: window.getByText(label, { exact: true }) })
 }
+
+// Two ways into one list. They are built from the same function, and this is
+// what would catch a second list being grown beside it.
+test('the tab strip menu offers exactly what the row does', async ({ window }) => {
+  await open(window, ALPHA)
+
+  await window.locator('.session-row', { hasText: ALPHA }).click({ button: 'right' })
+  const fromRow = await window.locator('.line-menu').first().locator('> button, > .line-sub > button').allInnerTexts()
+  await window.keyboard.press('Escape')
+
+  await window.locator('.tab-menu').click()
+  const fromTabs = await window.locator('.line-menu').first().locator('> button, > .line-sub > button').allInnerTexts()
+
+  expect(fromTabs).toEqual(fromRow)
+  expect(fromRow).toContain('Delete')
+})
 
 test('a segment dragged up the list moves left along the bar', async ({ window }) => {
   await open(window, ALPHA)

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -63,7 +63,12 @@ test('the bar grows with the text size rather than clipping it', async ({ window
   expect((await bar(window).boundingBox())?.height).toBe(18)
 
   await openSettings(window)
-  const field = window.locator('.setting-row', { hasText: 'Status line size' }).locator('input')
+  // Scoped to the group: "Text size" is also the label of the markdown size in
+  // the theme group above it.
+  const field = window
+    .locator('.settings-group', { hasText: 'Status line' })
+    .locator('.setting-row', { hasText: 'Text size' })
+    .locator('input')
   await field.fill('16')
   await field.blur()
   await window.keyboard.press('Escape')

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -47,8 +47,15 @@ test('the bar is no taller than the text it holds', async ({ window }) => {
 
   // The strip above it is the other half of the saving, and the buttons a
   // terminal tab brings with it used to be what set its height.
+  //
+  // Level with the sidebar's switch, not merely short: the two sit side by side
+  // at the same y and read as one row, and they drifted apart the first time
+  // this strip was trimmed.
   const tabs = await window.locator('.panel-tabs').boundingBox()
+  const modes = await window.locator('.sidebar-modes').boundingBox()
   expect(tabs?.height).toBe(28)
+  expect(modes?.height).toBe(tabs?.height)
+  expect(modes?.y).toBe(tabs?.y)
 })
 
 test('the bar grows with the text size rather than clipping it', async ({ window }) => {

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import type { PrefsStore } from './prefs.ts'
 import type { TerminalManager } from './terminals.ts'
 import type { ThemeRegistry } from './themes.ts'
 import type { UpdateChecker } from './updates.ts'
+import type { SegmentId } from '../shared/status-line.ts'
 import { DEFAULT_INTENSITY } from '../shared/theme/backdrop.ts'
 import type { BackdropSpec } from '../shared/theme/vscode.ts'
 import type { AppearancePrefs, BackdropState, Density } from '../shared/models.ts'
@@ -198,11 +199,13 @@ export function registerIpc(deps: IpcDeps): void {
     glassSupported: boolean
     proseSize: number
     density: Density
+    statusLine: SegmentId[]
   } => ({
     theme: themes.active(),
     terminal: themes.activeTerminal(),
     proseSize: themes.getPrefs().proseSize,
     density: themes.getPrefs().density,
+    statusLine: themes.getPrefs().statusLine,
     // A property of the chosen theme, not a setting of its own: picking a
     // glass theme is the whole of the request. A theme with no backdrop of its
     // own is gated on the platform, because a preference to show a backdrop

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -200,12 +200,14 @@ export function registerIpc(deps: IpcDeps): void {
     proseSize: number
     density: Density
     statusLine: SegmentId[]
+    statusLineSize: number
   } => ({
     theme: themes.active(),
     terminal: themes.activeTerminal(),
     proseSize: themes.getPrefs().proseSize,
     density: themes.getPrefs().density,
     statusLine: themes.getPrefs().statusLine,
+    statusLineSize: themes.getPrefs().statusLineSize,
     // A property of the chosen theme, not a setting of its own: picking a
     // glass theme is the whole of the request. A theme with no backdrop of its
     // own is gated on the platform, because a preference to show a backdrop

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import { DEFAULT_STATUS_LINE, parseStatusLine } from '../shared/status-line.ts'
 import { mergeThemes, resolveTheme, type HeliosTheme, type ThemeMode } from '../shared/theme/resolve.ts'
 import { parseJsonc, type BackdropSpec, type VSCodeTheme } from '../shared/theme/vscode.ts'
 import type { AppearancePrefs, Density, ThemeSummary } from '../shared/models.ts'
@@ -14,6 +15,7 @@ export const DEFAULT_APPEARANCE: AppearancePrefs = {
   terminalTheme: 'match',
   proseSize: 14,
   density: 'comfortable',
+  statusLine: DEFAULT_STATUS_LINE,
 }
 
 /* Clamped rather than trusted: the file is hand-editable, and a zero or a
@@ -70,6 +72,7 @@ export class ThemeRegistry {
         terminalTheme: parsed.terminalTheme ?? DEFAULT_APPEARANCE.terminalTheme,
         proseSize: proseSize(parsed.proseSize ?? DEFAULT_APPEARANCE.proseSize),
         density: density(parsed.density ?? DEFAULT_APPEARANCE.density),
+        statusLine: parseStatusLine(parsed.statusLine),
       }
     } catch {
       this.prefs = { ...DEFAULT_APPEARANCE }
@@ -210,6 +213,7 @@ export class ThemeRegistry {
     this.prefs = { ...this.prefs, ...next }
     this.prefs.proseSize = proseSize(this.prefs.proseSize)
     this.prefs.density = density(this.prefs.density)
+    this.prefs.statusLine = parseStatusLine(this.prefs.statusLine)
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
     fs.writeFileSync(this.file, JSON.stringify(this.prefs, null, 2))
     return this.getPrefs()

--- a/desktop/src/main/themes.ts
+++ b/desktop/src/main/themes.ts
@@ -16,12 +16,18 @@ export const DEFAULT_APPEARANCE: AppearancePrefs = {
   proseSize: 14,
   density: 'comfortable',
   statusLine: DEFAULT_STATUS_LINE,
+  statusLineSize: 11,
 }
 
 /* Clamped rather than trusted: the file is hand-editable, and a zero or a
    thousand there is a window with no readable way back to the setting. */
 const MIN_PROSE = 10
 const MAX_PROSE = 28
+
+/* The bar's height is derived from this, so the ceiling is what keeps a status
+   line from becoming a second header — the thing it was built to replace. */
+const MIN_STATUS = 9
+const MAX_STATUS = 16
 
 /** What a backdrop image may be, and therefore what the media scheme serves. */
 const IMAGE_TYPES = new Set(['.png', '.jpg', '.jpeg', '.webp'])
@@ -36,6 +42,12 @@ function proseSize(value: unknown): number {
   const size = Math.round(Number(value))
   if (!Number.isFinite(size)) return DEFAULT_APPEARANCE.proseSize
   return Math.min(Math.max(size, MIN_PROSE), MAX_PROSE)
+}
+
+function statusLineSize(value: unknown): number {
+  const size = Math.round(Number(value))
+  if (!Number.isFinite(size)) return DEFAULT_APPEARANCE.statusLineSize
+  return Math.min(Math.max(size, MIN_STATUS), MAX_STATUS)
 }
 
 /**
@@ -73,6 +85,7 @@ export class ThemeRegistry {
         proseSize: proseSize(parsed.proseSize ?? DEFAULT_APPEARANCE.proseSize),
         density: density(parsed.density ?? DEFAULT_APPEARANCE.density),
         statusLine: parseStatusLine(parsed.statusLine),
+        statusLineSize: statusLineSize(parsed.statusLineSize),
       }
     } catch {
       this.prefs = { ...DEFAULT_APPEARANCE }
@@ -214,6 +227,7 @@ export class ThemeRegistry {
     this.prefs.proseSize = proseSize(this.prefs.proseSize)
     this.prefs.density = density(this.prefs.density)
     this.prefs.statusLine = parseStatusLine(this.prefs.statusLine)
+    this.prefs.statusLineSize = statusLineSize(this.prefs.statusLineSize)
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
     fs.writeFileSync(this.file, JSON.stringify(this.prefs, null, 2))
     return this.getPrefs()

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
 import type { Density } from '../shared/models.ts'
-import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
+import { applyDensity, applyProseSize, applyStatusSize, applyTheme } from '../shared/theme/apply.ts'
 import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
 
 interface ThemeBoot {
@@ -11,6 +11,7 @@ interface ThemeBoot {
   glassSupported: boolean
   proseSize: number
   density: Density
+  statusLineSize: number
 }
 
 /**
@@ -61,6 +62,7 @@ const boot = ipcRenderer.sendSync('theme:boot') as ThemeBoot
 const paint = (): void => {
   applyTheme(document.documentElement, boot.theme, boot.glass)
   applyProseSize(document.documentElement, boot.proseSize)
+  applyStatusSize(document.documentElement, boot.statusLineSize)
   applyDensity(document.documentElement, boot.density)
 }
 

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -15,6 +15,8 @@ export interface ThemePayload {
   density: Density
   /** Which segments the session status line draws, in the order it draws them. */
   statusLine: SegmentId[]
+  /** Text size of the status line, in px. The bar's height follows it. */
+  statusLineSize: number
 }
 import type {
   AppearancePrefs,

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -1,3 +1,4 @@
+import type { SegmentId } from '../shared/status-line.ts'
 import type { HeliosTheme, XtermTheme } from '../shared/theme/resolve.ts'
 import type { BackdropSpec } from '../shared/theme/vscode.ts'
 
@@ -12,6 +13,8 @@ export interface ThemePayload {
   /** Reading size for rendered markdown, in px. */
   proseSize: number
   density: Density
+  /** Which segments the session status line draws, in the order it draws them. */
+  statusLine: SegmentId[]
 }
 import type {
   AppearancePrefs,

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
 import { useHostNotifications, useHostSessions } from '../host-data.ts'
-import { providersQuery, sessionQuery } from '../queries.ts'
+import { sessionQuery } from '../queries.ts'
 import { currentLayout, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { ChatPanel } from './chat.tsx'
@@ -11,6 +11,7 @@ import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
 import { GitPanel } from './git.tsx'
 import { SchedulePanel } from './schedules.tsx'
+import { StatusLine } from './status-line.tsx'
 import {
   isVisible,
   panelItem,
@@ -25,14 +26,7 @@ import {
   type Layout,
 } from './layout.ts'
 import { TerminalPane, TerminalPlaceholder } from './terminal.tsx'
-import {
-  BUSY_STATUSES,
-  canResume,
-  needsRecovery,
-  sessionLabel,
-  statusLabel,
-  type Session,
-} from '../../shared/models.ts'
+import { canResume, type Session } from '../../shared/models.ts'
 
 const PANELS: RightPanel[] = ['chat', 'terminal', 'approvals', 'git', 'files']
 
@@ -211,18 +205,7 @@ export function Detail(): JSX.Element {
         </div>
       )}
       <div className="detail" style={showingSchedules ? { display: 'none' } : undefined}>
-      {hostId && session && (
-        <>
-          {/* Keyed: the header holds a rename in progress, and switching
-              sessions has to end it rather than carry it across. */}
-          <SessionHeader
-            key={`${hostId}:${session.session_id}`}
-            hostId={hostId}
-            session={session}
-          />
-          <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />
-        </>
-      )}
+      {hostId && session && <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />}
 
       <div
         className={`panel-body ${axis}`}
@@ -373,6 +356,8 @@ export function Detail(): JSX.Element {
             />
           ))}
         </div>
+
+      {hostId && session && <StatusLine hostId={hostId} session={session} />}
       </div>
     </>
   )
@@ -858,179 +843,6 @@ function ShellTab({
       </span>
     </button>
   )
-}
-
-function SessionHeader({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
-  const [renaming, setRenaming] = useState(false)
-  const [title, setTitle] = useState(session.title ?? '')
-  const busy = BUSY_STATUSES.has(session.status)
-  const terminated = canResume(session)
-  const cold = needsRecovery(session)
-
-  const run = async (fn: () => Promise<unknown>): Promise<void> => {
-    try {
-      await fn()
-      await store.invalidateSessionsFor(hostId)
-    } catch (err) {
-      store.fail(err)
-    }
-  }
-
-  return (
-    <header className="detail-head">
-      <div className="detail-title">
-        {renaming ? (
-          <input
-            autoFocus
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-            onBlur={() => {
-              setRenaming(false)
-              if (title !== (session.title ?? '')) {
-                void store.patchSessionField(hostId, session.session_id, { title })
-              }
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') event.currentTarget.blur()
-              if (event.key === 'Escape') {
-                setTitle(session.title ?? '')
-                setRenaming(false)
-              }
-            }}
-          />
-        ) : (
-          /* Seeded on open rather than kept in step with the session: the
-             draft only means anything while the field is up, and the title can
-             have moved under it since — the daemon names a session itself
-             after the first exchange. */
-          <h1
-            onDoubleClick={() => {
-              setTitle(session.title ?? '')
-              setRenaming(true)
-            }}
-          >
-            {sessionLabel(session)}
-          </h1>
-        )}
-        <span className="detail-cwd" title={session.cwd}>
-          {session.cwd}
-        </span>
-      </div>
-
-      <div className="detail-actions">
-        <span className={`chip ${session.status}`}>
-          <span className={busy ? 'dot pulse' : 'dot'} />
-          {statusLabel(session.status)}
-        </span>
-
-        {session.memory_bytes !== undefined && (
-          <span className="card-ram" title="Memory this session's terminal holds">
-            {formatBytes(session.memory_bytes)}
-          </span>
-        )}
-
-        {cold && (
-          <button
-            className="ghost cold"
-            title="Cold — no live terminal. Resume brings the agent back."
-            onClick={() => void store.resumeSession(hostId, session.session_id)}
-          >
-            ⚯ Cold
-          </button>
-        )}
-
-        <PermissionMode hostId={hostId} session={session} />
-
-        {/* Resume has no equivalent anywhere else, so it stays. Terminated is
-            the one state the daemon refuses prompts for outright, and this is
-            the only control that clears it.
-
-            Waking is not like that. A cold session wakes itself the moment it
-            is given something to do: the daemon starts a host on send, and the
-            composer already says so. The terminal pane offers its own button
-            for the case where a terminal is what you want. A header button as
-            well was a third way to say the same thing. */}
-        {terminated && (
-          <button className="filled" onClick={() => void store.resumeSession(hostId, session.session_id)}>
-            Resume
-          </button>
-        )}
-
-        {busy && <button className="ghost" onClick={() => void run(() => api(hostId).stop(session.session_id))}>Stop</button>}
-
-        {/* Terminate, Pin, Delete and Regenerate title are on the row's own
-            right-click menu. They were here as a button and an overflow beside
-            it, which put the actions for one session at the far corner from
-            the list of them — and made acting on any other session a matter of
-            selecting it first and re-reading the header to be sure it had
-            changed. See sessionActions in sidebar.tsx. */}
-      </div>
-    </header>
-  )
-}
-
-/**
- * Switching mode restarts the agent, because the CLI takes it as a launch flag.
- * The daemon refuses while a session is mid-turn; the control is disabled to
- * match, but the server check is the one that counts.
- */
-function PermissionMode({ hostId, session }: { hostId: string; session: Session }): JSX.Element | null {
-  const [pending, setPending] = useState(false)
-  // The list is asked for when the select is focused rather than on mount: the
-  // same answer serves the new-session dialog, so this is usually a cache hit,
-  // but a session panel that has never been touched should not pay for it.
-  const [wanted, setWanted] = useState(false)
-  const { data: providers, error } = useQuery({ ...providersQuery(hostId), enabled: wanted })
-  const modes = providers
-    ? (providers.find((p) => p.id === session.source)?.permission_modes ?? [])
-    : error
-      ? []
-      : null
-
-  // Nothing to show for a provider with no modes. The list arrives only after
-  // the select is focused, so before that this renders for every provider —
-  // an empty control on a provider that has none, which is why the check is
-  // here rather than in a comment claiming it happens.
-  if (modes !== null && modes.length === 0) return null
-
-  const load = (): void => setWanted(true)
-
-  const switchable = session.status === 'idle'
-
-  const change = async (mode: string): Promise<void> => {
-    if (!mode || mode === session.permission_mode) return
-    setPending(true)
-    try {
-      await store.setPermissionMode(hostId, session.session_id, mode)
-    } finally {
-      setPending(false)
-    }
-  }
-
-  return (
-    <select
-      className="mode-select"
-      value={session.permission_mode ?? ''}
-      disabled={!switchable || pending}
-      title={switchable ? 'Restarts the agent' : 'Only while the session is idle'}
-      onFocus={() => load()}
-      onChange={(event) => void change(event.target.value)}
-    >
-      {/* The modes list loads on focus, so the current value needs an option of
-          its own until it arrives. */}
-      {!session.permission_mode && <option value="">default</option>}
-      {(modes ?? [session.permission_mode].filter((m): m is string => Boolean(m))).map((mode) => (
-        <option key={mode} value={mode}>
-          {mode}
-        </option>
-      ))}
-    </select>
-  )
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
-  return `${Math.round(bytes / 1024 ** 2)} MB`
 }
 
 /**

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
-import { useHostNotifications, useHostSessions } from '../host-data.ts'
-import { sessionQuery } from '../queries.ts'
+import { useHostGroups, useHostNotifications, useHostSessions } from '../host-data.ts'
+import { providersQuery, sessionQuery } from '../queries.ts'
 import { currentLayout, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { ChatPanel } from './chat.tsx'
@@ -11,6 +11,8 @@ import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
 import { GitPanel } from './git.tsx'
 import { SchedulePanel } from './schedules.tsx'
+import { SelectionMenu } from './selection-menu.tsx'
+import { sessionActions } from './session-menu.ts'
 import { StatusLine } from './status-line.tsx'
 import {
   isVisible,
@@ -565,7 +567,54 @@ function GroupTabs({
           +
         </button>
       )}
+
+      {showAdd && <SessionMenuButton hostId={hostId} session={session} />}
     </nav>
+  )
+}
+
+/**
+ * The session's own menu, at the right-hand end of the strip.
+ *
+ * The same actions the row offers on a right-click, and built from the same
+ * function: a second list that drifted from the first would be worse than no
+ * second way in at all. It is here because the sidebar can be scrolled away
+ * from the session being read, or dragged narrow enough to hide it.
+ */
+function SessionMenuButton({ hostId, session }: { hostId: string; session: Session }): JSX.Element {
+  const [at, setAt] = useState<{ x: number; y: number } | null>(null)
+  const { groups, unsupported } = useHostGroups()
+  // Only once the menu is open, for the same reason the sidebar's copy waits:
+  // the answer never goes stale, but a strip nobody has opened a menu on should
+  // not fetch it.
+  const { data: providers } = useQuery({ ...providersQuery(hostId), enabled: at !== null })
+
+  return (
+    <>
+      <button
+        className="tab-menu"
+        title="Session actions"
+        aria-label="Session actions"
+        onClick={(event) => {
+          const box = event.currentTarget.getBoundingClientRect()
+          // Below the button rather than at the pointer: this one has a fixed
+          // place on screen, unlike a right-click, and a menu that lands
+          // wherever the click did reads as unmoored from it.
+          setAt({ x: box.left, y: box.bottom + 4 })
+        }}
+      >
+        ⋯
+      </button>
+
+      {at && (
+        <SelectionMenu
+          x={at.x}
+          y={at.y}
+          actions={sessionActions(hostId, session, unsupported[hostId] ? [] : (groups[hostId] ?? []), providers)}
+          onClose={() => setAt(null)}
+        />
+      )}
+    </>
   )
 }
 

--- a/desktop/src/renderer/components/selection-menu.tsx
+++ b/desktop/src/renderer/components/selection-menu.tsx
@@ -3,12 +3,23 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObje
 /** One entry of a popover: what it says, and what it does. */
 export interface MenuAction {
   label: string
-  run: () => void
+  /** Absent on a row that only opens `children`. */
+  run?: () => void
   /** Destructive, and coloured to say so before it is clicked. */
   danger?: boolean
   /** Hovered explanation, for an action whose reach is wider than its label —
    *  and for one that does not stop to ask before it acts. */
   title?: string
+  /** Shown, but refusing. The title is where the reason goes. */
+  disabled?: boolean
+  /**
+   * A second menu, opened from this row.
+   *
+   * The row keeps its height whether or not the children have arrived, which is
+   * the point: a list fetched when the menu opens would otherwise grow it under
+   * the pointer.
+   */
+  children?: MenuAction[]
 }
 
 /**
@@ -73,19 +84,100 @@ export function SelectionMenu({
       style={shifted ?? { left, top: y }}
       onMouseDown={(event) => event.preventDefault()}
     >
-      {actions.map((action) => (
-        <button
-          key={action.label}
-          className={action.danger ? 'danger' : undefined}
-          title={action.title}
-          onClick={() => {
-            action.run()
-            onClose()
-          }}
+      {actions.map((action) =>
+        action.children ? (
+          <SubMenu key={action.label} action={action} onClose={onClose} />
+        ) : (
+          <button
+            key={action.label}
+            className={action.danger ? 'danger' : undefined}
+            title={action.title}
+            disabled={action.disabled}
+            onClick={() => {
+              action.run?.()
+              onClose()
+            }}
+          >
+            {action.label}
+          </button>
+        ),
+      )}
+    </div>
+  )
+}
+
+/** How long the pointer may be off both the row and its children before it shuts. */
+const SUBMENU_GRACE = 120
+
+/**
+ * A row that opens a second menu beside itself.
+ *
+ * The child is a descendant of the parent's box rather than a portal, so the
+ * dismiss handler above — which ignores mousedown inside that box — needs no
+ * case for it.
+ */
+function SubMenu({ action, onClose }: { action: MenuAction; onClose: () => void }): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [flip, setFlip] = useState(false)
+  const row = useRef<HTMLDivElement | null>(null)
+  const child = useRef<HTMLDivElement | null>(null)
+  const closing = useRef<number | undefined>(undefined)
+
+  // Delayed, so the pointer can cross the gap between the row and the child.
+  const hold = (): void => window.clearTimeout(closing.current)
+  const release = (): void => {
+    closing.current = window.setTimeout(() => setOpen(false), SUBMENU_GRACE)
+  }
+
+  useEffect(() => () => window.clearTimeout(closing.current), [])
+
+  // Opens to the left instead when there is no room on the right. Measured
+  // before paint for the same reason the parent menu measures itself: a menu
+  // that jumps has already been read in the wrong place.
+  useLayoutEffect(() => {
+    if (!open) return
+    const at = row.current?.getBoundingClientRect()
+    const box = child.current?.getBoundingClientRect()
+    if (!at || !box) return
+    setFlip(at.right + box.width > window.innerWidth - 8)
+  }, [open, action.children?.length])
+
+  return (
+    <div className="line-sub" ref={row} onMouseEnter={() => { hold(); setOpen(true) }} onMouseLeave={release}>
+      <button
+        className={action.danger ? 'danger' : undefined}
+        title={action.title}
+        disabled={action.disabled}
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+      >
+        {action.label}
+        <span className="line-sub-mark">›</span>
+      </button>
+
+      {open && (
+        <div
+          className={`line-menu line-sub-menu${flip ? ' flip' : ''}`}
+          ref={child}
+          onMouseEnter={hold}
+          onMouseLeave={release}
         >
-          {action.label}
-        </button>
-      ))}
+          {action.children?.map((entry) => (
+            <button
+              key={entry.label}
+              className={entry.danger ? 'danger' : undefined}
+              title={entry.title}
+              disabled={entry.disabled}
+              onClick={() => {
+                entry.run?.()
+                onClose()
+              }}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/desktop/src/renderer/components/session-menu.ts
+++ b/desktop/src/renderer/components/session-menu.ts
@@ -24,14 +24,30 @@ export function modeActions(
   if (modes.length === 0) return [{ label: 'This provider has no modes', disabled: true }]
 
   const switchable = session.status === 'idle'
-  return modes.map((mode) => ({
+  const entries: MenuAction[] = modes.map((mode) => ({
     // The tick convention the group entries in this menu already use.
     label: `${mode === session.permission_mode ? '✓ ' : ' '}${mode}`,
     disabled: !switchable,
-    title: switchable ? 'Switching restarts the agent' : 'Only while the session is idle',
+    title: switchable ? 'Switching restarts the agent' : undefined,
     run: () => void store.setPermissionMode(hostId, session.session_id, mode),
   }))
+
+  if (switchable) return entries
+
+  // A row of its own rather than a tooltip on the greyed-out modes. A disabled
+  // button fires no pointer events, so its `title` never opens — the one place
+  // the explanation cannot be read is the control it explains.
+  //
+  // Which way out depends on why it is refused: a session mid-turn has to be
+  // stopped, and a terminated one has nothing left running to restart.
+  return [{ label: canResume(session) ? RESUME_FIRST : STOP_FIRST, disabled: true }, ...entries]
 }
+
+/* Named after the control that clears it rather than the state it wants: Stop
+   is the ■ beside the prompt, Resume is on the session's own row. Kept short
+   because the widest entry sets the width of the whole menu. */
+const STOP_FIRST = 'Stop the agent to change this'
+const RESUME_FIRST = 'Resume the session to change this'
 
 /**
  * What can be done to a session, as the right-click on its row offers it.

--- a/desktop/src/renderer/components/session-menu.ts
+++ b/desktop/src/renderer/components/session-menu.ts
@@ -1,6 +1,7 @@
+import { api } from '../bridge.ts'
 import { store } from '../store.ts'
 import type { MenuAction } from './selection-menu.tsx'
-import type { ProviderInfo, Session } from '../../shared/models.ts'
+import { canResume, type ProviderInfo, type Session, type SessionGroup } from '../../shared/models.ts'
 
 /**
  * The permission modes one session may be switched between.
@@ -30,4 +31,120 @@ export function modeActions(
     title: switchable ? 'Switching restarts the agent' : 'Only while the session is idle',
     run: () => void store.setPermissionMode(hostId, session.session_id, mode),
   }))
+}
+
+/**
+ * What can be done to a session, as the right-click on its row offers it.
+ *
+ * These were buttons in the detail header, where they applied to whichever
+ * session happened to be open: acting on any other one meant selecting it
+ * first and reading the header to check it had changed. On the row they name
+ * the session under the pointer, which is the one being pointed at.
+ */
+export function sessionActions(
+  hostId: string,
+  session: Session,
+  groups: SessionGroup[],
+  providers: ProviderInfo[] | undefined,
+): MenuAction[] {
+  const run = async (fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await fn()
+      await store.invalidateSessionsFor(hostId)
+    } catch (err) {
+      store.fail(err)
+    }
+  }
+
+  const held = session.group_key ?? ''
+
+  // One entry per group, ticked on the one this session is filed under.
+  // Choosing another moves it; choosing the current one takes it out.
+  const actions: MenuAction[] = groups.map((group) => {
+    const inside = held === group.key
+    return {
+      label: `${inside ? '✓ ' : '\u2003'}${group.name}`,
+      run: () => void store.setSessionGroup(hostId, session.session_id, inside ? '' : group.key),
+    }
+  })
+
+  actions.push({
+    label: 'New group…',
+    run: () => {
+      const name = window.prompt('Name the group')?.trim()
+      if (!name) return
+      void store.createGroup(hostId, name).then((group) => {
+        if (group) void store.setSessionGroup(hostId, session.session_id, group.key)
+      })
+    },
+  })
+
+  actions.push(
+    {
+      // Prompted rather than edited in place, as New group above is. The title
+      // used to be an input in the detail header; with the header gone this is
+      // the only way to set one by hand.
+      label: 'Rename…',
+      run: () => {
+        const title = window.prompt('Name the session', session.title ?? '')?.trim()
+        if (title === undefined || title === (session.title ?? '')) return
+        void store.patchSessionField(hostId, session.session_id, { title })
+      },
+    },
+    {
+      label: 'Regenerate title',
+      // The daemon waits for the model before answering, so this can sit for
+      // several seconds. Saying what came back is the difference between a
+      // slow menu item and a broken one.
+      run: () =>
+        void run(async () => {
+          store.notify('Naming the session…')
+          const result = await api(hostId).generateTitle(session.session_id)
+          if (result.title) store.notify(result.title)
+          else store.notify('The model did not return a usable title', 'error')
+        }),
+    },
+    {
+      label: session.pinned ? 'Unpin' : 'Pin',
+      run: () => void store.patchSessionField(hostId, session.session_id, { pinned: !session.pinned }),
+    },
+  )
+
+  // A child menu rather than entries of its own: the list comes from the daemon
+  // when the menu opens, and a parent row keeps its one-row height whether or
+  // not it has arrived — entries appearing here would grow the menu under the
+  // pointer, on top of the actions below.
+  actions.push({
+    label: 'Permission mode',
+    children: modeActions(hostId, session, providers),
+  })
+
+  // Nothing to end when it has already ended, and the row itself carries the
+  // Resume that a terminated session is waiting for.
+  if (!canResume(session)) {
+    actions.push({
+      label: 'Terminate',
+      danger: true,
+      run: () => {
+        if (confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
+          void run(() => api(hostId).terminate(session.session_id))
+        }
+      },
+    })
+  }
+
+  actions.push({
+    label: 'Delete',
+    danger: true,
+    run: () => {
+      // Deleting drops the daemon's record; the agent's own transcript on disk
+      // is untouched, which is worth saying before the click.
+      if (confirm('Remove this session from Helios? The transcript file stays on disk.')) {
+        store.closeTab(`${hostId}:${session.session_id}`)
+        void run(() => api(hostId).deleteSession(session.session_id))
+      }
+    },
+  })
+
+  return actions
 }

--- a/desktop/src/renderer/components/session-menu.ts
+++ b/desktop/src/renderer/components/session-menu.ts
@@ -1,0 +1,33 @@
+import { store } from '../store.ts'
+import type { MenuAction } from './selection-menu.tsx'
+import type { ProviderInfo, Session } from '../../shared/models.ts'
+
+/**
+ * The permission modes one session may be switched between.
+ *
+ * Two callers want the same list: the row's context menu, and the status line
+ * segment that shows which one is in force. Neither owns it, so it lives here.
+ *
+ * Switching restarts the agent, because the CLI takes the mode as a launch
+ * flag. The daemon refuses while a session is mid-turn; the entries are
+ * disabled to match, but the server check is the one that counts.
+ */
+export function modeActions(
+  hostId: string,
+  session: Session,
+  providers: ProviderInfo[] | undefined,
+): MenuAction[] {
+  if (!providers) return [{ label: 'Loading…', disabled: true }]
+
+  const modes = providers.find((provider) => provider.id === session.source)?.permission_modes ?? []
+  if (modes.length === 0) return [{ label: 'This provider has no modes', disabled: true }]
+
+  const switchable = session.status === 'idle'
+  return modes.map((mode) => ({
+    // The tick convention the group entries in this menu already use.
+    label: `${mode === session.permission_mode ? '✓ ' : ' '}${mode}`,
+    disabled: !switchable,
+    title: switchable ? 'Switching restarts the agent' : 'Only while the session is idle',
+    run: () => void store.setPermissionMode(hostId, session.session_id, mode),
+  }))
+}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type DragEvent, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createPortal } from 'react-dom'
 
@@ -9,6 +9,14 @@ import { settingsQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
 import { Modal } from './newsession.tsx'
 import { ALERT_TYPES } from '../../shared/notifications.ts'
+import {
+  DEFAULT_STATUS_LINE,
+  SEGMENTS,
+  hiddenSegments,
+  moveSegment,
+  toggleSegment,
+  type SegmentId,
+} from '../../shared/status-line.ts'
 import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
@@ -192,6 +200,11 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         />
 
         <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
+
+        <StatusLineRows
+          order={appearance?.statusLine ?? DEFAULT_STATUS_LINE}
+          onChange={(statusLine) => void setTheme({ statusLine })}
+        />
 
         <Backdrop />
 
@@ -789,6 +802,87 @@ function Row({
       </span>
       <div className="setting-row-control">{children}</div>
     </div>
+  )
+}
+
+/** Where a dragged segment would land, drawn as a line between two rows. */
+const DRAG_TYPE = 'application/x-helios-segment'
+
+/**
+ * Which segments the session status line draws, and in what order.
+ *
+ * Shown as one list rather than two: the enabled ones on top in the order they
+ * appear in the bar, then the rest under a divider. A segment turned off drops
+ * below it and loses its place, which is the honest reading — the stored value
+ * is the enabled order, and there is nowhere to remember where an absent
+ * segment used to be.
+ */
+function StatusLineRows({
+  order,
+  onChange,
+}: {
+  order: SegmentId[]
+  onChange: (order: SegmentId[]) => void
+}): JSX.Element {
+  const [over, setOver] = useState<number | null>(null)
+  const hidden = hiddenSegments(order)
+  const labels = new Map(SEGMENTS.map((segment) => [segment.id, segment.label]))
+
+  const drop = (index: number) => (event: DragEvent) => {
+    event.preventDefault()
+    const id = event.dataTransfer.getData(DRAG_TYPE) as SegmentId
+    setOver(null)
+    if (id) onChange(moveSegment(order, id, index))
+  }
+
+  // Above the midpoint means before this row, below means after it. The same
+  // rule the session list uses when a row is dragged onto another.
+  const hover = (index: number) => (event: DragEvent) => {
+    if (!event.dataTransfer.types.includes(DRAG_TYPE)) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    const box = event.currentTarget.getBoundingClientRect()
+    setOver(event.clientY < box.top + box.height / 2 ? index : index + 1)
+  }
+
+  return (
+    <Row
+      label="Status line"
+      info="The bar at the foot of a session. Drag to reorder; untick to hide. Turning everything off hides the bar."
+    >
+      <div className="seg-list" onDragLeave={() => setOver(null)}>
+        {order.map((id, index) => (
+          <label
+            key={id}
+            className={`seg-row${over === index ? ' over' : ''}${over === index + 1 && index === order.length - 1 ? ' over-last' : ''}`}
+            draggable
+            onDragStart={(event) => {
+              event.dataTransfer.effectAllowed = 'move'
+              event.dataTransfer.setData(DRAG_TYPE, id)
+            }}
+            onDragEnd={() => setOver(null)}
+            onDragOver={hover(index)}
+            onDrop={drop(index)}
+          >
+            <span className="seg-grip" aria-hidden>
+              ⠿
+            </span>
+            <input type="checkbox" checked onChange={() => onChange(toggleSegment(order, id))} />
+            <span className="seg-label">{labels.get(id)}</span>
+          </label>
+        ))}
+
+        {hidden.length > 0 && <span className="seg-divider">Not shown</span>}
+
+        {hidden.map((id) => (
+          <label key={id} className="seg-row off">
+            <span className="seg-grip" aria-hidden />
+            <input type="checkbox" checked={false} onChange={() => onChange(toggleSegment(order, id))} />
+            <span className="seg-label">{labels.get(id)}</span>
+          </label>
+        ))}
+      </div>
+    </Row>
   )
 }
 

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -208,25 +208,36 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           onPick={(proseSize) => void setTheme({ proseSize })}
         />
 
+        <Backdrop />
+
+        <button className="ghost" onClick={() => void reloadThemes()}>
+          Reload themes
+        </button>
+      </section>
+
+      {/* Its own group rather than another row among the themes. The segment
+          list is many rows tall, and in the middle of a form of single-line
+          controls it broke the theme pickers into two halves that looked
+          unrelated. */}
+      <section className="settings-group">
+        <h3>
+          Status line
+          <Info>The bar along the foot of a session, in place of a header above it.</Info>
+        </h3>
+
         <StatusLineRows
           order={appearance?.statusLine ?? DEFAULT_STATUS_LINE}
           onChange={(statusLine) => void setTheme({ statusLine })}
         />
 
         <PixelSize
-          label="Status line size"
+          label="Text size"
           info="In pixels, between 9 and 16. The bar's height follows the text, so a larger size is a taller bar."
           size={appearance?.statusLineSize}
           min={9}
           max={16}
           onPick={(statusLineSize) => void setTheme({ statusLineSize })}
         />
-
-        <Backdrop />
-
-        <button className="ghost" onClick={() => void reloadThemes()}>
-          Reload themes
-        </button>
       </section>
             </>
           )}
@@ -863,8 +874,8 @@ function StatusLineRows({
 
   return (
     <Row
-      label="Status line"
-      info="The bar at the foot of a session. Drag to reorder; untick to hide. Turning everything off hides the bar."
+      label="Segments"
+      info="Drag to reorder; untick to hide. Turning everything off hides the bar."
     >
       <div className="seg-list" onDragLeave={() => setOver(null)}>
         {order.map((id, index) => (

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -199,11 +199,27 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
           onPick={(id) => void setTheme({ terminalTheme: id })}
         />
 
-        <ProseSize size={appearance?.proseSize} onPick={(size) => void setTheme({ proseSize: size })} />
+        <PixelSize
+          label="Text size"
+          info="In pixels, between 10 and 28. Sets the size of rendered markdown — the transcript and the file previews both. It does not touch the terminal."
+          size={appearance?.proseSize}
+          min={10}
+          max={28}
+          onPick={(proseSize) => void setTheme({ proseSize })}
+        />
 
         <StatusLineRows
           order={appearance?.statusLine ?? DEFAULT_STATUS_LINE}
           onChange={(statusLine) => void setTheme({ statusLine })}
+        />
+
+        <PixelSize
+          label="Status line size"
+          info="In pixels, between 9 and 16. The bar's height follows the text, so a larger size is a taller bar."
+          size={appearance?.statusLineSize}
+          min={9}
+          max={16}
+          onPick={(statusLineSize) => void setTheme({ statusLineSize })}
         />
 
         <Backdrop />
@@ -1231,23 +1247,44 @@ function previewOf(
   return backdropValue({ style, intensity, ...(image ? { image } : {}) }, base, stops)
 }
 
-function ProseSize({ size, onPick }: { size: number | undefined; onPick: (size: number) => void }): JSX.Element {
+/**
+ * A size in pixels, typed rather than dragged.
+ *
+ * The draft is held while the field is focused and only clamped on the way out,
+ * so typing "1" on the way to "12" is not answered by the field correcting
+ * itself to the minimum under the cursor.
+ */
+function PixelSize({
+  label,
+  info,
+  size,
+  min,
+  max,
+  onPick,
+}: {
+  label: string
+  info: string
+  size: number | undefined
+  min: number
+  max: number
+  onPick: (size: number) => void
+}): JSX.Element {
   const [draft, setDraft] = useState('')
   const shown = draft || String(size ?? '')
 
   const commit = (): void => {
     setDraft('')
     const next = Number(shown)
-    if (Number.isFinite(next) && next !== size) onPick(Math.min(Math.max(Math.round(next), 10), 28))
+    if (Number.isFinite(next) && next !== size) onPick(Math.min(Math.max(Math.round(next), min), max))
   }
 
   return (
-    <Row label="Text size" info="In pixels, between 10 and 28. Sets the size of rendered markdown — the transcript and the file previews both. It does not touch the terminal.">
+    <Row label={label} info={info}>
       <input
         className="prose-size"
         type="number"
-        min={10}
-        max={28}
+        min={min}
+        max={max}
         step={1}
         value={shown}
         disabled={size === undefined}

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 
 import { api, bridge } from '../bridge.ts'
+import { providersQuery } from '../queries.ts'
 import {
   useHostGroups,
   useHostJobSessions,
@@ -21,6 +23,7 @@ import {
   statusLabel,
   timeAgo,
   type HostRecord,
+  type ProviderInfo,
   type Session,
   type SessionGroup,
   type HostStats,
@@ -37,6 +40,7 @@ import {
 import { GroupPicker } from './group-picker.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
+import { modeActions } from './session-menu.ts'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -217,6 +221,14 @@ export function Sidebar({
   // instead of opening another beside it — and one piece of state, so a header
   // menu and a row menu can never be open at once.
   const [menu, setMenu] = useState<RowMenu | HeadMenu | null>(null)
+  // Only once a row menu is open, and never for a header one. The list is
+  // shared with the new-session dialog and never goes stale, so this is usually
+  // a cache hit — but a sidebar nobody has right-clicked should not pay for one
+  // request per host on mount.
+  const { data: providers } = useQuery({
+    ...providersQuery(menu?.kind === 'session' ? menu.hostId : ''),
+    enabled: menu?.kind === 'session',
+  })
   // Which group is having a child named, keyed by host and group. Empty string
   // is the root of that host, so one piece of state covers both.
   const [creatingIn, setCreatingIn] = useState<string | null>(null)
@@ -928,6 +940,7 @@ export function Sidebar({
                   menu.hostId,
                   menu.session,
                   groupsUnsupported[menu.hostId] ? [] : (groupsByHost[menu.hostId] ?? []),
+                  providers,
                 )
               : groupActions(menu.hostId, menu.key, () =>
                   setRenaming(`${menu.hostId}:${menu.key}`),
@@ -962,7 +975,12 @@ export function Sidebar({
  * first and reading the header to check it had changed. On the row they name
  * the session under the pointer, which is the one being pointed at.
  */
-function sessionActions(hostId: string, session: Session, groups: SessionGroup[]): MenuAction[] {
+function sessionActions(
+  hostId: string,
+  session: Session,
+  groups: SessionGroup[],
+  providers: ProviderInfo[] | undefined,
+): MenuAction[] {
   const run = async (fn: () => Promise<unknown>): Promise<void> => {
     try {
       await fn()
@@ -997,6 +1015,17 @@ function sessionActions(hostId: string, session: Session, groups: SessionGroup[]
 
   actions.push(
     {
+      // Prompted rather than edited in place, as New group above is. The title
+      // used to be an input in the detail header; with the header gone this is
+      // the only way to set one by hand.
+      label: 'Rename…',
+      run: () => {
+        const title = window.prompt('Name the session', session.title ?? '')?.trim()
+        if (title === undefined || title === (session.title ?? '')) return
+        void store.patchSessionField(hostId, session.session_id, { title })
+      },
+    },
+    {
       label: 'Regenerate title',
       // The daemon waits for the model before answering, so this can sit for
       // several seconds. Saying what came back is the difference between a
@@ -1014,6 +1043,15 @@ function sessionActions(hostId: string, session: Session, groups: SessionGroup[]
       run: () => void store.patchSessionField(hostId, session.session_id, { pinned: !session.pinned }),
     },
   )
+
+  // A child menu rather than entries of its own: the list comes from the daemon
+  // when the menu opens, and a parent row keeps its one-row height whether or
+  // not it has arrived — entries appearing here would grow the menu under the
+  // pointer, on top of the actions below.
+  actions.push({
+    label: 'Permission mode',
+    children: modeActions(hostId, session, providers),
+  })
 
   // Nothing to end when it has already ended, and the row itself carries the
   // Resume that a terminated session is waiting for.

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
-import { api, bridge } from '../bridge.ts'
+import { bridge } from '../bridge.ts'
 import { providersQuery } from '../queries.ts'
 import {
   useHostGroups,
@@ -23,9 +23,7 @@ import {
   statusLabel,
   timeAgo,
   type HostRecord,
-  type ProviderInfo,
   type Session,
-  type SessionGroup,
   type HostStats,
 } from '../../shared/models.ts'
 import { Chevron, Console, Cpu, Memory, Plus, Search, Sort } from './icons.tsx'
@@ -40,7 +38,7 @@ import {
 import { GroupPicker } from './group-picker.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
-import { modeActions } from './session-menu.ts'
+import { sessionActions } from './session-menu.ts'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -965,122 +963,6 @@ export function Sidebar({
       />
     </aside>
   )
-}
-
-/**
- * What can be done to a session, as the right-click on its row offers it.
- *
- * These were buttons in the detail header, where they applied to whichever
- * session happened to be open: acting on any other one meant selecting it
- * first and reading the header to check it had changed. On the row they name
- * the session under the pointer, which is the one being pointed at.
- */
-function sessionActions(
-  hostId: string,
-  session: Session,
-  groups: SessionGroup[],
-  providers: ProviderInfo[] | undefined,
-): MenuAction[] {
-  const run = async (fn: () => Promise<unknown>): Promise<void> => {
-    try {
-      await fn()
-      await store.invalidateSessionsFor(hostId)
-    } catch (err) {
-      store.fail(err)
-    }
-  }
-
-  const held = session.group_key ?? ''
-
-  // One entry per group, ticked on the one this session is filed under.
-  // Choosing another moves it; choosing the current one takes it out.
-  const actions: MenuAction[] = groups.map((group) => {
-    const inside = held === group.key
-    return {
-      label: `${inside ? '✓ ' : '\u2003'}${group.name}`,
-      run: () => void store.setSessionGroup(hostId, session.session_id, inside ? '' : group.key),
-    }
-  })
-
-  actions.push({
-    label: 'New group…',
-    run: () => {
-      const name = window.prompt('Name the group')?.trim()
-      if (!name) return
-      void store.createGroup(hostId, name).then((group) => {
-        if (group) void store.setSessionGroup(hostId, session.session_id, group.key)
-      })
-    },
-  })
-
-  actions.push(
-    {
-      // Prompted rather than edited in place, as New group above is. The title
-      // used to be an input in the detail header; with the header gone this is
-      // the only way to set one by hand.
-      label: 'Rename…',
-      run: () => {
-        const title = window.prompt('Name the session', session.title ?? '')?.trim()
-        if (title === undefined || title === (session.title ?? '')) return
-        void store.patchSessionField(hostId, session.session_id, { title })
-      },
-    },
-    {
-      label: 'Regenerate title',
-      // The daemon waits for the model before answering, so this can sit for
-      // several seconds. Saying what came back is the difference between a
-      // slow menu item and a broken one.
-      run: () =>
-        void run(async () => {
-          store.notify('Naming the session…')
-          const result = await api(hostId).generateTitle(session.session_id)
-          if (result.title) store.notify(result.title)
-          else store.notify('The model did not return a usable title', 'error')
-        }),
-    },
-    {
-      label: session.pinned ? 'Unpin' : 'Pin',
-      run: () => void store.patchSessionField(hostId, session.session_id, { pinned: !session.pinned }),
-    },
-  )
-
-  // A child menu rather than entries of its own: the list comes from the daemon
-  // when the menu opens, and a parent row keeps its one-row height whether or
-  // not it has arrived — entries appearing here would grow the menu under the
-  // pointer, on top of the actions below.
-  actions.push({
-    label: 'Permission mode',
-    children: modeActions(hostId, session, providers),
-  })
-
-  // Nothing to end when it has already ended, and the row itself carries the
-  // Resume that a terminated session is waiting for.
-  if (!canResume(session)) {
-    actions.push({
-      label: 'Terminate',
-      danger: true,
-      run: () => {
-        if (confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
-          void run(() => api(hostId).terminate(session.session_id))
-        }
-      },
-    })
-  }
-
-  actions.push({
-    label: 'Delete',
-    danger: true,
-    run: () => {
-      // Deleting drops the daemon's record; the agent's own transcript on disk
-      // is untouched, which is worth saying before the click.
-      if (confirm('Remove this session from Helios? The transcript file stays on disk.')) {
-        store.closeTab(`${hostId}:${session.session_id}`)
-        void run(() => api(hostId).deleteSession(session.session_id))
-      }
-    },
-  })
-
-  return actions
 }
 
 /**

--- a/desktop/src/renderer/components/status-line.tsx
+++ b/desktop/src/renderer/components/status-line.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { PathLabel } from './path-label.tsx'
+import { SelectionMenu } from './selection-menu.tsx'
+import { modeActions } from './session-menu.ts'
+import { gitStatusQuery, providersQuery } from '../queries.ts'
+import { useStore } from '../store.ts'
+import type { SegmentId } from '../../shared/status-line.ts'
+import { BUSY_STATUSES, statusLabel, type Session } from '../../shared/models.ts'
+
+/**
+ * One line at the foot of the pane saying where the session is and what it is
+ * doing.
+ *
+ * It replaced a 67px header carrying the same facts, so it is deliberately as
+ * short as it can be read at: a fixed height rather than padding, and a tint
+ * rather than a rule, because a hairline costs a pixel and reads heavier than
+ * the thing it separates.
+ *
+ * One bar for the pane rather than one per split group. Every fact here belongs
+ * to the session — its directory, its model, whether it is busy — and none of
+ * them changes with which panel happens to be in front.
+ */
+export function StatusLine({ hostId, session }: { hostId: string; session: Session }): JSX.Element | null {
+  const order = useStore((s) => s.statusLine)
+  const hosts = useStore((s) => s.hosts)
+  const [modeMenu, setModeMenu] = useState<{ x: number; y: number } | null>(null)
+
+  const wanted = new Set(order)
+
+  // Asked for whenever the bar shows the branch, which is the point: the branch
+  // was previously only knowable by opening the Git panel. It costs nothing to
+  // keep current — the key sits under `keys.git(hostId)`, which a file_changed
+  // event already invalidates, so a checkout lands here without polling.
+  const { data: git } = useQuery({
+    ...gitStatusQuery(hostId, session.cwd),
+    enabled: wanted.has('branch') && session.cwd !== '',
+  })
+
+  // Only once the mode menu has been asked for. The list is shared with the new
+  // session dialog and never goes stale, so this is usually a cache hit, but a
+  // bar that nobody has clicked should not pay for it.
+  const { data: providers } = useQuery({ ...providersQuery(hostId), enabled: modeMenu !== null })
+
+  if (order.length === 0) return null
+
+  const segment = (id: SegmentId): JSX.Element | null => {
+    switch (id) {
+      case 'cwd':
+        return <PathLabel key={id} path={session.cwd} className="status-cwd" />
+
+      // Bare, as the Git panel and the worktree list already show it. A glyph
+      // in front reads as noise at 11px, and the branch is legible without one.
+      case 'branch':
+        if (!git?.branch) return null
+        return (
+          <span key={id} title={git.dirty ? `${git.branch} — uncommitted changes` : git.branch}>
+            <span className="branch">
+              {git.branch}
+              {git.dirty && '*'}
+            </span>
+            {git.ahead > 0 && `↑${git.ahead}`}
+            {git.behind > 0 && `↓${git.behind}`}
+          </span>
+        )
+
+      case 'model':
+        if (!session.model) return null
+        return (
+          <span key={id} title="Model">
+            {session.model}
+          </span>
+        )
+
+      case 'mode':
+        if (!session.permission_mode) return null
+        return (
+          <button
+            key={id}
+            className="status-mode"
+            title="Permission mode — click to change"
+            onClick={(event) => setModeMenu({ x: event.clientX, y: event.clientY })}
+          >
+            {session.permission_mode}
+          </button>
+        )
+
+      // The header's chip, stripped of its pill by the stylesheet. Reused
+      // rather than restated so the status colours have one definition.
+      case 'status':
+        return (
+          <span key={id} className={`chip ${session.status}`}>
+            <span className={BUSY_STATUSES.has(session.status) ? 'dot pulse' : 'dot'} />
+            {statusLabel(session.status)}
+          </span>
+        )
+
+      case 'memory':
+        if (session.memory_bytes === undefined) return null
+        return (
+          <span key={id} className="card-ram" title="Memory this session's terminal holds">
+            {formatBytes(session.memory_bytes)}
+          </span>
+        )
+
+      case 'host':
+        return (
+          <span key={id} title="Host">
+            {hosts.find((host) => host.id === hostId)?.name ?? hostId}
+          </span>
+        )
+
+      case 'id':
+        return (
+          <span key={id} title={session.session_id}>
+            {session.session_id.slice(0, 8)}
+          </span>
+        )
+    }
+  }
+
+  return (
+    <footer className="status-line">
+      {order.map(segment)}
+
+      {modeMenu && (
+        <SelectionMenu
+          x={modeMenu.x}
+          y={modeMenu.y}
+          actions={modeActions(hostId, session, providers)}
+          onClose={() => setModeMenu(null)}
+        />
+      )}
+    </footer>
+  )
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  return `${Math.round(bytes / 1024 ** 2)} MB`
+}

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -31,6 +31,7 @@ import {
   type ItemId,
   type Layout,
 } from './components/layout.ts'
+import type { SegmentId } from '../shared/status-line.ts'
 import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type {
@@ -243,6 +244,8 @@ export interface State {
    * which way it is set.
    */
   density: Density
+  /** Which segments the session status line draws, in the order it draws them. */
+  statusLine: SegmentId[]
   /**
    * How the sidebar splits the list: not at all, by the user's group tree, or
    * by each session's directory.
@@ -403,6 +406,7 @@ const initial: State = {
   terminalTheme: bridge.theme.boot().terminal,
   terminalUploads: readTerminalUploads(),
   density: bridge.theme.boot().density,
+  statusLine: bridge.theme.boot().statusLine,
   toast: null,
   pairingLink: null,
   grouping: readGroupMode(),
@@ -488,11 +492,11 @@ class Store {
     // The preload painted the boot theme already; this keeps up with changes
     // made afterwards, whether from the settings dialog or the OS switching
     // between light and dark underneath us.
-    bridge.theme.onChanged(({ theme, terminal, glass, proseSize, density }) => {
+    bridge.theme.onChanged(({ theme, terminal, glass, proseSize, density, statusLine }) => {
       applyTheme(document.documentElement, theme, glass)
       applyProseSize(document.documentElement, proseSize)
       applyDensity(document.documentElement, density)
-      this.set({ terminalTheme: terminal, density })
+      this.set({ terminalTheme: terminal, density, statusLine })
     })
 
     bridge.hosts.onChanged((hosts) => {

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -32,7 +32,7 @@ import {
   type Layout,
 } from './components/layout.ts'
 import type { SegmentId } from '../shared/status-line.ts'
-import { applyDensity, applyProseSize, applyTheme } from '../shared/theme/apply.ts'
+import { applyDensity, applyProseSize, applyStatusSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
 import type {
   Density,
@@ -492,9 +492,10 @@ class Store {
     // The preload painted the boot theme already; this keeps up with changes
     // made afterwards, whether from the settings dialog or the OS switching
     // between light and dark underneath us.
-    bridge.theme.onChanged(({ theme, terminal, glass, proseSize, density, statusLine }) => {
+    bridge.theme.onChanged(({ theme, terminal, glass, proseSize, density, statusLine, statusLineSize }) => {
       applyTheme(document.documentElement, theme, glass)
       applyProseSize(document.documentElement, proseSize)
+      applyStatusSize(document.documentElement, statusLineSize)
       applyDensity(document.documentElement, density)
       this.set({ terminalTheme: terminal, density, statusLine })
     })

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -477,15 +477,15 @@ small {
   background: transparent;
 }
 
-/* No inset at the top: the titlebar above is painted the same as the panes, so
-   they continue it rather than sitting below it. The room the strips need is
-   inside them — see --strip-h. */
+/* No margin and no channel between the panes. The window used to hold two
+   rounded cards on a field of bare --surface; on a theme whose surface is a
+   strong colour that field was a stripe down the middle of the screen and a
+   border around the outside, and it carried nothing. The panes meet on a
+   hairline instead. */
 .body {
   flex: 1;
   display: flex;
   min-height: 0;
-  gap: 8px;
-  padding: 0 8px 8px;
 }
 
 .main {
@@ -532,7 +532,10 @@ small {
   display: flex;
   flex-direction: column;
   background: var(--surface-low);
-  border-radius: var(--r-lg);
+  /* The only thing dividing it from the pane, now that they are the same
+     colour and touching. A shadow rather than a border so it costs no width
+     and the grip above it still lands on the edge. */
+  box-shadow: 1px 0 0 var(--outline-variant);
   overflow: hidden;
 }
 
@@ -1364,7 +1367,6 @@ small {
   flex-direction: column;
   min-height: 0;
   background: var(--surface-low);
-  border-radius: var(--r-lg);
   overflow: hidden;
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1389,10 +1389,12 @@ small {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 18px;
+  /* Derived from the text rather than set beside it, so a bar sized up in
+     settings gains room instead of clipping. 11px, the default, gives 18. */
+  height: calc(var(--status-size, 11px) + 7px);
   padding: 0 10px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--status-size, 11px);
   line-height: 1;
   color: var(--on-surface-variant);
   background: color-mix(in srgb, var(--on-surface) 4%, transparent);
@@ -1451,9 +1453,10 @@ small {
   color: var(--on-surface);
 }
 
+/* Compact keeps the chosen text size and takes the breathing room instead —
+   the size is a legibility setting, and density should not overrule it. */
 [data-density='compact'] .status-line {
-  height: 15px;
-  font-size: 10px;
+  height: calc(var(--status-size, 11px) + 4px);
 }
 
 .menu {
@@ -1519,8 +1522,14 @@ small {
 }
 
 /* M3 primary tabs. */
+/* A fixed height with the tabs filling it, rather than each tab's padding
+   adding up to one. The strip holds a 22px close button and an 18px plus as
+   well as its labels, and letting the tallest of them decide is how it came to
+   be 37px — a third of which was air above and below the words. */
 .panel-tabs {
   display: flex;
+  flex: none;
+  height: 28px;
   gap: 4px;
   padding: 0 12px;
   box-shadow: inset 0 -1px 0 var(--outline-variant);
@@ -1533,35 +1542,61 @@ small {
   display: none;
 }
 
-.panel-tabs button {
+/* Direct children only. The session menu renders inside this strip so that its
+   button can stick to the right edge, and a descendant selector would give the
+   popover the tabs' capitalisation and underline — "New group…" came out as
+   "New Group…". Every button in the strip is a child of it; the close and
+   reload controls inside a tab are spans, since a button cannot hold one.
+
+   Full height rather than vertical padding, so the underline lands on the
+   strip's own bottom edge whatever the tab holds. */
+.panel-tabs > button {
   display: flex;
   align-items: center;
+  flex: none;
+  height: 100%;
   gap: 6px;
   border-radius: 0;
-  padding: 10px 14px 9px;
+  padding: 0 12px;
   color: var(--on-surface-variant);
   border-bottom: 2px solid transparent;
   text-transform: capitalize;
-  font-size: 13px;
+  font-size: 12.5px;
 }
 
-.panel-tabs button:hover {
+.panel-tabs > button:hover {
   background: color-mix(in srgb, var(--on-surface) 6%, transparent);
 }
 
-.panel-tabs button.active {
+.panel-tabs > button.active {
   color: var(--primary);
   border-bottom-color: var(--primary);
 }
 
-.panel-tabs button {
-  flex: none;
+.tab-add {
+  font-size: 16px;
+  padding: 0 10px;
+  color: var(--on-surface-variant);
 }
 
-.tab-add {
-  font-size: 18px;
-  padding: 8px 12px;
+/* Held at the right-hand end while the tabs scroll under it. `margin-left:auto`
+   would only push it past the last tab, which in a strip wide enough to scroll
+   is somewhere off screen. Sticky keeps it in view, and the background stops
+   the tabs showing through as they pass beneath. */
+.tab-menu {
+  position: sticky;
+  right: 0;
+  margin-left: auto;
+  flex: none;
+  padding: 0 10px;
+  font-size: 15px;
+  line-height: 1;
   color: var(--on-surface-variant);
+  background: var(--surface-low);
+}
+
+.tab-menu:hover {
+  color: var(--on-surface);
 }
 
 /* Renaming happens in place, at the size of the tab it replaces, so the strip
@@ -1601,13 +1636,13 @@ small {
 
 /* A group that is not the focused one still reads its tabs, but the underline
    marking the one in front belongs to the group with the keyboard. */
-.panel-tabs:not(.focused) button.active {
+.panel-tabs:not(.focused) > button.active {
   color: var(--on-surface-variant);
   border-bottom-color: var(--outline-variant);
 }
 
 /* Where a dragged tab would land in this strip. */
-.panel-tabs button.insert {
+.panel-tabs > button.insert {
   box-shadow: inset 2px 0 0 var(--primary);
 }
 
@@ -3527,8 +3562,9 @@ figure.mermaid svg {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  flex: none;
+  width: 18px;
+  height: 18px;
   padding: 0;
   border-radius: 50%;
   font-size: 15px;
@@ -3544,9 +3580,9 @@ figure.mermaid svg {
 
 /* ⟳ draws smaller than the power glyph beside it at the same point size. */
 .tab-close.reload {
-  width: 26px;
-  height: 26px;
-  font-size: 22px;
+  width: 22px;
+  height: 22px;
+  font-size: 18px;
 }
 
 .pane-empty {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -73,6 +73,11 @@
   --r-lg: 16px;
   --r-xl: 28px;
   --sidebar: 360px;
+  /* The strip across the top of both panes: the sidebar's sessions/schedules
+     switch, and the detail's tabs. One variable because they sit side by side
+     at the same y, and a reader sees them as one row — two numbers that agreed
+     by coincidence is how they came to be 10px apart. */
+  --strip-h: 28px;
   /* Reading width for the transcript and its composer. It exists to stop a
      reply and the prompt above it drifting to opposite edges of the window,
      not to hold prose to a paragraph width — code blocks and diffs want the
@@ -1529,7 +1534,7 @@ small {
 .panel-tabs {
   display: flex;
   flex: none;
-  height: 28px;
+  height: var(--strip-h);
   gap: 4px;
   padding: 0 12px;
   box-shadow: inset 0 -1px 0 var(--outline-variant);
@@ -5118,20 +5123,26 @@ hr {
 
 /* Sessions or schedules, above everything: it decides what the search, the
    arrange control and the + button below it are about. */
+/* The same height as the detail pane's tab strip, which sits beside it at the
+   same y. See --strip-h. */
 .sidebar-modes {
   display: flex;
+  align-items: center;
+  flex: none;
+  height: var(--strip-h);
   gap: 2px;
-  padding: 10px 10px 6px;
+  padding: 0 10px;
 }
 
 .sidebar-modes button {
   flex: 1;
+  height: 22px;
   background: var(--surface-low);
   border: 1px solid transparent;
   border-radius: var(--r-sm);
   color: var(--on-surface-variant);
   font-size: 11px;
-  padding: 4px 0;
+  padding: 0;
   cursor: pointer;
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -456,23 +456,36 @@ small {
   height: 100%;
 }
 
-/* Room for the traffic lights under titleBarStyle: hiddenInset. */
+/* Room for the traffic lights under titleBarStyle: hiddenInset. The height is
+   the OS's to choose, not ours — nothing sets trafficLightPosition, so the
+   lights land where a 32px bar puts them.
+
+   Painted as the panes are, and with no gap under it, so the top of the window
+   is one field rather than a band of bare --surface above two cards. On a
+   theme whose surface is a strong colour that band was the loudest thing on
+   the screen, and it held nothing. */
 .titlebar {
   height: 32px;
   flex: none;
+  background: var(--surface-low);
   -webkit-app-region: drag;
 }
 
-/* Inset on all four sides, the same 8px as the gap between the panes. The top
-   was 0 while the strips inside carried their own padding; now that both are a
-   fixed 28px with their contents centred, nothing else supplies the gap and
-   the panes' rounded corners meet the titlebar square on. */
+/* Except where the backdrop is the point: an opaque strip here would be a bar
+   of paint across the top of an otherwise translucent window. */
+[data-glass='on'] .titlebar {
+  background: transparent;
+}
+
+/* No inset at the top: the titlebar above is painted the same as the panes, so
+   they continue it rather than sitting below it. The room the strips need is
+   inside them — see --strip-h. */
 .body {
   flex: 1;
   display: flex;
   min-height: 0;
   gap: 8px;
-  padding: 8px;
+  padding: 0 8px 8px;
 }
 
 .main {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -463,12 +463,16 @@ small {
   -webkit-app-region: drag;
 }
 
+/* Inset on all four sides, the same 8px as the gap between the panes. The top
+   was 0 while the strips inside carried their own padding; now that both are a
+   fixed 28px with their contents centred, nothing else supplies the gap and
+   the panes' rounded corners meet the titlebar square on. */
 .body {
   flex: 1;
   display: flex;
   min-height: 0;
   gap: 8px;
-  padding: 0 8px 8px;
+  padding: 8px;
 }
 
 .main {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -221,15 +221,6 @@ button.link {
   padding: 4px 8px;
 }
 
-/* Cold, not broken: amber rather than red, as on the mobile app bar. */
-button.cold {
-  color: var(--s-waiting);
-}
-
-button.cold:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--s-waiting) 14%, transparent);
-}
-
 button.danger {
   color: var(--error);
 }
@@ -1258,7 +1249,7 @@ small {
   font-size: 11.5px;
 }
 
-/* What a session's terminal is holding. Also the detail header's, which is why
+/* What a session's terminal is holding. Also the status line's, which is why
    it outlives the card it was named for. */
 .card-ram {
   font-size: 11px;
@@ -1389,57 +1380,80 @@ small {
   color: var(--on-surface-variant);
 }
 
-.detail-head {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 14px 16px;
-}
-
-.detail-title {
-  flex: 1;
-  min-width: 0;
-}
-
-.detail-title h1 {
-  margin: 0;
-  font-family: 'Helios Glyphs', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif;
-  font-size: 17px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.detail-title input {
-  width: 100%;
-  font-size: 16px;
-}
-
-.detail-cwd {
-  display: block;
-  margin-top: 3px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
-  color: var(--on-surface-variant);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.detail-actions {
+/* One line at the foot of the pane, in place of the header that used to sit
+   above it. A fixed height with line-height 1 rather than padding, so the bar
+   is exactly as tall as it claims; a tint rather than a border-top, because a
+   hairline costs a pixel and reads heavier than the surfaces it divides. */
+.status-line {
+  flex: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  height: 18px;
+  padding: 0 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--on-surface-variant);
+  background: color-mix(in srgb, var(--on-surface) 4%, transparent);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.mode-select {
-  max-width: 160px;
-  font-size: 12px;
-  padding: 6px 26px 6px 10px;
-  background-color: var(--surface-high);
-  border-radius: 999px;
+/* The directory is the one segment worth losing characters over: everything
+   else is short, and a truncated model name says less than none.
+
+   gap: 0 because PathLabel splits the path into two spans so the directory can
+   truncate without taking the leaf with it. They are one word, and the gap
+   between segments must not open up inside it. */
+.status-line .status-cwd {
+  min-width: 0;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* The branch keeps its colour from .branch, but not the 12px that would set the
+   height of an 18px bar. */
+.status-line .branch {
+  font-size: inherit;
+}
+
+.status-line > span {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* The status chip, with the pill taken off it: the colours are worth reusing,
+   the 22px pill would set the height of a bar built to be 18. */
+.status-line .chip {
+  height: auto;
+  padding: 0;
+  background: none;
+  font-size: inherit;
+  font-weight: 400;
+  letter-spacing: normal;
+}
+
+/* A control, but it may not make the bar any taller than the text beside it. */
+.status-mode {
+  flex: none;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.status-mode:hover {
+  color: var(--on-surface);
+}
+
+[data-density='compact'] .status-line {
+  height: 15px;
+  font-size: 10px;
 }
 
 .menu {
@@ -2835,6 +2849,52 @@ figure.mermaid svg {
 
 .line-menu button.danger {
   color: var(--error);
+}
+
+.line-menu button:disabled {
+  color: var(--on-surface-variant);
+  cursor: default;
+  opacity: 0.5;
+}
+
+.line-menu button:disabled:hover {
+  background: none;
+}
+
+/* The row a child menu hangs off. Relative, so the child is placed against its
+   own edge rather than measured against the window. */
+.line-sub {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.line-sub > button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.line-sub-mark {
+  color: var(--on-surface-variant);
+}
+
+/* Overlapping the parent's 4px padding rather than clearing it: a gap between
+   the two is somewhere the pointer falls through and shuts the menu it was
+   travelling towards. */
+.line-sub-menu {
+  position: absolute;
+  top: -4px;
+  left: 100%;
+  margin-left: -4px;
+}
+
+.line-sub-menu.flip {
+  left: auto;
+  right: 100%;
+  margin-left: 0;
+  margin-right: -4px;
 }
 
 .git-diff pre,
@@ -4269,6 +4329,75 @@ hr {
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+/* Every other control is one line tall, so the shared row centres them. This
+   one is a list, and a label floating beside its middle reads as unrelated. */
+.setting-row:has(.seg-list) {
+  align-items: start;
+}
+
+/* The status line's segments. A list rather than a row of chips, because the
+   order is the setting and a list is the shape an order is dragged in. */
+.seg-list {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  border-radius: 8px;
+  background: var(--surface-high);
+}
+
+.seg-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 4px;
+  border-top: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: grab;
+}
+
+.seg-row:hover {
+  background: var(--surface-highest);
+}
+
+/* Off, so there is no order to drag it into: the grip keeps its width to hold
+   the labels in one column, but the row does not offer to move. */
+.seg-row.off {
+  cursor: default;
+  color: var(--on-surface-variant);
+}
+
+.seg-row.over {
+  border-top-color: var(--primary);
+}
+
+.seg-row.over-last {
+  border-bottom-color: var(--primary);
+}
+
+.seg-grip {
+  width: 10px;
+  color: var(--on-surface-variant);
+  cursor: grab;
+}
+
+.seg-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seg-divider {
+  padding: 6px 4px 2px;
+  font-size: 11px;
+  color: var(--on-surface-variant);
 }
 
 /* The control takes the row; a swatch or a unit beside it does not. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -80,7 +80,7 @@
      switch, and the detail's tabs. One variable because they sit side by side
      at the same y, and a reader sees them as one row — two numbers that agreed
      by coincidence is how they came to be 10px apart. */
-  --strip-h: 28px;
+  --strip-h: 34px;
   /* Reading width for the transcript and its composer. It exists to stop a
      reply and the prompt above it drifting to opposite edges of the window,
      not to hold prose to a paragraph width — code blocks and diffs want the

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1589,8 +1589,9 @@ small {
 
 /* Held at the right-hand end while the tabs scroll under it. `margin-left:auto`
    would only push it past the last tab, which in a strip wide enough to scroll
-   is somewhere off screen. Sticky keeps it in view, and the background stops
-   the tabs showing through as they pass beneath. */
+   is somewhere off screen. Sticky keeps it in view, and the fill stops the tabs
+   showing through as they pass beneath — the panel's own colour, so it is not
+   a block sitting on the strip. */
 .tab-menu {
   position: sticky;
   right: 0;
@@ -1605,6 +1606,14 @@ small {
 
 .tab-menu:hover {
   color: var(--on-surface);
+}
+
+/* Under a backdrop the panel is translucent, and a fill matching its *colour*
+   matches nothing — it reads as a dark block pasted into the corner. Gives way
+   like the panes below it do, at the cost of tabs showing through on a strip
+   long enough to scroll. */
+[data-glass='on'] .tab-menu {
+  background: transparent;
 }
 
 /* Renaming happens in place, at the size of the tab it replaces, so the strip

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -68,10 +68,13 @@
   --s-error: #ffb4ab;
   --s-off: #8e9099;
 
-  --r-sm: 8px;
-  --r-md: 12px;
-  --r-lg: 16px;
-  --r-xl: 28px;
+  /* Closer to AppKit than to the web. macOS rounds a window at about 10px, a
+     sheet at 12 and a push button at 5 — the scale here was roughly double
+     that at every step, which reads as a web app wearing a Mac's chrome. */
+  --r-sm: 5px;
+  --r-md: 8px;
+  --r-lg: 10px;
+  --r-xl: 12px;
   --sidebar: 360px;
   /* The strip across the top of both panes: the sidebar's sessions/schedules
      switch, and the detail's tabs. One variable because they sit side by side
@@ -2859,7 +2862,7 @@ figure.mermaid svg {
   flex-direction: column;
   min-width: 180px;
   padding: 4px;
-  border-radius: 10px;
+  border-radius: var(--r-md);
   background: var(--surface-high);
   box-shadow: 0 8px 24px var(--shadow-soft);
 }

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -630,6 +630,8 @@ export interface AppearancePrefs {
   density: Density
   /** Which segments the session status line draws, in the order it draws them. */
   statusLine: SegmentId[]
+  /** Text size of the status line, in px. The bar's height follows it. */
+  statusLineSize: number
 }
 
 export type Density = 'comfortable' | 'compact'

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -3,6 +3,7 @@
 // Go names, and optional fields are optional here for the same reason they are
 // pointers there.
 
+import type { SegmentId } from './status-line.ts'
 import type { BackdropStyle } from './theme/vscode.ts'
 
 export interface Session {
@@ -627,6 +628,8 @@ export interface AppearancePrefs {
   proseSize: number
   /** How much of a session the sidebar shows: everything, or one line each. */
   density: Density
+  /** Which segments the session status line draws, in the order it draws them. */
+  statusLine: SegmentId[]
 }
 
 export type Density = 'comfortable' | 'compact'

--- a/desktop/src/shared/status-line.ts
+++ b/desktop/src/shared/status-line.ts
@@ -1,0 +1,79 @@
+/**
+ * What the session status line may show, and in what order it shows it.
+ *
+ * The stored value is the enabled segments, in the order they are drawn.
+ * Absence is how a segment is hidden — there is no second list of the ones that
+ * are off, because the catalogue below already says what the whole set is and
+ * anything missing from the stored order is the difference.
+ *
+ * Shared rather than renderer-only: the main process sanitises the preference
+ * on the way off disk, and it cannot do that against a list it does not have.
+ */
+
+export type SegmentId = 'cwd' | 'branch' | 'model' | 'mode' | 'status' | 'memory' | 'host' | 'id'
+
+/** Every segment there is, in the order the settings list offers them. */
+export const SEGMENTS: { id: SegmentId; label: string }[] = [
+  { id: 'cwd', label: 'Working directory' },
+  { id: 'branch', label: 'Git branch' },
+  { id: 'model', label: 'Model' },
+  { id: 'mode', label: 'Permission mode' },
+  { id: 'status', label: 'Status' },
+  { id: 'memory', label: 'Memory' },
+  { id: 'host', label: 'Host' },
+  { id: 'id', label: 'Session id' },
+]
+
+/**
+ * What a new install shows.
+ *
+ * The five that answer "where am I, what is running, and is it busy" — which is
+ * what the deleted header was for. Memory, host and id are for a specific
+ * question rather than a glance, so they are off until asked for.
+ */
+export const DEFAULT_STATUS_LINE: SegmentId[] = ['cwd', 'branch', 'model', 'mode', 'status']
+
+const KNOWN = new Set<string>(SEGMENTS.map((segment) => segment.id))
+
+/**
+ * A stored order, or the default if it is anything else.
+ *
+ * An empty array is a real answer — it means the user turned everything off —
+ * so only a non-array falls back. Unknown ids are dropped rather than rejecting
+ * the whole list: a preference written by a later version that knew about one
+ * more segment should lose that segment, not every segment.
+ */
+export function parseStatusLine(raw: unknown): SegmentId[] {
+  if (!Array.isArray(raw)) return [...DEFAULT_STATUS_LINE]
+  const seen = new Set<SegmentId>()
+  for (const value of raw) {
+    if (typeof value === 'string' && KNOWN.has(value)) seen.add(value as SegmentId)
+  }
+  return [...seen]
+}
+
+/** Turns a segment off, or back on at the end of the line. */
+export function toggleSegment(order: SegmentId[], id: SegmentId): SegmentId[] {
+  return order.includes(id) ? order.filter((one) => one !== id) : [...order, id]
+}
+
+/**
+ * Moves a segment to an index, counted in the list as it was before the move.
+ *
+ * The index is where the drop landed among the rows on screen, so it is read
+ * before the dragged row is taken out — dropping row 0 onto the gap below row 2
+ * means index 2, and removing it first would make that mean row 3.
+ */
+export function moveSegment(order: SegmentId[], id: SegmentId, index: number): SegmentId[] {
+  const from = order.indexOf(id)
+  if (from < 0) return order
+  const target = Math.max(0, Math.min(index, order.length))
+  const rest = order.filter((one) => one !== id)
+  rest.splice(from < target ? target - 1 : target, 0, id)
+  return rest
+}
+
+/** The segments that are off, in catalogue order. */
+export function hiddenSegments(order: SegmentId[]): SegmentId[] {
+  return SEGMENTS.map((segment) => segment.id).filter((id) => !order.includes(id))
+}

--- a/desktop/src/shared/theme/apply.ts
+++ b/desktop/src/shared/theme/apply.ts
@@ -18,6 +18,16 @@ export function applyProseSize(root: HTMLElement, size: number): void {
 }
 
 /**
+ * The status line's text size, which the bar's own height is derived from.
+ *
+ * One variable rather than a size and a height: a bar measured independently of
+ * its text clips at one setting and pads at another.
+ */
+export function applyStatusSize(root: HTMLElement, size: number): void {
+  root.style.setProperty('--status-size', `${size}px`)
+}
+
+/**
  * How much of a session the sidebar shows.
  *
  * An attribute rather than variables, for the same reason as glass: density

--- a/desktop/test/status-line.test.ts
+++ b/desktop/test/status-line.test.ts
@@ -1,0 +1,90 @@
+// What the status line shows, and in what order.
+//
+// The stored value is hand-editable and comes off disk before either process
+// has looked at it, so the sanitiser is the part worth pinning down: a
+// preference written by a newer build should lose the segment it does not
+// know, not the whole bar.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_STATUS_LINE,
+  hiddenSegments,
+  moveSegment,
+  parseStatusLine,
+  SEGMENTS,
+  toggleSegment,
+  type SegmentId,
+} from '../src/shared/status-line.ts'
+
+test('a missing or malformed preference falls back to the default', () => {
+  assert.deepEqual(parseStatusLine(undefined), DEFAULT_STATUS_LINE)
+  assert.deepEqual(parseStatusLine(null), DEFAULT_STATUS_LINE)
+  assert.deepEqual(parseStatusLine('cwd'), DEFAULT_STATUS_LINE)
+  assert.deepEqual(parseStatusLine({ cwd: true }), DEFAULT_STATUS_LINE)
+})
+
+// Not the same as a malformed one. Turning every segment off is a thing a user
+// can do, and answering it with the default would put the bar back.
+test('an empty list is an answer, not a mistake', () => {
+  assert.deepEqual(parseStatusLine([]), [])
+})
+
+test('unknown ids are dropped rather than rejecting the list', () => {
+  assert.deepEqual(parseStatusLine(['cwd', 'weather', 'status', 7]), ['cwd', 'status'])
+})
+
+test('a duplicate id is kept once, in its first position', () => {
+  assert.deepEqual(parseStatusLine(['status', 'cwd', 'status']), ['status', 'cwd'])
+})
+
+test('the stored order is preserved, not sorted into catalogue order', () => {
+  assert.deepEqual(parseStatusLine(['status', 'branch', 'cwd']), ['status', 'branch', 'cwd'])
+})
+
+test('the default is only made of ids the catalogue knows', () => {
+  const known = new Set(SEGMENTS.map((segment) => segment.id))
+  for (const id of DEFAULT_STATUS_LINE) assert.ok(known.has(id), `${id} is not a segment`)
+})
+
+test('toggling off removes, toggling on appends to the end', () => {
+  const order: SegmentId[] = ['cwd', 'branch', 'status']
+  assert.deepEqual(toggleSegment(order, 'branch'), ['cwd', 'status'])
+  assert.deepEqual(toggleSegment(order, 'memory'), ['cwd', 'branch', 'status', 'memory'])
+})
+
+test('hidden segments come back in catalogue order, whatever the stored order', () => {
+  assert.deepEqual(hiddenSegments(['status', 'cwd']), ['branch', 'model', 'mode', 'memory', 'host', 'id'])
+})
+
+// The index is read off the rows on screen, before the dragged row leaves the
+// list. Moving down therefore has to account for the gap the row leaves behind,
+// which is the only place this is easy to get wrong.
+test('a segment dragged down lands after the row it was dropped past', () => {
+  const order: SegmentId[] = ['cwd', 'branch', 'model', 'mode']
+  assert.deepEqual(moveSegment(order, 'cwd', 2), ['branch', 'cwd', 'model', 'mode'])
+  assert.deepEqual(moveSegment(order, 'cwd', 4), ['branch', 'model', 'mode', 'cwd'])
+})
+
+test('a segment dragged up lands before the row it was dropped on', () => {
+  const order: SegmentId[] = ['cwd', 'branch', 'model', 'mode']
+  assert.deepEqual(moveSegment(order, 'mode', 0), ['mode', 'cwd', 'branch', 'model'])
+  assert.deepEqual(moveSegment(order, 'model', 1), ['cwd', 'model', 'branch', 'mode'])
+})
+
+test('dropping a segment back where it started changes nothing', () => {
+  const order: SegmentId[] = ['cwd', 'branch', 'model']
+  assert.deepEqual(moveSegment(order, 'branch', 1), order)
+  assert.deepEqual(moveSegment(order, 'branch', 2), order)
+})
+
+test('an out-of-range index clamps rather than dropping the segment', () => {
+  const order: SegmentId[] = ['cwd', 'branch', 'model']
+  assert.deepEqual(moveSegment(order, 'model', 99), ['cwd', 'branch', 'model'])
+  assert.deepEqual(moveSegment(order, 'model', -3), ['model', 'cwd', 'branch'])
+})
+
+test('moving a segment that is not shown leaves the order alone', () => {
+  const order: SegmentId[] = ['cwd', 'branch']
+  assert.equal(moveSegment(order, 'memory', 0), order)
+})


### PR DESCRIPTION
## Summary

The session detail pane spent 136px of height on chrome before any content
appeared: a 32px titlebar, a 67px header and a 37px tab strip. The header was
the part that did not earn it — a title, the cwd, an `Idle` chip, a memory
figure and a permission-mode select, every one of which was either duplicated
elsewhere or rarely read. Meanwhile there was nowhere to see the git branch
without opening the Git panel.

The header is gone. What it carried is now in a thin status line at the foot of
the pane, and the user chooses what that line shows.

**Chrome above the transcript: 136px → 66px.**

### Where each part of the header went

| Header item | New home |
|---|---|
| Title `h1` | Dropped — the sidebar already shows the selection |
| Double-click rename | `Rename…` on the row's context menu |
| cwd | Status line |
| `Idle` chip | Status line |
| Memory `1.3 GB` | Status line, off by default |
| Cold / Resume / Stop buttons | Already on the row and in the composer |
| `PermissionMode` select | `Permission mode ▸` submenu on the row's context menu |

### The status line

Eight segments — cwd, git branch, model, permission mode, status, memory, host,
session id — of which five are on by default. Settings → Appearance → Status
line turns them on and off and drags them into order; the text size is
adjustable and the bar's height follows it. Turning every segment off hides the
bar. The order lives in `AppearancePrefs` and rides the existing
`theme:changed` broadcast, so an open window follows a change with no reload.

The branch comes from the existing `gitStatusQuery`, which sits under
`keys.git(hostId)` and is already invalidated by `file_changed` — so it stays
current with no polling added.

### Along the way

- `SelectionMenu` gained real submenus, opened on hover with a grace period and
  flipped when they would overflow. The child renders inside the parent's box,
  so the existing dismiss handler needed no special case.
- The tab strip is 34px rather than 37px, and level with the sidebar's
  sessions/schedules switch beside it — one `--strip-h` for both.
- A `⋯` button at the right of the tab strip opens the same menu the row's
  right-click does, built from the same function.
- The permission modes grey out mid-turn. A disabled button fires no pointer
  events, so a tooltip on them would be unreadable by construction; the menu
  says `Stop the agent to change this` on a row of its own.
- Corner radii tightened towards macOS: 28px → 12px at the largest.
- The titlebar is painted as the panes are, and the sidebar and the pane touch
  on a hairline. The window used to hold two rounded cards on a field of bare
  `--surface`; on a theme whose surface is a strong colour that field was a
  stripe down the middle of the screen, and it held nothing.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 262 pass, including 13 new for `shared/status-line.ts`
- [x] `npx playwright test` — 29 pass, including 8 new in `e2e/status-line.spec.ts`
- [x] Measured rather than eyeballed: the e2e suite asserts the bar is 18px, the
      strips 34px, and the two strips level with each other — a later padding
      tweak would otherwise put the height back unnoticed
- [x] Toggled and dragged segments in an already-open window and watched the bar
      follow, which is the `theme:changed` broadcast rather than a reload