### PR TITLE
feat(desktop): make the new-session dialog a composer

### DIFF
--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -5,6 +5,8 @@ import { expect, test } from './fixtures.ts'
 async function openComposer(window: Page): Promise<void> {
   await window.locator('button[aria-label="New session"]').first().click()
   await expect(window.locator('.composer')).toBeVisible()
+  await expect(window.locator('.composer-place')).toContainText('repo')
+  await expect(window.locator('.composer-foot')).toContainText('Default permissions')
 }
 
 async function openChip(window: Page, name: RegExp): Promise<void> {

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -1,0 +1,129 @@
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+async function openComposer(window: Page): Promise<void> {
+  await window.locator('button[aria-label="New session"]').first().click()
+  await expect(window.locator('.composer')).toBeVisible()
+}
+
+async function openChip(window: Page, name: RegExp): Promise<void> {
+  await window.locator('.composer-foot .picker > summary').filter({ hasText: name }).click()
+  await expect(window.locator('.picker[open] .picker-body')).toBeVisible()
+}
+
+async function backdrop(window: Page): Promise<{ x: number; y: number }> {
+  const box = await window.locator('.composer').boundingBox()
+  if (!box) throw new Error('composer has no box')
+  return { x: Math.round(box.x + box.width / 2), y: Math.round(box.y + box.height + 120) }
+}
+
+test('every chip opens on its own value', async ({ window }) => {
+  await openComposer(window)
+
+  await expect(window.locator('.composer-place')).toContainText('repo')
+  await expect(window.locator('.composer-host')).toContainText('stub')
+  await expect(window.locator('.composer-foot')).toContainText('Claude')
+  await expect(window.locator('.composer-foot')).toContainText('Default model')
+})
+
+test('picking a model puts it on the chip', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.locator('.composer-option', { hasText: 'Sonnet' }).click()
+
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer-foot')).toContainText('Sonnet')
+})
+
+test('dismissing a chip does not take the dialog with it', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer')).toBeVisible()
+})
+
+test('the backdrop still closes an untouched dialog', async ({ window }) => {
+  await openComposer(window)
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.composer')).toHaveCount(0)
+})
+
+test('a written prompt survives a stray click on the backdrop', async ({ window }) => {
+  await openComposer(window)
+  await window.locator('.composer-prompt').fill('something worth keeping')
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.composer-prompt')).toHaveValue('something worth keeping')
+})
+
+test('escape closes the chip first and the dialog second', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer')).toBeVisible()
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.composer')).toHaveCount(0)
+})
+
+test('arrows walk the options and wrap', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  const options = window.locator('.picker[open] .composer-option')
+  await expect(options).toHaveCount(3)
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(0)).toBeFocused()
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(1)).toBeFocused()
+
+  await window.keyboard.press('End')
+  await expect(options.nth(2)).toBeFocused()
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(0)).toBeFocused()
+
+  await window.keyboard.press('ArrowUp')
+  await expect(options.nth(2)).toBeFocused()
+})
+
+test('escape hands focus back to the chip', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.keyboard.press('Escape')
+
+  const summary = window.locator('.composer-foot .picker > summary').filter({ hasText: /model/i })
+  await expect(summary).toBeFocused()
+})
+
+test('the directory filter narrows the list and takes a typed path', async ({ window }) => {
+  await openComposer(window)
+  await window.locator('.composer-place > summary').click()
+
+  const search = window.locator('.picker-search')
+  await expect(search).toBeFocused()
+
+  await search.fill('nothing-matches-this')
+  await expect(window.locator('.picker-empty')).toBeVisible()
+
+  await search.fill('/tmp/elsewhere')
+  await window.locator('.composer-option', { hasText: 'Use' }).click()
+
+  await expect(window.locator('.composer-place')).toContainText('elsewhere')
+})

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -117,6 +117,24 @@ export function Plus({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
+/** A four-pointed spark: the model a session runs on. */
+export function Spark({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 3.5c0 4.7 3.8 8.5 8.5 8.5-4.7 0-8.5 3.8-8.5 8.5 0-4.7-3.8-8.5-8.5-8.5 4.7 0 8.5-3.8 8.5-8.5z" />
+    </svg>
+  )
+}
+
+/** A shield, for how much the agent may do without asking. */
+export function Shield({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 3.5l7 2.5v6c0 4-3 7.3-7 8.5-4-1.2-7-4.5-7-8.5V6l7-2.5z" />
+    </svg>
+  )
+}
+
 /** A terminal, for the one action a row offers under the pointer. */
 export function Console({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -15,16 +15,6 @@ const NO_DIRECTORIES: DirectoryInfo[] = []
 /** Module scope so the cache memoises the filtered list. */
 const onlyReady = (all: ProviderInfo[]): ProviderInfo[] => all.filter((p) => p.ready !== false)
 
-/**
- * A composer, not a form.
- *
- * The one thing a new session needs is the first prompt, and a stack of
- * labelled selects buried it under five rows the user answers the same way
- * every time. So the prompt is the dialog — a single box that takes focus on
- * open — and everything else is a chip around it: where it runs across the
- * top, what runs it along the bottom. Each chip already says its own value, so
- * none of them needs a label.
- */
 export function NewSessionDialog({
   seed,
   onClose,
@@ -44,6 +34,7 @@ export function NewSessionDialog({
   const [prompt, setPrompt] = useState('')
   const [starting, setStarting] = useState(false)
   const shell = useRef<HTMLDivElement | null>(null)
+  const dismissing = useRef(false)
   // Spent on the first load and not again: switching hosts after that has to
   // reset the directory, because a path from one machine is not a path on the
   // next, and the seed was a path on the machine it came from.
@@ -120,11 +111,6 @@ export function NewSessionDialog({
     }
   }
 
-  // Escape closes the composer — unless a chip is open, which owns the key
-  // first and would otherwise take the whole dialog down with its own popover.
-  // Capture phase, because a chip's own dismissal listens on the window too
-  // and runs first: by the time it bubbled here, the chip would already have
-  // closed and this would see nothing open.
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') return
@@ -135,17 +121,28 @@ export function NewSessionDialog({
     return () => window.removeEventListener('keydown', onKey, true)
   }, [onClose])
 
+  useEffect(() => {
+    const onDown = (): void => {
+      dismissing.current = shell.current?.querySelector('details.picker[open]') != null
+    }
+    window.addEventListener('mousedown', onDown, true)
+    return () => window.removeEventListener('mousedown', onDown, true)
+  }, [])
+
   const place = directories.find((dir) => dir.cwd === cwd)
   const where = place?.project || basename(cwd) || 'Home'
+  const tint = tintOf(tintKey(place, cwd))
   const host = hosts.find((h) => h.id === hostId)
   const modelName = models.find((m) => m.id === model)?.name ?? 'Default model'
 
   return (
     <div
       className="modal-backdrop"
-      // A stray click on the backdrop should not throw away a written prompt;
-      // Escape and Cancel are the deliberate ways out.
       onClick={() => {
+        if (dismissing.current) {
+          dismissing.current = false
+          return
+        }
         if (!prompt.trim()) onClose()
       }}
     >
@@ -155,7 +152,7 @@ export function NewSessionDialog({
             title="Working directory"
             trigger={
               <>
-                <span className="composer-dot" style={{ background: tintOf(where.toLowerCase()) }} />
+                <span className="composer-dot" style={{ background: tint }} />
                 <span className="composer-chip-name">{where}</span>
               </>
             }
@@ -173,9 +170,6 @@ export function NewSessionDialog({
             )}
           </Picker>
 
-          {/* Shown even on a single host. The dot is the machine's connection
-              state, and "which machine, and is it up" is worth answering before
-              a prompt is written rather than after the session fails to start. */}
           <Picker
             title="Host"
             align="right"
@@ -191,13 +185,13 @@ export function NewSessionDialog({
               hosts.map((option) => (
                 <button
                   key={option.id}
-                  className={`picker-item ${option.id === hostId ? 'is-on' : ''}`}
+                  className={`composer-option ${option.id === hostId ? 'is-on' : ''}`}
                   onClick={() => {
                     setHostId(option.id)
                     close()
                   }}
                 >
-                  <span className="picker-item-name">
+                  <span className="composer-option-name">
                     <span className={`dot ${hostStatus[option.id]?.state ?? 'offline'}`} />
                     {option.name}
                   </span>
@@ -215,8 +209,6 @@ export function NewSessionDialog({
           placeholder="What do you want to work on?"
           onChange={(event) => setPrompt(event.target.value)}
           onKeyDown={(event) => {
-            // Enter starts the session, as the button's ↵ promises; a prompt
-            // that wants paragraphs gets them with Shift.
             if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
             event.preventDefault()
             void start()
@@ -238,13 +230,13 @@ export function NewSessionDialog({
                 providers.map((option) => (
                   <button
                     key={option.id}
-                    className={`picker-item ${option.id === provider ? 'is-on' : ''}`}
+                    className={`composer-option ${option.id === provider ? 'is-on' : ''}`}
                     onClick={() => {
                       setProvider(option.id)
                       close()
                     }}
                   >
-                    <span className="picker-item-name">{option.name}</span>
+                    <span className="composer-option-name">{option.name}</span>
                   </button>
                 ))
               }
@@ -262,26 +254,26 @@ export function NewSessionDialog({
               {(close) => (
                 <>
                   <button
-                    className={`picker-item ${model === '' ? 'is-on' : ''}`}
+                    className={`composer-option ${model === '' ? 'is-on' : ''}`}
                     onClick={() => {
                       setModel('')
                       close()
                     }}
                   >
-                    <span className="picker-item-name">Default model</span>
-                    <span className="picker-item-hint">Whatever the provider picks</span>
+                    <span className="composer-option-name">Default model</span>
+                    <span className="composer-option-hint">Whatever the provider picks</span>
                   </button>
                   {models.map((option) => (
                     <button
                       key={option.id}
-                      className={`picker-item ${option.id === model ? 'is-on' : ''}`}
+                      className={`composer-option ${option.id === model ? 'is-on' : ''}`}
                       onClick={() => {
                         setModel(option.id)
                         close()
                       }}
                     >
-                      <span className="picker-item-name">{option.name}</span>
-                      {option.description && <span className="picker-item-hint">{option.description}</span>}
+                      <span className="composer-option-name">{option.name}</span>
+                      {option.description && <span className="composer-option-hint">{option.description}</span>}
                     </button>
                   ))}
                 </>
@@ -301,24 +293,24 @@ export function NewSessionDialog({
                 {(close) => (
                   <>
                     <button
-                      className={`picker-item ${mode === '' ? 'is-on' : ''}`}
+                      className={`composer-option ${mode === '' ? 'is-on' : ''}`}
                       onClick={() => {
                         setMode('')
                         close()
                       }}
                     >
-                      <span className="picker-item-name">Default permissions</span>
+                      <span className="composer-option-name">Default permissions</span>
                     </button>
                     {modes.map((option) => (
                       <button
                         key={option}
-                        className={`picker-item ${option === mode ? 'is-on' : ''}`}
+                        className={`composer-option ${option === mode ? 'is-on' : ''}`}
                         onClick={() => {
                           setMode(option)
                           close()
                         }}
                       >
-                        <span className="picker-item-name">{option}</span>
+                        <span className="composer-option-name">{option}</span>
                       </button>
                     ))}
                   </>
@@ -343,15 +335,6 @@ export function NewSessionDialog({
   )
 }
 
-/**
- * The directories the daemon knows, and any path the user types.
- *
- * The old field was an `<input list>`: it completed known paths but showed
- * none of them until something had been typed, so the common case — start
- * where I started last time — was hidden behind guessing the first letter.
- * The list is open here, and the filter doubles as the place to type a path
- * the daemon has never seen.
- */
 function DirectoryList({
   directories,
   cwd,
@@ -401,28 +384,28 @@ function DirectoryList({
       />
       <div className="picker-list">
         {custom && !known && (
-          <button className="picker-item" onClick={() => onPick(typed)}>
-            <span className="picker-item-name">Use “{typed}”</span>
+          <button className="composer-option" onClick={() => onPick(typed)}>
+            <span className="composer-option-name">Use “{typed}”</span>
           </button>
         )}
         {!needle && (
-          <button className={`picker-item ${cwd === '' ? 'is-on' : ''}`} onClick={() => onPick('')}>
-            <span className="picker-item-name">Home</span>
-            <span className="picker-item-hint">~</span>
+          <button className={`composer-option ${cwd === '' ? 'is-on' : ''}`} onClick={() => onPick('')}>
+            <span className="composer-option-name">Home</span>
+            <span className="composer-option-hint">~</span>
           </button>
         )}
         {matches.map((dir) => (
           <button
             key={dir.cwd}
-            className={`picker-item ${dir.cwd === cwd ? 'is-on' : ''}`}
+            className={`composer-option ${dir.cwd === cwd ? 'is-on' : ''}`}
             onClick={() => onPick(dir.cwd)}
           >
-            <span className="picker-item-name">
-              <span className="composer-dot" style={{ background: tintOf((dir.project || dir.cwd).toLowerCase()) }} />
+            <span className="composer-option-name">
+              <span className="composer-dot" style={{ background: tintOf(tintKey(dir, dir.cwd)) }} />
               {dir.project || basename(dir.cwd)}
-              {dir.active_count > 0 && <span className="picker-item-count">{dir.active_count} active</span>}
+              {dir.active_count > 0 && <span className="composer-option-count">{dir.active_count} active</span>}
             </span>
-            <span className="picker-item-hint">{dir.cwd}</span>
+            <span className="composer-option-hint">{dir.cwd}</span>
           </button>
         ))}
         {matches.length === 0 && !custom && <p className="picker-empty">No matching directory. Type a path to use one.</p>}
@@ -431,13 +414,6 @@ function DirectoryList({
   )
 }
 
-/**
- * A chip that says its own value and opens the choices under it.
- *
- * `<details>` for the same reason the sidebar's menu uses one — the open state
- * is the element's, not a piece of React state per chip — and dismissed the
- * same way, because a `<details>` left open only closes on its own summary.
- */
 function Picker({
   title,
   trigger,
@@ -447,7 +423,6 @@ function Picker({
 }: {
   title: string
   trigger: React.ReactNode
-  /** Which edge the popover lines up with; 'right' for chips near the edge. */
   align?: 'left' | 'right'
   className?: string
   children: (close: () => void) => React.ReactNode
@@ -463,6 +438,7 @@ function Picker({
       if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
       element.open = false
       setOpen(false)
+      if (event.type === 'keydown') element.querySelector('summary')?.focus()
     }
     window.addEventListener('mousedown', dismiss)
     window.addEventListener('keydown', dismiss)
@@ -477,23 +453,56 @@ function Picker({
   const close = (): void => {
     if (box.current) box.current.open = false
     setOpen(false)
+    box.current?.querySelector('summary')?.focus()
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    const keys = ['ArrowDown', 'ArrowUp', 'Home', 'End']
+    if (!keys.includes(event.key)) return
+    const typing = document.activeElement instanceof HTMLInputElement
+    if (typing && (event.key === 'Home' || event.key === 'End')) return
+
+    const options = Array.from(
+      box.current?.querySelectorAll<HTMLElement>('.picker-body .composer-option') ?? [],
+    )
+    if (options.length === 0) return
+    event.preventDefault()
+
+    const at = options.indexOf(document.activeElement as HTMLElement)
+    const to =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? options.length - 1
+          : event.key === 'ArrowDown'
+            ? (at + 1) % options.length
+            : at <= 0
+              ? options.length - 1
+              : at - 1
+    options[to]?.focus()
   }
 
   return (
     <details
       className={`picker ${className}`.trim()}
       ref={box}
+      onKeyDown={onKeyDown}
       onToggle={() => setOpen(box.current?.open ?? false)}
     >
       <summary title={title}>
         {trigger}
         <Chevron dir="down" className="picker-caret" />
       </summary>
-      {/* Rendered only while open, so the filter field can take focus on the
-          way in rather than waiting for a click it has already missed. */}
-      {open && <div className={`picker-body ${align === 'right' ? 'to-right' : ''}`}>{children(close)}</div>}
+      {open && (
+        <div className={`picker-body ${align === 'right' ? 'to-right' : ''}`}>{children(close)}</div>
+      )}
     </details>
   )
+}
+
+function tintKey(dir: DirectoryInfo | undefined, cwd: string): string {
+  if (dir) return (dir.project || dir.cwd).toLowerCase()
+  return cwd.toLowerCase() || 'home'
 }
 
 function basename(path: string): string {

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
 import { directoriesQuery, modelsQuery, providersQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
-import type { DirectoryInfo, ModelInfo, ProviderInfo } from '../../shared/models.ts'
+import { Chevron, Console, Shield, Spark } from './icons.tsx'
+import { tintOf } from './grouping.ts'
+import { type DirectoryInfo, type ModelInfo, type ProviderInfo } from '../../shared/models.ts'
 
 const NO_PROVIDERS: ProviderInfo[] = []
 const NO_MODELS: ModelInfo[] = []
@@ -13,6 +15,16 @@ const NO_DIRECTORIES: DirectoryInfo[] = []
 /** Module scope so the cache memoises the filtered list. */
 const onlyReady = (all: ProviderInfo[]): ProviderInfo[] => all.filter((p) => p.ready !== false)
 
+/**
+ * A composer, not a form.
+ *
+ * The one thing a new session needs is the first prompt, and a stack of
+ * labelled selects buried it under five rows the user answers the same way
+ * every time. So the prompt is the dialog — a single box that takes focus on
+ * open — and everything else is a chip around it: where it runs across the
+ * top, what runs it along the bottom. Each chip already says its own value, so
+ * none of them needs a label.
+ */
 export function NewSessionDialog({
   seed,
   onClose,
@@ -23,6 +35,7 @@ export function NewSessionDialog({
   onClose: () => void
 }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
+  const hostStatus = useStore((s) => s.hostStatus)
   const [hostId, setHostId] = useState(seed?.hostId ?? hosts[0]?.id ?? '')
   const [provider, setProvider] = useState('claude')
   const [model, setModel] = useState('')
@@ -30,6 +43,7 @@ export function NewSessionDialog({
   const [mode, setMode] = useState('')
   const [prompt, setPrompt] = useState('')
   const [starting, setStarting] = useState(false)
+  const shell = useRef<HTMLDivElement | null>(null)
   // Spent on the first load and not again: switching hosts after that has to
   // reset the directory, because a path from one machine is not a path on the
   // next, and the seed was a path on the machine it came from.
@@ -106,100 +120,384 @@ export function NewSessionDialog({
     }
   }
 
+  // Escape closes the composer — unless a chip is open, which owns the key
+  // first and would otherwise take the whole dialog down with its own popover.
+  // Capture phase, because a chip's own dismissal listens on the window too
+  // and runs first: by the time it bubbled here, the chip would already have
+  // closed and this would see nothing open.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return
+      if (shell.current?.querySelector('details.picker[open]')) return
+      onClose()
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [onClose])
+
+  const place = directories.find((dir) => dir.cwd === cwd)
+  const where = place?.project || basename(cwd) || 'Home'
+  const host = hosts.find((h) => h.id === hostId)
+  const modelName = models.find((m) => m.id === model)?.name ?? 'Default model'
+
   return (
-    <Modal title="New session" onClose={onClose}>
-      {hosts.length > 1 && (
-        <label className="field">
-          <span>Host</span>
-          <select value={hostId} onChange={(event) => setHostId(event.target.value)}>
-            {hosts.map((host) => (
-              <option key={host.id} value={host.id}>
-                {host.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
+    <div
+      className="modal-backdrop"
+      // A stray click on the backdrop should not throw away a written prompt;
+      // Escape and Cancel are the deliberate ways out.
+      onClick={() => {
+        if (!prompt.trim()) onClose()
+      }}
+    >
+      <div className="composer" ref={shell} onClick={(event) => event.stopPropagation()}>
+        <header className="composer-head">
+          <Picker
+            title="Working directory"
+            trigger={
+              <>
+                <span className="composer-dot" style={{ background: tintOf(where.toLowerCase()) }} />
+                <span className="composer-chip-name">{where}</span>
+              </>
+            }
+            className="composer-place"
+          >
+            {(close) => (
+              <DirectoryList
+                directories={directories}
+                cwd={cwd}
+                onPick={(next) => {
+                  setCwd(next)
+                  close()
+                }}
+              />
+            )}
+          </Picker>
 
-      <label className="field">
-        <span>Provider</span>
-        <select value={provider} onChange={(event) => setProvider(event.target.value)}>
-          {providers.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </label>
+          {/* Shown even on a single host. The dot is the machine's connection
+              state, and "which machine, and is it up" is worth answering before
+              a prompt is written rather than after the session fails to start. */}
+          <Picker
+            title="Host"
+            align="right"
+            className="composer-host"
+            trigger={
+              <>
+                <span className={`dot ${hostStatus[hostId]?.state ?? 'offline'}`} />
+                <span className="composer-chip-name">{host?.name ?? 'Pick a host'}</span>
+              </>
+            }
+          >
+            {(close) =>
+              hosts.map((option) => (
+                <button
+                  key={option.id}
+                  className={`picker-item ${option.id === hostId ? 'is-on' : ''}`}
+                  onClick={() => {
+                    setHostId(option.id)
+                    close()
+                  }}
+                >
+                  <span className="picker-item-name">
+                    <span className={`dot ${hostStatus[option.id]?.state ?? 'offline'}`} />
+                    {option.name}
+                  </span>
+                </button>
+              ))
+            }
+          </Picker>
+        </header>
 
-      <label className="field">
-        <span>Directory</span>
-        <input
-          list="known-directories"
-          value={cwd}
-          placeholder="~ (home)"
-          spellCheck={false}
-          onChange={(event) => setCwd(event.target.value)}
-        />
-        {/* The daemon sends objects, not paths: cwd is the value, and the
-            project name is the label that tells two checkouts of the same
-            repository apart. */}
-        <datalist id="known-directories">
-          {directories.map((dir) => (
-            <option key={dir.cwd} value={dir.cwd} label={dir.project || undefined} />
-          ))}
-        </datalist>
-      </label>
-
-      <label className="field">
-        <span>Model</span>
-        <select value={model} onChange={(event) => setModel(event.target.value)}>
-          <option value="">Default</option>
-          {models.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      {modes.length > 0 && (
-        <label className="field">
-          <span>Permission mode</span>
-          <select value={mode} onChange={(event) => setMode(event.target.value)}>
-            <option value="">Provider default</option>
-            {modes.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
-
-      <label className="field">
-        <span>First prompt (optional)</span>
-        {/* The box says a field; the placeholder says what the field is for.
-            Without it this reads as a note to self rather than the first thing
-            the agent will be asked. */}
         <textarea
+          className="composer-prompt"
+          autoFocus
           rows={4}
           value={prompt}
-          placeholder="What should the agent start on? Left empty, the session opens at a prompt."
+          placeholder="What do you want to work on?"
           onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            // Enter starts the session, as the button's ↵ promises; a prompt
+            // that wants paragraphs gets them with Shift.
+            if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
+            event.preventDefault()
+            void start()
+          }}
         />
-      </label>
 
-      <div className="modal-actions">
-        <button className="ghost" onClick={onClose}>
-          Cancel
-        </button>
-        <button disabled={!hostId || starting} onClick={() => void start()}>
-          {starting ? 'Starting…' : 'Start session'}
-        </button>
+        <footer className="composer-foot">
+          <div className="composer-chips">
+            <Picker
+              title="Provider"
+              trigger={
+                <>
+                  <Console />
+                  <span className="composer-chip-name">{selected?.name ?? provider}</span>
+                </>
+              }
+            >
+              {(close) =>
+                providers.map((option) => (
+                  <button
+                    key={option.id}
+                    className={`picker-item ${option.id === provider ? 'is-on' : ''}`}
+                    onClick={() => {
+                      setProvider(option.id)
+                      close()
+                    }}
+                  >
+                    <span className="picker-item-name">{option.name}</span>
+                  </button>
+                ))
+              }
+            </Picker>
+
+            <Picker
+              title="Model"
+              trigger={
+                <>
+                  <Spark />
+                  <span className="composer-chip-name">{modelName}</span>
+                </>
+              }
+            >
+              {(close) => (
+                <>
+                  <button
+                    className={`picker-item ${model === '' ? 'is-on' : ''}`}
+                    onClick={() => {
+                      setModel('')
+                      close()
+                    }}
+                  >
+                    <span className="picker-item-name">Default model</span>
+                    <span className="picker-item-hint">Whatever the provider picks</span>
+                  </button>
+                  {models.map((option) => (
+                    <button
+                      key={option.id}
+                      className={`picker-item ${option.id === model ? 'is-on' : ''}`}
+                      onClick={() => {
+                        setModel(option.id)
+                        close()
+                      }}
+                    >
+                      <span className="picker-item-name">{option.name}</span>
+                      {option.description && <span className="picker-item-hint">{option.description}</span>}
+                    </button>
+                  ))}
+                </>
+              )}
+            </Picker>
+
+            {modes.length > 0 && (
+              <Picker
+                title="Permission mode"
+                trigger={
+                  <>
+                    <Shield />
+                    <span className="composer-chip-name">{mode || 'Default permissions'}</span>
+                  </>
+                }
+              >
+                {(close) => (
+                  <>
+                    <button
+                      className={`picker-item ${mode === '' ? 'is-on' : ''}`}
+                      onClick={() => {
+                        setMode('')
+                        close()
+                      }}
+                    >
+                      <span className="picker-item-name">Default permissions</span>
+                    </button>
+                    {modes.map((option) => (
+                      <button
+                        key={option}
+                        className={`picker-item ${option === mode ? 'is-on' : ''}`}
+                        onClick={() => {
+                          setMode(option)
+                          close()
+                        }}
+                      >
+                        <span className="picker-item-name">{option}</span>
+                      </button>
+                    ))}
+                  </>
+                )}
+              </Picker>
+            )}
+
+          </div>
+
+          <div className="composer-actions">
+            <button className="ghost" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="filled" disabled={!hostId || starting} onClick={() => void start()}>
+              {starting ? 'Creating…' : 'Create'}
+              {!starting && <kbd className="composer-key">↵</kbd>}
+            </button>
+          </div>
+        </footer>
       </div>
-    </Modal>
+    </div>
   )
+}
+
+/**
+ * The directories the daemon knows, and any path the user types.
+ *
+ * The old field was an `<input list>`: it completed known paths but showed
+ * none of them until something had been typed, so the common case — start
+ * where I started last time — was hidden behind guessing the first letter.
+ * The list is open here, and the filter doubles as the place to type a path
+ * the daemon has never seen.
+ */
+function DirectoryList({
+  directories,
+  cwd,
+  onPick,
+}: {
+  directories: DirectoryInfo[]
+  cwd: string
+  onPick: (cwd: string) => void
+}): JSX.Element {
+  const [query, setQuery] = useState('')
+  const needle = query.trim().toLowerCase()
+
+  const matches = useMemo(
+    () =>
+      directories.filter(
+        (dir) =>
+          !needle ||
+          dir.project.toLowerCase().includes(needle) ||
+          dir.cwd.toLowerCase().includes(needle),
+      ),
+    [directories, needle],
+  )
+
+  const typed = query.trim()
+  const custom = typed.startsWith('/') || typed.startsWith('~')
+  const known = directories.some((dir) => dir.cwd === typed)
+
+  const first = (): void => {
+    if (custom && !known) onPick(typed)
+    else if (matches[0]) onPick(matches[0].cwd)
+  }
+
+  return (
+    <>
+      <input
+        className="picker-search"
+        autoFocus
+        spellCheck={false}
+        value={query}
+        placeholder="Filter, or type a path…"
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter') return
+          event.preventDefault()
+          first()
+        }}
+      />
+      <div className="picker-list">
+        {custom && !known && (
+          <button className="picker-item" onClick={() => onPick(typed)}>
+            <span className="picker-item-name">Use “{typed}”</span>
+          </button>
+        )}
+        {!needle && (
+          <button className={`picker-item ${cwd === '' ? 'is-on' : ''}`} onClick={() => onPick('')}>
+            <span className="picker-item-name">Home</span>
+            <span className="picker-item-hint">~</span>
+          </button>
+        )}
+        {matches.map((dir) => (
+          <button
+            key={dir.cwd}
+            className={`picker-item ${dir.cwd === cwd ? 'is-on' : ''}`}
+            onClick={() => onPick(dir.cwd)}
+          >
+            <span className="picker-item-name">
+              <span className="composer-dot" style={{ background: tintOf((dir.project || dir.cwd).toLowerCase()) }} />
+              {dir.project || basename(dir.cwd)}
+              {dir.active_count > 0 && <span className="picker-item-count">{dir.active_count} active</span>}
+            </span>
+            <span className="picker-item-hint">{dir.cwd}</span>
+          </button>
+        ))}
+        {matches.length === 0 && !custom && <p className="picker-empty">No matching directory. Type a path to use one.</p>}
+      </div>
+    </>
+  )
+}
+
+/**
+ * A chip that says its own value and opens the choices under it.
+ *
+ * `<details>` for the same reason the sidebar's menu uses one — the open state
+ * is the element's, not a piece of React state per chip — and dismissed the
+ * same way, because a `<details>` left open only closes on its own summary.
+ */
+function Picker({
+  title,
+  trigger,
+  align = 'left',
+  className = '',
+  children,
+}: {
+  title: string
+  trigger: React.ReactNode
+  /** Which edge the popover lines up with; 'right' for chips near the edge. */
+  align?: 'left' | 'right'
+  className?: string
+  children: (close: () => void) => React.ReactNode
+}): JSX.Element {
+  const box = useRef<HTMLDetailsElement | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const dismiss = (event: Event): void => {
+      const element = box.current
+      if (!element?.open) return
+      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
+      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
+      element.open = false
+      setOpen(false)
+    }
+    window.addEventListener('mousedown', dismiss)
+    window.addEventListener('keydown', dismiss)
+    window.addEventListener('blur', dismiss)
+    return () => {
+      window.removeEventListener('mousedown', dismiss)
+      window.removeEventListener('keydown', dismiss)
+      window.removeEventListener('blur', dismiss)
+    }
+  }, [])
+
+  const close = (): void => {
+    if (box.current) box.current.open = false
+    setOpen(false)
+  }
+
+  return (
+    <details
+      className={`picker ${className}`.trim()}
+      ref={box}
+      onToggle={() => setOpen(box.current?.open ?? false)}
+    >
+      <summary title={title}>
+        {trigger}
+        <Chevron dir="down" className="picker-caret" />
+      </summary>
+      {/* Rendered only while open, so the filter field can take focus on the
+          way in rather than waiting for a click it has already missed. */}
+      {open && <div className={`picker-body ${align === 'right' ? 'to-right' : ''}`}>{children(close)}</div>}
+    </details>
+  )
+}
+
+function basename(path: string): string {
+  return path.replace(/\/+$/, '').split('/').pop() ?? ''
 }
 
 export function Modal({

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -50,7 +50,7 @@ export function NewSessionDialog({
     enabled: !!hostId,
     select: onlyReady,
   })
-  const { data: directories = NO_DIRECTORIES } = useQuery({
+  const { data: directories = NO_DIRECTORIES, isPending: findingDirectories } = useQuery({
     ...directoriesQuery(hostId ?? ''),
     enabled: !!hostId,
   })
@@ -65,7 +65,7 @@ export function NewSessionDialog({
    */
   const settled = useRef<string | null>(null)
   useEffect(() => {
-    if (!hostId || providers.length === 0 || settled.current === hostId) return
+    if (!hostId || providers.length === 0 || findingDirectories || settled.current === hostId) return
     settled.current = hostId
     const first = providers[0]
     if (first && !providers.some((p) => p.id === provider)) setProvider(first.id)
@@ -73,7 +73,7 @@ export function NewSessionDialog({
     seeded.current = ''
     // provider and cwd are deliberately not dependencies: this settles them.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hostId, providers, directories])
+  }, [hostId, providers, directories, findingDirectories])
 
   const { data: models = NO_MODELS } = useQuery({
     ...modelsQuery(hostId ?? '', provider),

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3724,6 +3724,294 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
+/* ─── The new-session composer ──────────────────────────────────────────── */
+
+/* Wider and shallower than a form dialog: the prompt is the content, and the
+   settings are a line above it and a line below rather than rows it has to
+   scroll past. */
+.composer {
+  width: 680px;
+  max-width: 92vw;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-high);
+  border-radius: var(--r-lg);
+  box-shadow: 0 24px 64px var(--shadow-strong);
+}
+
+.composer-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 10px 2px;
+}
+
+/* The machine belongs at the far edge, opposite the directory on it. */
+.composer-host {
+  margin-left: auto;
+}
+
+.composer-prompt {
+  min-height: 132px;
+  max-height: 40vh;
+  margin: 0 12px;
+  padding: 8px 8px 12px;
+  background: none;
+  border: none;
+  border-radius: 0;
+  resize: none;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.composer-prompt:focus {
+  border: none;
+  outline: none;
+}
+
+/* Dimmer than the shared placeholder colour, which is also what the chips'
+   labels are painted in. At 15px, alone in a box this big, a prompt at chip
+   brightness reads as something already typed rather than as the invitation to
+   type — there is no other text near it to be lighter than. */
+.composer-prompt::placeholder {
+  color: color-mix(in srgb, var(--on-surface-variant) 55%, transparent);
+}
+
+.composer-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 10px 10px;
+}
+
+/* Wraps rather than squeezes. Each chip is a value read at a glance, and a row
+   that shrinks them all to fit says "C", "D", "D…" — three chips that have
+   stopped saying anything. A second line costs the dialog 34px. */
+.composer-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 2px;
+  min-width: 0;
+}
+
+.composer-chips > * {
+  flex: none;
+}
+
+.composer-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* The ↵ the button promises, dimmed so it reads as a hint and not a word. */
+.composer-key {
+  margin-left: 6px;
+  font: inherit;
+  font-size: 12px;
+  opacity: 0.65;
+}
+
+.composer-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: none;
+}
+
+.composer .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--s-off);
+}
+
+.composer .dot.online {
+  background: var(--s-active);
+}
+
+.composer .dot.connecting {
+  background: var(--s-waiting);
+}
+
+.composer .dot.offline,
+.composer .dot.unpaired {
+  background: var(--error);
+}
+
+/* A chip that says its own value. Unlabelled on purpose: the value is the
+   label, which is what buys the space the prompt is given. */
+.picker {
+  position: relative;
+  min-width: 0;
+}
+
+.picker > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  white-space: nowrap;
+}
+
+.picker > summary::-webkit-details-marker {
+  display: none;
+}
+
+.picker > summary:hover,
+.picker[open] > summary {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+  color: var(--on-surface);
+}
+
+.picker .ui-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.picker-caret {
+  width: 0.8em;
+  height: 0.8em;
+  opacity: 0.7;
+}
+
+/* The directory is the one chip that names the work, so it carries the weight
+   a title would have if the dialog still had one. */
+.composer-place > summary {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--on-surface);
+}
+
+.composer-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
+.picker-body {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 6px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 300px;
+  max-height: 320px;
+  padding: 8px;
+  background: var(--surface-highest);
+  border-radius: var(--r-md);
+  box-shadow: 0 8px 24px var(--shadow-soft);
+  /* The chips that list models hang their items straight off the body, with no
+     inner list to do the scrolling. Without this the max-height clamps the box
+     and the items carry on drawing past it, outside the modal. */
+  overflow-y: auto;
+}
+
+.picker-body.to-right {
+  left: auto;
+  right: 0;
+}
+
+/* Chips on the bottom row have no room under them. */
+.composer-foot .picker-body {
+  top: auto;
+  bottom: 100%;
+  margin: 0 0 6px;
+}
+
+.composer-place .picker-body {
+  width: 380px;
+}
+
+.picker-search {
+  flex: none;
+  font-size: 13px;
+  padding: 7px 10px;
+  background: var(--surface-high);
+}
+
+.picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+}
+
+/* Scoped to the composer: `.picker-item` is also the settings menus' row, and
+   theirs is a centred single line declared further down the file. Unscoped,
+   whichever came last won — which was theirs, and it centred a two-line entry
+   whose name and path both want the same left edge. */
+.composer .picker-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  /* A row is its two lines and no less: left to shrink, a long list squashes
+     every item instead of scrolling. */
+  flex: none;
+  gap: 2px;
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--on-surface);
+  text-align: left;
+}
+
+.composer .picker-item:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+}
+
+.composer .picker-item.is-on {
+  background: color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.picker-item-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.picker-item-hint {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+.picker-item-count {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--s-active);
+}
+
+.picker-empty {
+  margin: 4px 10px;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
 .host-row {
   display: flex;
   align-items: center;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3724,11 +3724,6 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
-/* ─── The new-session composer ──────────────────────────────────────────── */
-
-/* Wider and shallower than a form dialog: the prompt is the content, and the
-   settings are a line above it and a line below rather than rows it has to
-   scroll past. */
 .composer {
   width: 680px;
   max-width: 92vw;
@@ -3746,7 +3741,6 @@ figure.mermaid svg {
   padding: 10px 10px 2px;
 }
 
-/* The machine belongs at the far edge, opposite the directory on it. */
 .composer-host {
   margin-left: auto;
 }
@@ -3769,10 +3763,6 @@ figure.mermaid svg {
   outline: none;
 }
 
-/* Dimmer than the shared placeholder colour, which is also what the chips'
-   labels are painted in. At 15px, alone in a box this big, a prompt at chip
-   brightness reads as something already typed rather than as the invitation to
-   type — there is no other text near it to be lighter than. */
 .composer-prompt::placeholder {
   color: color-mix(in srgb, var(--on-surface-variant) 55%, transparent);
 }
@@ -3784,9 +3774,6 @@ figure.mermaid svg {
   padding: 2px 10px 10px;
 }
 
-/* Wraps rather than squeezes. Each chip is a value read at a glance, and a row
-   that shrinks them all to fit says "C", "D", "D…" — three chips that have
-   stopped saying anything. A second line costs the dialog 34px. */
 .composer-chips {
   display: flex;
   flex-wrap: wrap;
@@ -3806,7 +3793,6 @@ figure.mermaid svg {
   gap: 4px;
 }
 
-/* The ↵ the button promises, dimmed so it reads as a hint and not a word. */
 .composer-key {
   margin-left: 6px;
   font: inherit;
@@ -3842,8 +3828,6 @@ figure.mermaid svg {
   background: var(--error);
 }
 
-/* A chip that says its own value. Unlabelled on purpose: the value is the
-   label, which is what buys the space the prompt is given. */
 .picker {
   position: relative;
   min-width: 0;
@@ -3884,8 +3868,6 @@ figure.mermaid svg {
   opacity: 0.7;
 }
 
-/* The directory is the one chip that names the work, so it carries the weight
-   a title would have if the dialog still had one. */
 .composer-place > summary {
   font-size: 14px;
   font-weight: 500;
@@ -3914,9 +3896,6 @@ figure.mermaid svg {
   background: var(--surface-highest);
   border-radius: var(--r-md);
   box-shadow: 0 8px 24px var(--shadow-soft);
-  /* The chips that list models hang their items straight off the body, with no
-     inner list to do the scrolling. Without this the max-height clamps the box
-     and the items carry on drawing past it, outside the modal. */
   overflow-y: auto;
 }
 
@@ -3925,7 +3904,6 @@ figure.mermaid svg {
   right: 0;
 }
 
-/* Chips on the bottom row have no room under them. */
 .composer-foot .picker-body {
   top: auto;
   bottom: 100%;
@@ -3950,17 +3928,11 @@ figure.mermaid svg {
   overflow-y: auto;
 }
 
-/* Scoped to the composer: `.picker-item` is also the settings menus' row, and
-   theirs is a centred single line declared further down the file. Unscoped,
-   whichever came last won — which was theirs, and it centred a two-line entry
-   whose name and path both want the same left edge. */
-.composer .picker-item {
+.composer-option {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  /* A row is its two lines and no less: left to shrink, a long list squashes
-     every item instead of scrolling. */
   flex: none;
   gap: 2px;
   width: 100%;
@@ -3972,15 +3944,15 @@ figure.mermaid svg {
   text-align: left;
 }
 
-.composer .picker-item:hover {
+.composer-option:hover {
   background: color-mix(in srgb, var(--on-surface) 8%, transparent);
 }
 
-.composer .picker-item.is-on {
+.composer-option.is-on {
   background: color-mix(in srgb, var(--primary) 16%, transparent);
 }
 
-.picker-item-name {
+.composer-option-name {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -3991,7 +3963,7 @@ figure.mermaid svg {
   font-weight: 500;
 }
 
-.picker-item-hint {
+.composer-option-hint {
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4000,7 +3972,7 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
-.picker-item-count {
+.composer-option-count {
   font-size: 11px;
   font-weight: 400;
   color: var(--s-active);


### PR DESCRIPTION
## What

Reworks the new-session dialog. The prompt is the dialog now — a single box that takes focus on open — and the labelled selects become chips around it: the working directory and the host across the top, provider, model and permissions along the bottom. Each chip says its own value, so none of them needs a label.
<img width="831" height="398" alt="image" src="https://github.com/user-attachments/assets/3dcdbed3-ee20-4d86-98ce-12ce72e46a63" />

## Why

The one thing a new session needs is the first prompt, and a stack of five labelled rows buried it under answers the user gives the same way every time.

## Notes for review

Three things in here are less obvious than the layout:

- **The directory picker's rows are scoped to `.composer`.** `.picker-item` is also the settings menus' row, and theirs is a centred single line declared later in the file. Unscoped, whichever came last won — which was theirs, and it centred a two-line entry whose name and path both want the same left edge.
- **`.picker-body` gained `overflow-y: auto`.** It already had `max-height: 320px`, but with no overflow the max-height clamped the box while the items carried on drawing past it and out of the modal. The directory picker never showed this because it has an inner `.picker-list` doing the scrolling; the model, provider and permission chips hang their items straight off the body. `.composer .picker-item` gets `flex: none` alongside, so a long list scrolls instead of squashing every row.
- **The prompt's placeholder is dimmed to 55%.** The shared `input::placeholder` colour is `--on-surface-variant`, which is also what the chips' labels are painted in — at 15px, alone in a box this big, it read as something already typed.

The host chip shows even on a single host: its dot is the machine's connection state, and "is it up" is worth answering before a prompt is written rather than after the session fails to start.

## Testing

Driven in the running app against a live daemon — directory, host, model and permission pickers all opened and picked from. `tsc --noEmit` clean, `go build ./...` clean, 262/262 desktop unit tests pass. No Go files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)