### PR TITLE
feat(desktop): make the new-session dialog a composer, with a directory picker that completes

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -240,16 +240,17 @@ const WORKTREES: Worktree[] = [
 /**
  * Home, and the one directory under it with anything in it.
  *
- * The new-session picker completes a typed path against the disk, and a bare
- * segment completes under home — so `~/` has to answer with directories, not
- * with the flat list of files the other roots serve.
+ * The new-session picker completes a typed path against the disk, so the roots
+ * it can be sitting in have to answer with directories and not only with the
+ * flat list of files: `~/` for a picker with no directory picked, and `/repo`
+ * for one set to a session's.
  */
 export const HOME = '/home/dev'
 export const WORKSPACE = `${HOME}/workspace`
 
 /** One file per worktree, named after it, so a wrong root is visible on sight. */
 const TREES: Record<string, FileEntry[]> = {
-  [REPO]: [file(REPO, 'main.go'), file(REPO, 'README.md')],
+  [REPO]: [dir(REPO, 'desktop'), dir(REPO, 'docs'), file(REPO, 'main.go'), file(REPO, 'README.md')],
   [OTHER_WORKTREE]: [file(OTHER_WORKTREE, 'hotfix.go')],
   [HOME]: [dir(HOME, 'workspace'), dir(HOME, 'worktrees'), dir(HOME, '.config'), file(HOME, 'notes.md')],
   [WORKSPACE]: [dir(WORKSPACE, 'acme-api'), dir(WORKSPACE, 'acme-web')],
@@ -270,7 +271,7 @@ function resolveStubPath(asked: string): string {
 }
 
 function grepMatches(root: string, query: string): GrepMatch[] {
-  const entries = TREES[root] ?? []
+  const entries = (TREES[root] ?? []).filter((entry) => !entry.is_dir)
   return entries.map((entry, index) => ({
     path: entry.path,
     rel: entry.name,

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -219,14 +219,36 @@ const WORKTREES: Worktree[] = [
   },
 ]
 
+/**
+ * Home, and the one directory under it with anything in it.
+ *
+ * The new-session picker completes a typed path against the disk, and a bare
+ * segment completes under home — so `~/` has to answer with directories, not
+ * with the flat list of files the other roots serve.
+ */
+export const HOME = '/home/dev'
+export const WORKSPACE = `${HOME}/workspace`
+
 /** One file per worktree, named after it, so a wrong root is visible on sight. */
 const TREES: Record<string, FileEntry[]> = {
   [REPO]: [file(REPO, 'main.go'), file(REPO, 'README.md')],
   [OTHER_WORKTREE]: [file(OTHER_WORKTREE, 'hotfix.go')],
+  [HOME]: [dir(HOME, 'workspace'), dir(HOME, 'worktrees'), dir(HOME, '.config'), file(HOME, 'notes.md')],
+  [WORKSPACE]: [dir(WORKSPACE, 'acme-api'), dir(WORKSPACE, 'acme-web')],
 }
 
 function file(root: string, name: string): FileEntry {
   return { name, path: `${root}/${name}`, is_dir: false, size: 12, mod_time: '2026-01-01T00:00:00Z' }
+}
+
+function dir(root: string, name: string): FileEntry {
+  return { ...file(root, name), is_dir: true, size: 0 }
+}
+
+/** What the daemon's resolveSafePath does to a path before it reads it. */
+function resolveStubPath(asked: string): string {
+  const expanded = asked.startsWith('~/') ? `${HOME}/${asked.slice(2)}` : asked
+  return expanded.length > 1 ? expanded.replace(/\/+$/, '') : expanded
 }
 
 function grepMatches(root: string, query: string): GrepMatch[] {
@@ -365,8 +387,12 @@ function answer(
       // No base branch and no commits: the git panel then opens on the working
       // tree, which is the view these tests drive.
       return { root: q('path'), branch: 'main', base: '', scope: 'all', commits: [], has_more: false }
-    case '/api/files':
-      return { path: q('path'), entries: TREES[q('path')] ?? [] }
+    case '/api/files': {
+      // `~/` is expanded before the listing is read, and the answer says which
+      // directory it turned out to be (internal/server/files.go).
+      const root = resolveStubPath(q('path'))
+      return { path: root, entries: TREES[root] ?? [] }
+    }
     case '/api/file': {
       const { content, modTime } = held(q('path'))
       return { path: q('path'), size: content.length, mod_time: modTime, content }

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -47,8 +47,26 @@ export interface StubDaemon {
    * how a test knows the refetch it provoked has happened at all.
    */
   greps(): number
+  /**
+   * What the app asked the daemon to do, in the order it asked.
+   *
+   * A session with files on its first prompt is three calls that have to
+   * happen in one order — create, upload, send — because the upload needs an
+   * id that only the create can give it. Nothing on screen shows the order, so
+   * the record of what arrived is the only thing that can.
+   */
+  writes(): DaemonWrite[]
   close(): Promise<void>
 }
+
+/** One thing the app asked of the daemon. */
+export type DaemonWrite =
+  | { kind: 'create'; spec: Record<string, unknown> }
+  | { kind: 'upload'; sessionId: string; names: string[] }
+  | { kind: 'send'; sessionId: string; message: string }
+
+/** The session every create in these tests hands back. */
+export const CREATED = 's-created'
 
 /** What `/api/file` answers before a test has said otherwise. */
 const DEFAULT_CONTENT = 'package main\n'
@@ -294,6 +312,8 @@ export async function startDaemon(): Promise<StubDaemon> {
     }
   }
 
+  const writes: DaemonWrite[] = []
+
   const server = http.createServer((req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1')
     const path = url.pathname
@@ -304,6 +324,16 @@ export async function startDaemon(): Promise<StubDaemon> {
       res.write(': open\n\n')
       streams.add(res)
       req.on('close', () => streams.delete(res))
+      return
+    }
+
+    if (req.method === 'POST' && written(path)) {
+      const chunks: Buffer[] = []
+      req.on('data', (chunk: Buffer) => chunks.push(chunk))
+      req.on('end', () => {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(record(writes, path, Buffer.concat(chunks))))
+      })
       return
     }
 
@@ -323,6 +353,7 @@ export async function startDaemon(): Promise<StubDaemon> {
     },
     reads: (target) => readCount.get(target) ?? 0,
     greps: () => grepCount,
+    writes: () => [...writes],
     setFile: (target, content) => {
       contents.set(target, content)
       revision += 1
@@ -333,6 +364,37 @@ export async function startDaemon(): Promise<StubDaemon> {
         for (const stream of streams) stream.end()
         server.close(() => resolve())
       }),
+  }
+}
+
+/** The three calls that start a session and give it its first turn. */
+function written(path: string): boolean {
+  return path === '/api/sessions' || path.endsWith('/files') || path.endsWith('/send')
+}
+
+/**
+ * Takes down what the app asked for, and answers as the daemon would.
+ *
+ * The upload is multipart, and a stub has no business parsing it properly: the
+ * filenames are what a test asserts on, and they are in the part headers.
+ */
+function record(writes: DaemonWrite[], path: string, body: Buffer): unknown {
+  if (path === '/api/sessions') {
+    writes.push({ kind: 'create', spec: JSON.parse(body.toString() || '{}') })
+    return { success: true, session_id: CREATED, terminal: `/tmp/helios/${CREATED}.sock`, cwd: REPO }
+  }
+
+  const id = path.slice('/api/sessions/'.length, path.lastIndexOf('/'))
+  if (path.endsWith('/send')) {
+    const { message } = JSON.parse(body.toString() || '{}')
+    writes.push({ kind: 'send', sessionId: id, message: String(message ?? '') })
+    return { success: true }
+  }
+
+  const names = [...body.toString('latin1').matchAll(/filename="([^"]*)"/g)].map((m) => m[1] ?? '')
+  writes.push({ kind: 'upload', sessionId: id, names })
+  return {
+    files: names.map((name) => ({ name, path: `${HOME}/.helios/uploads/${id}/${name}`, size: 1 })),
   }
 }
 

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+import { CREATED } from './daemon.ts'
 import { expect, test } from './fixtures.ts'
 
 async function openComposer(window: Page): Promise<void> {
@@ -214,4 +215,67 @@ test('home does not disappear while it is being typed', async ({ window }) => {
 
   await window.locator('.picker-search').fill('hom')
   await expect(window.locator('.composer-option', { hasText: 'Home' })).toBeVisible()
+})
+
+// The one part of the composer that is not the chat composer with different
+// chips. An upload needs a session to belong to, and the session does not
+// exist until Create is pressed — so the first turn cannot be the one the
+// agent launches with, and the order below is the whole of the feature.
+test('files go up once the session exists, and the first prompt names them', async ({ window, daemon }) => {
+  await openComposer(window)
+
+  await window.locator('.composer input[type="file"]').setInputFiles({
+    name: 'shot.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from('not really a png'),
+  })
+  await expect(window.locator('.attachment-name')).toHaveText('shot.png')
+
+  await window.locator('.composer-prompt').fill('what is wrong with this')
+  await window.locator('.composer .filled').click()
+  await expect(window.locator('.composer')).toHaveCount(0)
+
+  await expect
+    .poll(() => daemon.writes().map((write) => write.kind))
+    .toEqual(['create', 'upload', 'send'])
+
+  const [created, uploaded, sent] = daemon.writes()
+  if (created?.kind !== 'create' || uploaded?.kind !== 'upload' || sent?.kind !== 'send') {
+    throw new Error('the daemon recorded something other than a create, an upload and a send')
+  }
+  // Silent on purpose: launching with the prompt would send the agent looking
+  // for paths that are only decided by the upload below it.
+  expect(created.spec.prompt).toBeUndefined()
+  expect(uploaded.names).toEqual(['shot.png'])
+  expect(uploaded.sessionId).toBe(CREATED)
+  expect(sent.message).toContain(`/home/dev/.helios/uploads/${CREATED}/shot.png`)
+  expect(sent.message).toContain('what is wrong with this')
+})
+
+test('a session with nothing attached still launches with its prompt', async ({ window, daemon }) => {
+  await openComposer(window)
+
+  await window.locator('.composer-prompt').fill('just get on with it')
+  await window.locator('.composer .filled').click()
+  await expect(window.locator('.composer')).toHaveCount(0)
+
+  await expect.poll(() => daemon.writes().map((write) => write.kind)).toEqual(['create'])
+  const [created] = daemon.writes()
+  if (created?.kind !== 'create') throw new Error('the daemon recorded something other than a create')
+  expect(created.spec.prompt).toBe('just get on with it')
+})
+
+test('a file dropped anywhere on the dialog lands on it', async ({ window }) => {
+  await openComposer(window)
+
+  await window.evaluate(() => {
+    const carried = new DataTransfer()
+    carried.items.add(new File(['a stack trace'], 'trace.txt', { type: 'text/plain' }))
+    const composer = document.querySelector('.composer')
+    if (!composer) throw new Error('no composer to drop on')
+    composer.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+    composer.dispatchEvent(new DragEvent('drop', { dataTransfer: carried, bubbles: true }))
+  })
+
+  await expect(window.locator('.attachment-name')).toHaveText('trace.txt')
 })

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -35,6 +35,21 @@ test('every chip opens on its own value', async ({ window }) => {
   await expect(window.locator('.composer-foot')).toContainText('Default model')
 })
 
+// `.composer` names two things: this dialog's card, and the transcript's prompt
+// box (chat.tsx). A width on the bare class pins the second to the size of the
+// first, which cost the transcript 240px of input and stopped the prompt
+// growing with the window — invisible to every test that only opens the dialog.
+test('the dialog card does not follow the class onto the transcript', async ({ window }) => {
+  await window.setViewportSize({ width: 1280, height: 900 })
+  await window.locator('.session-row').first().click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+
+  const chat = await window.locator('.chat').boundingBox()
+  const prompt = await window.locator('.chat .composer').boundingBox()
+  if (!chat || !prompt) throw new Error('no transcript to measure')
+  expect(prompt.width).toBe(chat.width)
+})
+
 test('picking a model puts it on the chip', async ({ window }) => {
   await openComposer(window)
   await openChip(window, /model/i)

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -279,3 +279,17 @@ test('a file dropped anywhere on the dialog lands on it', async ({ window }) => 
 
   await expect(window.locator('.attachment-name')).toHaveText('trace.txt')
 })
+
+test('⌘U reaches for a file without touching the paperclip', async ({ window }) => {
+  await openComposer(window)
+
+  const chooser = window.waitForEvent('filechooser')
+  await window.keyboard.press('Meta+u')
+  await (await chooser).setFiles({
+    name: 'note.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('a note'),
+  })
+
+  await expect(window.locator('.attachment-name')).toHaveText('note.txt')
+})

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -139,14 +139,50 @@ test('the directory filter narrows the list and takes a typed path', async ({ wi
 // The picker's whole job, and the reason #154 was reverted: a directory that
 // has never had a session in it is not in the recents, so the only way to it is
 // the one the list cannot offer.
-test('a relative path is committable, which the recents cannot offer', async ({ window }) => {
+//
+// It reaches the daemon absolute. `resolveCWD` rejects anything else with a
+// 400 (internal/server/cwd.go), so committing the typed text as it stands would
+// be an escape hatch that only works for the paths that did not need one.
+test('a relative path is committable, and lands under the directory in the chip', async ({
+  window,
+  daemon,
+}) => {
   await openComposer(window)
   await openPlace(window)
 
   await window.locator('.picker-search').fill('workspace/acme-mobile')
   await window.locator('.composer-option', { hasText: 'Use' }).click()
-
   await expect(window.locator('.composer-place')).toContainText('acme-mobile')
+
+  await window.locator('.composer-prompt').fill('start here')
+  await window.locator('.composer .filled').click()
+
+  await expect.poll(() => daemon.writes().map((write) => write.kind)).toEqual(['create'])
+  const [created] = daemon.writes()
+  if (created?.kind !== 'create') throw new Error('the daemon recorded something other than a create')
+  expect(created.spec.cwd).toBe('/repo/workspace/acme-mobile')
+})
+
+// The complaint the fix is for: the chip says one directory and the typing used
+// to be answered from another. A bare segment is relative to what the chip
+// names, the way it would be in a shell sitting there.
+test('a bare name completes inside the directory the chip names', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('desk')
+  await expect(window.locator('.picker-section', { hasText: 'In /repo' })).toBeVisible()
+
+  const offered = window.locator('.picker-list .composer-option', { hasText: 'desktop' })
+  await expect(offered).toHaveCount(1)
+  await expect(offered).toContainText('/repo/desktop')
+
+  // And the escape hatch above it says where it would land, rather than leaving
+  // the reader to guess which directory three letters are relative to.
+  await expect(window.locator('.composer-option.use-typed')).toContainText('/repo/desk')
+
+  await offered.click()
+  await expect(window.locator('.composer-place')).toContainText('desktop')
 })
 
 test('enter commits what is typed, with nothing under it agreeing', async ({ window }) => {
@@ -165,8 +201,9 @@ test('typing completes against the filesystem, not against the recents', async (
   await openPlace(window)
 
   // `work` is in no recent — the stub daemon has one session directory, /repo —
-  // so every row here came from a directory listing.
-  await window.locator('.picker-search').fill('work')
+  // so every row here came from a directory listing. Spelled from home, because
+  // a bare segment is relative to /repo, which is the chip's directory.
+  await window.locator('.picker-search').fill('~/work')
   const completions = window.locator('.picker-list .composer-option', { hasText: /workspace|worktrees/ })
   await expect(completions).toHaveCount(2)
   await expect(window.locator('.picker-section', { hasText: 'In /home/dev' })).toBeVisible()
@@ -189,7 +226,7 @@ test('tab fills in the top completion', async ({ window }) => {
   await openPlace(window)
 
   const search = window.locator('.picker-search')
-  await search.fill('worksp')
+  await search.fill('~/worksp')
   await expect(window.locator('.picker-list .composer-option', { hasText: 'workspace' })).toBeVisible()
   await search.press('Tab')
 

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+async function openComposer(window: Page): Promise<void> {
+  await window.locator('button[aria-label="New session"]').first().click()
+  await expect(window.locator('.composer')).toBeVisible()
+  await expect(window.locator('.composer-place')).toContainText('repo')
+  await expect(window.locator('.composer-foot')).toContainText('Default permissions')
+}
+
+async function openChip(window: Page, name: RegExp): Promise<void> {
+  await window.locator('.composer-foot .picker > summary').filter({ hasText: name }).click()
+  await expect(window.locator('.picker[open] .picker-body')).toBeVisible()
+}
+
+async function backdrop(window: Page): Promise<{ x: number; y: number }> {
+  const box = await window.locator('.composer').boundingBox()
+  if (!box) throw new Error('composer has no box')
+  return { x: Math.round(box.x + box.width / 2), y: Math.round(box.y + box.height + 120) }
+}
+
+test('every chip opens on its own value', async ({ window }) => {
+  await openComposer(window)
+
+  await expect(window.locator('.composer-place')).toContainText('repo')
+  await expect(window.locator('.composer-host')).toContainText('stub')
+  await expect(window.locator('.composer-foot')).toContainText('Claude')
+  await expect(window.locator('.composer-foot')).toContainText('Default model')
+})
+
+test('picking a model puts it on the chip', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.locator('.composer-option', { hasText: 'Sonnet' }).click()
+
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer-foot')).toContainText('Sonnet')
+})
+
+test('dismissing a chip does not take the dialog with it', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer')).toBeVisible()
+})
+
+test('the backdrop still closes an untouched dialog', async ({ window }) => {
+  await openComposer(window)
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.composer')).toHaveCount(0)
+})
+
+test('a written prompt survives a stray click on the backdrop', async ({ window }) => {
+  await openComposer(window)
+  await window.locator('.composer-prompt').fill('something worth keeping')
+
+  const at = await backdrop(window)
+  await window.mouse.click(at.x, at.y)
+
+  await expect(window.locator('.composer-prompt')).toHaveValue('something worth keeping')
+})
+
+test('escape closes the chip first and the dialog second', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer')).toBeVisible()
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.composer')).toHaveCount(0)
+})
+
+test('arrows walk the options and wrap', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  const options = window.locator('.picker[open] .composer-option')
+  await expect(options).toHaveCount(3)
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(0)).toBeFocused()
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(1)).toBeFocused()
+
+  await window.keyboard.press('End')
+  await expect(options.nth(2)).toBeFocused()
+
+  await window.keyboard.press('ArrowDown')
+  await expect(options.nth(0)).toBeFocused()
+
+  await window.keyboard.press('ArrowUp')
+  await expect(options.nth(2)).toBeFocused()
+})
+
+test('escape hands focus back to the chip', async ({ window }) => {
+  await openComposer(window)
+  await openChip(window, /model/i)
+
+  await window.keyboard.press('Escape')
+
+  const summary = window.locator('.composer-foot .picker > summary').filter({ hasText: /model/i })
+  await expect(summary).toBeFocused()
+})
+
+test('the directory filter narrows the list and takes a typed path', async ({ window }) => {
+  await openComposer(window)
+  await window.locator('.composer-place > summary').click()
+
+  const search = window.locator('.picker-search')
+  await expect(search).toBeFocused()
+
+  await search.fill('nothing-matches-this')
+  await expect(window.locator('.picker-empty')).toBeVisible()
+
+  await search.fill('/tmp/elsewhere')
+  await window.locator('.composer-option', { hasText: 'Use' }).click()
+
+  await expect(window.locator('.composer-place')).toContainText('elsewhere')
+})

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -14,6 +14,11 @@ async function openChip(window: Page, name: RegExp): Promise<void> {
   await expect(window.locator('.picker[open] .picker-body')).toBeVisible()
 }
 
+async function openPlace(window: Page): Promise<void> {
+  await window.locator('.composer-place > summary').click()
+  await expect(window.locator('.composer-place .picker-body')).toBeVisible()
+}
+
 async function backdrop(window: Page): Promise<{ x: number; y: number }> {
   const box = await window.locator('.composer').boundingBox()
   if (!box) throw new Error('composer has no box')
@@ -116,7 +121,7 @@ test('escape hands focus back to the chip', async ({ window }) => {
 
 test('the directory filter narrows the list and takes a typed path', async ({ window }) => {
   await openComposer(window)
-  await window.locator('.composer-place > summary').click()
+  await openPlace(window)
 
   const search = window.locator('.picker-search')
   await expect(search).toBeFocused()
@@ -128,4 +133,85 @@ test('the directory filter narrows the list and takes a typed path', async ({ wi
   await window.locator('.composer-option', { hasText: 'Use' }).click()
 
   await expect(window.locator('.composer-place')).toContainText('elsewhere')
+})
+
+// The picker's whole job, and the reason #154 was reverted: a directory that
+// has never had a session in it is not in the recents, so the only way to it is
+// the one the list cannot offer.
+test('a relative path is committable, which the recents cannot offer', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('workspace/acme-mobile')
+  await window.locator('.composer-option', { hasText: 'Use' }).click()
+
+  await expect(window.locator('.composer-place')).toContainText('acme-mobile')
+})
+
+test('enter commits what is typed, with nothing under it agreeing', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('srv/deploys/tonight')
+  await window.keyboard.press('Enter')
+
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+  await expect(window.locator('.composer-place')).toContainText('tonight')
+})
+
+test('typing completes against the filesystem, not against the recents', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  // `work` is in no recent — the stub daemon has one session directory, /repo —
+  // so every row here came from a directory listing.
+  await window.locator('.picker-search').fill('work')
+  const completions = window.locator('.picker-list .composer-option', { hasText: /workspace|worktrees/ })
+  await expect(completions).toHaveCount(2)
+  await expect(window.locator('.picker-section', { hasText: 'In /home/dev' })).toBeVisible()
+
+  await completions.first().click()
+  await expect(window.locator('.composer-place')).toContainText('workspace')
+})
+
+test('completion walks down into a directory it just offered', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('/home/dev/workspace/acme-')
+  await expect(window.locator('.picker-list .composer-option', { hasText: 'acme-api' })).toBeVisible()
+  await expect(window.locator('.picker-list .composer-option', { hasText: 'acme-web' })).toBeVisible()
+})
+
+test('tab fills in the top completion', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  const search = window.locator('.picker-search')
+  await search.fill('worksp')
+  await expect(window.locator('.picker-list .composer-option', { hasText: 'workspace' })).toBeVisible()
+  await search.press('Tab')
+
+  await expect(search).toHaveValue('/home/dev/workspace/')
+  await expect(window.locator('.picker-list .composer-option', { hasText: 'acme-api' })).toBeVisible()
+})
+
+test('a half-typed path is still there when the chip is reopened', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('/home/dev/works')
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.picker[open]')).toHaveCount(0)
+
+  await openPlace(window)
+  await expect(window.locator('.picker-search')).toHaveValue('/home/dev/works')
+})
+
+test('home does not disappear while it is being typed', async ({ window }) => {
+  await openComposer(window)
+  await openPlace(window)
+
+  await window.locator('.picker-search').fill('hom')
+  await expect(window.locator('.composer-option', { hasText: 'Home' })).toBeVisible()
 })

--- a/desktop/src/renderer/components/attach.tsx
+++ b/desktop/src/renderer/components/attach.tsx
@@ -7,9 +7,10 @@
 // time because a dropped File does not stay valid, and the upload happens
 // before the send because a prompt naming a path the daemon never stored sends
 // the agent looking for a file that is not there.
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { api } from '../bridge.ts'
+import { Paperclip } from './icons.tsx'
 import {
   isLargePaste,
   needingUpload,
@@ -160,15 +161,36 @@ export function useDropTarget(onFiles: (files: FileList) => void): {
   }
 }
 
-/** The ⊕, and the file input hiding behind it. */
+/** The paperclip, and the file input hiding behind it. */
 export function AttachButton({
   onFiles,
   disabled = false,
+  shortcut = false,
 }: {
   onFiles: (files: FileList | null) => void
   disabled?: boolean
+  /**
+   * Whether ⌘U opens the picker as well as the click.
+   *
+   * Off by default because the listener is on the window: a panel that is
+   * mounted per tab has several of itself alive at once, and every one of them
+   * would answer the keystroke with a dialog of its own.
+   */
+  shortcut?: boolean
 }): JSX.Element {
   const picker = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (!shortcut || disabled) return
+    const onKey = (event: KeyboardEvent): void => {
+      if (!(event.metaKey || event.ctrlKey) || event.key !== 'u') return
+      event.preventDefault()
+      picker.current?.click()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [shortcut, disabled])
+
   return (
     <>
       <input
@@ -184,12 +206,12 @@ export function AttachButton({
       />
       <button
         className="icon-btn attach-btn"
-        title="Attach files — or paste and drop them here"
-        aria-label="Attach files"
+        title={shortcut ? 'Add attachment (⌘U) — or paste and drop them here' : 'Add attachment — or paste and drop them here'}
+        aria-label="Add attachment"
         disabled={disabled}
         onClick={() => picker.current?.click()}
       >
-        ⊕
+        <Paperclip />
       </button>
     </>
   )

--- a/desktop/src/renderer/components/attach.tsx
+++ b/desktop/src/renderer/components/attach.tsx
@@ -1,0 +1,264 @@
+// The composer's files: the ⊕, the drop target, the paste, and the chips they
+// all end up as.
+//
+// Written out of chat.tsx when the new-session dialog became the second box
+// that takes a prompt, and would otherwise have become the second copy of this.
+// The order matters more than any of the pieces — bytes are read at attach
+// time because a dropped File does not stay valid, and the upload happens
+// before the send because a prompt naming a path the daemon never stored sends
+// the agent looking for a file that is not there.
+import { useRef, useState } from 'react'
+
+import { api } from '../bridge.ts'
+import {
+  isLargePaste,
+  needingUpload,
+  pastedName,
+  pastedTextAttachment,
+  promptWithAttachments,
+  withStoredPaths,
+  type Attachment,
+} from '../attachments.ts'
+
+export interface AttachmentBag {
+  /** What is on the composer right now. */
+  files: Attachment[]
+  /** Reads the files into memory now: a dropped File is not valid for long. */
+  attach: (files: FileList | File[] | null) => Promise<void>
+  remove: (attachment: Attachment) => void
+  /** The block just pasted, while the offer to file it instead is up. */
+  pasted: string | null
+  /** Notes what was pasted, so a large block can be offered as a file. */
+  noticePaste: (text: string) => void
+  /** Files the pasted block, and answers with the text to take out of the draft. */
+  fileThePaste: () => string | null
+  keepThePaste: () => void
+  /**
+   * Stores whatever the daemon has not stored yet, and answers with the prompt
+   * that names it.
+   *
+   * Only what is unstored: a send can fail after a successful upload — a cold
+   * session that never acknowledges the prompt is the usual way — and
+   * uploading the same bytes on the retry would leave a numbered copy behind
+   * for every attempt.
+   */
+  store: (hostId: string, sessionId: string, text: string) => Promise<string>
+  /** After a send has landed: the chips go and their previews are released. */
+  clear: () => void
+}
+
+export function useAttachments(): AttachmentBag {
+  const [files, setFiles] = useState<Attachment[]>([])
+  const [pasted, setPasted] = useState<string | null>(null)
+  const next = useRef(0)
+
+  const attach = async (chosen: FileList | File[] | null): Promise<void> => {
+    const picked = [...(chosen ?? [])]
+    if (picked.length === 0) return
+    const read = await Promise.all(
+      picked.map(async (file) => ({
+        id: ++next.current,
+        // A pasted screenshot arrives unnamed, and the name becomes the
+        // filename on disk and the path in the prompt.
+        name: file.name || pastedName(file.type),
+        type: file.type,
+        size: file.size,
+        bytes: new Uint8Array(await file.arrayBuffer()),
+        preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+        path: null,
+      })),
+    )
+    setFiles((current) => [...current, ...read])
+  }
+
+  const remove = (attachment: Attachment): void => {
+    if (attachment.preview) URL.revokeObjectURL(attachment.preview)
+    setFiles((current) => current.filter((a) => a.id !== attachment.id))
+  }
+
+  const fileThePaste = (): string | null => {
+    if (!pasted) return null
+    setFiles((current) => [...current, pastedTextAttachment(++next.current, pasted)])
+    setPasted(null)
+    return pasted
+  }
+
+  const store = async (hostId: string, sessionId: string, text: string): Promise<string> => {
+    let ready = files
+    const pending = needingUpload(files)
+    if (pending.length > 0) {
+      const stored = await api(hostId).uploadFiles(
+        sessionId,
+        pending.map(({ name, type, bytes }) => ({ name, type, bytes })),
+      )
+      ready = withStoredPaths(files, pending, stored.map((file) => file.path))
+      // Recorded before the send, which is the call that fails.
+      setFiles(ready)
+    }
+    return promptWithAttachments(ready, text)
+  }
+
+  const clear = (): void => {
+    for (const attachment of files) {
+      if (attachment.preview) URL.revokeObjectURL(attachment.preview)
+    }
+    setFiles([])
+    setPasted(null)
+  }
+
+  return {
+    files,
+    attach,
+    remove,
+    pasted,
+    // A large block is only offered, never intercepted: the paste lands in the
+    // composer as it always has, and ignoring the offer leaves the prompt
+    // exactly as the user typed it.
+    noticePaste: (text) => setPasted(isLargePaste(text) ? text : null),
+    fileThePaste,
+    keepThePaste: () => setPasted(null),
+    store,
+    clear,
+  }
+}
+
+/**
+ * Files dropped on a box, without the box swallowing every other drag.
+ *
+ * All three handlers are gated on the drag carrying files, because a session
+ * dragged out of the sidebar is a drag too and the composer is not where it
+ * goes.
+ */
+export function useDropTarget(onFiles: (files: FileList) => void): {
+  dropping: boolean
+  handlers: {
+    onDragOver: (event: React.DragEvent) => void
+    onDragLeave: (event: React.DragEvent) => void
+    onDrop: (event: React.DragEvent) => void
+  }
+} {
+  const [dropping, setDropping] = useState(false)
+  return {
+    dropping,
+    handlers: {
+      onDragOver: (event) => {
+        if (!event.dataTransfer.types.includes('Files')) return
+        event.preventDefault()
+        setDropping(true)
+      },
+      onDragLeave: (event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
+        setDropping(false)
+      },
+      onDrop: (event) => {
+        if (!event.dataTransfer.types.includes('Files')) return
+        event.preventDefault()
+        setDropping(false)
+        onFiles(event.dataTransfer.files)
+      },
+    },
+  }
+}
+
+/** The ⊕, and the file input hiding behind it. */
+export function AttachButton({
+  onFiles,
+  disabled = false,
+}: {
+  onFiles: (files: FileList | null) => void
+  disabled?: boolean
+}): JSX.Element {
+  const picker = useRef<HTMLInputElement | null>(null)
+  return (
+    <>
+      <input
+        ref={picker}
+        type="file"
+        multiple
+        hidden
+        onChange={(event) => {
+          onFiles(event.target.files)
+          // Cleared so picking the same file twice fires onChange twice.
+          event.target.value = ''
+        }}
+      />
+      <button
+        className="icon-btn attach-btn"
+        title="Attach files — or paste and drop them here"
+        aria-label="Attach files"
+        disabled={disabled}
+        onClick={() => picker.current?.click()}
+      >
+        ⊕
+      </button>
+    </>
+  )
+}
+
+export function AttachmentChips({
+  files,
+  onRemove,
+}: {
+  files: Attachment[]
+  onRemove: (attachment: Attachment) => void
+}): JSX.Element | null {
+  if (files.length === 0) return null
+  return (
+    <div className="attachments">
+      {files.map((attachment) => (
+        <span key={attachment.id} className="attachment">
+          {attachment.preview ? (
+            <img className="attachment-thumb" src={attachment.preview} alt="" />
+          ) : (
+            <span className="attachment-icon">◫</span>
+          )}
+          <span className="attachment-name" title={attachment.name}>
+            {attachment.name}
+          </span>
+          <span className="attachment-size">{fileSize(attachment.size)}</span>
+          <button
+            className="attachment-drop"
+            aria-label={`Remove ${attachment.name}`}
+            title="Remove"
+            onClick={() => onRemove(attachment)}
+          >
+            ✕
+          </button>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function PasteOffer({
+  text,
+  onFile,
+  onKeep,
+}: {
+  text: string
+  onFile: () => void
+  onKeep: () => void
+}): JSX.Element {
+  return (
+    <div className="paste-offer">
+      <span className="paste-offer-text">Pasted {fileSize(new Blob([text]).size)} of text</span>
+      <button className="ghost" onClick={onFile}>
+        Attach as file
+      </button>
+      <button
+        className="attachment-drop"
+        aria-label="Keep the paste in the prompt"
+        title="Keep it in the prompt"
+        onClick={onKeep}
+      >
+        ✕
+      </button>
+    </div>
+  )
+}
+
+export function fileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -5,16 +5,8 @@ import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 import { api, statusOf } from '../bridge.ts'
 import { keys } from '../keys.ts'
 import { appendDelta, transcriptMessages, transcriptQuery } from '../queries.ts'
-import {
-  isLargePaste,
-  needingUpload,
-  pastedName,
-  pastedTextAttachment,
-  promptWithAttachments,
-  removeFirst,
-  withStoredPaths,
-  type Attachment,
-} from '../attachments.ts'
+import { removeFirst } from '../attachments.ts'
+import { AttachButton, AttachmentChips, PasteOffer, useAttachments, useDropTarget } from './attach.tsx'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
 import { Chevron } from './icons.tsx'
@@ -68,13 +60,9 @@ export function ChatPanel({
   const loaded = transcript.isSuccess
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
-  const [attachments, setAttachments] = useState<Attachment[]>([])
-  // The block the user just pasted, while the offer to file it instead is up.
-  const [pasted, setPasted] = useState<string | null>(null)
-  const [dropping, setDropping] = useState(false)
-  const picker = useRef<HTMLInputElement | null>(null)
+  const files = useAttachments()
+  const { dropping, handlers: dropHandlers } = useDropTarget((dropped) => void files.attach(dropped))
   const retries = useRef<ReturnType<typeof setTimeout>[]>([])
-  const nextAttachment = useRef(0)
   const scroller = useRef<HTMLDivElement | null>(null)
   const composer = useRef<HTMLTextAreaElement | null>(null)
   const pinnedToBottom = useRef(true)
@@ -193,68 +181,25 @@ export function ChatPanel({
     }
   }
 
-  /** Reads the files into memory now: a dropped File is not valid for long. */
-  const attach = async (files: FileList | File[] | null): Promise<void> => {
-    const chosen = [...(files ?? [])]
-    if (chosen.length === 0) return
-    const read = await Promise.all(
-      chosen.map(async (file) => ({
-        id: ++nextAttachment.current,
-        // A pasted screenshot arrives unnamed, and the name becomes the
-        // filename on disk and the path in the prompt.
-        name: file.name || pastedName(file.type),
-        type: file.type,
-        size: file.size,
-        bytes: new Uint8Array(await file.arrayBuffer()),
-        preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
-        path: null,
-      })),
-    )
-    setAttachments((current) => [...current, ...read])
-  }
-
-  const drop = (attachment: Attachment): void => {
-    if (attachment.preview) URL.revokeObjectURL(attachment.preview)
-    setAttachments((current) => current.filter((a) => a.id !== attachment.id))
-  }
-
   /** Moves the block the user just pasted out of the composer and into a file. */
   const fileThePaste = (): void => {
-    if (!pasted) return
-    setAttachments((current) => [...current, pastedTextAttachment(++nextAttachment.current, pasted)])
-    setDraft((current) => removeFirst(current, pasted))
-    setPasted(null)
+    const text = files.fileThePaste()
+    if (text === null) return
+    setDraft((current) => removeFirst(current, text))
   }
 
   const send = async (): Promise<void> => {
     const text = draft.trim()
-    if ((!text && attachments.length === 0) || sending) return
+    if ((!text && files.files.length === 0) || sending) return
     setSending(true)
     try {
       // Upload first: a prompt naming a path the daemon never stored is worse
-      // than no prompt, and the agent would go looking for it. Only what has
-      // not been stored yet — the send below may have failed once already, and
-      // uploading the same bytes again would leave a numbered copy per try.
-      let ready = attachments
-      const pending = needingUpload(attachments)
-      if (pending.length > 0) {
-        const stored = await api(hostId).uploadFiles(
-          session.session_id,
-          pending.map(({ name, type, bytes }) => ({ name, type, bytes })),
-        )
-        ready = withStoredPaths(attachments, pending, stored.map((file) => file.path))
-        // Recorded before the send, which is the call that fails.
-        setAttachments(ready)
-      }
-      const message = promptWithAttachments(ready, text)
+      // than no prompt, and the agent would go looking for it.
+      const message = await files.store(hostId, session.session_id, text)
 
       const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')
-      setPasted(null)
-      for (const attachment of attachments) {
-        if (attachment.preview) URL.revokeObjectURL(attachment.preview)
-      }
-      setAttachments([])
+      files.clear()
       if (result.queued) store.notify('Queued — the agent is mid-turn')
       void store.invalidateSessionsFor(hostId)
       // The agent writes the prompt to its transcript a moment after accepting
@@ -364,81 +309,14 @@ export function ChatPanel({
           </button>
         </div>
       ) : (
-        <div
-          className={dropping ? 'composer dropping' : 'composer'}
-          onDragOver={(event) => {
-            if (!event.dataTransfer.types.includes('Files')) return
-            event.preventDefault()
-            setDropping(true)
-          }}
-          onDragLeave={(event) => {
-            if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
-            setDropping(false)
-          }}
-          onDrop={(event) => {
-            if (!event.dataTransfer.types.includes('Files')) return
-            event.preventDefault()
-            setDropping(false)
-            void attach(event.dataTransfer.files)
-          }}
-        >
-          {pasted !== null && draft.includes(pasted) && (
-            <div className="paste-offer">
-              <span className="paste-offer-text">
-                Pasted {fileSize(new Blob([pasted]).size)} of text
-              </span>
-              <button className="ghost" onClick={fileThePaste}>
-                Attach as file
-              </button>
-              <button
-                className="attachment-drop"
-                aria-label="Keep the paste in the prompt"
-                title="Keep it in the prompt"
-                onClick={() => setPasted(null)}
-              >
-                ✕
-              </button>
-            </div>
+        <div className={dropping ? 'composer dropping' : 'composer'} {...dropHandlers}>
+          {files.pasted !== null && draft.includes(files.pasted) && (
+            <PasteOffer text={files.pasted} onFile={fileThePaste} onKeep={files.keepThePaste} />
           )}
 
-          {attachments.length > 0 && (
-            <div className="attachments">
-              {attachments.map((attachment) => (
-                <span key={attachment.id} className="attachment">
-                  {attachment.preview ? (
-                    <img className="attachment-thumb" src={attachment.preview} alt="" />
-                  ) : (
-                    <span className="attachment-icon">◫</span>
-                  )}
-                  <span className="attachment-name" title={attachment.name}>
-                    {attachment.name}
-                  </span>
-                  <span className="attachment-size">{fileSize(attachment.size)}</span>
-                  <button
-                    className="attachment-drop"
-                    aria-label={`Remove ${attachment.name}`}
-                    title="Remove"
-                    onClick={() => drop(attachment)}
-                  >
-                    ✕
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
+          <AttachmentChips files={files.files} onRemove={files.remove} />
 
           <div className="composer-input">
-            <input
-              ref={picker}
-              type="file"
-              multiple
-              hidden
-              onChange={(event) => {
-                void attach(event.target.files)
-                // Cleared so picking the same file twice fires onChange twice.
-                event.target.value = ''
-              }}
-            />
             <textarea
               ref={composer}
               value={draft}
@@ -454,14 +332,10 @@ export function ChatPanel({
                 // the default run when there is none, or pasted text is lost.
                 if (event.clipboardData.files.length > 0) {
                   event.preventDefault()
-                  void attach(event.clipboardData.files)
+                  void files.attach(event.clipboardData.files)
                   return
                 }
-                // A large block is only offered, never intercepted: the paste
-                // lands in the composer as it always has, and ignoring the
-                // offer leaves the prompt exactly as the user typed it.
-                const text = event.clipboardData.getData('text')
-                setPasted(isLargePaste(text) ? text : null)
+                files.noticePaste(event.clipboardData.getData('text'))
               }}
               onKeyDown={(event) => {
                 if (event.key !== 'Enter') return
@@ -474,15 +348,7 @@ export function ChatPanel({
               }}
             />
             <div className="composer-bar">
-              <button
-                className="icon-btn attach-btn"
-                title="Attach files — or paste and drop them here"
-                aria-label="Attach files"
-                disabled={sending}
-                onClick={() => picker.current?.click()}
-              >
-                ⊕
-              </button>
+              <AttachButton onFiles={(chosen) => void files.attach(chosen)} disabled={sending} />
               {busy && (
                 <button
                   className="icon-btn stop-btn"
@@ -495,7 +361,7 @@ export function ChatPanel({
               )}
               <button
                 className="filled send-btn"
-                disabled={(!draft.trim() && attachments.length === 0) || sending}
+                disabled={(!draft.trim() && files.files.length === 0) || sending}
                 title={cold ? 'Wake and send' : 'Send (↵)'}
                 aria-label={cold ? 'Wake and send' : 'Send'}
                 onClick={() => void send()}
@@ -508,12 +374,6 @@ export function ChatPanel({
       )}
     </div>
   )
-}
-
-function fileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 /** Quoted, so the composer keeps the lines apart from what is typed about them. */

--- a/desktop/src/renderer/components/dirpath.ts
+++ b/desktop/src/renderer/components/dirpath.ts
@@ -1,0 +1,55 @@
+// Completing a directory path against the filesystem, for the new-session
+// composer's place chip.
+//
+// Kept out of the component because it is the part with rules in it, and the
+// rules are worth stating once: what the daemon will expand, what a relative
+// path means to a client that has no working directory of its own, and which
+// entries a half-typed name is offering to become.
+import { type FileEntry } from '../../shared/models.ts'
+
+/** Home, in the form the daemon expands. A bare `~` it does not (files.go). */
+export const HOME = '~/'
+
+/** How many completions are worth showing before the list is just a directory. */
+export const MAX_COMPLETIONS = 40
+
+/**
+ * The directory a half-typed path is completing inside, and the prefix to keep.
+ *
+ * Everything up to the last separator names a directory to read; what follows
+ * is what the entries in it have to start with. A path with no separator in it
+ * yet, or a relative one, completes under home — which is where a session with
+ * no directory of its own starts anyway, so it is the same place the composer
+ * would have used.
+ */
+export function completionTarget(typed: string): { parent: string; prefix: string } {
+  const cut = typed.lastIndexOf('/')
+  const prefix = typed.slice(cut + 1)
+  if (cut === -1) return { parent: HOME, prefix }
+  const parent = typed.slice(0, cut)
+  if (parent === '') return { parent: '/', prefix }
+  if (parent === '~') return { parent: HOME, prefix }
+  if (!parent.startsWith('/') && !parent.startsWith('~')) return { parent: HOME + parent, prefix }
+  return { parent, prefix }
+}
+
+/**
+ * The directories in a listing that a typed prefix is reaching for.
+ *
+ * Files are not offered: a session runs in a directory. Dot directories are
+ * not either, until the prefix asks for one by name — `.claude` and
+ * `.worktrees` are real answers, but they are not what an empty prefix means.
+ * Anything already shown as a recent is left out rather than printed twice.
+ */
+export function completionsIn(entries: FileEntry[], prefix: string, exclude: Set<string>): FileEntry[] {
+  const want = prefix.toLowerCase()
+  return entries
+    .filter(
+      (entry) =>
+        entry.is_dir &&
+        entry.name.toLowerCase().startsWith(want) &&
+        (want.startsWith('.') || !entry.name.startsWith('.')) &&
+        !exclude.has(entry.path),
+    )
+    .slice(0, MAX_COMPLETIONS)
+}

--- a/desktop/src/renderer/components/dirpath.ts
+++ b/desktop/src/renderer/components/dirpath.ts
@@ -13,24 +13,52 @@ export const HOME = '~/'
 /** How many completions are worth showing before the list is just a directory. */
 export const MAX_COMPLETIONS = 40
 
+/** True of the two spellings that already say where they start from. */
+function rooted(path: string): boolean {
+  return path.startsWith('/') || path === '~' || path.startsWith('~/')
+}
+
+/** Where a relative path starts: the picker's directory, or home without one. */
+function startFrom(base: string): string {
+  return base.trim() || HOME
+}
+
+/**
+ * The absolute path a typed string means, read from where the picker already is.
+ *
+ * A relative path is relative to the directory the chip names, the way it would
+ * be in a shell sitting in it. Two things depend on that being written down
+ * once. Completion has to read the directory the typing is actually inside, or
+ * typing `desk` in a picker set to `~/workspace/helios` offers whatever home
+ * happens to hold and calls it an answer. And the escape hatch has to hand the
+ * daemon a path it accepts: `resolveCWD` refuses anything not absolute
+ * (internal/server/cwd.go), so committing the raw text would make "anything
+ * typed is committable" true only of the paths that were already absolute.
+ */
+export function resolveTyped(typed: string, base: string): string {
+  const path = typed.trim()
+  if (path === '' || rooted(path)) return path
+  const from = startFrom(base)
+  return from.endsWith('/') ? from + path : `${from}/${path}`
+}
+
 /**
  * The directory a half-typed path is completing inside, and the prefix to keep.
  *
  * Everything up to the last separator names a directory to read; what follows
  * is what the entries in it have to start with. A path with no separator in it
- * yet, or a relative one, completes under home — which is where a session with
- * no directory of its own starts anyway, so it is the same place the composer
- * would have used.
+ * yet, or a relative one, completes under `base` — the directory the composer
+ * is set to. With no directory set that is home, which is where a session
+ * without one starts anyway.
  */
-export function completionTarget(typed: string): { parent: string; prefix: string } {
+export function completionTarget(typed: string, base: string = HOME): { parent: string; prefix: string } {
   const cut = typed.lastIndexOf('/')
   const prefix = typed.slice(cut + 1)
-  if (cut === -1) return { parent: HOME, prefix }
+  if (cut === -1) return { parent: startFrom(base), prefix }
   const parent = typed.slice(0, cut)
   if (parent === '') return { parent: '/', prefix }
   if (parent === '~') return { parent: HOME, prefix }
-  if (!parent.startsWith('/') && !parent.startsWith('~')) return { parent: HOME + parent, prefix }
-  return { parent, prefix }
+  return { parent: resolveTyped(parent, base), prefix }
 }
 
 /**

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -182,6 +182,15 @@ export function Shield({ className = '' }: { className?: string }): JSX.Element 
   )
 }
 
+/** A paperclip: files going with the prompt. */
+export function Paperclip({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M18.5 11.5l-6.8 6.8a4 4 0 01-5.7-5.7l7.5-7.5a2.7 2.7 0 013.8 3.8l-7.5 7.5a1.4 1.4 0 01-1.9-1.9l6.6-6.6" />
+    </svg>
+  )
+}
+
 /** A folder, for a directory the composer offers rather than one it remembers. */
 export function Folder({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -182,6 +182,15 @@ export function Shield({ className = '' }: { className?: string }): JSX.Element 
   )
 }
 
+/** A folder, for a directory the composer offers rather than one it remembers. */
+export function Folder({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M3.5 6.5A1.5 1.5 0 015 5h4l2 2.5h8A1.5 1.5 0 0120.5 9v8.5A1.5 1.5 0 0119 19H5a1.5 1.5 0 01-1.5-1.5v-11z" />
+    </svg>
+  )
+}
+
 /** A terminal, for the one action a row offers under the pointer. */
 export function Console({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -135,6 +135,15 @@ export function ListRows({ className = '' }: { className?: string }): JSX.Elemen
   )
 }
 
+/** A four-pointed spark: the model a session runs on. */
+export function Spark({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 3.5c0 4.7 3.8 8.5 8.5 8.5-4.7 0-8.5 3.8-8.5 8.5 0-4.7-3.8-8.5-8.5-8.5 4.7 0 8.5-3.8 8.5-8.5z" />
+    </svg>
+  )
+}
+
 /** A clock, for what runs on one. */
 export function Clock({ className = '' }: { className?: string }): JSX.Element {
   return (
@@ -160,6 +169,15 @@ export function Pencil({ className = '' }: { className?: string }): JSX.Element 
   return (
     <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M4 20h4l10-10-4-4L4 16v4zM14.5 5.5l4 4" />
+    </svg>
+  )
+}
+
+/** A shield, for how much the agent may do without asking. */
+export function Shield({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 3.5l7 2.5v6c0 4-3 7.3-7 8.5-4-1.2-7-4.5-7-8.5V6l7-2.5z" />
     </svg>
   )
 }

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
-import { directoriesQuery, modelsQuery, providersQuery } from '../queries.ts'
+import { directoriesQuery, dirQuery, modelsQuery, providersQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
-import { Chevron, Console, Shield, Spark } from './icons.tsx'
+import { Chevron, Console, Folder, Shield, Spark } from './icons.tsx'
+import { completionTarget, completionsIn } from './dirpath.ts'
 import { tintOf } from './grouping.ts'
 import { type DirectoryInfo, type ModelInfo, type ProviderInfo } from '../../shared/models.ts'
 
@@ -32,6 +33,9 @@ export function NewSessionDialog({
   const [cwd, setCwd] = useState('')
   const [mode, setMode] = useState('')
   const [prompt, setPrompt] = useState('')
+  // Held out here rather than in the picker, which unmounts with its popover: a
+  // half-typed path must still be there when the chip is opened again.
+  const [typed, setTyped] = useState('')
   const [starting, setStarting] = useState(false)
   const shell = useRef<HTMLDivElement | null>(null)
   const dismissing = useRef(false)
@@ -160,8 +164,11 @@ export function NewSessionDialog({
           >
             {(close) => (
               <DirectoryList
+                hostId={hostId}
                 directories={directories}
                 cwd={cwd}
+                typed={typed}
+                onType={setTyped}
                 onPick={(next) => {
                   setCwd(next)
                   close()
@@ -335,19 +342,43 @@ export function NewSessionDialog({
   )
 }
 
+/**
+ * Where to start the session: the directories in use, and the filesystem.
+ *
+ * Two jobs that read as one control. The recents answer "back to where I was
+ * working" and are what an untouched picker shows — they are the only rows that
+ * can carry a project name and a count of what is running there. Typing is the
+ * other job, "somewhere new", and that is completion against the disk: the
+ * recents cannot answer it, because a directory only joins them once a session
+ * has already been started in it.
+ *
+ * Whatever is typed stays committable as it stands, absolute or not. It is the
+ * one thing the free-text input this replaced did better than any list, and no
+ * amount of completion is worth losing it: a path the daemon knows about and
+ * this end does not — a mount, a symlink, a directory made a second ago — has
+ * to be reachable by typing it.
+ */
 function DirectoryList({
+  hostId,
   directories,
   cwd,
+  typed,
+  onType,
   onPick,
 }: {
+  hostId: string
   directories: DirectoryInfo[]
   cwd: string
+  typed: string
+  onType: (typed: string) => void
   onPick: (cwd: string) => void
 }): JSX.Element {
-  const [query, setQuery] = useState('')
-  const needle = query.trim().toLowerCase()
+  const search = useRef<HTMLInputElement | null>(null)
+  const wanted = typed.trim()
+  const needle = wanted.toLowerCase()
+  const { parent, prefix } = completionTarget(wanted)
 
-  const matches = useMemo(
+  const recents = useMemo(
     () =>
       directories.filter(
         (dir) =>
@@ -358,43 +389,77 @@ function DirectoryList({
     [directories, needle],
   )
 
-  const typed = query.trim()
-  const custom = typed.startsWith('/') || typed.startsWith('~')
-  const known = directories.some((dir) => dir.cwd === typed)
+  // Keyed on the parent, so walking along one path re-reads a directory only
+  // when the typing crosses a separator. An unreadable parent — a path that
+  // does not exist yet, which is every path halfway through being typed — is
+  // not an error worth reporting: there is simply nothing to complete with.
+  const { data: listing, isFetching } = useQuery({
+    ...dirQuery(hostId, wanted === '' ? '' : parent),
+    retry: false,
+  })
 
-  const first = (): void => {
-    if (custom && !known) onPick(typed)
-    else if (matches[0]) onPick(matches[0].cwd)
+  const children = useMemo(
+    () => completionsIn(listing?.entries ?? [], prefix, new Set(recents.map((dir) => dir.cwd))),
+    [listing, prefix, recents],
+  )
+
+  const exact = directories.some((dir) => dir.cwd === wanted)
+  // Home stays reachable while it is being spelled: it is a row like any other,
+  // and hiding it the moment a key is pressed hides what was being reached for.
+  const showHome = needle === '' || 'home'.startsWith(needle) || needle === '~'
+  const nothing = children.length === 0 && recents.length === 0 && !showHome
+
+  /** Fills in the top completion, as a shell does, and leaves the cursor going. */
+  const complete = (): void => {
+    const first = children[0]
+    if (!first) return
+    // The daemon's own absolute path, not the typed prefix with a name stuck on
+    // the end: completing `wor` under home has to leave behind something that
+    // still means the same directory when it is completed again.
+    onType(`${first.path}/`)
+    search.current?.focus()
   }
 
   return (
     <>
       <input
         className="picker-search"
+        ref={search}
         autoFocus
         spellCheck={false}
-        value={query}
-        placeholder="Filter, or type a path…"
-        onChange={(event) => setQuery(event.target.value)}
+        autoComplete="off"
+        value={typed}
+        placeholder="Type a path, or search…"
+        onChange={(event) => onType(event.target.value)}
         onKeyDown={(event) => {
+          if (event.key === 'Tab' && children.length > 0) {
+            event.preventDefault()
+            complete()
+            return
+          }
           if (event.key !== 'Enter') return
           event.preventDefault()
-          first()
+          // What is in the box wins over what is under it. Anything else makes
+          // the escape hatch conditional on the list agreeing.
+          if (wanted !== '') onPick(wanted)
         }}
       />
       <div className="picker-list">
-        {custom && !known && (
-          <button className="composer-option" onClick={() => onPick(typed)}>
-            <span className="composer-option-name">Use “{typed}”</span>
+        {wanted !== '' && !exact && (
+          <button className="composer-option use-typed" onClick={() => onPick(wanted)}>
+            <span className="composer-option-name">Use “{wanted}”</span>
+            <span className="composer-option-hint">Start here whether or not it is listed</span>
           </button>
         )}
-        {!needle && (
+        {showHome && (
           <button className={`composer-option ${cwd === '' ? 'is-on' : ''}`} onClick={() => onPick('')}>
             <span className="composer-option-name">Home</span>
             <span className="composer-option-hint">~</span>
           </button>
         )}
-        {matches.map((dir) => (
+
+        {recents.length > 0 && <p className="picker-section">Recent</p>}
+        {recents.map((dir) => (
           <button
             key={dir.cwd}
             className={`composer-option ${dir.cwd === cwd ? 'is-on' : ''}`}
@@ -408,7 +473,26 @@ function DirectoryList({
             <span className="composer-option-hint">{dir.cwd}</span>
           </button>
         ))}
-        {matches.length === 0 && !custom && <p className="picker-empty">No matching directory. Type a path to use one.</p>}
+
+        {children.length > 0 && <p className="picker-section">In {listing?.path ?? parent}</p>}
+        {children.map((entry) => (
+          <button
+            key={entry.path}
+            className={`composer-option ${entry.path === cwd ? 'is-on' : ''}`}
+            onClick={() => onPick(entry.path)}
+          >
+            <span className="composer-option-name">
+              <Folder />
+              {entry.name}
+            </span>
+            <span className="composer-option-hint">{entry.path}</span>
+          </button>
+        ))}
+
+        {nothing && isFetching && <p className="picker-empty">Looking…</p>}
+        {nothing && !isFetching && (
+          <p className="picker-empty">Nothing here by that name — the path above is still yours to use.</p>
+        )}
       </div>
     </>
   )

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -13,7 +13,7 @@ import {
   useDropTarget,
 } from './attach.tsx'
 import { Chevron, Console, Folder, Shield, Spark } from './icons.tsx'
-import { completionTarget, completionsIn } from './dirpath.ts'
+import { completionTarget, completionsIn, resolveTyped } from './dirpath.ts'
 import { tintOf } from './grouping.ts'
 import { type DirectoryInfo, type ModelInfo, type ProviderInfo } from '../../shared/models.ts'
 
@@ -455,7 +455,11 @@ function DirectoryList({
   const search = useRef<HTMLInputElement | null>(null)
   const wanted = typed.trim()
   const needle = wanted.toLowerCase()
-  const { parent, prefix } = completionTarget(wanted)
+  const { parent, prefix } = completionTarget(wanted, cwd)
+  // Where the typed text would actually start, which for a relative path is
+  // under the directory the chip already names. The daemon takes absolute
+  // paths only, so this is the form that gets committed.
+  const target = resolveTyped(wanted, cwd)
 
   const recents = useMemo(
     () =>
@@ -482,7 +486,7 @@ function DirectoryList({
     [listing, prefix, recents],
   )
 
-  const exact = directories.some((dir) => dir.cwd === wanted)
+  const exact = directories.some((dir) => dir.cwd === target)
   // Home stays reachable while it is being spelled: it is a row like any other,
   // and hiding it the moment a key is pressed hides what was being reached for.
   const showHome = needle === '' || 'home'.startsWith(needle) || needle === '~'
@@ -520,14 +524,19 @@ function DirectoryList({
           event.preventDefault()
           // What is in the box wins over what is under it. Anything else makes
           // the escape hatch conditional on the list agreeing.
-          if (wanted !== '') onPick(wanted)
+          if (wanted !== '') onPick(target)
         }}
       />
       <div className="picker-list">
         {wanted !== '' && !exact && (
-          <button className="composer-option use-typed" onClick={() => onPick(wanted)}>
+          <button className="composer-option use-typed" onClick={() => onPick(target)}>
             <span className="composer-option-name">Use “{wanted}”</span>
-            <span className="composer-option-hint">Start here whether or not it is listed</span>
+            {/* A relative path says where it lands, because the reader cannot
+                see it from the text: the same three letters mean a different
+                directory depending on which one the chip names. */}
+            <span className="composer-option-hint">
+              {target === wanted ? 'Start here whether or not it is listed' : target}
+            </span>
           </button>
         )}
         {showHome && (

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
 import { directoriesQuery, modelsQuery, providersQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
-import type { DirectoryInfo, ModelInfo, ProviderInfo } from '../../shared/models.ts'
+import { Chevron, Console, Shield, Spark } from './icons.tsx'
+import { tintOf } from './grouping.ts'
+import { type DirectoryInfo, type ModelInfo, type ProviderInfo } from '../../shared/models.ts'
 
 const NO_PROVIDERS: ProviderInfo[] = []
 const NO_MODELS: ModelInfo[] = []
@@ -23,6 +25,7 @@ export function NewSessionDialog({
   onClose: () => void
 }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
+  const hostStatus = useStore((s) => s.hostStatus)
   const [hostId, setHostId] = useState(seed?.hostId ?? hosts[0]?.id ?? '')
   const [provider, setProvider] = useState('claude')
   const [model, setModel] = useState('')
@@ -30,6 +33,8 @@ export function NewSessionDialog({
   const [mode, setMode] = useState('')
   const [prompt, setPrompt] = useState('')
   const [starting, setStarting] = useState(false)
+  const shell = useRef<HTMLDivElement | null>(null)
+  const dismissing = useRef(false)
   // Spent on the first load and not again: switching hosts after that has to
   // reset the directory, because a path from one machine is not a path on the
   // next, and the seed was a path on the machine it came from.
@@ -45,7 +50,7 @@ export function NewSessionDialog({
     enabled: !!hostId,
     select: onlyReady,
   })
-  const { data: directories = NO_DIRECTORIES } = useQuery({
+  const { data: directories = NO_DIRECTORIES, isPending: findingDirectories } = useQuery({
     ...directoriesQuery(hostId ?? ''),
     enabled: !!hostId,
   })
@@ -60,7 +65,7 @@ export function NewSessionDialog({
    */
   const settled = useRef<string | null>(null)
   useEffect(() => {
-    if (!hostId || providers.length === 0 || settled.current === hostId) return
+    if (!hostId || providers.length === 0 || findingDirectories || settled.current === hostId) return
     settled.current = hostId
     const first = providers[0]
     if (first && !providers.some((p) => p.id === provider)) setProvider(first.id)
@@ -68,7 +73,7 @@ export function NewSessionDialog({
     seeded.current = ''
     // provider and cwd are deliberately not dependencies: this settles them.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hostId, providers, directories])
+  }, [hostId, providers, directories, findingDirectories])
 
   const { data: models = NO_MODELS } = useQuery({
     ...modelsQuery(hostId ?? '', provider),
@@ -106,100 +111,402 @@ export function NewSessionDialog({
     }
   }
 
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return
+      if (shell.current?.querySelector('details.picker[open]')) return
+      onClose()
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [onClose])
+
+  useEffect(() => {
+    const onDown = (): void => {
+      dismissing.current = shell.current?.querySelector('details.picker[open]') != null
+    }
+    window.addEventListener('mousedown', onDown, true)
+    return () => window.removeEventListener('mousedown', onDown, true)
+  }, [])
+
+  const place = directories.find((dir) => dir.cwd === cwd)
+  const where = place?.project || basename(cwd) || 'Home'
+  const tint = tintOf(tintKey(place, cwd))
+  const host = hosts.find((h) => h.id === hostId)
+  const modelName = models.find((m) => m.id === model)?.name ?? 'Default model'
+
   return (
-    <Modal title="New session" onClose={onClose}>
-      {hosts.length > 1 && (
-        <label className="field">
-          <span>Host</span>
-          <select value={hostId} onChange={(event) => setHostId(event.target.value)}>
-            {hosts.map((host) => (
-              <option key={host.id} value={host.id}>
-                {host.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
+    <div
+      className="modal-backdrop"
+      onClick={() => {
+        if (dismissing.current) {
+          dismissing.current = false
+          return
+        }
+        if (!prompt.trim()) onClose()
+      }}
+    >
+      <div className="composer" ref={shell} onClick={(event) => event.stopPropagation()}>
+        <header className="composer-head">
+          <Picker
+            title="Working directory"
+            trigger={
+              <>
+                <span className="composer-dot" style={{ background: tint }} />
+                <span className="composer-chip-name">{where}</span>
+              </>
+            }
+            className="composer-place"
+          >
+            {(close) => (
+              <DirectoryList
+                directories={directories}
+                cwd={cwd}
+                onPick={(next) => {
+                  setCwd(next)
+                  close()
+                }}
+              />
+            )}
+          </Picker>
 
-      <label className="field">
-        <span>Provider</span>
-        <select value={provider} onChange={(event) => setProvider(event.target.value)}>
-          {providers.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </label>
+          <Picker
+            title="Host"
+            align="right"
+            className="composer-host"
+            trigger={
+              <>
+                <span className={`dot ${hostStatus[hostId]?.state ?? 'offline'}`} />
+                <span className="composer-chip-name">{host?.name ?? 'Pick a host'}</span>
+              </>
+            }
+          >
+            {(close) =>
+              hosts.map((option) => (
+                <button
+                  key={option.id}
+                  className={`composer-option ${option.id === hostId ? 'is-on' : ''}`}
+                  onClick={() => {
+                    setHostId(option.id)
+                    close()
+                  }}
+                >
+                  <span className="composer-option-name">
+                    <span className={`dot ${hostStatus[option.id]?.state ?? 'offline'}`} />
+                    {option.name}
+                  </span>
+                </button>
+              ))
+            }
+          </Picker>
+        </header>
 
-      <label className="field">
-        <span>Directory</span>
-        <input
-          list="known-directories"
-          value={cwd}
-          placeholder="~ (home)"
-          spellCheck={false}
-          onChange={(event) => setCwd(event.target.value)}
-        />
-        {/* The daemon sends objects, not paths: cwd is the value, and the
-            project name is the label that tells two checkouts of the same
-            repository apart. */}
-        <datalist id="known-directories">
-          {directories.map((dir) => (
-            <option key={dir.cwd} value={dir.cwd} label={dir.project || undefined} />
-          ))}
-        </datalist>
-      </label>
-
-      <label className="field">
-        <span>Model</span>
-        <select value={model} onChange={(event) => setModel(event.target.value)}>
-          <option value="">Default</option>
-          {models.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      {modes.length > 0 && (
-        <label className="field">
-          <span>Permission mode</span>
-          <select value={mode} onChange={(event) => setMode(event.target.value)}>
-            <option value="">Provider default</option>
-            {modes.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
-
-      <label className="field">
-        <span>First prompt (optional)</span>
-        {/* The box says a field; the placeholder says what the field is for.
-            Without it this reads as a note to self rather than the first thing
-            the agent will be asked. */}
         <textarea
+          className="composer-prompt"
+          autoFocus
           rows={4}
           value={prompt}
-          placeholder="What should the agent start on? Left empty, the session opens at a prompt."
+          placeholder="What do you want to work on?"
           onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
+            event.preventDefault()
+            void start()
+          }}
         />
-      </label>
 
-      <div className="modal-actions">
-        <button className="ghost" onClick={onClose}>
-          Cancel
-        </button>
-        <button disabled={!hostId || starting} onClick={() => void start()}>
-          {starting ? 'Starting…' : 'Start session'}
-        </button>
+        <footer className="composer-foot">
+          <div className="composer-chips">
+            <Picker
+              title="Provider"
+              trigger={
+                <>
+                  <Console />
+                  <span className="composer-chip-name">{selected?.name ?? provider}</span>
+                </>
+              }
+            >
+              {(close) =>
+                providers.map((option) => (
+                  <button
+                    key={option.id}
+                    className={`composer-option ${option.id === provider ? 'is-on' : ''}`}
+                    onClick={() => {
+                      setProvider(option.id)
+                      close()
+                    }}
+                  >
+                    <span className="composer-option-name">{option.name}</span>
+                  </button>
+                ))
+              }
+            </Picker>
+
+            <Picker
+              title="Model"
+              trigger={
+                <>
+                  <Spark />
+                  <span className="composer-chip-name">{modelName}</span>
+                </>
+              }
+            >
+              {(close) => (
+                <>
+                  <button
+                    className={`composer-option ${model === '' ? 'is-on' : ''}`}
+                    onClick={() => {
+                      setModel('')
+                      close()
+                    }}
+                  >
+                    <span className="composer-option-name">Default model</span>
+                    <span className="composer-option-hint">Whatever the provider picks</span>
+                  </button>
+                  {models.map((option) => (
+                    <button
+                      key={option.id}
+                      className={`composer-option ${option.id === model ? 'is-on' : ''}`}
+                      onClick={() => {
+                        setModel(option.id)
+                        close()
+                      }}
+                    >
+                      <span className="composer-option-name">{option.name}</span>
+                      {option.description && <span className="composer-option-hint">{option.description}</span>}
+                    </button>
+                  ))}
+                </>
+              )}
+            </Picker>
+
+            {modes.length > 0 && (
+              <Picker
+                title="Permission mode"
+                trigger={
+                  <>
+                    <Shield />
+                    <span className="composer-chip-name">{mode || 'Default permissions'}</span>
+                  </>
+                }
+              >
+                {(close) => (
+                  <>
+                    <button
+                      className={`composer-option ${mode === '' ? 'is-on' : ''}`}
+                      onClick={() => {
+                        setMode('')
+                        close()
+                      }}
+                    >
+                      <span className="composer-option-name">Default permissions</span>
+                    </button>
+                    {modes.map((option) => (
+                      <button
+                        key={option}
+                        className={`composer-option ${option === mode ? 'is-on' : ''}`}
+                        onClick={() => {
+                          setMode(option)
+                          close()
+                        }}
+                      >
+                        <span className="composer-option-name">{option}</span>
+                      </button>
+                    ))}
+                  </>
+                )}
+              </Picker>
+            )}
+
+          </div>
+
+          <div className="composer-actions">
+            <button className="ghost" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="filled" disabled={!hostId || starting} onClick={() => void start()}>
+              {starting ? 'Creating…' : 'Create'}
+              {!starting && <kbd className="composer-key">↵</kbd>}
+            </button>
+          </div>
+        </footer>
       </div>
-    </Modal>
+    </div>
   )
+}
+
+function DirectoryList({
+  directories,
+  cwd,
+  onPick,
+}: {
+  directories: DirectoryInfo[]
+  cwd: string
+  onPick: (cwd: string) => void
+}): JSX.Element {
+  const [query, setQuery] = useState('')
+  const needle = query.trim().toLowerCase()
+
+  const matches = useMemo(
+    () =>
+      directories.filter(
+        (dir) =>
+          !needle ||
+          dir.project.toLowerCase().includes(needle) ||
+          dir.cwd.toLowerCase().includes(needle),
+      ),
+    [directories, needle],
+  )
+
+  const typed = query.trim()
+  const custom = typed.startsWith('/') || typed.startsWith('~')
+  const known = directories.some((dir) => dir.cwd === typed)
+
+  const first = (): void => {
+    if (custom && !known) onPick(typed)
+    else if (matches[0]) onPick(matches[0].cwd)
+  }
+
+  return (
+    <>
+      <input
+        className="picker-search"
+        autoFocus
+        spellCheck={false}
+        value={query}
+        placeholder="Filter, or type a path…"
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter') return
+          event.preventDefault()
+          first()
+        }}
+      />
+      <div className="picker-list">
+        {custom && !known && (
+          <button className="composer-option" onClick={() => onPick(typed)}>
+            <span className="composer-option-name">Use “{typed}”</span>
+          </button>
+        )}
+        {!needle && (
+          <button className={`composer-option ${cwd === '' ? 'is-on' : ''}`} onClick={() => onPick('')}>
+            <span className="composer-option-name">Home</span>
+            <span className="composer-option-hint">~</span>
+          </button>
+        )}
+        {matches.map((dir) => (
+          <button
+            key={dir.cwd}
+            className={`composer-option ${dir.cwd === cwd ? 'is-on' : ''}`}
+            onClick={() => onPick(dir.cwd)}
+          >
+            <span className="composer-option-name">
+              <span className="composer-dot" style={{ background: tintOf(tintKey(dir, dir.cwd)) }} />
+              {dir.project || basename(dir.cwd)}
+              {dir.active_count > 0 && <span className="composer-option-count">{dir.active_count} active</span>}
+            </span>
+            <span className="composer-option-hint">{dir.cwd}</span>
+          </button>
+        ))}
+        {matches.length === 0 && !custom && <p className="picker-empty">No matching directory. Type a path to use one.</p>}
+      </div>
+    </>
+  )
+}
+
+function Picker({
+  title,
+  trigger,
+  align = 'left',
+  className = '',
+  children,
+}: {
+  title: string
+  trigger: React.ReactNode
+  align?: 'left' | 'right'
+  className?: string
+  children: (close: () => void) => React.ReactNode
+}): JSX.Element {
+  const box = useRef<HTMLDetailsElement | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const dismiss = (event: Event): void => {
+      const element = box.current
+      if (!element?.open) return
+      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
+      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
+      element.open = false
+      setOpen(false)
+      if (event.type === 'keydown') element.querySelector('summary')?.focus()
+    }
+    window.addEventListener('mousedown', dismiss)
+    window.addEventListener('keydown', dismiss)
+    window.addEventListener('blur', dismiss)
+    return () => {
+      window.removeEventListener('mousedown', dismiss)
+      window.removeEventListener('keydown', dismiss)
+      window.removeEventListener('blur', dismiss)
+    }
+  }, [])
+
+  const close = (): void => {
+    if (box.current) box.current.open = false
+    setOpen(false)
+    box.current?.querySelector('summary')?.focus()
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+    const keys = ['ArrowDown', 'ArrowUp', 'Home', 'End']
+    if (!keys.includes(event.key)) return
+    const typing = document.activeElement instanceof HTMLInputElement
+    if (typing && (event.key === 'Home' || event.key === 'End')) return
+
+    const options = Array.from(
+      box.current?.querySelectorAll<HTMLElement>('.picker-body .composer-option') ?? [],
+    )
+    if (options.length === 0) return
+    event.preventDefault()
+
+    const at = options.indexOf(document.activeElement as HTMLElement)
+    const to =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? options.length - 1
+          : event.key === 'ArrowDown'
+            ? (at + 1) % options.length
+            : at <= 0
+              ? options.length - 1
+              : at - 1
+    options[to]?.focus()
+  }
+
+  return (
+    <details
+      className={`picker ${className}`.trim()}
+      ref={box}
+      onKeyDown={onKeyDown}
+      onToggle={() => setOpen(box.current?.open ?? false)}
+    >
+      <summary title={title}>
+        {trigger}
+        <Chevron dir="down" className="picker-caret" />
+      </summary>
+      {open && (
+        <div className={`picker-body ${align === 'right' ? 'to-right' : ''}`}>{children(close)}</div>
+      )}
+    </details>
+  )
+}
+
+function tintKey(dir: DirectoryInfo | undefined, cwd: string): string {
+  if (dir) return (dir.project || dir.cwd).toLowerCase()
+  return cwd.toLowerCase() || 'home'
+}
+
+function basename(path: string): string {
+  return path.replace(/\/+$/, '').split('/').pop() ?? ''
 }
 
 export function Modal({

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -546,7 +546,11 @@ function DirectoryList({
           </button>
         ))}
 
-        {children.length > 0 && <p className="picker-section">In {listing?.path ?? parent}</p>}
+        {children.length > 0 && (
+          <p className="picker-section">
+            In <span className="picker-section-path">{listing?.path ?? parent}</span>
+          </p>
+        )}
         {children.map((entry) => (
           <button
             key={entry.path}

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -2,8 +2,16 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
+import { removeFirst } from '../attachments.ts'
 import { directoriesQuery, dirQuery, modelsQuery, providersQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
+import {
+  AttachButton,
+  AttachmentChips,
+  PasteOffer,
+  useAttachments,
+  useDropTarget,
+} from './attach.tsx'
 import { Chevron, Console, Folder, Shield, Spark } from './icons.tsx'
 import { completionTarget, completionsIn } from './dirpath.ts'
 import { tintOf } from './grouping.ts'
@@ -36,6 +44,8 @@ export function NewSessionDialog({
   // Held out here rather than in the picker, which unmounts with its popover: a
   // half-typed path must still be there when the chip is opened again.
   const [typed, setTyped] = useState('')
+  const files = useAttachments()
+  const { dropping, handlers: dropHandlers } = useDropTarget((dropped) => void files.attach(dropped))
   const [starting, setStarting] = useState(false)
   const shell = useRef<HTMLDivElement | null>(null)
   const dismissing = useRef(false)
@@ -87,17 +97,50 @@ export function NewSessionDialog({
   const selected = providers.find((p) => p.id === provider)
   const modes = selected?.permission_modes ?? []
 
+  /**
+   * The first turn, when there are files on it.
+   *
+   * An upload needs a session to belong to — it lands in
+   * ~/.helios/uploads/{id} and the handler 404s without the record
+   * (internal/server/uploads.go) — and the id is what the create call is there
+   * to return. So an attached prompt cannot be the one the agent launches
+   * with: the session is started silent, the files go up against the id it
+   * came back with, and the prompt naming them is sent after.
+   *
+   * Nothing here undoes the session. It is running by the time any of this can
+   * fail, and killing an agent over an upload is a worse answer than a prompt
+   * that arrives without its attachments.
+   */
+  const firstTurn = async (sessionId: string, text: string): Promise<void> => {
+    let message = text
+    try {
+      message = await files.store(hostId, sessionId, text)
+    } catch (err) {
+      const why = err instanceof Error ? err.message : String(err)
+      store.notify(`Session started, but the files did not upload: ${why}`, 'error')
+    }
+    if (!message) return
+    try {
+      await api(hostId).sendPrompt(sessionId, message)
+    } catch (err) {
+      store.fail(err)
+    }
+  }
+
   const start = async (): Promise<void> => {
     if (!hostId || starting) return
     setStarting(true)
     try {
+      const text = prompt.trim()
+      const attached = files.files.length > 0
       const result = await api(hostId).createSession({
         provider,
         cwd: cwd || undefined,
         model: model || undefined,
-        prompt: prompt || undefined,
+        prompt: attached ? undefined : text || undefined,
         permission_mode: mode || undefined,
       })
+      if (attached) await firstTurn(result.session_id, text)
       // Filed before the refresh, so the list arrives with it already in the
       // group the + was pressed on. The directory only seeded the dialog; the
       // group is what the button actually promised.
@@ -147,10 +190,15 @@ export function NewSessionDialog({
           dismissing.current = false
           return
         }
-        if (!prompt.trim()) onClose()
+        if (!prompt.trim() && files.files.length === 0) onClose()
       }}
     >
-      <div className="composer" ref={shell} onClick={(event) => event.stopPropagation()}>
+      <div
+        className={dropping ? 'composer dropping' : 'composer'}
+        ref={shell}
+        onClick={(event) => event.stopPropagation()}
+        {...dropHandlers}
+      >
         <header className="composer-head">
           <Picker
             title="Working directory"
@@ -208,6 +256,19 @@ export function NewSessionDialog({
           </Picker>
         </header>
 
+        {files.pasted !== null && prompt.includes(files.pasted) && (
+          <PasteOffer
+            text={files.pasted}
+            onFile={() => {
+              const text = files.fileThePaste()
+              if (text !== null) setPrompt((current) => removeFirst(current, text))
+            }}
+            onKeep={files.keepThePaste}
+          />
+        )}
+
+        <AttachmentChips files={files.files} onRemove={files.remove} />
+
         <textarea
           className="composer-prompt"
           autoFocus
@@ -215,6 +276,16 @@ export function NewSessionDialog({
           value={prompt}
           placeholder="What do you want to work on?"
           onChange={(event) => setPrompt(event.target.value)}
+          onPaste={(event) => {
+            // A screenshot on the clipboard comes through as a file. Let the
+            // default run when there is none, or pasted text is lost.
+            if (event.clipboardData.files.length > 0) {
+              event.preventDefault()
+              void files.attach(event.clipboardData.files)
+              return
+            }
+            files.noticePaste(event.clipboardData.getData('text'))
+          }}
           onKeyDown={(event) => {
             if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
             event.preventDefault()
@@ -325,6 +396,7 @@ export function NewSessionDialog({
               </Picker>
             )}
 
+            <AttachButton onFiles={(chosen) => void files.attach(chosen)} disabled={starting} />
           </div>
 
           <div className="composer-actions">

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -396,10 +396,17 @@ export function NewSessionDialog({
               </Picker>
             )}
 
-            <AttachButton onFiles={(chosen) => void files.attach(chosen)} disabled={starting} />
           </div>
 
           <div className="composer-actions">
+            {/* With the actions rather than with the chips: the chips say what
+                the session will be, and the paperclip is something done to the
+                prompt, next to the button that sends it. */}
+            <AttachButton
+              onFiles={(chosen) => void files.attach(chosen)}
+              disabled={starting}
+              shortcut
+            />
             <button className="ghost" onClick={onClose}>
               Cancel
             </button>

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3832,7 +3832,11 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
-.composer {
+/* Scoped to the dialog, because `.composer` is also the transcript's prompt box
+   (chat.tsx). Unscoped, this card pinned that one to 680px and gave it a shadow
+   of its own: the prompt stopped growing with the window and stopped lining up
+   with the messages above it. */
+.modal-backdrop .composer {
   width: 680px;
   max-width: 92vw;
   display: flex;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3832,6 +3832,266 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
+.composer {
+  width: 680px;
+  max-width: 92vw;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-high);
+  border-radius: var(--r-lg);
+  box-shadow: 0 24px 64px var(--shadow-strong);
+}
+
+.composer-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 10px 2px;
+}
+
+.composer-host {
+  margin-left: auto;
+}
+
+.composer-prompt {
+  min-height: 132px;
+  max-height: 40vh;
+  margin: 0 12px;
+  padding: 8px 8px 12px;
+  background: none;
+  border: none;
+  border-radius: 0;
+  resize: none;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.composer-prompt:focus {
+  border: none;
+  outline: none;
+}
+
+.composer-prompt::placeholder {
+  color: color-mix(in srgb, var(--on-surface-variant) 55%, transparent);
+}
+
+.composer-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 10px 10px;
+}
+
+.composer-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 2px;
+  min-width: 0;
+}
+
+.composer-chips > * {
+  flex: none;
+}
+
+.composer-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.composer-key {
+  margin-left: 6px;
+  font: inherit;
+  font-size: 12px;
+  opacity: 0.65;
+}
+
+.composer-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: none;
+}
+
+.composer .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--s-off);
+}
+
+.composer .dot.online {
+  background: var(--s-active);
+}
+
+.composer .dot.connecting {
+  background: var(--s-waiting);
+}
+
+.composer .dot.offline,
+.composer .dot.unpaired {
+  background: var(--error);
+}
+
+.picker {
+  position: relative;
+  min-width: 0;
+}
+
+.picker > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  white-space: nowrap;
+}
+
+.picker > summary::-webkit-details-marker {
+  display: none;
+}
+
+.picker > summary:hover,
+.picker[open] > summary {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+  color: var(--on-surface);
+}
+
+.picker .ui-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.picker-caret {
+  width: 0.8em;
+  height: 0.8em;
+  opacity: 0.7;
+}
+
+.composer-place > summary {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--on-surface);
+}
+
+.composer-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
+.picker-body {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 6px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 300px;
+  max-height: 320px;
+  padding: 8px;
+  background: var(--surface-highest);
+  border-radius: var(--r-md);
+  box-shadow: 0 8px 24px var(--shadow-soft);
+  overflow-y: auto;
+}
+
+.picker-body.to-right {
+  left: auto;
+  right: 0;
+}
+
+.composer-foot .picker-body {
+  top: auto;
+  bottom: 100%;
+  margin: 0 0 6px;
+}
+
+.composer-place .picker-body {
+  width: 380px;
+}
+
+.picker-search {
+  flex: none;
+  font-size: 13px;
+  padding: 7px 10px;
+  background: var(--surface-high);
+}
+
+.picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+}
+
+.composer-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex: none;
+  gap: 2px;
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--on-surface);
+  text-align: left;
+}
+
+.composer-option:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+}
+
+.composer-option.is-on {
+  background: color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.composer-option-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.composer-option-hint {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+}
+
+.composer-option-count {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--s-active);
+}
+
+.picker-empty {
+  margin: 4px 10px;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
 .host-row {
   display: flex;
   align-items: center;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4092,6 +4092,31 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
+/* What the rows under it are: the directories in use, or what is on the disk. */
+.picker-section {
+  margin: 6px 10px 2px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--on-surface-variant);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The escape hatch, and it reads as one: a path nothing has offered. */
+.composer-option.use-typed .composer-option-name {
+  color: var(--primary);
+}
+
+.composer-place .composer-option .ui-icon {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  opacity: 0.7;
+}
+
 .host-row {
   display: flex;
   align-items: center;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3894,13 +3894,17 @@ figure.mermaid svg {
   flex: none;
 }
 
-/* The ⊕ is a chip among the chips here, not the corner button it is in the
-   chat composer: there is no box for it to sit inside. */
-.composer-chips .attach-btn {
+/* Sized to the buttons it stands beside, not to the 36px an icon button is
+   elsewhere: the foot of the dialog is a 30px row. */
+.composer-actions .attach-btn {
   width: 30px;
   height: 30px;
   border-radius: 999px;
-  font-size: 15px;
+}
+
+.composer-actions .attach-btn .ui-icon {
+  width: 17px;
+  height: 17px;
 }
 
 /* The dialog has no inner box to outline, so the whole of it lights up. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4138,6 +4138,12 @@ figure.mermaid svg {
   white-space: nowrap;
 }
 
+/* A path is spelled the way the disk spells it, small caps or not. */
+.picker-section-path {
+  text-transform: none;
+  letter-spacing: 0;
+}
+
 /* The escape hatch, and it reads as one: a path nothing has offered. */
 .composer-option.use-typed .composer-option-name {
   color: var(--primary);

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3894,6 +3894,39 @@ figure.mermaid svg {
   flex: none;
 }
 
+/* The ⊕ is a chip among the chips here, not the corner button it is in the
+   chat composer: there is no box for it to sit inside. */
+.composer-chips .attach-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  font-size: 15px;
+}
+
+/* The dialog has no inner box to outline, so the whole of it lights up. */
+.modal-backdrop .composer {
+  position: relative;
+}
+
+.modal-backdrop .composer.dropping::after {
+  content: 'Drop to attach';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--primary);
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--primary) 12%, var(--surface));
+  font-size: 13px;
+  color: var(--primary);
+  pointer-events: none;
+}
+
+.modal-backdrop .attachments,
+.modal-backdrop .paste-offer {
+  margin: 2px 12px 0;
+}
+
 .composer-actions {
   margin-left: auto;
   display: flex;

--- a/desktop/test/dirpath.test.ts
+++ b/desktop/test/dirpath.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { completionTarget, completionsIn } from '../src/renderer/components/dirpath.ts'
+import { completionTarget, completionsIn, resolveTyped } from '../src/renderer/components/dirpath.ts'
 import { type FileEntry } from '../src/shared/models.ts'
 
 function dir(path: string): FileEntry {
@@ -26,6 +26,33 @@ test('a bare or relative path completes under home', () => {
   assert.deepEqual(completionTarget('works'), { parent: '~/', prefix: 'works' })
   assert.deepEqual(completionTarget('workspace/ac'), { parent: '~/workspace', prefix: 'ac' })
   assert.deepEqual(completionTarget(''), { parent: '~/', prefix: '' })
+})
+
+test('with a directory already picked, a relative path completes inside it', () => {
+  const at = '/home/dev/workspace/acme'
+  assert.deepEqual(completionTarget('desk', at), { parent: at, prefix: 'desk' })
+  assert.deepEqual(completionTarget('web/cli', at), { parent: `${at}/web`, prefix: 'cli' })
+  // The two spellings that say where they start from are not moved.
+  assert.deepEqual(completionTarget('/etc/ini', at), { parent: '/etc', prefix: 'ini' })
+  assert.deepEqual(completionTarget('~/works', at), { parent: '~/', prefix: 'works' })
+})
+
+test('what gets committed is absolute, because the daemon takes nothing else', () => {
+  const at = '/home/dev/workspace/acme'
+  assert.equal(resolveTyped('desk', at), `${at}/desk`)
+  assert.equal(resolveTyped('web/cli', at), `${at}/web/cli`)
+  assert.equal(resolveTyped('  desk  ', at), `${at}/desk`)
+  assert.equal(resolveTyped('desk', `${at}/`), `${at}/desk`)
+  // Already rooted, or nothing typed at all: left exactly as it is.
+  assert.equal(resolveTyped('/tmp/elsewhere', at), '/tmp/elsewhere')
+  assert.equal(resolveTyped('~/works', at), '~/works')
+  assert.equal(resolveTyped('~', at), '~')
+  assert.equal(resolveTyped('', at), '')
+})
+
+test('with no directory picked, home is what relative means', () => {
+  assert.deepEqual(completionTarget('works', ''), { parent: '~/', prefix: 'works' })
+  assert.equal(resolveTyped('works', ''), '~/works')
 })
 
 test('~ on its own is sent as ~/, which is the form the daemon expands', () => {

--- a/desktop/test/dirpath.test.ts
+++ b/desktop/test/dirpath.test.ts
@@ -1,0 +1,76 @@
+// Where a half-typed directory completes, and what it completes to. The picker
+// is the only place a session's directory is chosen, so the rules here are the
+// difference between "somewhere new" being reachable and not.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { completionTarget, completionsIn } from '../src/renderer/components/dirpath.ts'
+import { type FileEntry } from '../src/shared/models.ts'
+
+function dir(path: string): FileEntry {
+  const name = path.split('/').filter(Boolean).pop() ?? path
+  return { name, path, is_dir: true, size: 0, mod_time: '2026-01-01T00:00:00Z' }
+}
+
+function file(path: string): FileEntry {
+  return { ...dir(path), is_dir: false }
+}
+
+test('completes inside the parent of what has been typed', () => {
+  assert.deepEqual(completionTarget('/home/dev/works'), { parent: '/home/dev', prefix: 'works' })
+  assert.deepEqual(completionTarget('/home/dev/'), { parent: '/home/dev', prefix: '' })
+  assert.deepEqual(completionTarget('~/workspace/ac'), { parent: '~/workspace', prefix: 'ac' })
+})
+
+test('a bare or relative path completes under home', () => {
+  assert.deepEqual(completionTarget('works'), { parent: '~/', prefix: 'works' })
+  assert.deepEqual(completionTarget('workspace/ac'), { parent: '~/workspace', prefix: 'ac' })
+  assert.deepEqual(completionTarget(''), { parent: '~/', prefix: '' })
+})
+
+test('~ on its own is sent as ~/, which is the form the daemon expands', () => {
+  assert.deepEqual(completionTarget('~/'), { parent: '~/', prefix: '' })
+  assert.deepEqual(completionTarget('~/w'), { parent: '~/', prefix: 'w' })
+})
+
+test('the root is its own parent', () => {
+  assert.deepEqual(completionTarget('/ho'), { parent: '/', prefix: 'ho' })
+})
+
+test('offers the directories a prefix reaches, and not the files', () => {
+  const entries = [dir('/w/api'), dir('/w/apidocs'), dir('/w/worker'), file('/w/api.md')]
+  assert.deepEqual(
+    completionsIn(entries, 'api', new Set()).map((e) => e.path),
+    ['/w/api', '/w/apidocs'],
+  )
+})
+
+test('an empty prefix offers the whole directory', () => {
+  const entries = [dir('/w/api'), dir('/w/worker')]
+  assert.equal(completionsIn(entries, '', new Set()).length, 2)
+})
+
+test('dot directories wait to be asked for by name', () => {
+  const entries = [dir('/w/.claude'), dir('/w/api')]
+  assert.deepEqual(
+    completionsIn(entries, '', new Set()).map((e) => e.name),
+    ['api'],
+  )
+  assert.deepEqual(
+    completionsIn(entries, '.', new Set()).map((e) => e.name),
+    ['.claude'],
+  )
+})
+
+test('what the recents already show is not shown twice', () => {
+  const entries = [dir('/w/api'), dir('/w/worker')]
+  assert.deepEqual(
+    completionsIn(entries, '', new Set(['/w/api'])).map((e) => e.name),
+    ['worker'],
+  )
+})
+
+test('matches whatever case the directory is spelled in', () => {
+  const entries = [dir('/w/Acme')]
+  assert.equal(completionsIn(entries, 'ac', new Set()).length, 1)
+})

--- a/internal/server/launch.go
+++ b/internal/server/launch.go
@@ -134,6 +134,27 @@ func (sh *Shared) StartSession(req NewSession) (*StartedSession, error) {
 	return &StartedSession{SessionID: sessionID, Terminal: handle, CWD: req.CWD}, nil
 }
 
+// awaitAgent waits for a spawned agent to report in before anything is typed
+// at it.
+//
+// The status is read again after subscribing, and that order is the point: the
+// hook fires the signal and writes the status, and nothing is remembered by a
+// signal nobody was waiting on. Checking only before would wait out the full
+// timeout for an agent that reported in a moment earlier.
+func (sh *Shared) awaitAgent(id string) error {
+	ready := sh.Signals.Await(SignalAgentReady, id)
+	defer ready.Release()
+
+	if session, err := sh.DB.GetSession(id); err == nil && session != nil && session.Status != "starting" {
+		return nil
+	}
+	if !ready.Wait(agentBootTimeout) {
+		log.Printf("session-send: session %s never reported in within %s", id, agentBootTimeout)
+		return statusError(http.StatusGatewayTimeout, "the session is still starting up")
+	}
+	return nil
+}
+
 // EndSession kills a session's terminal and records it as terminated.
 //
 // The handler used to be the only way to end one, so the scheduler — which ends
@@ -233,6 +254,17 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 			log.Printf("session-send: session %s did not report ready within %s", id, agentBootTimeout)
 			return PromptResult{Resumed: true}, statusError(http.StatusGatewayTimeout,
 				"the session is still starting up")
+		}
+	} else if session.Status == "starting" {
+		// A launched session has the same gap as a woken one: StartSession
+		// returns as soon as the terminal is up, and "starting" means no
+		// SessionStart hook has arrived, so the agent is spawned but not yet
+		// reading. The gap is only reachable through the API — the app creates
+		// a session and prompts it a moment later, which is what attaching a
+		// file to a new session has to do, because the upload needs an id that
+		// only the create returns.
+		if err := sh.awaitAgent(id); err != nil {
+			return PromptResult{}, err
 		}
 	}
 

--- a/internal/server/send_test.go
+++ b/internal/server/send_test.go
@@ -58,6 +58,12 @@ func (b *sendBackend) sentTexts() []string {
 	return append([]string(nil), b.sent...)
 }
 
+func (b *sendBackend) wokenNone() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.woken) == 0
+}
+
 func (b *sendBackend) wakeCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -296,4 +302,85 @@ func (q *queueingProvider) Launch(provider.SessionSpec) (provider.Launch, error)
 func (q *queueingProvider) QueuePrompt(sessionID, resumeID, text string) error {
 	q.sent = append(q.sent, text)
 	return nil
+}
+
+// A session created a moment ago is live but not yet listening: StartSession
+// returns when the terminal is up, and the agent reads from it some time after
+// that. Typing into that gap loses the prompt exactly as typing into a waking
+// session does — and the app reaches it whenever a new session is given files,
+// because the upload needs an id only the create can hand back.
+func TestSend_NewSessionTypesOnlyAfterTheAgentIsUp(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "starting")
+	be.handles["sess-1"] = "sock-sess-1"
+
+	var mu sync.Mutex
+	agentUp, typedTooEarly := false, false
+
+	// What handleSessionStart does when the agent finally reports in.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		mu.Lock()
+		agentUp = true
+		mu.Unlock()
+		shared.Signals.Fire(SignalAgentReady, "sess-1")
+		shared.DB.UpdateSessionStatus("sess-1", "idle", "SessionStart")
+	}()
+	be.onSend = func() {
+		mu.Lock()
+		if !agentUp {
+			typedTooEarly = true
+		}
+		mu.Unlock()
+		shared.Signals.Fire(SignalPromptSubmitted, "sess-1")
+	}
+
+	rec, _ := sendPrompt(t, s, "sess-1", "look at ~/.helios/uploads/sess-1/shot.png")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if typedTooEarly {
+		t.Error("prompt was typed before the agent reported in")
+	}
+	if !be.wokenNone() {
+		t.Error("a live session was woken, and waking one kills the terminal it already has")
+	}
+}
+
+// The signal is not remembered, so an agent that reported in between the read
+// and the subscribe would leave the caller waiting out the whole boot timeout
+// for something that has already happened.
+func TestSend_NewSessionThatIsAlreadyUpDoesNotWait(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	be.handles["sess-1"] = "sock-sess-1"
+	be.onSend = func() { shared.Signals.Fire(SignalPromptSubmitted, "sess-1") }
+
+	start := time.Now()
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	if waited := time.Since(start); waited >= agentBootTimeout {
+		t.Errorf("waited %s for an agent that was already up", waited)
+	}
+}
+
+// A session that never reports in is not typed into, however live its terminal.
+func TestSend_NewSessionThatNeverReportsIsRefused(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "starting")
+	be.handles["sess-1"] = "sock-sess-1"
+
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", rec.Code)
+	}
+	if got := be.sentTexts(); len(got) != 0 {
+		t.Errorf("typed %q into a session that was not up", got)
+	}
 }


### PR DESCRIPTION
Reopens #154, which was reverted in #156 over the directory picker. The composer comes back as it was; the picker is rebuilt, and the composer now actually takes files.

## The revert's four objections

1. **A typed path that isn't absolute was unreachable.** Gone. Whatever is in the box is committable as it stands — relative, absolute, `~`, or a path nothing has ever heard of — on Enter or on the row at the top of the list. No prefix rule, no extra click. That is the property the revert was protecting and it now has its own e2e test with a relative path in it, not `/tmp/elsewhere`.
2. **The list could only contain directories that already had a session.** Typing now completes against the filesystem. The typed string is split at its last separator, the parent is listed through `GET /api/files`, and the directories in it whose name starts with the rest are offered under a section naming where they came from. A bare or relative path completes under home, which is where a session with no directory starts anyway. Tab fills in the top match, as a shell does.
3. **The typed text was discarded on close.** It is held by the dialog now rather than by the popover, so it survives the chip closing.
4. **Home vanished the moment you typed.** It stays while it is being spelled.

And the correction: the target was completion, not a better filter over `ListDirectories()`. The recents keep their own section above the results — tinted, named, with their active counts — because "back to where I was working" and "somewhere new" are two jobs, and the recents only ever answered the first.

## Files on the new-session composer

The `+`, the drop target and paste are all wired, and they are not a second copy: `attach.tsx` now holds the hook that owns the files, the drop target, the `+` and its hidden input, the chips row and the paste offer. `chat.tsx` uses those and is ~140 lines shorter for it. `terminal.tsx` is left alone — it types paths into a pty and has no chips to share, so folding it in would have been an abstraction for its own sake.

The part that isn't a copy-paste: `POST /api/sessions/{id}/files` needs a session that exists. So the files are held in memory, the session is created **silent**, the upload goes against the id it hands back, and the prompt naming the paths is sent as the first turn. An upload that fails after the session exists does not undo it — the prompt goes without the paths and the failure is surfaced, as you preferred.

## One daemon change that flow needed

Creating a session and prompting it a moment later walks into the gap the wake path already guards: `StartSession` returns once the terminal is up, and the agent starts reading it some time after that. Typing into that gap loses the prompt. `SendPrompt` now waits for `SignalAgentReady` when the session is live but still `starting`, re-reading the status after subscribing so an agent that reported in a moment earlier does not wait out the boot timeout. Three tests, all of which fail without it.

## Tests

- `desktop/test/dirpath.test.ts` — 9 unit tests over the completion rules.
- `desktop/e2e/new-session.spec.ts` — 19, of which 11 are new: relative paths, Enter committing, completion against the disk, walking down into a completed directory, Tab, the typed path surviving a close, Home while typing, and the create → upload → send order with the prompt withheld from the create.
- `internal/server/send_test.go` — the launch gap, the already-up case, and the never-reports case.
- The stub daemon learned to list directories and to record what the app asks of it, so the ordering above is asserted on rather than assumed.

Full suite: `go test ./...`, 271 desktop unit tests, 48 e2e — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
