### PR TITLE
fix(desktop): rename a session on its row, not through window.prompt

### DIFF
--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -117,6 +117,15 @@ export function Plus({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
+/** A pencil, for the title a row lets you type over. */
+export function Pencil({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4 20h4l10-10-4-4L4 16v4zM14.5 5.5l4 4" />
+    </svg>
+  )
+}
+
 /** A terminal, for the one action a row offers under the pointer. */
 export function Console({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/session-menu.ts
+++ b/desktop/src/renderer/components/session-menu.ts
@@ -97,15 +97,11 @@ export function sessionActions(
 
   actions.push(
     {
-      // Prompted rather than edited in place, as New group above is. The title
-      // used to be an input in the detail header; with the header gone this is
-      // the only way to set one by hand.
-      label: 'Rename…',
-      run: () => {
-        const title = window.prompt('Name the session', session.title ?? '')?.trim()
-        if (title === undefined || title === (session.title ?? '')) return
-        void store.patchSessionField(hostId, session.session_id, { title })
-      },
+      // Edited on the row itself, where a group header is renamed. Prompting
+      // was not a choice between two designs: window.prompt throws in Electron,
+      // so this item did nothing until the field replaced it.
+      label: 'Rename',
+      run: () => store.renameSession(hostId, session.session_id),
     },
     {
       label: 'Regenerate title',

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -26,7 +26,7 @@ import {
   type Session,
   type HostStats,
 } from '../../shared/models.ts'
-import { Chevron, Console, Cpu, Memory, Plus, Search, Sort } from './icons.tsx'
+import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort } from './icons.tsx'
 import {
   buildCwdTree,
   buildTree,
@@ -184,6 +184,7 @@ export function Sidebar({
   const jobSessions = useHostJobSessions()
   const autoRunsOpen = useStore((s) => s.autoRunsOpen)
   const selection = useStore((s) => s.selection)
+  const renamingSession = useStore((s) => s.renamingSession)
   const mode = useStore((s) => s.sidebarMode)
   // Its own search, because the two lists hold different things and a query
   // typed against one is meaningless against the other.
@@ -544,6 +545,10 @@ export function Sidebar({
                 // header's own dragend never fires, because it is not the source.
                 setGroupDrop(null)
               }}
+              editing={
+                renamingSession?.hostId === host.id &&
+                renamingSession.sessionId === session.session_id
+              }
               onContextMenu={(x, y) => setMenu({ kind: 'session', hostId: host.id, session, x, y })}
               onDropBefore={(draggedId) => {
                 // The id off the drag itself, not React state: the drop can
@@ -603,7 +608,7 @@ export function Sidebar({
                   }}
                 >
                   {editing ? (
-                    <NewGroupField
+                    <InlineNameField
                       initial={node.name}
                       onCancel={() => setRenaming(null)}
                       onCommit={(name) => {
@@ -754,7 +759,7 @@ export function Sidebar({
                         click mounts two fields, the second steals focus from
                         the first, and the first's blur cancels both. */}
                     {real && creatingIn === `${host.id}:${node.key}` && (
-                      <NewGroupField
+                      <InlineNameField
                         onCancel={() => setCreatingIn(null)}
                         onCommit={(name) => {
                           setCreatingIn(null)
@@ -823,7 +828,7 @@ export function Sidebar({
               </div>
 
               {!isCollapsed && groupMode === 'manual' && creatingIn === `${host.id}:` && (
-                <NewGroupField
+                <InlineNameField
                   onCancel={() => setCreatingIn(null)}
                   onCommit={(name) => {
                     setCreatingIn(null)
@@ -869,6 +874,10 @@ export function Sidebar({
                         draggable={false}
                         dragging={false}
                         accepts={false}
+                        editing={
+                          renamingSession?.hostId === host.id &&
+                          renamingSession.sessionId === session.session_id
+                        }
                         onDragStart={() => {}}
                         onDragEnd={() => {}}
                         onContextMenu={(x, y) =>
@@ -987,16 +996,20 @@ function groupActions(hostId: string, key: string, onRename: () => void): MenuAc
 }
 
 /**
- * Names a new group, in place.
+ * Names a group or a session, in place.
  *
  * Inline rather than a dialog: the point of a `+` on a header is that the
  * parent is already chosen by where you clicked, and a modal would ask again
- * with a field the header could just have shown.
+ * with a field the header could just have shown. The same holds for a row —
+ * and a dialog is not on offer anyway, since Electron does not implement
+ * window.prompt.
  */
-function NewGroupField({
+function InlineNameField({
   onCommit,
   onCancel,
   initial = '',
+  className = 'new-group',
+  placeholder = 'Group name',
 }: {
   onCommit: (name: string) => void
   onCancel: () => void
@@ -1004,6 +1017,8 @@ function NewGroupField({
    *  one. Seeded into state rather than left as a defaultValue, so the field
    *  stays controlled — see below for what uncontrolled cost. */
   initial?: string
+  className?: string
+  placeholder?: string
 }): JSX.Element {
   const [draft, setDraft] = useState(initial)
   const field = useRef<HTMLInputElement | null>(null)
@@ -1031,8 +1046,8 @@ function NewGroupField({
   return (
     <input
       ref={field}
-      className="new-group"
-      placeholder="Group name"
+      className={className}
+      placeholder={placeholder}
       value={draft}
       onChange={(event) => setDraft(event.target.value)}
       onKeyDown={(event) => {
@@ -1112,6 +1127,7 @@ function SessionRow({
   draggable,
   dragging,
   accepts,
+  editing,
   onDragStart,
   onDragEnd,
   onContextMenu,
@@ -1126,6 +1142,9 @@ function SessionRow({
   dragging: boolean
   /** A drag is in flight and this row is somewhere it may be dropped. */
   accepts: boolean
+  /** The title is a field rather than a label, because this is the row being
+   *  renamed. */
+  editing: boolean
   onDragStart: () => void
   onDragEnd: () => void
   onContextMenu: (x: number, y: number) => void
@@ -1146,7 +1165,10 @@ function SessionRow({
   return (
     <article
       className={classes.filter(Boolean).join(' ')}
-      draggable={draggable}
+      // A draggable ancestor takes the pointer off the field inside it: the
+      // browser starts a drag instead of placing the caret, so a title cannot
+      // be clicked into while the row can be moved.
+      draggable={draggable && !editing}
       onDragStart={(event) => {
         // Firefox and Chromium both want data on the transfer or the drag never
         // starts; the id is also what makes the drop unambiguous.
@@ -1179,16 +1201,34 @@ function SessionRow({
       }}
       // A terminated session has to be resumed before it has a terminal worth
       // opening, so the shortcut resumes instead of waking one it will refuse.
-      onDoubleClick={() =>
+      // Double-clicking a word in the field is how you edit one word of a
+      // title, and it must not also open the terminal underneath.
+      onDoubleClick={() => {
+        if (editing) return
         void (terminated
           ? store.resumeSession(hostId, session.session_id)
           : store.openTerminal(hostId, session, !live))
-      }
+      }}
     >
       <div className="row-main">
-        <span className="row-title" title={label}>
-          {label}
-        </span>
+        {editing ? (
+          <InlineNameField
+            className="row-rename"
+            placeholder={label}
+            initial={session.title ?? ''}
+            onCancel={() => store.endSessionRename()}
+            onCommit={(title) => {
+              store.endSessionRename()
+              if (title !== (session.title ?? '')) {
+                void store.patchSessionField(hostId, session.session_id, { title })
+              }
+            }}
+          />
+        ) : (
+          <span className="row-title" title={label}>
+            {label}
+          </span>
+        )}
         {cold && (
           <span className="cold-mark" title="Cold — no live terminal">
             ⚯
@@ -1211,6 +1251,22 @@ function SessionRow({
             is what makes hovering feel jarring. A terminated one gets the word,
             because resuming is the only move it has left and it should not have
             to be hovered to say so. */}
+        {/* Held in the row like the action beside it, so the title does not
+            shift when the pointer arrives. Hidden while the field is up: it
+            opens what is already open. */}
+        {!editing && (
+          <button
+            className="row-act"
+            aria-label="Rename session"
+            title="Rename"
+            onClick={(event) => {
+              event.stopPropagation()
+              store.renameSession(hostId, session.session_id)
+            }}
+          >
+            <Pencil />
+          </button>
+        )}
         {terminated ? (
           <button
             className="row-btn resume"

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -185,6 +185,12 @@ export interface State {
   tabs: Tab[]
   selection: Selection | null
   /**
+   * The session whose title is being typed, if any. Held here rather than in
+   * the sidebar because the row menu is shared with the detail panel's ⋯, and
+   * both start the same edit on the same row.
+   */
+  renamingSession: Selection | null
+  /**
    * Which list the sidebar is showing.
    *
    * Sessions and schedules are two lists of the same shape — grouped by host,
@@ -391,6 +397,7 @@ const initial: State = {
   hostStatus: {},
   tabs: [],
   selection: null,
+  renamingSession: null,
   sidebarMode: 'sessions',
   scheduleQuery: '',
   autoRunsOpen: {},
@@ -601,6 +608,20 @@ class Store {
       .map((session) => session.session_id)
     await api(hostId).setSessionOrder(ordered)
     await this.invalidateSessions(hostId)
+  }
+
+  /**
+   * Puts one row's title into a field, where the row is.
+   *
+   * The window.prompt this replaces threw: Electron does not implement it, so
+   * Rename was a menu item that did nothing at all.
+   */
+  renameSession(hostId: string, sessionId: string): void {
+    this.set({ renamingSession: { hostId, sessionId } })
+  }
+
+  endSessionRename(): void {
+    if (this.state.renamingSession) this.set({ renamingSession: null })
   }
 
   /**

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1158,6 +1158,23 @@ small {
   text-overflow: ellipsis;
 }
 
+/* The title as a field, sized like the label it stands in for so the row keeps
+   its height and the words do not move on the way in and out. */
+.row-rename {
+  flex: 1;
+  min-width: 0;
+  padding: 0 4px;
+  margin: -1px 0;
+  border: 1px solid var(--primary);
+  border-radius: 4px;
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
 /* A session that has ended is still worth listing and no longer worth reading
    first. */
 .session-row.terminated .row-title,


### PR DESCRIPTION
## Summary
- `Rename…` in the session menu called `window.prompt`, which Electron does not implement — it throws `prompt() is not supported.`, so the item did nothing.
- The title is now edited in place on the sidebar row: a pencil fades in under the pointer beside the terminal button, and the menu item opens the same field. Enter commits, Escape and blur match the group header rename.
- The row being renamed lives in the store, because the same menu is opened from the detail panel's ⋯.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (262 pass)
- [x] Drove a dev instance over CDP: pencil opens a focused field seeded with the current title; Enter writes it to the daemon (`PATCH /api/sessions/{id}`) and the row shows the new title; the menu item opens the same field; Escape cancels with the title unchanged.