### PR TITLE
feat(desktop): switch modes from a left rail, Settings becomes a mode

### DIFF
--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -4,16 +4,17 @@ import { bridge } from './bridge.ts'
 import type { UpdateInfo } from '../shared/models.ts'
 import { store, terminalId, useStore } from './store.ts'
 import { Detail } from './components/detail.tsx'
-import { HostsDialog } from './components/hosts.tsx'
 import { NewSessionDialog } from './components/newsession.tsx'
-import { SettingsDialog } from './components/settings.tsx'
+import { Rail } from './components/rail.tsx'
 import { Sidebar } from './components/sidebar.tsx'
 
 export function App(): JSX.Element {
   const loading = useStore((s) => s.loading)
   const toast = useStore((s) => s.toast)
   const pairingLink = useStore((s) => s.pairingLink)
-  const [dialog, setDialog] = useState<'new' | 'hosts' | 'settings' | null>(null)
+  // Starting a session is the last thing that interrupts the window. Settings
+  // and hosts are modes now, reached from the rail.
+  const [dialog, setDialog] = useState<'new' | null>(null)
   // Where the new-session dialog should start when it was opened from a
   // project rather than from the toolbar: the point of the project's own
   // button is that it does not ask again which project it meant.
@@ -23,13 +24,13 @@ export function App(): JSX.Element {
     void store.init()
   }, [])
 
-  // A pairing link from the OS should surface the dialog that can use it.
+  // A pairing link from the OS should surface the pane that can use it.
   useEffect(() => {
-    if (pairingLink) setDialog('hosts')
+    if (pairingLink) store.openSettings('hosts')
   }, [pairingLink])
 
   // The Settings item in the app menu lives in the main process.
-  useEffect(() => bridge.app.onOpenSettings(() => setDialog('settings')), [])
+  useEffect(() => bridge.app.onOpenSettings(() => store.openSettings()), [])
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
@@ -73,13 +74,12 @@ export function App(): JSX.Element {
       <div className="titlebar" />
       <UpdateBanner />
       <div className="body">
+        <Rail />
         <Sidebar
           onNewSession={(from) => {
             setSeed(from ?? null)
             setDialog('new')
           }}
-          onAddHost={() => setDialog('hosts')}
-          onSettings={() => setDialog('settings')}
         />
         <main className="main">
           <Detail />
@@ -87,8 +87,6 @@ export function App(): JSX.Element {
       </div>
 
       {dialog === 'new' && <NewSessionDialog seed={seed} onClose={() => setDialog(null)} />}
-      {dialog === 'hosts' && <HostsDialog onClose={() => setDialog(null)} />}
-      {dialog === 'settings' && <SettingsDialog onClose={() => setDialog(null)} />}
 
       {toast && <div className={`toast ${toast.kind}`}>{toast.text}</div>}
     </div>

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -33,10 +33,11 @@ import { canResume, type Session } from '../../shared/models.ts'
 
 const PANELS: RightPanel[] = ['chat', 'terminal', 'approvals', 'git', 'files']
 
-// The transcript is the agent's side of the session, not a chat room. The
-// store key stays 'chat' — it is persisted and referenced from elsewhere.
+// The transcript is the agent's side of the session, not a chat room, and not
+// the agent either — the agent is the thing running, of which this is the
+// record. The store key stays 'chat': it is persisted and referenced elsewhere.
 const PANEL_LABELS: Record<RightPanel, string> = {
-  chat: 'agent',
+  chat: 'transcript',
   terminal: 'terminal',
   approvals: 'approvals',
   git: 'git',

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -13,6 +13,7 @@ import { GitPanel } from './git.tsx'
 import { SchedulePanel } from './schedules.tsx'
 import { SelectionMenu } from './selection-menu.tsx'
 import { sessionActions } from './session-menu.ts'
+import { SettingsPane } from './settings.tsx'
 import { StatusLine } from './status-line.tsx'
 import {
   isVisible,
@@ -196,6 +197,7 @@ export function Detail(): JSX.Element {
   // with no layout, and TerminalPane's ResizeObserver refits it on the way
   // back.
   const showingSchedules = sidebarMode === 'schedules'
+  const showingSettings = sidebarMode === 'settings'
 
   return (
     <>
@@ -206,7 +208,14 @@ export function Detail(): JSX.Element {
           </PanelBoundary>
         </div>
       )}
-      <div className="detail" style={showingSchedules ? { display: 'none' } : undefined}>
+      {showingSettings && (
+        <div className="detail">
+          <PanelBoundary resetKey="settings">
+            <SettingsPane />
+          </PanelBoundary>
+        </div>
+      )}
+      <div className="detail" style={showingSchedules || showingSettings ? { display: 'none' } : undefined}>
       {hostId && session && <ShowNoteStrip hostId={hostId} sessionId={session.session_id} />}
 
       <div

--- a/desktop/src/renderer/components/hosts.tsx
+++ b/desktop/src/renderer/components/hosts.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 
 import { bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
-import { Modal } from './newsession.tsx'
 
 /**
  * Adding a daemon.
@@ -11,8 +10,11 @@ import { Modal } from './newsession.tsx'
  * admin port, which is the same trust the CLI assumes. A remote one needs the
  * `helios://pair` link that `helios setup` prints as a QR, since a desktop has
  * no camera to point at it.
+ *
+ * A settings pane rather than the dialog it was: which machines the app talks
+ * to is a setting, and pairing one was the last thing left behind a modal.
  */
-export function HostsDialog({ onClose }: { onClose: () => void }): JSX.Element {
+export function HostsPane(): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
   const pairingLink = useStore((s) => s.pairingLink)
@@ -54,7 +56,8 @@ export function HostsDialog({ onClose }: { onClose: () => void }): JSX.Element {
   }
 
   return (
-    <Modal title="Hosts" onClose={onClose}>
+    <>
+      <h3>Hosts</h3>
       <div className="host-rows">
         {hosts.map((host) => (
           <div key={host.id} className="host-row">
@@ -112,14 +115,11 @@ export function HostsDialog({ onClose }: { onClose: () => void }): JSX.Element {
         </small>
       </label>
 
-      <div className="modal-actions">
-        <button className="ghost" onClick={onClose}>
-          Close
-        </button>
+      <div className="pane-actions">
         <button disabled={busy || !link.trim()} onClick={() => void pairRemote()}>
           {busy ? 'Pairing…' : 'Add host'}
         </button>
       </div>
-    </Modal>
+    </>
   )
 }

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -117,6 +117,36 @@ export function Plus({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
+/** A list of sessions, for the rail. Bulleted, so it is not the sort icon. */
+export function ListRows({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4.5 6.5h.01M4.5 12h.01M4.5 17.5h.01" strokeLinecap="round" strokeWidth="2.4" />
+      <path d="M9 6.5h10.5M9 12h10.5M9 17.5h10.5" />
+    </svg>
+  )
+}
+
+/** A clock, for what runs on one. */
+export function Clock({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M12 7.5V12l3 2" />
+    </svg>
+  )
+}
+
+/** A gear, for the settings mode. */
+export function Gear({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="3.2" />
+      <path d="M12 3.2l1.6 2.5 2.9-.6.5 2.9 2.6 1.5-1.6 2.5 1.6 2.5-2.6 1.5-.5 2.9-2.9-.6L12 20.8l-1.6-2.5-2.9.6-.5-2.9L4.4 14.5 6 12 4.4 9.5 7 8l.5-2.9 2.9.6z" />
+    </svg>
+  )
+}
+
 /** A pencil, for the title a row lets you type over. */
 export function Pencil({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -117,12 +117,20 @@ export function Plus({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
-/** A list of sessions, for the rail. Bulleted, so it is not the sort icon. */
+/**
+ * A list of sessions, for the rail. Bulleted, so it is not the sort icon.
+ *
+ * The bullets are circles rather than dotted line caps: a cap thick enough to
+ * read as a bullet is nearly twice the weight of every other stroke in the set,
+ * and next to the clock beside it that looked like a different icon family.
+ */
 export function ListRows({ className = '' }: { className?: string }): JSX.Element {
   return (
     <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4.5 6.5h.01M4.5 12h.01M4.5 17.5h.01" strokeLinecap="round" strokeWidth="2.4" />
-      <path d="M9 6.5h10.5M9 12h10.5M9 17.5h10.5" />
+      <circle cx="4.8" cy="6.5" r="1.1" fill="currentColor" stroke="none" />
+      <circle cx="4.8" cy="12" r="1.1" fill="currentColor" stroke="none" />
+      <circle cx="4.8" cy="17.5" r="1.1" fill="currentColor" stroke="none" />
+      <path d="M9.5 6.5h10M9.5 12h10M9.5 17.5h10" />
     </svg>
   )
 }
@@ -143,15 +151,6 @@ export function Gear({ className = '' }: { className?: string }): JSX.Element {
     <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <circle cx="12" cy="12" r="3.2" />
       <path d="M12 3.2l1.6 2.5 2.9-.6.5 2.9 2.6 1.5-1.6 2.5 1.6 2.5-2.6 1.5-.5 2.9-2.9-.6L12 20.8l-1.6-2.5-2.9.6-.5-2.9L4.4 14.5 6 12 4.4 9.5 7 8l.5-2.9 2.9.6z" />
-    </svg>
-  )
-}
-
-/** A filled square: the stop that ends a session's agent. */
-export function Stop({ className = '' }: { className?: string }): JSX.Element {
-  return (
-    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="6.5" y="6.5" width="11" height="11" rx="2" fill="currentColor" stroke="none" />
     </svg>
   )
 }

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -147,6 +147,15 @@ export function Gear({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
+/** A filled square: the stop that ends a session's agent. */
+export function Stop({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="6.5" y="6.5" width="11" height="11" rx="2" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
 /** A pencil, for the title a row lets you type over. */
 export function Pencil({ className = '' }: { className?: string }): JSX.Element {
   return (

--- a/desktop/src/renderer/components/rail.tsx
+++ b/desktop/src/renderer/components/rail.tsx
@@ -1,0 +1,39 @@
+import { store, useStore, type SidebarMode } from '../store.ts'
+import { Clock, Gear, ListRows } from './icons.tsx'
+
+/**
+ * What the window is showing, chosen from the left edge.
+ *
+ * A mode owns both columns: its own list in the sidebar, its own panel beside
+ * it. That is why the switch is out here rather than inside the sidebar, where
+ * it used to be a pair of words above a list it was not part of.
+ *
+ * Settings sits at the bottom, apart from the two lists: it is where you go to
+ * change the app, not another thing the app is holding.
+ */
+export function Rail(): JSX.Element {
+  const mode = useStore((s) => s.sidebarMode)
+
+  const item = (id: SidebarMode, label: string, icon: JSX.Element): JSX.Element => (
+    <button
+      className={mode === id ? 'rail-item on' : 'rail-item'}
+      // Pressed rather than current: these are three states of one control,
+      // and only one of them is on at a time.
+      aria-pressed={mode === id}
+      aria-label={label}
+      title={label}
+      onClick={() => store.setSidebarMode(id)}
+    >
+      {icon}
+    </button>
+  )
+
+  return (
+    <nav className="rail" aria-label="Modes">
+      {item('sessions', 'Sessions', <ListRows />)}
+      {item('schedules', 'Schedules', <Clock />)}
+      <span className="grow" />
+      {item('settings', 'Settings', <Gear />)}
+    </nav>
+  )
+}

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -7,7 +7,7 @@ import { keys, mergeSettings, settingValues, type SettingsDocument } from '../ke
 import { useHostSessions } from '../host-data.ts'
 import { settingsQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
-import { Modal } from './newsession.tsx'
+import { HostsPane } from './hosts.tsx'
 import { ALERT_TYPES } from '../../shared/notifications.ts'
 import {
   DEFAULT_STATUS_LINE,
@@ -20,7 +20,13 @@ import {
 import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
-import type { AppearancePrefs, BackdropState, NotificationPrefs, ThemeSummary } from '../../shared/models.ts'
+import type {
+  AppearancePrefs,
+  BackdropState,
+  NotificationPrefs,
+  SettingsSection,
+  ThemeSummary,
+} from '../../shared/models.ts'
 
 /**
  * Which types can be silenced, in the order the phone lists them. Keeping the
@@ -78,17 +84,20 @@ const MODES: { value: AppearancePrefs['mode']; label: string; detail: string }[]
  * theme pickers pushed the notification toggles out of sight — and the two have
  * nothing to do with each other.
  */
-type SectionId = 'appearance' | 'sessions' | 'terminal' | 'notifications'
-
-const SECTIONS: { id: SectionId; label: string }[] = [
+export const SECTIONS: { id: SettingsSection; label: string }[] = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'sessions', label: 'Sessions' },
   { id: 'terminal', label: 'Terminal' },
   { id: 'notifications', label: 'Notifications' },
+  // Last, and part of this list rather than a dialog of its own: which daemons
+  // the app talks to is a setting like the others.
+  { id: 'hosts', label: 'Hosts' },
 ]
 
-export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Element {
-  const [section, setSection] = useState<SectionId>('appearance')
+export function SettingsPane(): JSX.Element {
+  // In the store, not here: the list that chooses the pane is drawn by the
+  // sidebar, which is not this component's parent.
+  const section = useStore((s) => s.settingsSection)
   const [prefs, setPrefs] = useState<NotificationPrefs | null>(null)
   const [appearance, setAppearance] = useState<AppearancePrefs | null>(null)
   const [themes, setThemes] = useState<ThemeSummary[]>([])
@@ -130,20 +139,7 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
   }
 
   return (
-    <Modal title="Settings" onClose={onClose}>
-      <div className="settings-shell">
-        <nav className="settings-nav">
-          {SECTIONS.map((entry) => (
-            <button
-              key={entry.id}
-              className={section === entry.id ? 'active' : ''}
-              onClick={() => setSection(entry.id)}
-            >
-              {entry.label}
-            </button>
-          ))}
-        </nav>
-
+    <div className="settings-page">
         <div className="settings-panel">
           {section === 'appearance' && !appearance && <Loading title="Appearance" />}
 
@@ -289,18 +285,19 @@ export function SettingsDialog({ onClose }: { onClose: () => void }): JSX.Elemen
         </section>
       ))}
 
-      {MISSING.length > 0 && <p className="modal-note">Not listed: {MISSING.join(', ')}</p>}
+      {MISSING.length > 0 && <p className="pane-note">Not listed: {MISSING.join(', ')}</p>}
 
-      <div className="modal-actions">
+      <div className="pane-actions">
         <button className="ghost" onClick={() => void apply(bridge.prefs.reset())}>
           Reset to defaults
         </button>
       </div>
             </>
           )}
+
+          {section === 'hosts' && <HostsPane />}
         </div>
-      </div>
-    </Modal>
+    </div>
   )
 }
 
@@ -345,7 +342,7 @@ function SessionsPane(): JSX.Element {
   const [hostId, setHostId] = useState<string | null>(null)
   const selected = hosts.find((host) => host.id === hostId) ?? hosts[0]
 
-  if (!selected) return <p className="modal-note">No host paired.</p>
+  if (!selected) return <p className="pane-note">No host paired.</p>
 
   return (
     <>
@@ -604,7 +601,7 @@ function MemoryBudget({ hostId }: { hostId: string }): JSX.Element {
     return (
       <section className="settings-group">
         <h3>Memory</h3>
-        <p className="modal-note">This host is not reachable.</p>
+        <p className="pane-note">This host is not reachable.</p>
       </section>
     )
   }
@@ -708,7 +705,7 @@ function SessionTitles({ hostId }: { hostId: string }): JSX.Element {
     return (
       <section className="settings-group">
         <h3>Session titles</h3>
-        <p className="modal-note">This host is not reachable.</p>
+        <p className="pane-note">This host is not reachable.</p>
       </section>
     )
   }

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -26,7 +26,7 @@ import {
   type Session,
   type HostStats,
 } from '../../shared/models.ts'
-import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort } from './icons.tsx'
+import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort, Stop } from './icons.tsx'
 import {
   buildCwdTree,
   buildTree,
@@ -926,15 +926,21 @@ export function Sidebar({
         )}
       </div>
 
+      {/* Two buttons rather than the ⋯ menu they were behind: Settings left for
+          the rail, and a menu holding one item is a click in front of it. */}
       <footer className="sidebar-foot">
-        {/* Not in the settings mode, where it would sit an inch under the
-            Hosts pane it opens. */}
+        {/* Not in the settings mode, where it would sit an inch under the Hosts
+            pane it opens. */}
         {mode !== 'settings' && (
           <button className="link" onClick={() => store.openSettings('hosts')}>
             Add host
           </button>
         )}
-        <AppMenu />
+        {/* Closing the window leaves the app on the tray so approvals keep
+            arriving; this is the one control that actually ends it. */}
+        <button className="link danger" onClick={() => void bridge.app.quit()}>
+          Quit Helios
+        </button>
       </footer>
 
       {menu && (
@@ -1059,54 +1065,6 @@ function InlineNameField({
       }}
       onBlur={(event) => commit(event.target.value)}
     />
-  )
-}
-
-/**
- * Quit, which otherwise lives only on the tray and the app menu — neither of
- * which is where the eye goes, and the app menu is not somewhere a user looks
- * on the platforms where the window is the whole of the app. Settings left
- * here for the rail, which says what it is with an icon rather than an ⋯.
- */
-function AppMenu(): JSX.Element {
-  const menu = useRef<HTMLDetailsElement | null>(null)
-
-  // <details> only closes on its own summary, so a menu left open stays open
-  // over whatever the user clicks next.
-  useEffect(() => {
-    const close = (event: Event): void => {
-      const element = menu.current
-      if (!element?.open) return
-      if (event.type === 'keydown' && (event as KeyboardEvent).key !== 'Escape') return
-      if (event.type === 'mousedown' && event.target instanceof Node && element.contains(event.target)) return
-      element.open = false
-    }
-    window.addEventListener('mousedown', close)
-    window.addEventListener('keydown', close)
-    window.addEventListener('blur', close)
-    return () => {
-      window.removeEventListener('mousedown', close)
-      window.removeEventListener('keydown', close)
-      window.removeEventListener('blur', close)
-    }
-  }, [])
-
-  return (
-    <details className="menu drop-up" ref={menu}>
-      <summary title="More">⋯</summary>
-      <div
-        className="menu-body"
-        onClick={() => {
-          if (menu.current) menu.current.open = false
-        }}
-      >
-        {/* Closing the window leaves the app on the tray so approvals keep
-            arriving; this is the one control that actually ends it. */}
-        <button className="danger" onClick={() => void bridge.app.quit()}>
-          Quit Helios
-        </button>
-      </div>
-    </details>
   )
 }
 
@@ -1265,6 +1223,27 @@ function SessionRow({
             }}
           >
             <Pencil />
+          </button>
+        )}
+        {/* Ending a session was a right-click away, while resuming one is on
+            the row — the same pair of opposite actions reached two different
+            ways. Absent on a terminated session, which has nothing left to
+            end and offers Resume in this spot instead. */}
+        {!terminated && !editing && (
+          <button
+            className="row-act danger"
+            aria-label="Terminate session"
+            title="Terminate — the agent stops; Resume brings it back"
+            onClick={(event) => {
+              event.stopPropagation()
+              // The one row action that cannot be undone by clicking again.
+              if (!confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
+                return
+              }
+              void store.terminateSession(hostId, session.session_id)
+            }}
+          >
+            <Stop />
           </button>
         )}
         {terminated ? (

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -26,7 +26,7 @@ import {
   type Session,
   type HostStats,
 } from '../../shared/models.ts'
-import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort, Stop } from './icons.tsx'
+import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort } from './icons.tsx'
 import {
   buildCwdTree,
   buildTree,
@@ -1225,27 +1225,6 @@ function SessionRow({
             <Pencil />
           </button>
         )}
-        {/* Ending a session was a right-click away, while resuming one is on
-            the row — the same pair of opposite actions reached two different
-            ways. Absent on a terminated session, which has nothing left to
-            end and offers Resume in this spot instead. */}
-        {!terminated && !editing && (
-          <button
-            className="row-act danger"
-            aria-label="Terminate session"
-            title="Terminate — the agent stops; Resume brings it back"
-            onClick={(event) => {
-              event.stopPropagation()
-              // The one row action that cannot be undone by clicking again.
-              if (!confirm('Terminate this session? The agent stops, and only Resume brings it back.')) {
-                return
-              }
-              void store.terminateSession(hostId, session.session_id)
-            }}
-          >
-            <Stop />
-          </button>
-        )}
         {terminated ? (
           <button
             className="row-btn resume"
@@ -1268,6 +1247,25 @@ function SessionRow({
             }}
           >
             <Console />
+          </button>
+        )}
+        {/* Last of the row's actions, and the right-click for a pointer that
+            does not have one: the only way to reach Terminate, Pin, the groups
+            and the permission modes without knowing the menu is there. Opens
+            under the button rather than at the pointer, since the button has a
+            fixed place. */}
+        {!editing && (
+          <button
+            className="row-act row-more"
+            aria-label="Session actions"
+            title="Session actions"
+            onClick={(event) => {
+              event.stopPropagation()
+              const box = event.currentTarget.getBoundingClientRect()
+              onContextMenu(box.left, box.bottom + 4)
+            }}
+          >
+            ⋯
           </button>
         )}
         <span className="row-time">{timeAgo(session.last_event_at ?? session.created_at)}</span>

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -39,6 +39,7 @@ import { GroupPicker } from './group-picker.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 import { sessionActions } from './session-menu.ts'
+import { SECTIONS } from './settings.tsx'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
  *  session list taking half the window from the session itself. */
@@ -170,12 +171,8 @@ function dropModeFor(event: React.DragEvent, el: HTMLElement): DropMode {
 
 export function Sidebar({
   onNewSession,
-  onAddHost,
-  onSettings,
 }: {
   onNewSession: (seed?: { hostId: string; cwd: string; group?: string }) => void
-  onAddHost: () => void
-  onSettings: () => void
 }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
@@ -186,6 +183,7 @@ export function Sidebar({
   const selection = useStore((s) => s.selection)
   const renamingSession = useStore((s) => s.renamingSession)
   const mode = useStore((s) => s.sidebarMode)
+  const settingsSection = useStore((s) => s.settingsSection)
   // Its own search, because the two lists hold different things and a query
   // typed against one is meaningless against the other.
   const scheduleQuery = useStore((s) => s.scheduleQuery)
@@ -382,23 +380,21 @@ export function Sidebar({
 
   return (
     <aside className="sidebar" ref={aside}>
-      {/* Above everything, because it decides what everything below is about:
-          the search, the arrange control and the + button all belong to one
-          list or the other. */}
-      <div className="sidebar-modes">
-        <button
-          className={mode === 'sessions' ? 'active' : ''}
-          onClick={() => store.setSidebarMode('sessions')}
-        >
-          sessions
-        </button>
-        <button
-          className={mode === 'schedules' ? 'active' : ''}
-          onClick={() => store.setSidebarMode('schedules')}
-        >
-          schedules
-        </button>
-      </div>
+      {/* Which mode this is comes from the rail, so the list starts at its own
+          search rather than at a switch it is not part of. */}
+      {mode === 'settings' && (
+        <nav className="settings-nav">
+          {SECTIONS.map((entry) => (
+            <button
+              key={entry.id}
+              className={settingsSection === entry.id ? 'active' : ''}
+              onClick={() => store.setSettingsSection(entry.id)}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </nav>
+      )}
 
       {mode === 'schedules' && (
         <>
@@ -505,7 +501,7 @@ export function Sidebar({
       </header>
       )}
 
-      <div className="sidebar-list" hidden={mode === 'schedules'}>
+      <div className="sidebar-list" hidden={mode !== 'sessions'}>
         {grouped.map(({ host, rows, nodes, pending, count, hidden, loading }) => {
           const status = hostStatus[host.id]?.state ?? 'connecting'
           const isCollapsed = collapsed[host.id] ?? false
@@ -925,16 +921,20 @@ export function Sidebar({
             <p className="muted">
               Start one with <code>helios daemon</code>, or pair a remote machine.
             </p>
-            <button onClick={onAddHost}>Add host</button>
+            <button onClick={() => store.openSettings('hosts')}>Add host</button>
           </div>
         )}
       </div>
 
       <footer className="sidebar-foot">
-        <button className="link" onClick={onAddHost}>
-          Add host
-        </button>
-        <AppMenu onSettings={onSettings} />
+        {/* Not in the settings mode, where it would sit an inch under the
+            Hosts pane it opens. */}
+        {mode !== 'settings' && (
+          <button className="link" onClick={() => store.openSettings('hosts')}>
+            Add host
+          </button>
+        )}
+        <AppMenu />
       </footer>
 
       {menu && (
@@ -1063,11 +1063,12 @@ function InlineNameField({
 }
 
 /**
- * Settings and Quit, which otherwise live only on the tray and the app menu —
- * neither of which is where the eye goes, and the app menu is not somewhere a
- * user looks on the platforms where the window is the whole of the app.
+ * Quit, which otherwise lives only on the tray and the app menu — neither of
+ * which is where the eye goes, and the app menu is not somewhere a user looks
+ * on the platforms where the window is the whole of the app. Settings left
+ * here for the rail, which says what it is with an icon rather than an ⋯.
  */
-function AppMenu({ onSettings }: { onSettings: () => void }): JSX.Element {
+function AppMenu(): JSX.Element {
   const menu = useRef<HTMLDetailsElement | null>(null)
 
   // <details> only closes on its own summary, so a menu left open stays open
@@ -1099,7 +1100,6 @@ function AppMenu({ onSettings }: { onSettings: () => void }): JSX.Element {
           if (menu.current) menu.current.open = false
         }}
       >
-        <button onClick={onSettings}>Settings…</button>
         {/* Closing the window leaves the app on the tray so approvals keep
             arriving; this is the one control that actually ends it. */}
         <button className="danger" onClick={() => void bridge.app.quit()}>

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -41,6 +41,7 @@ import type {
   Notification,
   Session,
   SessionGroup,
+  SettingsSection,
   SSEEvent,
   TabStatus,
   HostStats,
@@ -72,7 +73,15 @@ function shellLabel(termId: string): string {
   return index ? `sh ${index}` : 'shell'
 }
 
-export type SidebarMode = 'sessions' | 'schedules'
+/**
+ * What the window is showing, both columns of it.
+ *
+ * The rail switches this, and the sidebar and the main panel both follow: each
+ * mode brings its own list and its own panel. Settings is a mode rather than a
+ * dialog because it is a screen and a half of controls, which a 760px box was
+ * never the shape for.
+ */
+export type SidebarMode = 'sessions' | 'schedules' | 'settings'
 
 /** What the main panel is showing about a schedule. */
 export interface ScheduleSelection {
@@ -198,6 +207,9 @@ export interface State {
    * rather than fighting for it. See docs/specs/55-scheduled-runs.md.
    */
   sidebarMode: SidebarMode
+  /** Which pane the settings mode is on. Kept while another mode is up, so
+   *  coming back lands where you left. */
+  settingsSection: SettingsSection
   /**
    * The schedules list's own search.
    *
@@ -399,6 +411,7 @@ const initial: State = {
   selection: null,
   renamingSession: null,
   sidebarMode: 'sessions',
+  settingsSection: 'appearance',
   scheduleQuery: '',
   autoRunsOpen: {},
   scheduleSelection: null,
@@ -1033,6 +1046,20 @@ class Store {
 
   setSidebarMode(mode: SidebarMode): void {
     this.set({ sidebarMode: mode })
+  }
+
+  /**
+   * Shows the settings, on a named pane when the caller has one in mind.
+   *
+   * ⌘, the app menu and the tray all arrive here, as does a `helios://pair`
+   * link — which names the Hosts pane, since pairing is what it came to do.
+   */
+  openSettings(section?: SettingsSection): void {
+    this.set(section ? { sidebarMode: 'settings', settingsSection: section } : { sidebarMode: 'settings' })
+  }
+
+  setSettingsSection(section: SettingsSection): void {
+    this.set({ settingsSection: section })
   }
 
   setScheduleQuery(query: string): void {

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1539,6 +1539,17 @@ class Store {
     this.set((s) => ({ tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, title: trimmed } : t)) }))
   }
 
+  /** Ends a session's agent. The transcript on disk is untouched, and Resume
+   *  is what brings it back. */
+  async terminateSession(hostId: string, sessionId: string): Promise<void> {
+    try {
+      await api(hostId).terminate(sessionId)
+    } catch (err) {
+      this.fail(err)
+    }
+    await this.invalidateSessions(hostId)
+  }
+
   /**
    * Brings a terminated session's agent back and moves the daemon's record out
    * of `terminated`, which is what re-enables prompts. Distinct from waking:

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -1539,17 +1539,6 @@ class Store {
     this.set((s) => ({ tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, title: trimmed } : t)) }))
   }
 
-  /** Ends a session's agent. The transcript on disk is untouched, and Resume
-   *  is what brings it back. */
-  async terminateSession(hostId: string, sessionId: string): Promise<void> {
-    try {
-      await api(hostId).terminate(sessionId)
-    } catch (err) {
-      this.fail(err)
-    }
-    await this.invalidateSessions(hostId)
-  }
-
   /**
    * Brings a terminated session's agent back and moves the daemon's record out
    * of `terminated`, which is what re-enables prompts. Distinct from waking:

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -542,12 +542,17 @@ small {
 }
 
 .rail-item {
+  position: relative;
   width: 34px;
   height: 34px;
   flex: none;
   display: grid;
   place-items: center;
-  border-radius: var(--r-lg);
+  /* The base button pads 7px/14px, which leaves a 6px content box in a 34px
+     square — the glyph then overflows it to the right and sits off-centre.
+     Every other icon button in the app zeroes this for the same reason. */
+  padding: 0;
+  border-radius: var(--r-md);
   background: none;
   color: var(--on-surface-variant);
   cursor: pointer;
@@ -558,11 +563,24 @@ small {
   color: var(--on-surface);
 }
 
-/* The same lit pill the settings nav uses for the pane it is on: one mode is
-   in force at a time, and both lists say so the same way. */
+/* Marked, not filled. A solid container this size is the shape of an app icon
+   — it read as a logo sitting above the list rather than as one of three
+   buttons — so the active mode is a tinted glyph with a bar on the window's
+   edge, which is where the eye already is. */
 .rail-item.on {
-  background: var(--primary-container);
-  color: var(--on-primary-container);
+  color: var(--primary);
+}
+
+/* Flush with the window's edge: the item is centred in a 48px rail, so -7px is
+   the rail's own left edge. A pixel further and the bar is off screen. */
+.rail-item.on::before {
+  content: '';
+  position: absolute;
+  left: -7px;
+  width: 2px;
+  height: 18px;
+  border-radius: 0 1px 1px 0;
+  background: var(--primary);
 }
 
 .rail-item .ui-icon {
@@ -865,9 +883,15 @@ small {
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  padding: 8px 8px 8px 16px;
+  padding: 8px 8px 8px 8px;
   color: var(--on-surface-variant);
   font-size: 12px;
+}
+
+/* One at each end. Pushed rather than spread, so the quit stays on the right
+   in the settings mode, where pairing is on the pane and this end is empty. */
+.sidebar-foot .link:first-child {
+  margin-right: auto;
 }
 
 /* Smaller than the one in the session header: this bar is 12px text, and a
@@ -1331,13 +1355,11 @@ small {
   height: 14px;
 }
 
-/* The square is small on purpose: it sits beside the terminal glyph, and at the
-   same 14px it outweighs it. Its red comes from button.danger — the row action
-   that cannot be undone by clicking it again should not look like the two
-   beside it that can. */
-.row-act.danger .ui-icon {
-  width: 11px;
-  height: 11px;
+/* A typed glyph, not a drawn one — and a small one in its em box, so it needs
+   the size the icons get from their viewBox. */
+.row-act.row-more {
+  font-size: 15px;
+  line-height: 1;
 }
 
 /* The word, not the glyph: resuming is the only move a terminated session has

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1331,6 +1331,15 @@ small {
   height: 14px;
 }
 
+/* The square is small on purpose: it sits beside the terminal glyph, and at the
+   same 14px it outweighs it. Its red comes from button.danger — the row action
+   that cannot be undone by clicking it again should not look like the two
+   beside it that can. */
+.row-act.danger .ui-icon {
+  width: 11px;
+  height: 11px;
+}
+
 /* The word, not the glyph: resuming is the only move a terminated session has
    left, so it says so without being hovered — and being always-on, it never
    moves anything either. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -523,6 +523,53 @@ small {
   color: var(--on-surface-variant);
 }
 
+/* ─── Rail ──────────────────────────────────────────────────────────────── */
+
+/* What the window is showing, chosen from the left edge. Inside .body rather
+   than beside the titlebar, so it starts below the traffic lights and takes
+   nothing away from the drag region. */
+.rail {
+  flex: none;
+  width: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 0;
+  background: var(--surface-low);
+  /* The same hairline the sidebar draws, for the same reason: no width. */
+  box-shadow: 1px 0 0 var(--outline-variant);
+}
+
+.rail-item {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-lg);
+  background: none;
+  color: var(--on-surface-variant);
+  cursor: pointer;
+}
+
+.rail-item:hover {
+  background: color-mix(in srgb, var(--on-surface) 8%, transparent);
+  color: var(--on-surface);
+}
+
+/* The same lit pill the settings nav uses for the pane it is on: one mode is
+   in force at a time, and both lists say so the same way. */
+.rail-item.on {
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+}
+
+.rail-item .ui-icon {
+  width: 19px;
+  height: 19px;
+}
+
 /* ─── Sidebar ───────────────────────────────────────────────────────────── */
 
 .sidebar {
@@ -4330,30 +4377,35 @@ hr {
 
 /* ─── Settings ──────────────────────────────────────────────────────────── */
 
-/* Wider than the other modals, since it carries a nav as well as a panel.
-   Selected on the content rather than through a prop, so the Modal shell stays
-   the same shell every other dialog uses. */
-.modal:has(.settings-shell) {
-  width: 760px;
-}
-
-.settings-shell {
+/* The panes, in the main area. Settings is a mode now: the sidebar holds the
+   nav, this holds whichever pane it points at, and the reading width keeps a
+   row of controls from stretching across a wide window. */
+.settings-page {
+  flex: 1;
+  min-height: 0;
   display: flex;
-  gap: 20px;
-  align-items: flex-start;
-  /* Tall enough that switching panes does not resize the dialog under the
-     pointer, short enough to sit on a laptop screen. */
-  height: min(60vh, 520px);
+  padding: 12px 16px 16px;
+  overflow: hidden;
 }
 
+/* In the sidebar rather than beside the panel it drives — the mode owns both
+   columns, so the list of panes is what its sidebar is for. It takes the whole
+   column, not the height of five buttons: the list below it is hidden in this
+   mode, and without something to fill the space the footer rides up under the
+   last section. */
 .settings-nav {
-  flex: none;
-  width: 150px;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
+  align-content: flex-start;
   gap: 2px;
-  position: sticky;
-  top: 0;
+  padding: 8px 8px 0;
+  overflow-y: auto;
+}
+
+.settings-nav button {
+  flex: none;
 }
 
 .settings-nav button {
@@ -4375,17 +4427,19 @@ hr {
   font-weight: 600;
 }
 
-/* The pane scrolls, not the dialog: the nav stays put while a long theme list
-   moves past it. */
+/* The pane scrolls, not the window: the nav is in the sidebar and stays put
+   while a long theme list moves past it. Held to a reading width, so a setting
+   and its control do not end up at opposite edges of a wide window. */
 .settings-panel {
   flex: 1;
   min-width: 0;
+  max-width: 720px;
   height: 100%;
   overflow-y: auto;
-  padding-right: 4px;
+  padding-right: 8px;
 }
 
-/* The first heading in a pane has the dialog title right above it. */
+/* The first heading in a pane has nothing above it to space away from. */
 .settings-panel > .settings-group:first-child,
 .settings-panel > h3:first-child {
   margin-top: 0;
@@ -4786,6 +4840,22 @@ hr {
   color: var(--on-surface-variant);
 }
 
+/* The same two, for a pane that is not in a dialog. Named apart rather than
+   shared, so a change made for the modals cannot quietly move a settings
+   pane. */
+.pane-note {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--on-surface-variant);
+}
+
+.pane-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
 /* Said once, above everything, and gone for good when dismissed: a release
    nobody has to act on today should not cost the layout permanently. */
 .update-banner {
@@ -5173,33 +5243,6 @@ hr {
    arrange control and the + button below it are about. */
 /* The same height as the detail pane's tab strip, which sits beside it at the
    same y. See --strip-h. */
-.sidebar-modes {
-  display: flex;
-  align-items: center;
-  flex: none;
-  height: var(--strip-h);
-  gap: 2px;
-  padding: 0 10px;
-}
-
-.sidebar-modes button {
-  flex: 1;
-  height: 22px;
-  background: var(--surface-low);
-  border: 1px solid transparent;
-  border-radius: var(--r-sm);
-  color: var(--on-surface-variant);
-  font-size: 11px;
-  padding: 0;
-  cursor: pointer;
-}
-
-.sidebar-modes button.active {
-  background: var(--surface-high);
-  border-color: var(--outline-variant);
-  color: var(--on-surface);
-}
-
 .sched-rows {
   display: flex;
   flex-direction: column;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -530,7 +530,9 @@ small {
    nothing away from the drag region. */
 .rail {
   flex: none;
-  width: 48px;
+  /* Three buttons wide is all it will ever be, so it is sized to the target
+     rather than to the 48px a toolbar would take. */
+  width: 44px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -571,21 +573,21 @@ small {
   color: var(--primary);
 }
 
-/* Flush with the window's edge: the item is centred in a 48px rail, so -7px is
+/* Flush with the window's edge: the item is centred in a 44px rail, so -5px is
    the rail's own left edge. A pixel further and the bar is off screen. */
 .rail-item.on::before {
   content: '';
   position: absolute;
-  left: -7px;
+  left: -5px;
   width: 2px;
-  height: 18px;
+  height: 17px;
   border-radius: 0 1px 1px 0;
   background: var(--primary);
 }
 
 .rail-item .ui-icon {
-  width: 19px;
-  height: 19px;
+  width: 18px;
+  height: 18px;
 }
 
 /* ─── Sidebar ───────────────────────────────────────────────────────────── */

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -637,6 +637,15 @@ export interface AppearancePrefs {
 export type Density = 'comfortable' | 'compact'
 
 /**
+ * Which settings pane is open.
+ *
+ * Here rather than beside the panes themselves: the section list is drawn by
+ * the sidebar and the pane by the main panel, so the state that joins them
+ * lives in the store, which cannot import a component.
+ */
+export type SettingsSection = 'appearance' | 'sessions' | 'terminal' | 'notifications' | 'hosts'
+
+/**
  * What the backdrop picker shows, for whichever theme is active.
  *
  * Not part of AppearancePrefs: the backdrop is saved into the theme file, since


### PR DESCRIPTION
## Summary
- A 44px icon rail on the left edge owns the mode switch: Sessions and Schedules at the top, Settings at the bottom. A mode takes both columns, so each keeps its own search, toolbar and panel — nothing about how the two lists behave changes. The `sessions` / `schedules` text toggle inside the sidebar is gone.
- Settings is a mode rather than a modal: the sidebar holds the section list, the main panel holds the section. Hosts joins it as a fifth section, which retires the last dialog either screen had. ⌘, the app menu, the tray and a `helios://pair` link all land on the mode (the link opens Hosts).
- Session rows: the ⋯ at the end of the row opens the same menu as a right-click, the transcript tab says `transcript` rather than `agent`, and the footer carries Add host and Quit Helios at either end instead of an ⋯ menu.

## Test plan
- [x] `npm run typecheck`, `npm run build`
- [x] `npm test` — 262 pass
- [x] Drove a dev instance over CDP: each rail icon swaps sidebar and panel and lights only itself; sessions and schedules keep their own searches; all five settings sections render; Hosts lists the paired daemon with the pairing controls; selecting a session returns to sessions mode with its terminal still attached; no renderer errors.
- [x] Measured the rail: glyph centres sit on the rail centre (the base `button` padding was pushing them 7px right).