### PR TITLE
fix(desktop): give the rail the sidebar's glass, and mend the e2e suite

### DIFF
--- a/desktop/e2e/schedules-sync.spec.ts
+++ b/desktop/e2e/schedules-sync.spec.ts
@@ -43,7 +43,13 @@ function transcript(window: Page): ReturnType<Page['locator']> {
 }
 
 async function switchSidebar(window: Page, mode: 'sessions' | 'schedules'): Promise<void> {
-  await window.locator('.sidebar-modes button', { hasText: mode }).click()
+  // The rail on the window's edge, not the words that used to sit above the
+  // list: a mode owns both columns now, so the switch is outside them.
+  await window.locator(`.rail-item[aria-label="${railLabel(mode)}"]`).click()
+}
+
+function railLabel(mode: 'sessions' | 'schedules'): string {
+  return mode === 'sessions' ? 'Sessions' : 'Schedules'
 }
 
 test.beforeEach(async ({ window }) => {
@@ -58,7 +64,7 @@ test.beforeEach(async ({ window }) => {
 // On screen that reads as the old transcript coming back.
 test('coming back to a session does not print its transcript twice', async ({ window }) => {
   await open(window, ALPHA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(transcript(window)).toHaveCount(1)
 
   await open(window, BETA_TITLE)
@@ -71,7 +77,7 @@ test('coming back to a session does not print its transcript twice', async ({ wi
 
 test('what was written while you were away is there when you come back', async ({ window }) => {
   await open(window, ALPHA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(transcript(window)).toHaveCount(1)
 
   await open(window, BETA_TITLE)
@@ -84,11 +90,11 @@ test('what was written while you were away is there when you come back', async (
 
 test('the transcript belongs to the session the sidebar has selected', async ({ window }) => {
   await open(window, ALPHA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(transcript(window)).toContainText(TRANSCRIPT_TEXT[ALPHA] as string)
 
   await open(window, BETA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(transcript(window)).toContainText(TRANSCRIPT_TEXT[BETA] as string)
   // The one that matters: no trace of the session that was on screen before.
   await expect(transcript(window)).not.toContainText(TRANSCRIPT_TEXT[ALPHA] as string)
@@ -104,7 +110,7 @@ test('the transcript belongs to the session the sidebar has selected', async ({ 
 // terminal, and "No transcript yet." beside it.
 test('a transcript that was empty when first asked for is asked again', async ({ window }) => {
   await open(window, GAMMA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(window.locator('.panel-keep:not([hidden])')).toContainText('No transcript yet')
 
   appendTranscript(GAMMA, 'the agent finally wrote something')
@@ -117,7 +123,7 @@ test('a transcript that was empty when first asked for is asked again', async ({
 
 test('coming back to a session picks up what the daemon has, without a spinner', async ({ window }) => {
   await open(window, GAMMA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(window.locator('.panel-keep:not([hidden])')).toContainText('No transcript yet')
 
   appendTranscript(GAMMA, 'written while nobody asked')
@@ -194,7 +200,7 @@ test('opening a run from its schedule unfolds the section and selects it', async
 
   // Back in the sessions list, with the section open and the run selected —
   // not left behind a header the user would have to know to open.
-  await expect(window.locator('.sidebar-modes button.active', { hasText: 'sessions' })).toBeVisible()
+  await expect(window.locator('.rail-item.on[aria-label="Sessions"]')).toBeVisible()
   const row = window.locator('.session-row', { hasText: 'Nightly run' })
   await expect(row).toBeVisible()
   await expect(row).toHaveClass(/selected/)
@@ -240,7 +246,7 @@ test('the new schedule form asks for the model, the mode and where it runs', asy
 
 test('the schedules list does not carry the session panels away with it', async ({ window }) => {
   await open(window, ALPHA_TITLE)
-  await showPanel(window, 'agent')
+  await showPanel(window, 'transcript')
   await expect(transcript(window)).toContainText(TRANSCRIPT_TEXT[ALPHA] as string)
 
   await switchSidebar(window, 'schedules')

--- a/desktop/e2e/status-line.spec.ts
+++ b/desktop/e2e/status-line.spec.ts
@@ -49,14 +49,14 @@ test('the bar is no taller than the text it holds', async ({ window }) => {
   // The strip above it is the other half of the saving, and the buttons a
   // terminal tab brings with it used to be what set its height.
   //
-  // Level with the sidebar's switch, not merely short: the two sit side by side
-  // at the same y and read as one row, and they drifted apart the first time
-  // this strip was trimmed.
+  // Level with the sidebar's own head, not merely short: the two sit side by
+  // side at the same y and read as one row, and they drifted apart the first
+  // time this strip was trimmed. It was the sessions/schedules switch that sat
+  // there until the rail took the switching over.
   const tabs = await window.locator('.panel-tabs').boundingBox()
-  const modes = await window.locator('.sidebar-modes').boundingBox()
+  const head = await window.locator('.sidebar-head').boundingBox()
   expect(tabs?.height).toBe(34)
-  expect(modes?.height).toBe(tabs?.height)
-  expect(modes?.y).toBe(tabs?.y)
+  expect(head?.y).toBe(tabs?.y)
 })
 
 test('the bar grows with the text size rather than clipping it', async ({ window }) => {
@@ -72,7 +72,7 @@ test('the bar grows with the text size rather than clipping it', async ({ window
     .locator('input')
   await field.fill('16')
   await field.blur()
-  await window.keyboard.press('Escape')
+  await closeSettings(window)
 
   // Height is derived from the size, not set beside it: 16 + 7.
   await expect
@@ -85,7 +85,9 @@ test('the permission mode is on the row menu, ticked on the one in force', async
 
   const menu = window.locator('.line-menu').first()
   await expect(menu).toBeVisible()
-  await expect(menu.getByText('Rename…')).toBeVisible()
+  // No ellipsis on it any more: the item opens a field on the row itself
+  // rather than the prompt it used to, which Electron never supported.
+  await expect(menu.getByText('Rename', { exact: true })).toBeVisible()
 
   // Hovering the parent row opens the child beside it. The parent is one row
   // tall whether or not the provider list has arrived, which is why the modes
@@ -97,10 +99,17 @@ test('the permission mode is on the row menu, ticked on the one in force', async
   await expect(submenu.getByText('bypassPermissions')).toBeVisible()
 })
 
+/** Settings is a mode now, opened from the rail and left the same way. */
 async function openSettings(window: Page): Promise<void> {
-  await window.locator('.sidebar-foot .menu summary').click()
-  await window.getByRole('button', { name: 'Settings' }).click()
+  await window.locator('.rail-item[aria-label="Settings"]').click()
+  await window.locator('.settings-nav button', { hasText: 'Appearance' }).click()
   await expect(window.locator('.seg-list')).toBeVisible()
+}
+
+/** Back to the sessions, where the session under test is still selected. */
+async function closeSettings(window: Page): Promise<void> {
+  await window.locator('.rail-item[aria-label="Sessions"]').click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
 }
 
 function segment(window: Page, label: string) {
@@ -153,7 +162,7 @@ test('a segment dragged up the list moves left along the bar', async ({ window }
 
   await expect(window.locator('.seg-row:not(.off) .seg-label').first()).toHaveText('Status')
 
-  await window.keyboard.press('Escape')
+  await closeSettings(window)
   await expect(bar(window).locator('> *').first()).toContainText('Idle')
 })
 
@@ -172,7 +181,7 @@ test('turning every segment off hides the bar', async ({ window }) => {
   }
 
   await expect(window.locator('.seg-list .seg-row:not(.off)')).toHaveCount(0)
-  await window.keyboard.press('Escape')
+  await closeSettings(window)
 
   // The preference went to the main process and came back over theme:changed —
   // no reload anywhere, which is the part worth asserting.

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -671,8 +671,19 @@ small {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--on-surface) 9%, transparent);
 }
 
-[data-glass='on'] .sidebar {
+/* The rail is the sidebar's own edge, so it takes the sidebar's glass. Left
+   opaque it was a black strip down the side of a translucent window — the one
+   surface that had not been told the backdrop exists. */
+[data-glass='on'] .sidebar,
+[data-glass='on'] .rail {
   background: var(--glass-sidebar);
+}
+
+/* A seam rather than the ring the two panels get: the rail and the sidebar are
+   adjacent sheets of the same tint, and without one they read as a single
+   panel with icons floating in it. */
+[data-glass='on'] .rail {
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--on-surface) 9%, transparent);
 }
 
 [data-glass='on'] .detail {


### PR DESCRIPTION
## Summary
- Under a glass theme the rail stayed opaque — a black strip down the side of an otherwise translucent window. It takes `--glass-sidebar` now, with a hairline seam so the rail and the sidebar do not read as one panel.
- The e2e suite still described the pre-rail window and was failing on main: it looked for the `sessions`/`schedules` words above the list, opened Settings through the footer's ⋯, closed it with Escape, and asked for a tab called `agent` and a menu item called `Rename…`. It drives the rail now.

## Test plan
- [x] `npm run typecheck`, `npm run build`
- [x] `npx playwright test` — 29 passed locally (6 were failing before this)
- [x] Checked the rail under the `liquid-glass` theme in a dev instance: `.rail` and `.sidebar` both compute to `rgba(22, 24, 28, 0.34)`, with the seam between them