### PR TITLE
feat(desktop): show what a release changed, once, instead of its number

### DIFF
--- a/desktop/e2e/fixtures.ts
+++ b/desktop/e2e/fixtures.ts
@@ -47,7 +47,14 @@ export const test = base.extend<Fixtures>({
 
     // '.' is the desktop package: the suite is run by `npm run e2e`, which puts
     // the working directory there and has already built dist/.
-    const app = await electron.launch({ args: ['.', `--user-data-dir=${userData}`] })
+    // An empty release list, so the update dialog never opens. Pointed at
+    // GitHub it raises itself over the window on launch — the app under test is
+    // several releases behind whatever is published — and every click in the
+    // suite lands on its backdrop.
+    const app = await electron.launch({
+      args: ['.', `--user-data-dir=${userData}`],
+      env: { ...process.env, HELIOS_RELEASES_URL: 'data:application/json,[]' },
+    })
     await use(app)
     await app.close()
     await fs.rm(userData, { recursive: true, force: true })

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -10,7 +10,11 @@ const REPO = 'kamrul1157024/helios'
    owed the notes for each release they skipped, and the newest is the first
    entry of this anyway. Thirty is a cap rather than a page to walk — twenty
    releases of history is not something anyone reads in a dialog. */
-const RELEASES = `https://api.github.com/repos/${REPO}/releases?per_page=30`
+/* Overridable because the e2e suite launches a real app against a stub daemon:
+   left pointing at GitHub, every run raises the release dialog over the window
+   and every click in the suite lands on its backdrop. */
+const RELEASES =
+  process.env.HELIOS_RELEASES_URL ?? `https://api.github.com/repos/${REPO}/releases?per_page=30`
 
 /** The fields of a GitHub release this reads. The rest of the payload is large
  *  and none of it is wanted. */

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -2,11 +2,26 @@ import { app } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { UpdateInfo } from '../shared/models.ts'
-import { isNewer } from '../shared/version.ts'
+import type { ReleaseNote, UpdateInfo } from '../shared/models.ts'
+import { releasesSince } from '../shared/version.ts'
 
 const REPO = 'kamrul1157024/helios'
-const LATEST = `https://api.github.com/repos/${REPO}/releases/latest`
+/* The list rather than /releases/latest: a reader several versions behind is
+   owed the notes for each release they skipped, and the newest is the first
+   entry of this anyway. Thirty is a cap rather than a page to walk — twenty
+   releases of history is not something anyone reads in a dialog. */
+const RELEASES = `https://api.github.com/repos/${REPO}/releases?per_page=30`
+
+/** The fields of a GitHub release this reads. The rest of the payload is large
+ *  and none of it is wanted. */
+interface GitHubRelease {
+  tag_name?: string
+  html_url?: string
+  body?: string
+  published_at?: string
+  draft?: boolean
+  prerelease?: boolean
+}
 
 /**
  * Whether a newer release exists, and whether the user has already been told.
@@ -40,20 +55,25 @@ export class UpdateChecker {
     if (this.checked) return this.suppressDismissed(this.checked)
 
     try {
-      const response = await fetch(LATEST, {
+      const response = await fetch(RELEASES, {
         headers: { Accept: 'application/vnd.github+json' },
         signal: AbortSignal.timeout(10_000),
       })
       if (!response.ok) return null
 
-      const body = (await response.json()) as { tag_name?: string; html_url?: string }
-      const latest = (body.tag_name ?? '').replace(/^v/, '')
-      if (!latest || !isNewer(latest, app.getVersion())) return null
+      const payload = (await response.json()) as GitHubRelease[]
+      // A draft is not published and a prerelease is not for everyone; neither
+      // is news the reader can act on.
+      const published = payload
+        .filter((release) => !release.draft && !release.prerelease)
+        .map(toNote)
+        .filter((note) => note.version !== '')
 
-      this.checked = {
-        version: latest,
-        url: body.html_url ?? `https://github.com/${REPO}/releases/latest`,
-      }
+      const notes = releasesSince(published, app.getVersion())
+      const newest = notes[0]
+      if (!newest) return null
+
+      this.checked = { version: newest.version, url: newest.url, notes }
       return this.suppressDismissed(this.checked)
     } catch {
       // An update notice is not worth a word to the user when the network is
@@ -68,12 +88,21 @@ export class UpdateChecker {
     try {
       fs.writeFileSync(this.file, JSON.stringify({ version }), 'utf8')
     } catch {
-      // Losing the record costs one more banner, which is not worth failing a
+      // Losing the record costs one more notice, which is not worth failing a
       // dismissal the user has already seen work.
     }
   }
 
   private suppressDismissed(info: UpdateInfo): UpdateInfo | null {
     return info.version === this.dismissed ? null : info
+  }
+}
+
+function toNote(release: GitHubRelease): ReleaseNote {
+  return {
+    version: (release.tag_name ?? '').replace(/^v/, ''),
+    body: release.body?.trim() ?? '',
+    url: release.html_url ?? `https://github.com/${REPO}/releases`,
+    publishedAt: release.published_at ?? '',
   }
 }

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 
 import { bridge } from './bridge.ts'
-import type { UpdateInfo } from '../shared/models.ts'
 import { store, terminalId, useStore } from './store.ts'
 import { Detail } from './components/detail.tsx'
 import { NewSessionDialog } from './components/newsession.tsx'
 import { Rail } from './components/rail.tsx'
 import { Sidebar } from './components/sidebar.tsx'
+import { ReleaseNotes } from './components/updates.tsx'
 
 export function App(): JSX.Element {
   const loading = useStore((s) => s.loading)
@@ -72,7 +72,7 @@ export function App(): JSX.Element {
   return (
     <div className="app">
       <div className="titlebar" />
-      <UpdateBanner />
+      <ReleaseNotes />
       <div className="body">
         <Rail />
         <Sidebar
@@ -89,50 +89,6 @@ export function App(): JSX.Element {
       {dialog === 'new' && <NewSessionDialog seed={seed} onClose={() => setDialog(null)} />}
 
       {toast && <div className={`toast ${toast.kind}`}>{toast.text}</div>}
-    </div>
-  )
-}
-
-/**
- * Says once that a newer release exists.
- *
- * None of the packages update themselves, so the most this can do is notice
- * and point at the download. Dismissing is remembered per version: the next
- * release earns one more mention, this one does not.
- */
-function UpdateBanner(): JSX.Element | null {
-  const [update, setUpdate] = useState<UpdateInfo | null>(null)
-
-  useEffect(() => {
-    void bridge.updates.check().then(setUpdate)
-  }, [])
-
-  if (!update) return null
-
-  return (
-    <div className="update-banner">
-      <span>helios {update.version} is out.</span>
-      {/* Worth saying outright: terminals are their own detached processes, so
-          neither the daemon restarting nor this app closing interrupts a
-          session that is running. */}
-      <span className="update-note">
-        Updating the daemon, desktop or app keeps running sessions alive.
-      </span>
-      {/* An anchor rather than a bridge call: the window open handler already
-          sends https elsewhere, and nothing in this app navigates itself. */}
-      <a className="ext-link" href={update.url} target="_blank" rel="noreferrer noopener">
-        Release notes
-      </a>
-      <span className="grow" />
-      <button
-        className="link dismiss"
-        onClick={() => {
-          void bridge.updates.dismiss(update.version)
-          setUpdate(null)
-        }}
-      >
-        Dismiss
-      </button>
     </div>
   )
 }

--- a/desktop/src/renderer/components/updates.tsx
+++ b/desktop/src/renderer/components/updates.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+
+import { bridge } from '../bridge.ts'
+import { renderMarkdown } from '../markdown.ts'
+import type { ReleaseNote, UpdateInfo } from '../../shared/models.ts'
+import { Modal } from './newsession.tsx'
+
+/**
+ * What arrived, once, when a newer release exists.
+ *
+ * This was a line across the top of the window saying a version number and
+ * nothing else — the reader had to leave for GitHub to find out whether it was
+ * worth the download, and somebody three releases behind got the same one
+ * line. The notes are what the announcement is for, so they are in it.
+ *
+ * Shown once per release: the main process remembers the version dismissed, so
+ * the check answers null on every launch after this one. Closing by any route
+ * counts as reading it — a dialog that returns tomorrow because it was closed
+ * with Escape is a dialog nobody trusts.
+ */
+export function ReleaseNotes(): JSX.Element | null {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null)
+
+  useEffect(() => {
+    void bridge.updates.check().then(setUpdate)
+  }, [])
+
+  if (!update) return null
+
+  const close = (): void => {
+    void bridge.updates.dismiss(update.version)
+    setUpdate(null)
+  }
+
+  return (
+    <Modal title={`Helios ${update.version} is out`} onClose={close}>
+      {/* Worth saying outright: terminals are their own detached processes, so
+          neither the daemon restarting nor this app closing interrupts a
+          session that is running. */}
+      <p className="pane-note">
+        Updating the daemon, desktop or app keeps running sessions alive. None of the packages
+        update themselves — the release page has the download.
+      </p>
+
+      <div className="release-notes">
+        {update.notes.map((note) => (
+          <Release key={note.version} note={note} />
+        ))}
+      </div>
+
+      <div className="pane-actions">
+        {/* An anchor rather than a bridge call: the window open handler already
+            sends https elsewhere, and nothing in this app navigates itself. */}
+        <a className="ext-link" href={update.url} target="_blank" rel="noreferrer noopener">
+          Download {update.version}
+        </a>
+        <button onClick={close}>Got it</button>
+      </div>
+    </Modal>
+  )
+}
+
+function Release({ note }: { note: ReleaseNote }): JSX.Element {
+  return (
+    <section className="release">
+      <h3>
+        {note.version}
+        {note.publishedAt && <span className="release-date">{released(note.publishedAt)}</span>}
+      </h3>
+      {note.body ? (
+        <div className="md" dangerouslySetInnerHTML={{ __html: renderMarkdown(note.body) }} />
+      ) : (
+        <p className="pane-note">No notes for this one.</p>
+      )}
+    </section>
+  )
+}
+
+/** The date alone. A release is news for a day; the hour it was cut is not. */
+function released(iso: string): string {
+  const at = new Date(iso)
+  if (Number.isNaN(at.getTime())) return ''
+  return at.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4900,31 +4900,63 @@ hr {
   margin-top: 20px;
 }
 
-/* Said once, above everything, and gone for good when dismissed: a release
-   nobody has to act on today should not cost the layout permanently. */
-.update-banner {
+/* What arrived, said once. Scrolls on its own so the dialog keeps its height
+   whether the reader skipped one release or ten. */
+.release-notes {
+  max-height: min(52vh, 460px);
+  overflow-y: auto;
+  margin-top: 12px;
+  padding-right: 4px;
+}
+
+.release + .release {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--outline-variant);
+}
+
+.release h3 {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 14px;
-  background: var(--primary-container);
-  color: var(--on-primary-container);
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.release-date {
   font-size: 12px;
-}
-
-/* The note carries the detail and the headline carries the version, so the
-   two are told apart by weight rather than by fading one of them. */
-.update-note {
   font-weight: 400;
+  color: var(--on-surface-variant);
 }
 
-.update-banner .ext-link {
-  color: inherit;
-  text-decoration: underline;
+/* Release notes are a list of one-line changes, not prose: the transcript's
+   paragraph spacing leaves them floating apart. */
+.release .md {
+  font-size: 13px;
 }
 
-.update-banner .dismiss {
-  color: inherit;
+/* A heading inside a release body is a section of that release, so it cannot
+   be louder than the version it sits under — which is what the transcript's
+   sizes would make it. */
+.release .md h1,
+.release .md h2,
+.release .md h3 {
+  margin: 12px 0 4px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.release .md ul {
+  margin: 4px 0;
+  padding-left: 18px;
+}
+
+.release .md li + li {
+  margin-top: 2px;
 }
 
 /* ─── Agent note ────────────────────────────────────────────────────────── */

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -691,8 +691,20 @@ export interface HostStats {
   memory_total: number
 }
 
+/** One release, as its author wrote it up. */
+export interface ReleaseNote {
+  version: string
+  /** The release body, in GitHub markdown. Empty when the author wrote none. */
+  body: string
+  url: string
+  publishedAt: string
+}
+
 /** A release newer than what is running, and where to get it. */
 export interface UpdateInfo {
   version: string
   url: string
+  /** Every release between the one running and this one, newest first — what
+   *  arrives on updating, rather than only the name of the last of them. */
+  notes: ReleaseNote[]
 }

--- a/desktop/src/shared/version.ts
+++ b/desktop/src/shared/version.ts
@@ -15,3 +15,17 @@ export function isNewer(candidate: string, current: string): boolean {
   }
   return false
 }
+
+/**
+ * Every release the reader has not got yet, newest first.
+ *
+ * A reader three releases behind is owed all three sets of notes, not the
+ * newest one — the versions in between are what they are about to install.
+ * Sorted here rather than trusted from the API, so a repo with a hand-made tag
+ * order still reads newest to oldest.
+ */
+export function releasesSince<T extends { version: string }>(releases: T[], current: string): T[] {
+  return releases
+    .filter((release) => isNewer(release.version, current))
+    .sort((a, b) => (isNewer(a.version, b.version) ? -1 : isNewer(b.version, a.version) ? 1 : 0))
+}

--- a/desktop/test/updates.test.ts
+++ b/desktop/test/updates.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { isNewer } from '../src/shared/version.ts'
+import { isNewer, releasesSince } from '../src/shared/version.ts'
 
 // The whole feature rests on this comparison: get it wrong in one direction
 // and nobody hears about a release, wrong in the other and everyone is told
@@ -37,4 +37,38 @@ test('an unparseable version is treated as older', () => {
 test('a shorter version is padded rather than misread', () => {
   assert.equal(isNewer('2.14', '2.14.0'), false)
   assert.equal(isNewer('2.14.1', '2.14'), true)
+})
+
+// The popup shows the notes for every release the reader skipped, so the list
+// it is given is the whole feature: one short and they miss a version's news.
+const RELEASES = [
+  { version: '2.13.0' },
+  { version: '2.15.0' },
+  { version: '2.14.0' },
+  { version: '2.12.0' },
+]
+
+test('every release after the running one is kept, newest first', () => {
+  assert.deepEqual(releasesSince(RELEASES, '2.13.0'), [{ version: '2.15.0' }, { version: '2.14.0' }])
+})
+
+test('nothing is kept when the newest release is already running', () => {
+  assert.deepEqual(releasesSince(RELEASES, '2.15.0'), [])
+})
+
+test('a reader far behind gets all of them', () => {
+  assert.equal(releasesSince(RELEASES, '1.0.0').length, 4)
+  assert.equal(releasesSince(RELEASES, '1.0.0')[0]?.version, '2.15.0')
+})
+
+// The API answers in its own order, and a hand-moved tag can put an older
+// release first. Ordering here rather than trusting that is what keeps the
+// dialog reading newest to oldest.
+test('the order comes from the versions, not the input', () => {
+  const shuffled = [{ version: '2.9.0' }, { version: '2.10.0' }, { version: '2.9.5' }]
+  assert.deepEqual(releasesSince(shuffled, '2.8.0').map((r) => r.version), [
+    '2.10.0',
+    '2.9.5',
+    '2.9.0',
+  ])
 })


### PR DESCRIPTION
## Summary
- The update banner was one line — a version and a link — so finding out what arrived meant leaving for GitHub, and someone three releases behind saw the same line as someone one behind. It is a dialog now, raised once per release, listing every version between the installed one and the newest with its notes rendered from the release body.
- `UpdateChecker` asks for the release list instead of `/releases/latest` and keeps what is newer than the running version. Drafts and prereleases are dropped. Which releases to show is `releasesSince()` in `shared/version.ts` — pure, so it is unit tested.
- Dismissal is unchanged: the version goes to `update-dismissed.json` and the check answers null from then on. Closing by any route dismisses.

## Test plan
- [x] `npm run typecheck`, `npm run build`
- [x] `npm test` — 266 pass (4 new cases for `releasesSince`)
- [x] `npx playwright test` — 29 pass
- [x] Drove a dev instance with the releases endpoint pointed at a local stub: the dialog titles itself with the newest version, lists three releases newest-first, renders their markdown, says so where a release has no body, skips the prerelease and the version older than the one running, writes `update-dismissed.json` on **Got it**, and does not return on relaunch.