### PR TITLE
feat: report the daemon's version, and say which daemons are behind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,14 @@ DMG_PATH = helios.dmg
 # per-platform build jobs, which never share a runner.
 DIST = dist
 
+# Stamped, not hardcoded: the daemon reports this over /api/health so a client
+# can say which machines are behind, and a number edited by hand goes stale the
+# first release nobody remembers to edit it. An untagged checkout keeps the
+# "dev" default, which is not something the clients nag about.
+LDFLAGS = -X github.com/kamrul1157024/helios/internal/version.Current=$(VERSION)
+
 build:
-	go build -o helios ./cmd/helios/
+	go build -ldflags "$(LDFLAGS)" -o helios ./cmd/helios/
 ifeq ($(UNAME_S),Darwin)
 	codesign -s - -f ./helios
 endif

--- a/cmd/helios/main.go
+++ b/cmd/helios/main.go
@@ -25,9 +25,8 @@ import (
 	"github.com/kamrul1157024/helios/internal/terminal"
 	"github.com/kamrul1157024/helios/internal/tui"
 	"github.com/kamrul1157024/helios/internal/tunnel"
+	"github.com/kamrul1157024/helios/internal/version"
 )
-
-const version = "0.2.0"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -69,7 +68,7 @@ func main() {
 	case "schedule", "schedules":
 		handleSchedule(os.Args[2:])
 	case "version":
-		fmt.Printf("helios v%s\n", version)
+		fmt.Printf("helios v%s\n", version.Current)
 	case "help", "--help", "-h":
 		printUsage()
 	default:

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -334,7 +334,9 @@ function answer(
 ): unknown {
   switch (path) {
     case '/api/health':
-      return { ok: true }
+      // The version the Hosts pane reads. Older than nothing in particular:
+      // the suite pins the release list to empty, so nothing is behind.
+      return { ok: true, version: '9.9.9' }
     case '/api/sessions': {
       // Three lists off one route, as the daemon serves them: the ordinary one,
       // everything a schedule started, and one schedule's runs.

--- a/desktop/e2e/hosts-version.spec.ts
+++ b/desktop/e2e/hosts-version.spec.ts
@@ -1,0 +1,20 @@
+// What each daemon is running, in Settings ▸ Hosts.
+//
+// Updating the desktop is half the job: the daemon runs the sessions and is
+// updated on its own machine. The pane can only say which ones are behind if
+// the version survives the trip from /api/health through the main process and
+// onto the host's status, which is what this covers.
+import { expect, test } from './fixtures.ts'
+
+test('the hosts pane shows the version each daemon reports', async ({ window }) => {
+  await window.locator('.rail-item[aria-label="Settings"]').click()
+  await window.locator('.settings-nav button', { hasText: 'Hosts' }).click()
+
+  const row = window.locator('.host-row').first()
+  await expect(row).toBeVisible()
+  await expect(row).toContainText('v9.9.9')
+
+  // The suite pins the release list to empty, so nothing can be behind — and
+  // a pane that marked a host anyway would be marking it on no evidence.
+  await expect(window.locator('.host-behind')).toHaveCount(0)
+})

--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -587,13 +587,19 @@ export class ApiClient {
     return res.devices ?? []
   }
 
-  /** Unauthenticated — used to check a host is reachable before pairing. */
-  async health(): Promise<boolean> {
+  /**
+   * Unauthenticated — a host is reachable before pairing, and says which
+   * version it runs. A daemon from before that field reported none, so an
+   * absent version means "old enough not to say" rather than unknown.
+   */
+  async health(): Promise<{ ok: boolean; version?: string }> {
     try {
       const res = await fetch(`${this.baseUrl}/api/health`, { signal: AbortSignal.timeout(5_000) })
-      return res.ok
+      if (!res.ok) return { ok: false }
+      const body = (await res.json()) as { version?: string }
+      return { ok: true, version: body.version }
     } catch {
-      return false
+      return { ok: false }
     }
   }
 }

--- a/desktop/src/main/hosts.ts
+++ b/desktop/src/main/hosts.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { ApiClient } from './api.ts'
 import { EventStream } from './sse.ts'
 import { generateDeviceKey, publicKeyBase64, type DeviceKey } from './keys.ts'
-import type { HostConnectionState, HostRecord } from '../shared/models.ts'
+import type { HostConnectionState, HostRecord, HostStatus } from '../shared/models.ts'
 
 /** The daemon's no-auth admin API, which only ever listens on loopback. */
 const INTERNAL_URL = 'http://127.0.0.1:7654'
@@ -26,6 +26,9 @@ export interface HostHandle {
   key: DeviceKey
   state: HostConnectionState
   error?: string
+  /** What the daemon last said it was running. Absent until it answers, and on
+   *  a daemon old enough not to report one at all. */
+  version?: string
 }
 
 /**
@@ -59,8 +62,13 @@ export class HostRegistry extends EventEmitter {
     return [...this.hosts.values()].map((h) => h.record)
   }
 
-  statuses(): { id: string; state: HostConnectionState; error?: string }[] {
-    return [...this.hosts.values()].map((h) => ({ id: h.record.id, state: h.state, error: h.error }))
+  statuses(): HostStatus[] {
+    return [...this.hosts.values()].map((h) => ({
+      id: h.record.id,
+      state: h.state,
+      error: h.error,
+      version: h.version,
+    }))
   }
 
   get(id: string): HostHandle | undefined {
@@ -82,6 +90,10 @@ export class HostRegistry extends EventEmitter {
     events.on('event', (event) => this.emit('event', { hostId: record.id, event }))
     events.on('state', (state: string) => {
       this.setState(record.id, state === 'open' ? 'online' : 'offline')
+      // Asked on the way up rather than on a timer: the version changes when
+      // the daemon restarts, and a restart is what closed and reopened this
+      // stream. Unauthenticated, so it answers even for a host mid-pairing.
+      if (state === 'open') void this.readVersion(record.id)
     })
     // An SSE failure is normal when a laptop sleeps; it reconnects itself and
     // the state change is the only thing worth surfacing.
@@ -97,7 +109,19 @@ export class HostRegistry extends EventEmitter {
     if (!host || (host.state === state && host.error === error)) return
     host.state = state
     host.error = error
-    this.emit('status', { id, state, error })
+    this.emit('status', { id, state, error, version: host.version })
+  }
+
+  /** The daemon's own version, for the Hosts pane to compare against the
+   *  newest release. A failure leaves the last answer alone: it means the
+   *  health call did not land, not that the daemon forgot its version. */
+  private async readVersion(id: string): Promise<void> {
+    const host = this.hosts.get(id)
+    if (!host) return
+    const { ok, version } = await host.api.health()
+    if (!ok || host.version === version) return
+    host.version = version
+    this.emit('status', { id, state: host.state, error: host.error, version })
   }
 
   // ─── Pairing ───────────────────────────────────────────────────────────

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -186,6 +186,7 @@ export function registerIpc(deps: IpcDeps): void {
   // ─── Updates ───────────────────────────────────────────────────────────
 
   handle('updates:check', async () => updates.check())
+  handle('updates:latest', async () => updates.latest())
   handle('updates:dismiss', async (_e, version: string) => updates.dismiss(version))
 
   // ─── Appearance ────────────────────────────────────────────────────────

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -86,6 +86,19 @@ export class UpdateChecker {
     }
   }
 
+  /**
+   * The newest release, dismissed or not.
+   *
+   * The Hosts pane compares each daemon against it, and that comparison does
+   * not stop being true because the dialog was waved away — `check` answers
+   * null then, which is right for the dialog and wrong for the pane.
+   */
+  async latest(): Promise<UpdateInfo | null> {
+    if (this.checked) return this.checked
+    await this.check()
+    return this.checked
+  }
+
   /** Stops this version being mentioned again, on this machine. */
   dismiss(version: string): void {
     this.dismissed = version

--- a/desktop/src/preload/preload.ts
+++ b/desktop/src/preload/preload.ts
@@ -144,6 +144,7 @@ const helios = {
   },
   updates: {
     check: () => call<unknown>('updates:check'),
+    latest: () => call<unknown>('updates:latest'),
     dismiss: (version: string) => call<void>('updates:dismiss', version),
   },
   app: {

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -152,6 +152,9 @@ interface RawBridge {
   updates: {
     /** The release worth mentioning, or null when there is nothing new. */
     check(): Promise<UpdateInfo | null>
+    /** The newest release, dismissed or not: what each daemon is compared
+     *  against, which waving the dialog away does not change. */
+    latest(): Promise<UpdateInfo | null>
     /** Stops this version being mentioned again on this machine. */
     dismiss(version: string): Promise<void>
   }

--- a/desktop/src/renderer/components/hosts.tsx
+++ b/desktop/src/renderer/components/hosts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { bridge } from '../bridge.ts'
 import { store, useStore } from '../store.ts'
+import { isBehind } from '../../shared/version.ts'
 
 /**
  * Adding a daemon.
@@ -20,6 +21,14 @@ export function HostsPane(): JSX.Element {
   const pairingLink = useStore((s) => s.pairingLink)
   const [link, setLink] = useState('')
   const [busy, setBusy] = useState(false)
+  // Dismissed or not: waving the dialog away does not make a daemon current.
+  const [latest, setLatest] = useState('')
+
+  useEffect(() => {
+    void bridge.updates.latest().then((info) => setLatest(info?.version ?? ''))
+  }, [])
+
+  const version = (id: string): string | undefined => hostStatus[id]?.version
 
   // A helios:// link handed to the app by the OS lands straight in the field.
   useEffect(() => {
@@ -74,7 +83,15 @@ export function HostsPane(): JSX.Element {
               <span className="muted">
                 {host.url}
                 {host.local ? ' · local' : ''}
+                {version(host.id) && ` · v${version(host.id)}`}
               </span>
+              {/* Updating this app is half the job: the daemon is what runs the
+                  sessions, and it is updated on its own machine. */}
+              {isBehind(version(host.id), latest) && (
+                <span className="host-behind" title={`Newest release is ${latest}`}>
+                  Update this daemon to {latest}
+                </span>
+              )}
               {hostStatus[host.id]?.error && (
                 <span className="error-text">{hostStatus[host.id]?.error}</span>
               )}

--- a/desktop/src/renderer/components/updates.tsx
+++ b/desktop/src/renderer/components/updates.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { bridge } from '../bridge.ts'
 import { renderMarkdown } from '../markdown.ts'
+import { store } from '../store.ts'
 import type { ReleaseNote, UpdateInfo } from '../../shared/models.ts'
 import { Modal } from './newsession.tsx'
 
@@ -34,12 +35,12 @@ export function ReleaseNotes(): JSX.Element | null {
 
   return (
     <Modal title={`Helios ${update.version} is out`} onClose={close}>
-      {/* Worth saying outright: terminals are their own detached processes, so
-          neither the daemon restarting nor this app closing interrupts a
-          session that is running. */}
+      {/* The half of the job this dialog used to leave out: every paired
+          machine runs its own daemon, and a session's behaviour comes from
+          that daemon rather than from the window looking at it. */}
       <p className="pane-note">
-        Updating the daemon, desktop or app keeps running sessions alive. None of the packages
-        update themselves — the release page has the download.
+        Update the daemon on each paired machine too — that is what runs the sessions. Nothing here
+        updates itself, and updating any part of it keeps running sessions alive.
       </p>
 
       <div className="release-notes">
@@ -54,7 +55,19 @@ export function ReleaseNotes(): JSX.Element | null {
         <a className="ext-link" href={update.url} target="_blank" rel="noreferrer noopener">
           Download {update.version}
         </a>
-        <button onClick={close}>Got it</button>
+        <button className="ghost" onClick={close}>
+          Got it
+        </button>
+        {/* The pane that names which daemons are behind, which is the question
+            this dialog raises and cannot answer itself. */}
+        <button
+          onClick={() => {
+            close()
+            store.openSettings('hosts')
+          }}
+        >
+          Review hosts
+        </button>
       </div>
     </Modal>
   )

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -4900,6 +4900,18 @@ hr {
   margin-top: 20px;
 }
 
+/* A daemon older than the newest release. Amber rather than red: it still
+   works, it is merely behind. */
+.host-behind {
+  align-self: flex-start;
+  margin-top: 2px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--s-waiting) 20%, transparent);
+  color: var(--s-waiting);
+  font-size: 11px;
+}
+
 /* What arrived, said once. Scrolls on its own so the dialog keeps its height
    whether the reader skipped one release or ten. */
 .release-notes {

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -582,6 +582,10 @@ export interface HostStatus {
   id: string
   state: HostConnectionState
   error?: string
+  /** What the daemon reports over /api/health. Absent while connecting, and on
+   *  a daemon old enough not to report one — which is itself a sign it is
+   *  behind, but not one worth guessing a number from. */
+  version?: string
 }
 
 /** Terminal tab lifecycle, as reported to the renderer. */

--- a/desktop/src/shared/version.ts
+++ b/desktop/src/shared/version.ts
@@ -17,6 +17,19 @@ export function isNewer(candidate: string, current: string): boolean {
 }
 
 /**
+ * Whether a daemon is older than the newest release.
+ *
+ * A daemon that reports nothing is one from before the version was in
+ * /api/health, and "dev" is a checkout somebody built themselves. Neither is
+ * something to nag about: the first cannot be compared and the second is
+ * deliberate.
+ */
+export function isBehind(daemon: string | undefined, latest: string): boolean {
+  if (!daemon || daemon === 'dev' || !latest) return false
+  return isNewer(latest, daemon)
+}
+
+/**
  * Every release the reader has not got yet, newest first.
  *
  * A reader three releases behind is owed all three sets of notes, not the

--- a/desktop/test/updates.test.ts
+++ b/desktop/test/updates.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { isNewer, releasesSince } from '../src/shared/version.ts'
+import { isBehind, isNewer, releasesSince } from '../src/shared/version.ts'
 
 // The whole feature rests on this comparison: get it wrong in one direction
 // and nobody hears about a release, wrong in the other and everyone is told
@@ -71,4 +71,29 @@ test('the order comes from the versions, not the input', () => {
     '2.9.5',
     '2.9.0',
   ])
+})
+
+// A daemon is updated on its own machine, so the Hosts pane says which ones
+// are behind. Two answers have to be "no" whatever the newest release is:
+// a daemon too old to report a version at all, and a checkout built by hand.
+test('a daemon older than the newest release is behind', () => {
+  assert.equal(isBehind('3.8.0', '3.9.0'), true)
+})
+
+test('a daemon on the newest release is not', () => {
+  assert.equal(isBehind('3.9.0', '3.9.0'), false)
+  assert.equal(isBehind('3.10.0', '3.9.0'), false)
+})
+
+test('a version nobody reported is not behind', () => {
+  assert.equal(isBehind(undefined, '3.9.0'), false)
+  assert.equal(isBehind('', '3.9.0'), false)
+})
+
+test('a build somebody made themselves is not nagged', () => {
+  assert.equal(isBehind('dev', '3.9.0'), false)
+})
+
+test('nothing is behind when the newest release is unknown', () => {
+  assert.equal(isBehind('3.8.0', ''), false)
 })

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kamrul1157024/helios/internal/reporter"
 	"github.com/kamrul1157024/helios/internal/store"
 	"github.com/kamrul1157024/helios/internal/transcript"
+	"github.com/kamrul1157024/helios/internal/version"
 )
 
 // ==================== Public Server API ====================
@@ -177,7 +178,13 @@ func (s *PublicServer) handleBatchNotifications(w http.ResponseWriter, r *http.R
 
 func (s *PublicServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, map[string]interface{}{
-		"status":      "ok",
+		"status": "ok",
+		// Here rather than behind a route of its own: this one is
+		// unauthenticated and already the first thing a client calls, so a
+		// version it can read before pairing costs no extra request. A client
+		// updating itself is only half the job — the daemon is what runs the
+		// sessions, and until now nothing said which machines were behind.
+		"version":     version.Current,
 		"sse_clients": s.shared.SSE.ClientCount(),
 		"pending":     s.shared.Mgr.PendingCount(),
 		"terminal":    s.shared.Backend.Status(),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,11 @@
+// Package version carries the release this binary belongs to.
+//
+// Its own package rather than a constant in main: the daemon reports the number
+// over /api/health so a client can say which machines are behind, and importing
+// package main is not a thing a server can do.
+package version
+
+// Current is stamped at build time with -ldflags "-X …/internal/version.Current=x.y.z".
+// A var, not a const, for that reason — and "dev" by default, because a
+// checkout built by hand belongs to no release and should not claim one.
+var Current = "dev"


### PR DESCRIPTION
## Summary
- The release dialog told the reader to update, but every paired machine runs its own daemon and nothing in the app said what version any of them were on. `/api/health` now reports it — unauthenticated and already the first call a client makes, so no extra request and it works before pairing.
- The number is real for the first time: `const version = "0.2.0"` in `cmd/helios/main.go` had not moved while the releases reached 3.9.0. It lives in `internal/version` now and the Makefile stamps it from the tag with `-ldflags`; an untagged checkout keeps `dev`.
- The desktop reads the version when a host's event stream opens (a daemon restart is what closed and reopened it) and carries it on the host's status. Settings ▸ Hosts shows it under each host and marks the ones older than the newest release. A daemon too old to report a version, and a `dev` build, are left alone.
- The release dialog's primary action is **Review hosts**, which opens Settings ▸ Hosts; the download link stays.

## Test plan
- [x] `gofmt`, `go vet ./...`, `go test ./internal/server/... ./cmd/...`
- [x] `make build && ./helios version` → `helios v3.8.0` (the tag), and `/api/health` carries it
- [x] `npm run typecheck`, `npm test` — 271 pass, including 5 new cases for `isBehind`
- [x] `npx playwright test` — 30 pass, including a new spec asserting the Hosts pane shows the version the stub daemon reports and marks nothing behind when there is no newer release

Not exercised end to end: the "behind" mark itself, which needs a daemon reporting an older version than a published release. `isBehind` is unit tested in both directions and the DOM path is covered by the new spec.