### PR TITLE
feat(mobile): show what a release changed, once, in place of the banner

### DIFF
--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:permission_handler/permission_handler.dart';
 // Both packages export Provider, ChangeNotifierProvider and Consumer.
 import 'package:flutter_riverpod/flutter_riverpod.dart' as rp;
@@ -33,7 +34,6 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
   final Map<String, StreamSubscription<SSEEvent>> _eventSubs = {};
   int _currentIndex = 0;
   bool _notifPermissionDenied = false;
-  UpdateInfo? _update;
 
   @override
   void initState() {
@@ -415,65 +415,23 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
     );
   }
 
-  /// Mentions a new release once. The APK does not update itself, and the
-  /// settings screen only says so to somebody already looking; dismissing is
+  /// Says what a new release changed, once.
+  ///
+  /// This was a banner carrying a version number and nothing else, so finding
+  /// out what had arrived meant leaving for GitHub — and somebody three
+  /// releases behind read the same line as somebody one behind. Dismissing is
   /// remembered per version, so the next release gets one mention and this one
-  /// gets none.
+  /// gets none. The settings screen still offers the download to anybody who
+  /// waved it away.
   Future<void> _checkForUpdate() async {
     final info = await UpdateService.instance.checkForUpdate();
     if (info == null || !mounted) return;
     if (await UpdateService.instance.isDismissed(info.latestVersion)) return;
-    if (mounted) setState(() => _update = info);
-  }
-
-  Widget _buildUpdateBanner(UpdateInfo update) {
-    final theme = Theme.of(context);
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      color: theme.colorScheme.primaryContainer,
-      child: Row(
-        children: [
-          Icon(Icons.system_update, size: 18, color: theme.colorScheme.onPrimaryContainer),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'helios ${update.latestVersion} is out.',
-                  style: TextStyle(fontSize: 12, color: theme.colorScheme.onPrimaryContainer),
-                ),
-                // Worth saying outright: the terminals are their own detached
-                // processes, so nothing here or on the daemon interrupts a
-                // session that is running.
-                Text(
-                  'Updating the daemon, desktop or app keeps running sessions alive.',
-                  style: TextStyle(
-                    fontSize: 11,
-                    color: theme.colorScheme.onPrimaryContainer.withValues(alpha: 0.75),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              UpdateService.instance.dismiss(update.latestVersion);
-              setState(() => _update = null);
-            },
-            child: const Text('Later', style: TextStyle(fontSize: 12)),
-          ),
-          TextButton(
-            onPressed: () => UpdateService.instance.install(update),
-            child: Text(
-              update.canDirectInstall ? 'Update' : 'Get it',
-              style: const TextStyle(fontSize: 12),
-            ),
-          ),
-        ],
-      ),
-    );
+    if (!mounted) return;
+    // Closing by any route counts as read: a dialog that comes back tomorrow
+    // because it was dismissed with the back button is one nobody trusts.
+    await showDialog<void>(context: context, builder: (ctx) => _ReleaseNotesDialog(update: info));
+    await UpdateService.instance.dismiss(info.latestVersion);
   }
 
   Widget _buildNotifPermissionBanner() {
@@ -555,7 +513,6 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
           ),
           body: Column(
             children: [
-              if (_update != null) _buildUpdateBanner(_update!),
               if (_notifPermissionDenied) _buildNotifPermissionBanner(),
               Expanded(
                 child: IndexedStack(
@@ -628,6 +585,101 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
           ),
         );
       },
+    );
+  }
+}
+
+/// What arrived, once: one section per release, newest first, with the body
+/// GitHub was given rendered rather than linked to.
+class _ReleaseNotesDialog extends StatelessWidget {
+  const _ReleaseNotesDialog({required this.update});
+
+  final UpdateInfo update;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text('Helios ${update.latestVersion} is out'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // The half an app update leaves out: each paired machine runs its
+              // own daemon, and that is what runs the sessions.
+              Text(
+                'Update the daemon on each paired machine too — that is what runs the '
+                'sessions. Updating any part of it keeps running sessions alive.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 12),
+              for (final note in update.notes) _ReleaseSection(note: note),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Got it')),
+        FilledButton(
+          onPressed: () {
+            Navigator.pop(context);
+            UpdateService.instance.install(update);
+          },
+          child: Text(update.canDirectInstall ? 'Install' : 'Download'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ReleaseSection extends StatelessWidget {
+  const _ReleaseSection({required this.note});
+
+  final ReleaseNote note;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final date = note.publishedAt;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(note.version, style: theme.textTheme.titleSmall),
+              if (date != null) ...[
+                const SizedBox(width: 8),
+                Text(
+                  '${date.day}/${date.month}/${date.year}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 4),
+          if (note.body.isEmpty)
+            Text(
+              'No notes for this one.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            MarkdownBody(data: note.body, shrinkWrap: true),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -10,18 +10,37 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 const _repo = 'kamrul1157024/helios';
-const _apiUrl = 'https://api.github.com/repos/$_repo/releases/latest';
+// The list rather than /releases/latest: somebody three releases behind is owed
+// the notes for each one they skipped, and the newest is its first entry
+// anyway. Thirty is a cap — twenty releases of history is not read on a phone.
+const _apiUrl = 'https://api.github.com/repos/$_repo/releases?per_page=30';
 const _releasesUrl = 'https://github.com/$_repo/releases/latest';
+
+/// One release, as its author wrote it up.
+class ReleaseNote {
+  final String version;
+
+  /// The release body, in GitHub markdown. Empty when the author wrote none.
+  final String body;
+  final DateTime? publishedAt;
+
+  const ReleaseNote({required this.version, required this.body, this.publishedAt});
+}
 
 class UpdateInfo {
   final String latestVersion;
   final String? apkDownloadUrl; // null on non-Android
   final String releasesPageUrl;
 
+  /// Every release between the one installed and the newest, newest first —
+  /// what arrives on updating, rather than only the name of the last of them.
+  final List<ReleaseNote> notes;
+
   const UpdateInfo({
     required this.latestVersion,
     required this.apkDownloadUrl,
     required this.releasesPageUrl,
+    this.notes = const [],
   });
 
   bool get canDirectInstall => apkDownloadUrl != null;
@@ -63,17 +82,23 @@ class UpdateService {
         return null;
       }
 
-      final data = jsonDecode(res.body) as Map<String, dynamic>;
-      final tag = (data['tag_name'] as String?)?.replaceFirst('v', '') ?? '';
-      if (tag.isEmpty) return null;
+      final payload = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
+      // A draft is not published and a prerelease is not for everyone; neither
+      // is news the reader can act on.
+      final published = payload
+          .where((r) => r['draft'] != true && r['prerelease'] != true)
+          .where((r) => ((r['tag_name'] as String?) ?? '').isNotEmpty)
+          .toList();
 
       final current = await currentVersion;
-      debugPrint('[UpdateService] latest=$tag running=$current');
-      if (!isNewer(tag, current)) return null;
+      final newer = releasesSince(published, current);
+      debugPrint('[UpdateService] ${newer.length} newer than $current');
+      if (newer.isEmpty) return null;
 
+      final latest = newer.first;
       String? apkUrl;
       if (Platform.isAndroid) {
-        final assets = (data['assets'] as List?) ?? [];
+        final assets = (latest['assets'] as List?) ?? [];
         final apkAsset = assets
             .cast<Map<String, dynamic>>()
             .where((a) => (a['name'] as String).endsWith('.apk'))
@@ -82,9 +107,10 @@ class UpdateService {
       }
 
       return UpdateInfo(
-        latestVersion: tag,
+        latestVersion: _tagOf(latest),
         apkDownloadUrl: apkUrl,
         releasesPageUrl: _releasesUrl,
+        notes: newer.map(_toNote).toList(),
       );
     } catch (e) {
       // Worth a line: a check that never succeeds is indistinguishable from
@@ -149,6 +175,29 @@ class UpdateService {
     }
     return false;
   }
+
+  /// Every release newer than what is running, newest first.
+  ///
+  /// Sorted here rather than trusted from the API: a hand-moved tag can put an
+  /// older release first, and the dialog reads top to bottom.
+  @visibleForTesting
+  List<Map<String, dynamic>> releasesSince(
+    List<Map<String, dynamic>> releases,
+    String current,
+  ) {
+    final newer = releases.where((r) => isNewer(_tagOf(r), current)).toList();
+    newer.sort((a, b) => isNewer(_tagOf(a), _tagOf(b)) ? -1 : (isNewer(_tagOf(b), _tagOf(a)) ? 1 : 0));
+    return newer;
+  }
+
+  String _tagOf(Map<String, dynamic> release) =>
+      ((release['tag_name'] as String?) ?? '').replaceFirst('v', '');
+
+  ReleaseNote _toNote(Map<String, dynamic> release) => ReleaseNote(
+    version: _tagOf(release),
+    body: ((release['body'] as String?) ?? '').trim(),
+    publishedAt: DateTime.tryParse((release['published_at'] as String?) ?? ''),
+  );
 
   /// Leading digits of each dotted component; anything else counts as zero.
   List<int> _parts(String version) => version

--- a/mobile/test/update_version_test.dart
+++ b/mobile/test/update_version_test.dart
@@ -27,4 +27,42 @@ void main() {
       expect(service.isNewer('2.15.0', '2.15.0-dev'), isFalse);
     });
   });
+
+  // The dialog shows the notes for every release the reader skipped, so the list
+  // it is handed is the whole feature: one short and a version's news is lost.
+  group('releasesSince', () {
+    final service = UpdateService.instance;
+    List<Map<String, dynamic>> releases() => [
+      {'tag_name': 'v2.13.0'},
+      {'tag_name': 'v2.15.0'},
+      {'tag_name': 'v2.14.0'},
+    ];
+
+    test('keeps what is newer, newest first', () {
+      final kept = service.releasesSince(releases(), '2.13.0');
+      expect(kept.map((r) => r['tag_name']), ['v2.15.0', 'v2.14.0']);
+    });
+
+    test('keeps nothing when the newest is already running', () {
+      expect(service.releasesSince(releases(), '2.15.0'), isEmpty);
+    });
+
+    test('orders by version rather than by what the API returned', () {
+      final shuffled = [
+        {'tag_name': 'v2.9.0'},
+        {'tag_name': 'v2.10.0'},
+        {'tag_name': 'v2.9.5'},
+      ];
+      expect(service.releasesSince(shuffled, '2.8.0').map((r) => r['tag_name']), [
+        'v2.10.0',
+        'v2.9.5',
+        'v2.9.0',
+      ]);
+    });
+
+    // A dev build reports "0.2.0-dev", and every published release is newer.
+    test('a dev build is offered everything', () {
+      expect(service.releasesSince(releases(), '0.2.0-dev').length, 3);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- The phone's update notice was one line and a number: the reader had to leave for GitHub to learn whether the download was worth it, and somebody three releases behind got the same one line. It now fetches the release list, keeps every release above the installed version, and shows the notes once in a dialog — the same shape the desktop got in #162.
- The dialog carries the daemon reminder too: every paired machine runs its own daemon, and that is what runs the sessions.
- Closing by any route counts as read, so a dismissed dialog does not return tomorrow because it was closed with the back button. The Settings tile stays, for whoever dismissed it and still wants the download.

## Test plan

- [x] `flutter analyze --no-fatal-infos` — no issues
- [x] `flutter test` — 179 pass, including the new `releasesSince` cases
- [x] Debug APK on a cabled device: the dialog lists the releases newest first with rendered markdown, **Got it** dismisses it, and a relaunch is quiet