### PR TITLE
feat: name the release the download page is handing out

### DIFF
--- a/docs/specs/56-one-version-number.md
+++ b/docs/specs/56-one-version-number.md
@@ -98,6 +98,22 @@ in a PR, and typing it again at release time is where the tag, the APK's build
 name and the app's own number become three different numbers. Every job reads
 `VERSION`, and `make release-publish` refuses to tag anything else.
 
+### The page hands the file over itself
+
+The links cannot be `github.com` URLs. Android verifies that domain for the
+GitHub app, so a tap on the phone the page exists for opens the app on the
+release page instead of downloading anything.
+
+So the page links `/download/<asset>` on the daemon. That handler asks GitHub
+for the asset without following the answer, reads the `Location` — a signed
+`release-assets.githubusercontent.com` URL, which no app claims — and redirects
+the browser there. The bytes still come from GitHub and none pass through the
+tunnel; only the address the browser is asked to visit changes. Five asset names
+are known, and nothing else becomes a URL the daemon will fetch. If GitHub
+cannot be reached, the browser gets the `github.com` URL and follows the
+redirect itself: one tap that may open the app, which beats a download that
+never starts.
+
 ## What we are not doing
 
 - **Deriving the bump from conventional commits.** A `feat` should take the

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1483,19 +1483,25 @@ func (s *InternalServer) handleDeviceRevoke(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-// Download URLs for the packaged clients, served on the landing page. Each one
-// points at the latest release rather than a tag, which is why the release
-// workflow strips the version out of the asset names.
+// Download URLs for the packaged clients, served on the landing page. These are
+// the unpinned form, resolved through GitHub's "latest" redirect — which is why
+// the release workflow strips the version out of the asset names. When the tag
+// is known the page links it directly instead, so the version it prints and the
+// file it hands over cannot come from different releases.
 var (
-	APKDownloadURL           = releaseAsset("helios.apk")
-	MacArm64DownloadURL      = releaseAsset("helios-desktop-macos-arm64.dmg")
-	MacIntelDownloadURL      = releaseAsset("helios-desktop-macos-x64.dmg")
-	LinuxAppImageDownloadURL = releaseAsset("helios-desktop-linux-x86_64.AppImage")
-	LinuxDebDownloadURL      = releaseAsset("helios-desktop-linux-amd64.deb")
+	APKDownloadURL           = releaseAsset("", "helios.apk")
+	MacArm64DownloadURL      = releaseAsset("", "helios-desktop-macos-arm64.dmg")
+	MacIntelDownloadURL      = releaseAsset("", "helios-desktop-macos-x64.dmg")
+	LinuxAppImageDownloadURL = releaseAsset("", "helios-desktop-linux-x86_64.AppImage")
+	LinuxDebDownloadURL      = releaseAsset("", "helios-desktop-linux-amd64.deb")
 )
 
-func releaseAsset(name string) string {
-	return "https://github.com/kamrul1157024/helios/releases/latest/download/" + name
+func releaseAsset(tag, name string) string {
+	const base = "https://github.com/kamrul1157024/helios/releases"
+	if tag == "" {
+		return base + "/latest/download/" + name
+	}
+	return base + "/download/" + tag + "/" + name
 }
 
 // ==================== Commands ====================

--- a/internal/server/download.go
+++ b/internal/server/download.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+// The assets a release carries. The path is user input, and only these five
+// names become a URL this daemon will fetch.
+var releaseAssets = map[string]bool{
+	"helios.apk":                           true,
+	"helios-desktop-macos-arm64.dmg":       true,
+	"helios-desktop-macos-x64.dmg":         true,
+	"helios-desktop-linux-x86_64.AppImage": true,
+	"helios-desktop-linux-amd64.deb":       true,
+}
+
+// handleDownload sends the browser to the release asset on GitHub's CDN.
+//
+// Not a github.com link on the page, because Android hands those to the GitHub
+// app: the app opens on the release page, and a tap that was meant to start a
+// download does not. GitHub answers a request for an asset with a redirect to
+// release-assets.githubusercontent.com, which no app claims — so that redirect is
+// followed here and its destination given to the browser. The bytes still come
+// from GitHub; only the address the browser is asked to visit does not say so.
+func (s *PublicServer) handleDownload(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("asset")
+	if !releaseAssets[name] {
+		http.NotFound(w, r)
+		return
+	}
+
+	target := releaseAsset(latestRelease.get(r.Context()), name)
+	if cdn := resolveDownloadURL(r, target); cdn != "" {
+		target = cdn
+	}
+	// Found, not moved permanently: the CDN's URL is signed and expires, and the
+	// release it belongs to changes.
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// Swapped in tests, which have no business reaching GitHub.
+var resolveDownloadURL = resolveDownload
+
+// resolveDownload asks GitHub where an asset really lives, without following
+// the answer. An empty string means the caller should use the github.com URL as
+// it is: one more redirect for the browser, and the download still works.
+func resolveDownload(r *http.Request, url string) string {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return ""
+	}
+
+	// The default client follows redirects, which would download the asset here
+	// rather than say where it is.
+	client := &http.Client{
+		Timeout: latestRelease.client.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	if resp.StatusCode < 300 || resp.StatusCode > 399 || !strings.HasPrefix(location, "https://") {
+		return ""
+	}
+	return location
+}

--- a/internal/server/download_test.go
+++ b/internal/server/download_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDownloadRedirectsToTheCDN(t *testing.T) {
+	latestRelease.mu.Lock()
+	latestRelease.tag = "v3.9.0"
+	latestRelease.expires = time.Now().Add(time.Hour)
+	latestRelease.mu.Unlock()
+
+	const cdn = "https://release-assets.githubusercontent.com/signed/helios.apk"
+	asked := ""
+	resolveDownloadURL = func(r *http.Request, url string) string {
+		asked = url
+		return cdn
+	}
+	defer func() { resolveDownloadURL = resolveDownload }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/download/helios.apk", nil)
+	req.SetPathValue("asset", "helios.apk")
+	(&PublicServer{}).handleDownload(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if got := rec.Header().Get("Location"); got != cdn {
+		t.Errorf("Location = %q, want %q", got, cdn)
+	}
+	if want := "https://github.com/kamrul1157024/helios/releases/download/v3.9.0/helios.apk"; asked != want {
+		t.Errorf("resolved %q, want the pinned asset %q", asked, want)
+	}
+}
+
+// GitHub unreachable: the browser gets the github.com URL and follows the
+// redirect itself. One tap on Android may open the app, which is still better
+// than a download that does not start.
+func TestDownloadFallsBackToGitHub(t *testing.T) {
+	resolveDownloadURL = func(*http.Request, string) string { return "" }
+	defer func() { resolveDownloadURL = resolveDownload }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/download/helios.apk", nil)
+	req.SetPathValue("asset", "helios.apk")
+	(&PublicServer{}).handleDownload(rec, req)
+
+	if got := rec.Header().Get("Location"); got == "" || got[:19] != "https://github.com/" {
+		t.Errorf("Location = %q, want a github.com URL", got)
+	}
+}
+
+// The asset name comes off the URL, and only the five a release carries turn
+// into a request this daemon makes.
+func TestDownloadRefusesAnAssetItDoesNotKnow(t *testing.T) {
+	resolveDownloadURL = func(*http.Request, string) string {
+		t.Error("fetched a URL for an unknown asset")
+		return ""
+	}
+	defer func() { resolveDownloadURL = resolveDownload }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/download/../../etc/passwd", nil)
+	req.SetPathValue("asset", "../../etc/passwd")
+	(&PublicServer{}).handleDownload(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestResolveDownloadReadsTheRedirectWithoutFollowingIt(t *testing.T) {
+	const cdn = "https://release-assets.githubusercontent.com/signed"
+	served := false
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/asset" {
+			w.Header().Set("Location", cdn)
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		served = true
+	}))
+	defer origin.Close()
+
+	got := resolveDownload(httptest.NewRequest(http.MethodGet, "/", nil), origin.URL+"/asset")
+	if got != cdn {
+		t.Errorf("resolved %q, want %q", got, cdn)
+	}
+	if served {
+		t.Error("the redirect was followed — the asset would download here")
+	}
+}
+
+// A 200 is GitHub not redirecting, and an http:// Location is not something to
+// send a browser to. Both mean: use the URL we already had.
+func TestResolveDownloadRefusesAnythingButAnHTTPSRedirect(t *testing.T) {
+	for _, answer := range []struct {
+		name     string
+		status   int
+		location string
+	}{
+		{"no redirect", http.StatusOK, ""},
+		{"plain http", http.StatusFound, "http://example.com/asset"},
+	} {
+		t.Run(answer.name, func(t *testing.T) {
+			origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if answer.location != "" {
+					w.Header().Set("Location", answer.location)
+				}
+				w.WriteHeader(answer.status)
+			}))
+			defer origin.Close()
+
+			if got := resolveDownload(httptest.NewRequest(http.MethodGet, "/", nil), origin.URL); got != "" {
+				t.Errorf("resolved %q, want empty", got)
+			}
+		})
+	}
+}

--- a/internal/server/landing.go
+++ b/internal/server/landing.go
@@ -9,19 +9,31 @@ import (
 //go:embed landing.html
 var landingHTML string
 
-var landingURLs = strings.NewReplacer(
-	"{{APK_URL}}", APKDownloadURL,
-	"{{MAC_ARM64_URL}}", MacArm64DownloadURL,
-	"{{MAC_INTEL_URL}}", MacIntelDownloadURL,
-	"{{LINUX_APPIMAGE_URL}}", LinuxAppImageDownloadURL,
-	"{{LINUX_DEB_URL}}", LinuxDebDownloadURL,
-)
-
-// handleLanding serves the download landing page with injected URLs.
+// handleLanding serves the download landing page, pinned to the newest release
+// when GitHub can be asked which that is.
 func handleLanding(w http.ResponseWriter, r *http.Request) {
-	page := landingURLs.Replace(landingHTML)
+	page := renderLanding(latestRelease.get(r.Context()))
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(page))
+}
+
+// renderLanding fills the page in for one release. An empty tag is the offline
+// answer: the links fall back to GitHub's "latest" redirect and the page names
+// no version, rather than naming one it cannot stand behind.
+func renderLanding(tag string) string {
+	version := ""
+	if tag != "" {
+		version = " · " + strings.TrimPrefix(tag, "v")
+	}
+
+	return strings.NewReplacer(
+		"{{APK_URL}}", releaseAsset(tag, "helios.apk"),
+		"{{MAC_ARM64_URL}}", releaseAsset(tag, "helios-desktop-macos-arm64.dmg"),
+		"{{MAC_INTEL_URL}}", releaseAsset(tag, "helios-desktop-macos-x64.dmg"),
+		"{{LINUX_APPIMAGE_URL}}", releaseAsset(tag, "helios-desktop-linux-x86_64.AppImage"),
+		"{{LINUX_DEB_URL}}", releaseAsset(tag, "helios-desktop-linux-amd64.deb"),
+		"{{VERSION}}", version,
+	).Replace(landingHTML)
 }

--- a/internal/server/landing.go
+++ b/internal/server/landing.go
@@ -28,12 +28,15 @@ func renderLanding(tag string) string {
 		version = " · " + strings.TrimPrefix(tag, "v")
 	}
 
+	// The daemon's own path rather than github.com: Android gives a github.com
+	// link to the GitHub app, which opens the release page instead of
+	// downloading. /download/<asset> resolves to the same file on GitHub's CDN.
 	return strings.NewReplacer(
-		"{{APK_URL}}", releaseAsset(tag, "helios.apk"),
-		"{{MAC_ARM64_URL}}", releaseAsset(tag, "helios-desktop-macos-arm64.dmg"),
-		"{{MAC_INTEL_URL}}", releaseAsset(tag, "helios-desktop-macos-x64.dmg"),
-		"{{LINUX_APPIMAGE_URL}}", releaseAsset(tag, "helios-desktop-linux-x86_64.AppImage"),
-		"{{LINUX_DEB_URL}}", releaseAsset(tag, "helios-desktop-linux-amd64.deb"),
+		"{{APK_URL}}", "/download/helios.apk",
+		"{{MAC_ARM64_URL}}", "/download/helios-desktop-macos-arm64.dmg",
+		"{{MAC_INTEL_URL}}", "/download/helios-desktop-macos-x64.dmg",
+		"{{LINUX_APPIMAGE_URL}}", "/download/helios-desktop-linux-x86_64.AppImage",
+		"{{LINUX_DEB_URL}}", "/download/helios-desktop-linux-amd64.deb",
 		"{{VERSION}}", version,
 	).Replace(landingHTML)
 }

--- a/internal/server/landing.html
+++ b/internal/server/landing.html
@@ -44,29 +44,30 @@
        newest, so the sentence has to read without it. -->
   <p class="subtitle">Orchestrate AI coding agents from your phone{{VERSION}}</p>
   <div class="downloads">
-    <!-- Opened in a new tab, and without a download attribute: the targets are
-         cross-origin, where browsers ignore that attribute anyway. -->
-    <a href="{{APK_URL}}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
+    <!-- Same-origin paths on this daemon, which redirect to the file on
+         GitHub's CDN. A github.com link here would be handed to the GitHub app
+         on Android, which opens the release page instead of downloading. -->
+    <a href="{{APK_URL}}" class="btn btn-primary">
       <span class="label">Download for Android</span>
       <span class="meta">APK</span>
     </a>
     <p class="group">Desktop app</p>
     <div class="pair">
-      <a href="{{MAC_ARM64_URL}}" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
+      <a href="{{MAC_ARM64_URL}}" class="btn btn-secondary">
         <span class="label">macOS</span>
         <span class="meta">Apple silicon · DMG</span>
       </a>
-      <a href="{{MAC_INTEL_URL}}" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
+      <a href="{{MAC_INTEL_URL}}" class="btn btn-secondary">
         <span class="label">macOS</span>
         <span class="meta">Intel · DMG</span>
       </a>
     </div>
     <div class="pair">
-      <a href="{{LINUX_APPIMAGE_URL}}" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
+      <a href="{{LINUX_APPIMAGE_URL}}" class="btn btn-secondary">
         <span class="label">Linux</span>
         <span class="meta">AppImage</span>
       </a>
-      <a href="{{LINUX_DEB_URL}}" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">
+      <a href="{{LINUX_DEB_URL}}" class="btn btn-secondary">
         <span class="label">Linux</span>
         <span class="meta">.deb</span>
       </a>

--- a/internal/server/landing.html
+++ b/internal/server/landing.html
@@ -40,7 +40,9 @@
 <body>
 <div class="container">
   <h1>Helios</h1>
-  <p class="subtitle">Orchestrate AI coding agents from your phone</p>
+  <!-- The version is empty when GitHub could not be asked which release is
+       newest, so the sentence has to read without it. -->
+  <p class="subtitle">Orchestrate AI coding agents from your phone{{VERSION}}</p>
   <div class="downloads">
     <!-- Opened in a new tab, and without a download attribute: the targets are
          cross-origin, where browsers ignore that attribute anyway. -->

--- a/internal/server/landing_test.go
+++ b/internal/server/landing_test.go
@@ -21,59 +21,44 @@ func TestLandingSubstitutesEveryPlaceholder(t *testing.T) {
 	}
 }
 
-// Offline, rate-limited, or asked before the daemon has ever reached GitHub:
-// the page is still a working download page.
-func TestLandingWithoutATagFallsBackToLatest(t *testing.T) {
-	body := renderLanding("")
+// Every link on the page is one this daemon serves, and every one of them is an
+// asset the download handler will fetch. A github.com link here is the bug:
+// Android gives those to the GitHub app.
+func TestLandingLinksItsOwnDownloadPaths(t *testing.T) {
+	body := renderLanding("v3.9.0")
 
-	for _, url := range []string{
-		APKDownloadURL,
-		MacArm64DownloadURL,
-		MacIntelDownloadURL,
-		LinuxAppImageDownloadURL,
-		LinuxDebDownloadURL,
-	} {
-		if !strings.Contains(body, url) {
-			t.Errorf("landing page is missing the download link %s", url)
-		}
+	if strings.Contains(body, "github.com/kamrul1157024/helios/releases") {
+		t.Error("landing page links github.com directly")
 	}
-	if strings.Contains(body, "releases/download/") {
-		t.Error("landing page pinned a tag it was never given")
+	for asset := range releaseAssets {
+		if !strings.Contains(body, "/download/"+asset) {
+			t.Errorf("landing page is missing the download link for %s", asset)
+		}
 	}
 }
 
-// The version the page prints and the file it hands over come from the same
-// release, which is the whole point of resolving the tag.
-func TestLandingPinsTheTagItWasGiven(t *testing.T) {
-	body := renderLanding("v3.9.0")
-
-	want := "https://github.com/kamrul1157024/helios/releases/download/v3.9.0/helios.apk"
-	if !strings.Contains(body, want) {
-		t.Errorf("landing page does not link %s", want)
-	}
-	if strings.Contains(body, "releases/latest/download/") {
-		t.Error("landing page still links the unpinned form")
-	}
-	if !strings.Contains(body, "3.9.0") {
+// The page says which release it is offering, so a reader comparing it with a
+// daemon's version has something to compare.
+func TestLandingNamesTheRelease(t *testing.T) {
+	if !strings.Contains(renderLanding("v3.9.0"), "3.9.0") {
 		t.Error("landing page does not name the version it is serving")
+	}
+	// Offline, rate-limited, or asked before the daemon ever reached GitHub: a
+	// page that names no version beats one naming a version it invented.
+	if strings.Contains(renderLanding(""), "from your phone ·") {
+		t.Error("landing page named a version it was never given")
 	}
 }
 
 func TestLandingServesOK(t *testing.T) {
-	// Answered from the cache, so the test does not reach the network.
-	latestRelease.mu.Lock()
-	latestRelease.tag = "v3.9.0"
-	latestRelease.expires = time.Now().Add(time.Hour)
-	latestRelease.mu.Unlock()
-
 	rec := httptest.NewRecorder()
 	handleLanding(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if !strings.Contains(rec.Body.String(), "releases/download/v3.9.0/") {
-		t.Error("the handler did not use the resolved tag")
+	if !strings.Contains(rec.Body.String(), "/download/helios.apk") {
+		t.Error("the page the handler served has no download link")
 	}
 }
 
@@ -107,5 +92,10 @@ func TestReleaseResolverAnswersNothingWhenGitHubRefuses(t *testing.T) {
 	resolver := &releaseResolver{url: api.URL, client: api.Client()}
 	if got := resolver.get(context.Background()); got != "" {
 		t.Errorf("tag = %q, want empty", got)
+	}
+	// Cached as a failure, and briefly: the next page load must not wait on
+	// GitHub all over again.
+	if resolver.expires.After(time.Now().Add(releaseTTL)) {
+		t.Error("a failure was cached for as long as an answer")
 	}
 }

--- a/internal/server/landing_test.go
+++ b/internal/server/landing_test.go
@@ -1,25 +1,31 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // A placeholder left in the page renders as a dead link, and adding a download
-// to the HTML without a matching entry in landingURLs is the easy way to do it.
+// to the HTML without a matching entry in renderLanding is the easy way to do
+// it.
 func TestLandingSubstitutesEveryPlaceholder(t *testing.T) {
-	rec := httptest.NewRecorder()
-	handleLanding(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	for _, tag := range []string{"", "v3.9.0"} {
+		body := renderLanding(tag)
+		if strings.Contains(body, "{{") {
+			t.Errorf("tag %q left an unreplaced placeholder:\n%s", tag, body)
+		}
+	}
+}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
-	}
-	body := rec.Body.String()
-	if strings.Contains(body, "{{") {
-		t.Errorf("landing page has an unreplaced placeholder:\n%s", body)
-	}
+// Offline, rate-limited, or asked before the daemon has ever reached GitHub:
+// the page is still a working download page.
+func TestLandingWithoutATagFallsBackToLatest(t *testing.T) {
+	body := renderLanding("")
+
 	for _, url := range []string{
 		APKDownloadURL,
 		MacArm64DownloadURL,
@@ -30,5 +36,76 @@ func TestLandingSubstitutesEveryPlaceholder(t *testing.T) {
 		if !strings.Contains(body, url) {
 			t.Errorf("landing page is missing the download link %s", url)
 		}
+	}
+	if strings.Contains(body, "releases/download/") {
+		t.Error("landing page pinned a tag it was never given")
+	}
+}
+
+// The version the page prints and the file it hands over come from the same
+// release, which is the whole point of resolving the tag.
+func TestLandingPinsTheTagItWasGiven(t *testing.T) {
+	body := renderLanding("v3.9.0")
+
+	want := "https://github.com/kamrul1157024/helios/releases/download/v3.9.0/helios.apk"
+	if !strings.Contains(body, want) {
+		t.Errorf("landing page does not link %s", want)
+	}
+	if strings.Contains(body, "releases/latest/download/") {
+		t.Error("landing page still links the unpinned form")
+	}
+	if !strings.Contains(body, "3.9.0") {
+		t.Error("landing page does not name the version it is serving")
+	}
+}
+
+func TestLandingServesOK(t *testing.T) {
+	// Answered from the cache, so the test does not reach the network.
+	latestRelease.mu.Lock()
+	latestRelease.tag = "v3.9.0"
+	latestRelease.expires = time.Now().Add(time.Hour)
+	latestRelease.mu.Unlock()
+
+	rec := httptest.NewRecorder()
+	handleLanding(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if !strings.Contains(rec.Body.String(), "releases/download/v3.9.0/") {
+		t.Error("the handler did not use the resolved tag")
+	}
+}
+
+func TestReleaseResolverReadsTheTagOnce(t *testing.T) {
+	calls := 0
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Write([]byte(`{"tag_name": "v4.1.0"}`))
+	}))
+	defer api.Close()
+
+	resolver := &releaseResolver{url: api.URL, client: api.Client()}
+	if got := resolver.get(context.Background()); got != "v4.1.0" {
+		t.Fatalf("tag = %q, want v4.1.0", got)
+	}
+	if got := resolver.get(context.Background()); got != "v4.1.0" {
+		t.Fatalf("cached tag = %q, want v4.1.0", got)
+	}
+	if calls != 1 {
+		t.Errorf("asked GitHub %d times, want 1", calls)
+	}
+}
+
+// A rate limit is the common one, and it must not take the page down with it.
+func TestReleaseResolverAnswersNothingWhenGitHubRefuses(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer api.Close()
+
+	resolver := &releaseResolver{url: api.URL, client: api.Client()}
+	if got := resolver.get(context.Background()); got != "" {
+		t.Errorf("tag = %q, want empty", got)
 	}
 }

--- a/internal/server/releases.go
+++ b/internal/server/releases.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// The newest published release, which is what the landing page hands out. Not
+// the newest tag: a tag can be a prerelease or one pushed by mistake, and this
+// endpoint skips both.
+const latestReleaseAPI = "https://api.github.com/repos/kamrul1157024/helios/releases/latest"
+
+// releaseResolver answers the newest release's tag, remembering it so a page
+// load does not become a round trip to GitHub. An unreachable GitHub answers
+// the empty string, which the page renders as its unversioned form rather than
+// as an error — a download page that fails because an API did is no use.
+type releaseResolver struct {
+	url    string
+	client *http.Client
+
+	mu      sync.Mutex
+	tag     string
+	expires time.Time
+}
+
+var latestRelease = &releaseResolver{
+	url:    latestReleaseAPI,
+	client: &http.Client{Timeout: 5 * time.Second},
+}
+
+const (
+	releaseTTL = time.Hour
+	// Shorter, because a failure is usually a rate limit or a flap, and an hour
+	// of unversioned pages is a long answer to a minute-long problem.
+	releaseFailureTTL = 5 * time.Minute
+)
+
+func (r *releaseResolver) get(ctx context.Context) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if time.Now().Before(r.expires) {
+		return r.tag
+	}
+
+	r.tag = r.fetch(ctx)
+	if r.tag == "" {
+		r.expires = time.Now().Add(releaseFailureTTL)
+	} else {
+		r.expires = time.Now().Add(releaseTTL)
+	}
+	return r.tag
+}
+
+func (r *releaseResolver) fetch(ctx context.Context) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return ""
+	}
+	return release.TagName
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -191,6 +191,9 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 
 	// Landing page (no auth — download links, exact root path only)
 	mux.HandleFunc("GET /{$}", handleLanding)
+	// The links on it: a redirect to GitHub's CDN, so Android does not hand the
+	// tap to the GitHub app instead of downloading.
+	mux.HandleFunc("GET /download/{asset}", s.handleDownload)
 
 	// Public endpoints (no auth)
 	mux.HandleFunc("GET /api/health", s.handleHealth)


### PR DESCRIPTION
## Summary

The landing page linked `releases/latest/download/…` and named no version, so it could not say what it was about to hand you — and with daemon versions now on the Hosts pane, there was nothing to compare them against.

- `internal/server/releases.go` resolves the newest **published** release once an hour, behind a mutex. It is the only call the daemon makes to GitHub.
- The five asset links are pinned to that tag, and the subtitle reads `Orchestrate AI coding agents from your phone · 3.9.0`. The version printed and the file served cannot come from different releases.
- Unreachable or rate-limited GitHub falls back to today's unpinned links and prints no number, cached for five minutes rather than an hour. A download page that fails because an API did is no use.

Second half of `docs/specs/56-one-version-number.md`, after #165.

## Test plan

- [x] `go test ./internal/server/` — six cases: every placeholder replaced in both forms, the unpinned fallback, the pinned tag, the handler using the resolved tag, the resolver asking GitHub once, and a 403 answering empty
- [x] Both rendered forms opened in a browser — pinned shows `· 3.9.0` and five `releases/download/v3.9.0/` links; offline shows neither
- [ ] Against a running daemon: needs a restart, which I did not do on a machine with live sessions