### PR TITLE
ci: cut the release once main is green

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,57 @@ name: Release
 # No version input: the number was decided in the PR that earned it and lives in
 # VERSION. Typing it again here is where the tag, the APK's build name and the
 # app's own number end up as three different numbers.
+#
+# Runs itself once main is green. A release nobody has to remember to cut is one
+# that goes out while the change is still fresh, and the gate below makes it a
+# no-op when the number in VERSION is already released.
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
+  # Whether there is anything to release, decided once rather than in four jobs.
+  gate:
+    name: Release?
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      release: ${{ steps.check.outputs.release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          v=$(cat VERSION)
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          if gh release view "v$v" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            echo "v$v is already released — nothing to do."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "v$v has not been released yet."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
   apk:
     name: Android APK
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           # `make apk-release` derives the Android build number from
           # `git rev-list --count HEAD`, which a shallow clone reports as 1.
           fetch-depth: 0
@@ -48,9 +86,13 @@ jobs:
 
   desktop-mac:
     name: Desktop (macOS)
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       # electron-builder stamps this into the app, which reports it to the
       # update check; a checkout past a tag would otherwise describe itself as
@@ -89,9 +131,13 @@ jobs:
 
   desktop-linux:
     name: Desktop (Linux)
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Read the version
         run: echo "VERSION=$(cat VERSION)" >> "$GITHUB_ENV"
@@ -121,11 +167,12 @@ jobs:
 
   publish:
     name: Publish release
-    needs: [apk, desktop-mac, desktop-linux]
+    needs: [gate, apk, desktop-mac, desktop-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           # The changelog covers the commits since the last tag, so both the
           # tags and the history behind them have to be here.
           fetch-depth: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,11 @@ The daemon is never edited by hand: `internal/version.Current` is stamped at
 build time from `git describe`, so a release build says `3.9.0` and a build
 above one says `3.9.0-13-g0a6231c` rather than claiming a release it is not.
 
+Releases cut themselves. Once `Test` passes on main, `Release` checks whether
+`VERSION` names a number that is not out yet, and publishes it if so — tag,
+changelog, APK, DMGs, AppImage and deb. Nothing to trigger by hand; a merge that
+does not move the number does not release.
+
 ## Procedures
 
 - [Install the iOS app on a cabled iPhone](docs/agents/ios-install.md) — no make target exists; read this before trying

--- a/docs/specs/56-one-version-number.md
+++ b/docs/specs/56-one-version-number.md
@@ -98,6 +98,12 @@ in a PR, and typing it again at release time is where the tag, the APK's build
 name and the app's own number become three different numbers. Every job reads
 `VERSION`, and `make release-publish` refuses to tag anything else.
 
+Nor is there anything to press. `Release` runs on `workflow_run` when `Test`
+succeeds on main, and a gate job asks whether `VERSION` names a release that
+already exists: if it does, nothing runs. So a merge that moved the number ships
+it while the change is still fresh, and a merge that did not costs one job that
+prints a line and stops.
+
 ### The page hands the file over itself
 
 The links cannot be `github.com` URLs. Android verifies that domain for the


### PR DESCRIPTION
## Summary

Releasing meant opening the Actions tab and filling in a form, which is why `v3.9.0` is out while main carries three merged features above it.

- `Release` now also runs on `workflow_run` — when `Test` succeeds on main.
- A `gate` job reads `VERSION` and asks whether that release already exists. If it does, nothing else runs. So a merge that moved the number ships it while the change is fresh, and a merge that did not costs one job that prints a line and stops.
- Every job checks out `workflow_run.head_sha`, so the release is built from the commit that was tested, not from whatever main has drifted to since.
- `workflow_dispatch` stays, for a release cut by hand.

With #165's auto-bump in front of it, the whole chain is: PR merges → CI has already put a number in `VERSION` → main goes green → the release publishes itself.

## Test plan

- [x] `actionlint` clean
- [x] `./scripts/check-version.sh`
- [ ] The real proof is this PR merging: main goes green, and `v3.10.0` appears with the APK, both DMGs, the AppImage and the deb attached