### PR TITLE
feat: give plan approval its own rows, and let a refusal carry words

### DIFF
--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -94,6 +94,91 @@ function readableInput(fields: Record<string, unknown> | null): string | null {
     .join('\n\n')
 }
 
+/**
+ * The two ways to say yes to a plan, worded as the CLI words them, and the
+ * name each one travels under.
+ *
+ * The name rather than the label, because the daemon presses the matching row
+ * on the CLI's own dialog and that copy is the CLI's to change.
+ */
+const planRows = [
+  {
+    choice: 'auto',
+    label: 'Yes, and use auto mode',
+    detail: 'Claude edits and runs commands without asking, for the rest of this session',
+  },
+  {
+    choice: 'manual',
+    label: 'Yes, manually approve edits',
+    detail: 'Claude asks before each edit, as it does now',
+  },
+] as const
+
+/**
+ * A plan waiting for approval.
+ *
+ * On the wire it is a permission like any other, but it is not a yes-or-no
+ * question: the answer picks the mode the session continues in, or sends the
+ * plan back in words. See docs/specs/57-plan-approval.md.
+ */
+function PlanCard({
+  plan,
+  busy,
+  act,
+}: {
+  plan: string
+  busy: boolean
+  act: (body: Record<string, unknown>) => Promise<void>
+}): JSX.Element {
+  const [choice, setChoice] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState('')
+  const words = feedback.trim()
+
+  return (
+    <>
+      <pre className="code">{plan}</pre>
+
+      {planRows.map((row) => (
+        <button
+          key={row.choice}
+          className={`option ${choice === row.choice ? 'chosen' : ''}`}
+          onClick={() => setChoice(row.choice)}
+        >
+          <span className="option-label">{row.label}</span>
+          <span className="option-desc">{row.detail}</span>
+        </button>
+      ))}
+
+      <label className="field">
+        <span>Tell Claude what to change</span>
+        <input
+          value={feedback}
+          placeholder="Send the plan back in your own words"
+          onChange={(event) => setFeedback(event.target.value)}
+        />
+      </label>
+
+      <Actions busy={busy}>
+        {/* A plan cannot be approved without saying which way. */}
+        <button
+          disabled={choice === null}
+          onClick={() => void act({ action: 'approve', plan_choice: choice })}
+        >
+          Approve
+        </button>
+        {/* Words turn a refusal into a re-plan, so the button says what it
+            will do with them. */}
+        <button
+          className="ghost"
+          onClick={() => void act(words === '' ? { action: 'deny' } : { action: 'deny', feedback: words })}
+        >
+          {words === '' ? 'Deny' : 'Send back'}
+        </button>
+      </Actions>
+    </>
+  )
+}
+
 function PermissionCard({
   payload,
   busy,
@@ -117,6 +202,13 @@ function PermissionCard({
   const [editing, setEditing] = useState(false)
   const [edited, setEdited] = useState(original)
   const [rule, setRule] = useState<number | null>(null)
+
+  // A plan is prose and its answer is not a yes-or-no. The state above is
+  // declared first so the hook order holds whichever card is drawn.
+  const plan = typeof fields?.plan === 'string' ? fields.plan : null
+  if (payload.tool_name === 'ExitPlanMode' && plan !== null) {
+    return <PlanCard plan={plan.trimEnd()} busy={busy} act={act} />
+  }
 
   const approve = (): void => {
     const body: Record<string, unknown> = { action: 'approve' }

--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import type { Notification } from '../../shared/models.ts'
-import { kindOf } from '../../shared/notifications.ts'
+import { kindOf, providerOf } from '../../shared/notifications.ts'
 
 /**
  * One notification, rendered with the controls its type needs.
@@ -37,7 +37,9 @@ export function NotificationCard({
   const body = ((): JSX.Element => {
     switch (kindOf(notif.type)) {
       case 'permission':
-        return <PermissionCard payload={payload} busy={busy} act={act} />
+        return (
+          <PermissionCard payload={payload} provider={providerOf(notif.type)} busy={busy} act={act} />
+        )
       case 'question':
         return <QuestionCard payload={payload} busy={busy} act={act} />
       case 'trust':
@@ -181,10 +183,12 @@ function PlanCard({
 
 function PermissionCard({
   payload,
+  provider,
   busy,
   act,
 }: {
   payload: Record<string, unknown>
+  provider: string
   busy: boolean
   act: (body: Record<string, unknown>) => Promise<void>
 }): JSX.Element {
@@ -202,6 +206,14 @@ function PermissionCard({
   const [editing, setEditing] = useState(false)
   const [edited, setEdited] = useState(original)
   const [rule, setRule] = useState<number | null>(null)
+  const [feedback, setFeedback] = useState('')
+
+  // Codex's own approval dialog offers "No, and tell Codex what to do
+  // differently". Helios paints over that dialog, so it has to offer the row
+  // too or the only refusal it leaves is a bare no. Claude's plan card carries
+  // its own field; its other tools take a rule instead.
+  const takesFeedback = provider === 'codex'
+  const words = feedback.trim()
 
   // A plan is prose and its answer is not a yes-or-no. The state above is
   // declared first so the hook order holds whichever card is drawn.
@@ -255,10 +267,26 @@ function PermissionCard({
         </div>
       )}
 
+      {takesFeedback && (
+        <label className="field">
+          <span>Tell Codex what to do differently</span>
+          <input
+            value={feedback}
+            placeholder="Say what to do instead"
+            onChange={(event) => setFeedback(event.target.value)}
+          />
+        </label>
+      )}
+
       <Actions busy={busy}>
         <button onClick={approve}>Approve</button>
-        <button className="ghost" onClick={() => void act({ action: 'deny' })}>
-          Deny
+        {/* Words turn a refusal into another attempt, so the button says what
+            it will do with them. */}
+        <button
+          className="ghost"
+          onClick={() => void act(words === '' ? { action: 'deny' } : { action: 'deny', feedback: words })}
+        >
+          {words === '' ? 'Deny' : 'Send back'}
         </button>
         <button className="link" onClick={() => setEditing(!editing)}>
           {editing ? 'Cancel editing' : 'Edit before approving'}

--- a/docs/specs/46-codex-provider.md
+++ b/docs/specs/46-codex-provider.md
@@ -706,7 +706,36 @@ Hook map:
 means *keep going*. Helios must return `{}`. Anything else restarts the turn.
 
 Action handlers: `codex.permission` only. It maps approve/deny onto
-`{"decision": {"behavior": "allow"}}` or `deny` with a message.
+`{"decision": {"behavior": "allow"}}` or `deny` with a message. A refusal may
+carry `feedback`, which becomes that message; see "A refusal can carry words".
+
+### A refusal can carry words
+
+Codex's own approval dialog offers eight rows, and one of them is
+`No, and tell Codex what to do differently`. Helios painted `Allow once` and
+`Deny` over it, and answered every refusal with `Denied via helios` — so the
+one thing the user most often wants to say, *not like that, like this*, had
+nowhere to go.
+
+The wire already carried it. `deny` with a message is one of the two responses
+`PermissionRequest` honours, measured against 0.150.1.
+
+So the overlay gains a third row that is not a choice: `AllowText` with
+`TextLabel: "Tell Codex what to do differently"`. Enter opens the field, Enter
+sends, and the words become the deny message under a line naming who is
+speaking — a refused call comes back to the model as an error, and bare text
+there reads as a malfunction rather than as a person talking. Escape still
+denies without a word and still says `Denied via helios`.
+
+The phone and the desktop app post `feedback` on the deny action and get the
+same field. Unlike Claude, the field is on every Codex permission card rather
+than on a plan card alone: Codex has no `ExitPlanMode`, and no rule to write
+instead.
+
+Two rows are still missing, for reasons that have not changed. There is no
+"don't ask again" because `updatedPermissions` fails closed. There is no plan
+card because leaving plan mode is a TUI prompt Codex draws itself — `Implement
+this plan?` — with no tool call and no hook behind it. Helios never sees it.
 
 ### What a Codex session will not have
 

--- a/docs/specs/57-plan-approval.md
+++ b/docs/specs/57-plan-approval.md
@@ -32,7 +32,10 @@ in words rather than with a bare no. And the plan itself, which nobody could rea
 | Terminal overlay | no | no | no — raw JSON, 100 chars |
 | Mobile / desktop | no | no | no |
 
-Every row but the first says no. This change makes the other two say yes.
+Every row but the first says no. This change makes the other two say yes on the first two
+columns. The third is answered differently on each surface: the phone and the desktop app
+have nowhere else to show the plan, so they show it. The terminal already has the CLI's
+own rendering of it directly above the box — see **The box does not reprint the plan**.
 
 ## What it looks like
 
@@ -58,16 +61,7 @@ After:
 
 ```
 ┌─ Ready to code? ───────────────────────────────────────────────────────────┐
-│ # Plan: give plan approval its own rows                                    │
-│                                                                            │
-│ ## Context                                                                 │
-│ The terminal offers Allow once and Deny. Plan approval needs the two       │
-│ mode rows and a way to disagree in words.                                  │
-│                                                                            │
-│ ## Implementation                                                          │
-│ 1. Branch on ExitPlanMode in showPermissionPrompt.                         │
-│ 2. Carry the typed text into the deny message.                             │
-│ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
+│ ~/.claude/plans/give-plan-approval-its-own-rows.md                         │
 │                                                                            │
 │ ❯ Yes, and use auto mode                                                   │
 │     Claude edits and runs commands without asking, for the rest of this    │
@@ -84,7 +78,7 @@ After Enter on the third row:
 
 ```
 ┌─ Ready to code? ───────────────────────────────────────────────────────────┐
-│ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
+│ ~/.claude/plans/give-plan-approval-its-own-rows.md                         │
 │                                                                            │
 │   Yes, and use auto mode                                                   │
 │     Claude edits and runs commands without asking, for the rest of this    │
@@ -93,32 +87,50 @@ After Enter on the third row:
 │     Claude asks before each edit, as it does now                           │
 │ ❯ Tell Claude what to change                                               │
 │   ┌──────────────────────────────────────────────────────────────────────┐ │
-│   │ split the plan on newlines, do not reflow it█                        │ │
+│   │ answer the CLI's dialog too, a hook cannot decide this█              │ │
 │   └──────────────────────────────────────────────────────────────────────┘ │
 │                                                                            │
 │ enter send · esc back to the list                                          │
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-The plan is down to one line in the second state. That is not a mockup shortcut:
-`RenderOverlay` anchors the box to the bottom of the viewport and clips from the top, so
-the three rows the field adds push the plan off. The user reads the plan, then trades it
-for the field. Capping the plan harder from the start would hold the height still, at the
-cost of showing less plan to the person who has not opened the field at all — and by the
-time they type, they have read it.
+The box holds its height when the field opens: nothing above the rows grows with the plan,
+so there is nothing for the three rows the field adds to push off. That matters because
+`RenderOverlay` anchors the box to the bottom of the viewport and clips from the top.
+
+## The box does not reprint the plan
+
+The first build of this put the plan in the box — `tool_input.plan` split into one
+`Prompt.Body` line each, capped at 14 with a `…57 more lines` tail. On screen it was
+unreadable, and the reason is not the cap:
+
+- The CLI has **already rendered the plan** into the transcript directly above, with
+  headings, colour and tables. The box repainted the same plan a second time, worse.
+- The overlay has no markdown renderer. It is box-drawn text assembled in
+  `internal/terminal/overlay.go` and written straight to every viewer's terminal, so
+  `#`, backticks and pipe-tables arrive as themselves.
+- There is nowhere to scroll to the rest, so a plan of any size was cut mid-sentence.
+- The height it took came out of the rows, on exactly the short screens where the rows
+  are hardest to fit.
+
+So the box says where the plan is written down and leaves the reading to the transcript
+above it. The alternative considered and rejected was a full-screen overlay with a
+markdown renderer: a new protocol field, host-side scrolling, a renderer dependency, and
+at the end of it a copy that covers the CLI's own better one.
+
+This applies to the terminal alone. The phone and the desktop app have no transcript
+beside the card, so they still carry the plan; see **The phone and the desktop app get the
+same rows**.
 
 ## What each part maps to
 
 **Title.** `ExitPlanMode` becomes `Ready to code?`, the CLI's own words. A tool name is
 right for `Bash`. For this tool it names the mechanism, not the decision.
 
-**Body.** `tool_input.plan` split on newlines into one `Prompt.Body` entry per line. This
-is load-bearing rather than cosmetic: `wrapLine` runs `strings.Fields`, so a whole plan
-passed as one entry collapses into a single paragraph and the headings vanish.
-
-**The cap line.** `…14 more lines · <planFilePath>` is not decoration. Without a cap the
-plan pushes the rows themselves off the screen. `planFilePath` is already in the hook
-payload, and it is where the whole plan lives.
+**Body.** `planFilePath` from the hook payload, one line, and nothing else. It is the one
+thing the transcript above does not say. A payload with no `plan` at all is the exception:
+the CLI printed nothing to read either, so the box falls back to `summarizeToolInput`.
+A payload with a plan but no path leaves the body empty rather than inventing one.
 
 **The rows.** Two mode rows. The text under each is `Prompt.Details`, which the overlay
 already draws and caps at two lines.

--- a/docs/specs/57-plan-approval.md
+++ b/docs/specs/57-plan-approval.md
@@ -1,13 +1,13 @@
-# Approving a Plan From the Terminal
+# Approving a Plan From a Phone
 
 ## The claim
 
 A plan is not a yes-or-no question, and helios asked it as one.
 
 When Claude finishes planning it calls `ExitPlanMode`. On the wire that is a permission
-like any other, so the `PermissionRequest` hook intercepts it and helios paints its own
-box over the CLI's. The box helios painted said `ExitPlanMode`, showed the raw tool input
-cut at 100 characters, and offered `Allow once` and `Deny`.
+like any other, so the `PermissionRequest` hook intercepts it, and the phone and the
+desktop app got a card saying `ExitPlanMode` with the raw tool input cut at 100 characters
+and two buttons: Approve and Deny.
 
 The CLI's own dialog, in the same moment, offers three rows:
 
@@ -20,152 +20,82 @@ Claude has written up a plan and is ready to execute. Would you like to proceed?
   ctrl+g to edit in Vim · ~/.claude/plans/give-plan-approval-its-own-rows.md
 ```
 
-Three things were lost. The mode the session continues in — the difference between
-approving one plan and approving every edit that follows from it. The ability to disagree
-in words rather than with a bare no. And the plan itself, which nobody could read.
+Three things were lost on the remote surfaces. The mode the session continues in — the
+difference between approving one plan and approving every edit that follows from it. The
+ability to disagree in words rather than with a bare no. And the plan itself, which nobody
+could read.
 
 ## Where we were
 
 | | Mode choice | Disagree with a reason | Plan readable |
 | --- | --- | --- | --- |
 | CLI's own dialog | yes, two rows | yes | yes |
-| Terminal overlay | no | no | no — raw JSON, 100 chars |
-| Mobile / desktop | no | no | no |
+| Mobile / desktop | no | no | no — raw JSON, 100 chars |
 
-Every row but the first says no. This change makes the other two say yes on the first two
-columns. The third is answered differently on each surface. The desktop app has the width,
-so it shows the plan on the card. The phone names the plan and opens it in the file viewer,
-which renders the markdown on a whole screen. The terminal already has the CLI's own
-rendering of it directly above the box — see **The box does not reprint the plan**.
+The CLI's row already says yes to all three. This change makes the phone and the desktop
+match it, and leaves the terminal alone.
 
-## What it looks like
+## The terminal keeps the CLI's dialog, and nothing else
 
-Drawn at the overlay's real geometry: 74-column content, the 4-column detail indent, and
-the nested field from `inputRows`. Three things ASCII cannot show — the selected row is a
-reverse-video bar across the full width, the descriptions are dim, and the footer is dim.
+Helios paints its own approval box over a session's terminal for every other tool. For a
+plan it paints nothing.
 
-Before:
+The first build of this did paint one — `Ready to code?`, the two mode rows, an answer
+field — and it made the terminal worse in two ways at once:
 
-```
-┌─ ExitPlanMode ─────────────────────────────────────────────────────────────┐
-│ {"plan":"# Plan: give plan approval its own rows\n\n## Context\nThe        │
-│ terminal only offers Allow onc...                                          │
-│                                                                            │
-│ ❯ Allow once                                                               │
-│   Deny                                                                     │
-│                                                                            │
-│ ↑↓ select · enter confirm · esc cancel                                     │
-└────────────────────────────────────────────────────────────────────────────┘
-```
+- **The screen became unreadable.** The CLI's dialog is already there. Helios's box is
+  composited over it by the host, so the two interleave character by character:
+  `Clau│ealreadyiwritten,aonlyntoncommiteady to execute. Would you like to proceed?`
+- **Helios could no longer read the screen it had to press.** The same capture feeds
+  `answerPlanDialog`, which is how a phone's answer reaches the CLI. With two boxes in it,
+  no row matched, and approving from the phone silently did nothing.
 
-After:
+There was nothing to gain for the cost. The CLI's dialog offers the same three rows, the
+same feedback path, and renders the plan above itself in full. A second copy of a better
+original is not worth an unreadable screen.
 
-```
-┌─ Ready to code? ───────────────────────────────────────────────────────────┐
-│ ~/.claude/plans/give-plan-approval-its-own-rows.md                         │
-│                                                                            │
-│ ❯ Yes, and use auto mode                                                   │
-│     Claude edits and runs commands without asking, for the rest of this    │
-│     session                                                                │
-│   Yes, manually approve edits                                              │
-│     Claude asks before each edit, as it does now                           │
-│   Tell Claude what to change                                               │
-│                                                                            │
-│ ↑↓ select · enter confirm · esc cancel                                     │
-└────────────────────────────────────────────────────────────────────────────┘
-```
+So `showPermissionPrompt` returns a no-op for `ExitPlanMode`. The person at the keyboard
+answers the CLI directly, exactly as they did before helios existed.
 
-After Enter on the third row:
-
-```
-┌─ Ready to code? ───────────────────────────────────────────────────────────┐
-│ ~/.claude/plans/give-plan-approval-its-own-rows.md                         │
-│                                                                            │
-│   Yes, and use auto mode                                                   │
-│     Claude edits and runs commands without asking, for the rest of this    │
-│     session                                                                │
-│   Yes, manually approve edits                                              │
-│     Claude asks before each edit, as it does now                           │
-│ ❯ Tell Claude what to change                                               │
-│   ┌──────────────────────────────────────────────────────────────────────┐ │
-│   │ answer the CLI's dialog too, a hook cannot decide this█              │ │
-│   └──────────────────────────────────────────────────────────────────────┘ │
-│                                                                            │
-│ enter send · esc back to the list                                          │
-└────────────────────────────────────────────────────────────────────────────┘
-```
-
-The box holds its height when the field opens: nothing above the rows grows with the plan,
-so there is nothing for the three rows the field adds to push off. That matters because
-`RenderOverlay` anchors the box to the bottom of the viewport and clips from the top.
-
-## The box does not reprint the plan
-
-The first build of this put the plan in the box — `tool_input.plan` split into one
-`Prompt.Body` line each, capped at 14 with a `…57 more lines` tail. On screen it was
-unreadable, and the reason is not the cap:
-
-- The CLI has **already rendered the plan** into the transcript directly above, with
-  headings, colour and tables. The box repainted the same plan a second time, worse.
-- The overlay has no markdown renderer. It is box-drawn text assembled in
-  `internal/terminal/overlay.go` and written straight to every viewer's terminal, so
-  `#`, backticks and pipe-tables arrive as themselves.
-- There is nowhere to scroll to the rest, so a plan of any size was cut mid-sentence.
-- The height it took came out of the rows, on exactly the short screens where the rows
-  are hardest to fit.
-
-So the box says where the plan is written down and leaves the reading to the transcript
-above it. The alternative considered and rejected was a full-screen overlay with a
-markdown renderer: a new protocol field, host-side scrolling, a renderer dependency, and
-at the end of it a copy that covers the CLI's own better one.
-
-This applies to the terminal alone. The desktop app has no transcript beside the card, so
-it still carries the plan, and the phone hands the reading to its file viewer; see **The
-phone and the desktop app get the same rows**.
-
-## What each part maps to
-
-**Title.** `ExitPlanMode` becomes `Ready to code?`, the CLI's own words. A tool name is
-right for `Bash`. For this tool it names the mechanism, not the decision.
-
-**Body.** `planFilePath` from the hook payload, one line, and nothing else. It is the one
-thing the transcript above does not say. A payload with no `plan` at all is the exception:
-the CLI printed nothing to read either, so the box falls back to `summarizeToolInput`.
-A payload with a plan but no path leaves the body empty rather than inventing one.
-
-**The rows.** Two mode rows. The text under each is `Prompt.Details`, which the overlay
-already draws and caps at two lines.
-
-**The third row is not an option.** It is `Prompt.AllowText` with
-`TextLabel: "Tell Claude what to change"`. Enter opens the field, Enter sends, and the
-text becomes the hook's deny message.
-
-**Escape** still denies, and gets a written reason in place of `"Denied via helios"`.
-
-## A plan is the one permission a hook cannot decide
+## Pressing the row a phone picked
 
 The CLI ignores an `allow` for `ExitPlanMode`. It shows its own dialog anyway and the plan
 does not start. That is measured, not assumed — see Evidence. So helios cannot answer a
 plan the way it answers `Bash`.
 
-What it does instead: it collects the answer on its own overlay, replies `ask` to get out
-of the CLI's way, and then presses the matching row on the CLI's dialog. The keystroke has
-to follow the reply rather than accompany it, because the CLI does not draw that dialog
-until the hook has answered. `answerPlanDialog` therefore runs in a goroutine and polls for
-up to 15 seconds, reusing `provider.ConfirmChoice` — the same screen-scraping row picker
-that answers the workspace trust dialog.
+What it does instead: it replies `ask` to get out of the CLI's way, then presses the row
+the phone chose. The keystroke has to follow the reply rather than accompany it, because
+the CLI does not draw that dialog until the hook has answered. `answerPlanDialog` therefore
+runs in a goroutine and polls for up to 15 seconds.
 
-The match is a substring of the CLI's row, kept to the words that carry the meaning:
-`auto mode` and `manually approve`. Failing to find it is survivable and deliberately
-quiet: the CLI's dialog is on screen, fully usable, and the person at the terminal answers
-it by hand. A renamed row degrades to that, not to a hung session.
+**It presses the row's number, not its highlight.** `provider.ConfirmChoice` — the
+screen-scraping picker that answers the workspace trust dialog — walks the highlight onto a
+row with arrow keys, and finds the highlight by looking for a cursor mark. Under a plan
+dialog sits the composer, carrying a `❯` of its own, and `locateChoice` takes the *lowest*
+match. It read the composer as the selection, pressed Up eight times, and gave up. The CLI
+numbers these rows and tells the user to press the number; helios presses the same key.
 
-| Row | Hook response | Then |
+**Nothing is pressed until the CLI's own question is on screen.** `would you like to
+proceed` has to appear in the capture first. A numbered list is an ordinary shape for a
+terminal to hold, and a digit sent at the wrong moment is a digit typed into the composer.
+
+The row is then found by wording. There is more than one candidate per row, because the
+copy belongs to the CLI and has already moved: 2.1.259 offers `Yes, and use auto mode`,
+2.1.126 offers `Yes, auto-accept edits`. Helios tries `auto-accept` then `auto mode` for
+the first, and `manually approve` for the second. Matching only the newer wording made
+approval a no-op on 2.1.126, and the log said no more than that no row was found — so a
+miss now prints the screen it looked at.
+
+Failing to find a row is survivable and deliberately quiet: the CLI's dialog is on screen,
+fully usable, and the person at the terminal answers it by hand. A renamed row degrades to
+that, not to a hung session.
+
+| The card's answer | Hook response | Then |
 | --- | --- | --- |
-| Yes, and use auto mode | `ask` | Enter on the CLI's `auto mode` row; record `auto` |
-| Yes, manually approve edits | `ask` | Enter on the CLI's `manually approve` row; record `manual` |
-| Tell Claude what to change | `deny`, `message` = a line naming the user, then their words | — |
-| Esc | `deny`, message says the plan was rejected and asks Claude to plan again | — |
+| Yes, and use auto mode | `ask` | press the CLI's `1`; record `auto` |
+| Yes, manually approve edits | `ask` | press the CLI's `2`; record `manual` |
+| Feedback typed, Send back | `deny`, `message` = a line naming the user, then their words | — |
+| Deny | `deny`, message says the plan was rejected and asks Claude to plan again | — |
 
 A denied tool reaches the model as `Error: <message>`, so the feedback needs someone
 attached to it. Bare text there reads as a malfunction rather than as a person talking.
@@ -254,12 +184,12 @@ A plan with no `planFilePath` keeps the whole text on the card. There is nothing
 so the card is the only copy. The desktop app keeps the plan on the card either way — it
 has the width for it, and the card sits beside no viewer to send the reader to.
 
-The daemon does not care which surface answered. `handlePermissionAction` and the terminal
-build the same `permissionAnswer`, so a plan approved from a phone is pressed onto the CLI's
-dialog exactly as one approved at the keyboard is.
+Either surface builds the same `permissionAnswer`, so the daemon does not care which one
+answered: `handlePermissionAction` turns it into a decision, and the decision presses the
+CLI's dialog.
 
 ## Known limit
 
-An older ptyhost reports overlay protocol < 2. `hitl.Ask` then drops `AllowText`, so the
-feedback row disappears and only the two mode rows remain. That is the established
-behaviour for the answer field, not a new failure.
+A plan answered at the keyboard is invisible to helios. The CLI's dialog is the CLI's, so
+the notification stays pending until it is dismissed or the session moves on — helios
+learns the mode only when a later hook reports it.

--- a/docs/specs/57-plan-approval.md
+++ b/docs/specs/57-plan-approval.md
@@ -1,0 +1,191 @@
+# Approving a Plan From the Terminal
+
+## The claim
+
+A plan is not a yes-or-no question, and helios asked it as one.
+
+When Claude finishes planning it calls `ExitPlanMode`. On the wire that is a permission
+like any other, so the `PermissionRequest` hook intercepts it and helios paints its own
+box over the CLI's. The box helios painted said `ExitPlanMode`, showed the raw tool input
+cut at 100 characters, and offered `Allow once` and `Deny`.
+
+The CLI's own dialog, in the same moment, offers three rows:
+
+```
+Claude has written up a plan and is ready to execute. Would you like to proceed?
+❯ 1. Yes, auto-accept edits
+  2. Yes, manually approve edits
+  3. Tell Claude what to change
+      shift+tab to approve with this feedback
+  ctrl+g to edit in Vim · ~/.claude/plans/give-plan-approval-its-own-rows.md
+```
+
+Three things were lost. The mode the session continues in — the difference between
+approving one plan and approving every edit that follows from it. The ability to disagree
+in words rather than with a bare no. And the plan itself, which nobody could read.
+
+## Where we are
+
+| | Mode choice | Disagree with a reason | Plan readable |
+| --- | --- | --- | --- |
+| CLI's own dialog | yes, two rows | yes | yes |
+| Terminal overlay | no | no | no — raw JSON, 100 chars |
+| Mobile / desktop | no | no | no |
+
+## What it looks like
+
+Drawn at the overlay's real geometry: 74-column content, the 4-column detail indent, and
+the nested field from `inputRows`. Three things ASCII cannot show — the selected row is a
+reverse-video bar across the full width, the descriptions are dim, and the footer is dim.
+
+Before:
+
+```
+┌─ ExitPlanMode ─────────────────────────────────────────────────────────────┐
+│ {"plan":"# Plan: give plan approval its own rows\n\n## Context\nThe        │
+│ terminal only offers Allow onc...                                          │
+│                                                                            │
+│ ❯ Allow once                                                               │
+│   Deny                                                                     │
+│                                                                            │
+│ ↑↓ select · enter confirm · esc cancel                                     │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+After:
+
+```
+┌─ Ready to code? ───────────────────────────────────────────────────────────┐
+│ # Plan: give plan approval its own rows                                    │
+│                                                                            │
+│ ## Context                                                                 │
+│ The terminal offers Allow once and Deny. Plan approval needs the two       │
+│ mode rows and a way to disagree in words.                                  │
+│                                                                            │
+│ ## Implementation                                                          │
+│ 1. Branch on ExitPlanMode in showPermissionPrompt.                         │
+│ 2. Carry the typed text into the deny message.                             │
+│ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
+│                                                                            │
+│ ❯ Yes, auto-accept edits                                                   │
+│     Claude edits files without asking for the rest of this session         │
+│   Yes, manually approve edits                                              │
+│     Claude asks before each edit, as it does now                           │
+│   Tell Claude what to change                                               │
+│                                                                            │
+│ ↑↓ select · enter confirm · esc cancel                                     │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+After Enter on the third row:
+
+```
+┌─ Ready to code? ───────────────────────────────────────────────────────────┐
+│ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
+│                                                                            │
+│   Yes, auto-accept edits                                                   │
+│     Claude edits files without asking for the rest of this session         │
+│   Yes, manually approve edits                                              │
+│     Claude asks before each edit, as it does now                           │
+│ ❯ Tell Claude what to change                                               │
+│   ┌──────────────────────────────────────────────────────────────────────┐ │
+│   │ split the plan on newlines, do not reflow it█                        │ │
+│   └──────────────────────────────────────────────────────────────────────┘ │
+│                                                                            │
+│ enter send · esc back to the list                                          │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+The plan is down to one line in the second state. That is not a mockup shortcut:
+`RenderOverlay` anchors the box to the bottom of the viewport and clips from the top, so
+the three rows the field adds push the plan off. The user reads the plan, then trades it
+for the field. Capping the plan harder from the start would hold the height still, at the
+cost of showing less plan to the person who has not opened the field at all — and by the
+time they type, they have read it.
+
+## What each part maps to
+
+**Title.** `ExitPlanMode` becomes `Ready to code?`, the CLI's own words. A tool name is
+right for `Bash`. For this tool it names the mechanism, not the decision.
+
+**Body.** `tool_input.plan` split on newlines into one `Prompt.Body` entry per line. This
+is load-bearing rather than cosmetic: `wrapLine` runs `strings.Fields`, so a whole plan
+passed as one entry collapses into a single paragraph and the headings vanish.
+
+**The cap line.** `…14 more lines · <planFilePath>` is not decoration. Without a cap the
+plan pushes the rows themselves off the screen. `planFilePath` is already in the hook
+payload, and it is where the whole plan lives.
+
+**The rows.** Two `setMode` rows. The text under each is `Prompt.Details`, which the
+overlay already draws and caps at two lines.
+
+**The third row is not an option.** It is `Prompt.AllowText` with
+`TextLabel: "Tell Claude what to change"`. Enter opens the field, Enter sends, and the
+text becomes the hook's deny message.
+
+**Escape** still denies, and gets a written reason in place of `"Denied via helios"`.
+
+## Wire effects
+
+| Row | Hook response |
+| --- | --- |
+| Yes, auto-accept edits | `allow` + `updatedPermissions: [{"type":"setMode","destination":"session","mode":"acceptEdits"}]` |
+| Yes, manually approve edits | `allow` + `setMode` `default` |
+| Tell Claude what to change | `deny`, `message` = a line naming the user, then their words |
+| Esc | `deny`, message says the plan was rejected and asks Claude to plan again |
+
+A denied tool reaches the model as `Error: <message>`, so the feedback needs someone
+attached to it. Bare text there reads as a malfunction rather than as a person talking.
+
+## The mode has to be written down twice
+
+`setMode` reaches the running CLI process and nothing else. Helios repeats
+`--permission-mode` from the session record on every resume
+(`internal/provider/claude/register.go:56`), so a session that left plan mode would wake
+back up inside it. Approving a plan therefore also writes the mode to the session record.
+
+The two vocabularies differ by one name: `setMode` calls the ask-each-time mode `default`,
+and `--permission-mode` calls it `manual`. `heliosMode` is that translation and refuses
+any mode helios cannot launch with.
+
+## Evidence
+
+Measured against Claude Code 2.1.259, in a real plan-mode session with a hook that logged
+the payload.
+
+The `PermissionRequest` hook does fire for `ExitPlanMode`:
+
+```json
+{"permission_mode":"plan","hook_event_name":"PermissionRequest",
+ "tool_name":"ExitPlanMode",
+ "tool_input":{"plan":"# Plan: Print Hello\n\n## Context\n...",
+               "planFilePath":"~/.claude/plans/....md"}}
+```
+
+`permission_suggestions` is **absent** for this tool, so the rows cannot be driven from
+it. Helios has to name them.
+
+The deny message reached the model:
+
+```
+⎿  Error: HELIOS_PROBE_FEEDBACK do not print hello, print goodbye instead
+⎿  Denied by PermissionRequest hook
+```
+
+Claude then said *"I see the feedback has changed the requirement"*, rewrote the plan, and
+called `ExitPlanMode` again. The disagree path already worked end to end. Helios simply
+never collected the words.
+
+## Not in this change
+
+The mobile and desktop cards keep their Approve / Deny pair
+(`mobile/lib/providers/cards.dart:267`). The daemon side is ready for them: the answer a
+surface posts to `/api/notifications/{id}/action` now carries `permission_updates` and
+`feedback`, so a phone can pick a mode or send a plan back in words as soon as the card
+draws the rows. That is the follow-up.
+
+## Known limit
+
+An older ptyhost reports overlay protocol < 2. `hitl.Ask` then drops `AllowText`, so the
+feedback row disappears and only the two mode rows remain. That is the established
+behaviour for the answer field, not a new failure.

--- a/docs/specs/57-plan-approval.md
+++ b/docs/specs/57-plan-approval.md
@@ -33,9 +33,10 @@ in words rather than with a bare no. And the plan itself, which nobody could rea
 | Mobile / desktop | no | no | no |
 
 Every row but the first says no. This change makes the other two say yes on the first two
-columns. The third is answered differently on each surface: the phone and the desktop app
-have nowhere else to show the plan, so they show it. The terminal already has the CLI's
-own rendering of it directly above the box — see **The box does not reprint the plan**.
+columns. The third is answered differently on each surface. The desktop app has the width,
+so it shows the plan on the card. The phone names the plan and opens it in the file viewer,
+which renders the markdown on a whole screen. The terminal already has the CLI's own
+rendering of it directly above the box — see **The box does not reprint the plan**.
 
 ## What it looks like
 
@@ -118,9 +119,9 @@ above it. The alternative considered and rejected was a full-screen overlay with
 markdown renderer: a new protocol field, host-side scrolling, a renderer dependency, and
 at the end of it a copy that covers the CLI's own better one.
 
-This applies to the terminal alone. The phone and the desktop app have no transcript
-beside the card, so they still carry the plan; see **The phone and the desktop app get the
-same rows**.
+This applies to the terminal alone. The desktop app has no transcript beside the card, so
+it still carries the plan, and the phone hands the reading to its file viewer; see **The
+phone and the desktop app get the same rows**.
 
 ## What each part maps to
 
@@ -232,12 +233,26 @@ entry — the chosen mode was in force.
 
 `mobile/lib/providers/cards.dart` and
 `desktop/src/renderer/components/notification-card.tsx` draw the permission card. For
-`ExitPlanMode` both now show the plan as prose, the two mode rows, and a feedback field, and
-post `plan_choice` or `feedback` to `/api/notifications/{id}/action`. Approve stays disabled
-until a row is picked; typing words relabels Deny to `Send back`.
+`ExitPlanMode` both now show the two mode rows and a feedback field, and post `plan_choice`
+or `feedback` to `/api/notifications/{id}/action`. Approve stays disabled until a row is
+picked; typing words relabels Deny to `Send back`.
 
 Both drop the quick rules and the edit field for a plan: the CLI sends no
 `permission_suggestions` for this tool, and there is no command to edit.
+
+**The phone names the plan instead of printing it.** A card on a phone is a few hundred
+pixels that also have to hold the rows, and the plan went into them as raw markdown in a
+scroll box — a small window dragged over a long document, with the buttons that answer it
+below. The card now carries the plan's first heading, the file's name, and a **View plan**
+button that opens the file in `FileViewerScreen`, which renders the markdown on a whole
+screen and is already how any other file is read from the phone. The daemon serves it:
+`resolveSafePath` expands `~` and does not confine a read to the session's cwd, so
+`~/.claude/plans/….md` opens like a file in the project does. The viewer is rooted at the
+plan's own folder rather than at the project, because that is the folder the file is in.
+
+A plan with no `planFilePath` keeps the whole text on the card. There is nothing to open,
+so the card is the only copy. The desktop app keeps the plan on the card either way — it
+has the width for it, and the card sits beside no viewer to send the reader to.
 
 The daemon does not care which surface answered. `handlePermissionAction` and the terminal
 build the same `permissionAnswer`, so a plan approved from a phone is pressed onto the CLI's

--- a/docs/specs/57-plan-approval.md
+++ b/docs/specs/57-plan-approval.md
@@ -13,7 +13,7 @@ The CLI's own dialog, in the same moment, offers three rows:
 
 ```
 Claude has written up a plan and is ready to execute. Would you like to proceed?
-❯ 1. Yes, auto-accept edits
+❯ 1. Yes, and use auto mode
   2. Yes, manually approve edits
   3. Tell Claude what to change
       shift+tab to approve with this feedback
@@ -24,13 +24,15 @@ Three things were lost. The mode the session continues in — the difference bet
 approving one plan and approving every edit that follows from it. The ability to disagree
 in words rather than with a bare no. And the plan itself, which nobody could read.
 
-## Where we are
+## Where we were
 
 | | Mode choice | Disagree with a reason | Plan readable |
 | --- | --- | --- | --- |
 | CLI's own dialog | yes, two rows | yes | yes |
 | Terminal overlay | no | no | no — raw JSON, 100 chars |
 | Mobile / desktop | no | no | no |
+
+Every row but the first says no. This change makes the other two say yes.
 
 ## What it looks like
 
@@ -67,8 +69,9 @@ After:
 │ 2. Carry the typed text into the deny message.                             │
 │ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
 │                                                                            │
-│ ❯ Yes, auto-accept edits                                                   │
-│     Claude edits files without asking for the rest of this session         │
+│ ❯ Yes, and use auto mode                                                   │
+│     Claude edits and runs commands without asking, for the rest of this    │
+│     session                                                                │
 │   Yes, manually approve edits                                              │
 │     Claude asks before each edit, as it does now                           │
 │   Tell Claude what to change                                               │
@@ -83,8 +86,9 @@ After Enter on the third row:
 ┌─ Ready to code? ───────────────────────────────────────────────────────────┐
 │ …14 more lines · ~/.claude/plans/give-plan-approval-its-own-rows.md        │
 │                                                                            │
-│   Yes, auto-accept edits                                                   │
-│     Claude edits files without asking for the rest of this session         │
+│   Yes, and use auto mode                                                   │
+│     Claude edits and runs commands without asking, for the rest of this    │
+│     session                                                                │
 │   Yes, manually approve edits                                              │
 │     Claude asks before each edit, as it does now                           │
 │ ❯ Tell Claude what to change                                               │
@@ -116,8 +120,8 @@ passed as one entry collapses into a single paragraph and the headings vanish.
 plan pushes the rows themselves off the screen. `planFilePath` is already in the hook
 payload, and it is where the whole plan lives.
 
-**The rows.** Two `setMode` rows. The text under each is `Prompt.Details`, which the
-overlay already draws and caps at two lines.
+**The rows.** Two mode rows. The text under each is `Prompt.Details`, which the overlay
+already draws and caps at two lines.
 
 **The third row is not an option.** It is `Prompt.AllowText` with
 `TextLabel: "Tell Claude what to change"`. Enter opens the field, Enter sends, and the
@@ -125,28 +129,41 @@ text becomes the hook's deny message.
 
 **Escape** still denies, and gets a written reason in place of `"Denied via helios"`.
 
-## Wire effects
+## A plan is the one permission a hook cannot decide
 
-| Row | Hook response |
-| --- | --- |
-| Yes, auto-accept edits | `allow` + `updatedPermissions: [{"type":"setMode","destination":"session","mode":"acceptEdits"}]` |
-| Yes, manually approve edits | `allow` + `setMode` `default` |
-| Tell Claude what to change | `deny`, `message` = a line naming the user, then their words |
-| Esc | `deny`, message says the plan was rejected and asks Claude to plan again |
+The CLI ignores an `allow` for `ExitPlanMode`. It shows its own dialog anyway and the plan
+does not start. That is measured, not assumed — see Evidence. So helios cannot answer a
+plan the way it answers `Bash`.
+
+What it does instead: it collects the answer on its own overlay, replies `ask` to get out
+of the CLI's way, and then presses the matching row on the CLI's dialog. The keystroke has
+to follow the reply rather than accompany it, because the CLI does not draw that dialog
+until the hook has answered. `answerPlanDialog` therefore runs in a goroutine and polls for
+up to 15 seconds, reusing `provider.ConfirmChoice` — the same screen-scraping row picker
+that answers the workspace trust dialog.
+
+The match is a substring of the CLI's row, kept to the words that carry the meaning:
+`auto mode` and `manually approve`. Failing to find it is survivable and deliberately
+quiet: the CLI's dialog is on screen, fully usable, and the person at the terminal answers
+it by hand. A renamed row degrades to that, not to a hung session.
+
+| Row | Hook response | Then |
+| --- | --- | --- |
+| Yes, and use auto mode | `ask` | Enter on the CLI's `auto mode` row; record `auto` |
+| Yes, manually approve edits | `ask` | Enter on the CLI's `manually approve` row; record `manual` |
+| Tell Claude what to change | `deny`, `message` = a line naming the user, then their words | — |
+| Esc | `deny`, message says the plan was rejected and asks Claude to plan again | — |
 
 A denied tool reaches the model as `Error: <message>`, so the feedback needs someone
 attached to it. Bare text there reads as a malfunction rather than as a person talking.
 
 ## The mode has to be written down twice
 
-`setMode` reaches the running CLI process and nothing else. Helios repeats
+The CLI applies the chosen mode to the running process and nothing else. Helios repeats
 `--permission-mode` from the session record on every resume
 (`internal/provider/claude/register.go:56`), so a session that left plan mode would wake
-back up inside it. Approving a plan therefore also writes the mode to the session record.
-
-The two vocabularies differ by one name: `setMode` calls the ask-each-time mode `default`,
-and `--permission-mode` calls it `manual`. `heliosMode` is that translation and refuses
-any mode helios cannot launch with.
+back up inside it. Approving a plan therefore also writes `auto` or `manual` to the session
+record.
 
 ## Evidence
 
@@ -176,13 +193,43 @@ Claude then said *"I see the feedback has changed the requirement"*, rewrote the
 called `ExitPlanMode` again. The disagree path already worked end to end. Helios simply
 never collected the words.
 
-## Not in this change
+**An `allow` for a plan is ignored.** The first cut of this change replied `allow` with a
+`setMode` permission update and stopped there. Run live, the plan never started and the
+CLI's own dialog came up regardless. Four runs in a single-hook environment — helios's own
+hooks are installed globally in `~/.claude/settings.json`, so the probe needed an isolated
+`HOME` to avoid two `PermissionRequest` hooks answering at once:
 
-The mobile and desktop cards keep their Approve / Deny pair
-(`mobile/lib/providers/cards.dart:267`). The daemon side is ready for them: the answer a
-surface posts to `/api/notifications/{id}/action` now carries `permission_updates` and
-`feedback`, so a phone can pick a mode or send a plan back in words as soon as the card
-draws the rows. That is the follow-up.
+| Probe | Result |
+| --- | --- |
+| `allow` for `ExitPlanMode` | ignored; dialog shown, plan not started |
+| `allow` + `setMode` for `ExitPlanMode` | ignored; same |
+| `allow` for `Bash` (control) | honoured; the command ran with no dialog |
+| `deny` with a message | honoured; Claude re-planned from the words |
+
+The control run is what makes this a statement about the tool rather than about the
+response shape: the same JSON, on `Bash`, works.
+
+**The dialog is drawn after the hook replies, not before.** A hook that blocked for 90
+seconds saw no dialog appear. So the keystroke cannot be sent alongside the reply.
+
+**The keystroke works, and the mode takes.** Sending `1` to the CLI's dialog started the
+plan in six seconds, and the `Write` that followed produced no `PermissionRequest` hook
+entry — the chosen mode was in force.
+
+## The phone and the desktop app get the same rows
+
+`mobile/lib/providers/cards.dart` and
+`desktop/src/renderer/components/notification-card.tsx` draw the permission card. For
+`ExitPlanMode` both now show the plan as prose, the two mode rows, and a feedback field, and
+post `plan_choice` or `feedback` to `/api/notifications/{id}/action`. Approve stays disabled
+until a row is picked; typing words relabels Deny to `Send back`.
+
+Both drop the quick rules and the edit field for a plan: the CLI sends no
+`permission_suggestions` for this tool, and there is no command to edit.
+
+The daemon does not care which surface answered. `handlePermissionAction` and the terminal
+build the same `permissionAnswer`, so a plan approved from a phone is pressed onto the CLI's
+dialog exactly as one approved at the keyboard is.
 
 ## Known limit
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -64,7 +64,7 @@ what is merged. Some are superseded and stay here for the history.
 | [54-file-change-events.md](54-file-change-events.md) | File Change Events: Watch What Someone Is Looking At |
 | [55-answering-a-question-from-the-terminal.md](55-answering-a-question-from-the-terminal.md) | Answering a Question From the Terminal |
 | [56-one-version-number.md](56-one-version-number.md) | One Version Number, and Builds That Do Not Lie About It |
-| [57-plan-approval.md](57-plan-approval.md) | Approving a Plan From the Terminal |
+| [57-plan-approval.md](57-plan-approval.md) | Approving a Plan From a Phone |
 | [58-files-without-a-root.md](58-files-without-a-root.md) | Files Without a Root: Folders, an Index, and a Path You Can Type |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -64,6 +64,7 @@ what is merged. Some are superseded and stay here for the history.
 | [54-file-change-events.md](54-file-change-events.md) | File Change Events: Watch What Someone Is Looking At |
 | [55-answering-a-question-from-the-terminal.md](55-answering-a-question-from-the-terminal.md) | Answering a Question From the Terminal |
 | [56-one-version-number.md](56-one-version-number.md) | One Version Number, and Builds That Do Not Lie About It |
+| [57-plan-approval.md](57-plan-approval.md) | Approving a Plan From the Terminal |
 | [58-files-without-a-root.md](58-files-without-a-root.md) | Files Without a Root: Folders, an Index, and a Path You Can Type |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -21,6 +21,12 @@ const (
 	KeyCtrlC  Key = "ctrl-c"
 	KeyUp     Key = "up"
 	KeyDown   Key = "down"
+	// A numbered dialog row answers to its own digit, which is what the CLI
+	// tells the user to press. Picking a row that way needs no highlight, and
+	// so cannot be thrown off by another cursor mark elsewhere on the screen.
+	Key1 Key = "1"
+	Key2 Key = "2"
+	Key3 Key = "3"
 )
 
 // Status reports backend health for the doctor/status endpoints.

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -349,6 +349,8 @@ func keySequence(key Key) ([]byte, error) {
 		return []byte("\x1b[A"), nil
 	case KeyDown:
 		return []byte("\x1b[B"), nil
+	case Key1, Key2, Key3:
+		return []byte(key), nil
 	default:
 		return nil, fmt.Errorf("backend: unknown key %q", key)
 	}

--- a/internal/provider/claude/actions.go
+++ b/internal/provider/claude/actions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/notifications"
@@ -19,32 +20,38 @@ func SetBackend(b backend.Backend) {
 	terminalBackend = b
 }
 
+// handlePermissionAction turns a remote surface's answer into a decision.
+//
+// The body is a permissionAnswer plus the action, so a phone can send anything
+// the terminal can: the mode to continue a plan in, or the words to send it
+// back with.
 func handlePermissionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {
-		Action          string                 `json:"action"`
-		UpdatedInput    map[string]interface{} `json:"updated_input,omitempty"`
-		ApplyPermission *int                   `json:"apply_permission,omitempty"`
+		Action string `json:"action"`
+		permissionAnswer
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return notifications.Decision{}, fmt.Errorf("invalid body: %w", err)
 	}
 
 	if req.Action == "deny" {
+		if text := strings.TrimSpace(req.Feedback); text != "" {
+			return deniedWithFeedback(text), nil
+		}
 		return notifications.Decision{Status: "denied"}, nil
 	}
 
-	respData := map[string]interface{}{}
-	if req.UpdatedInput != nil {
-		respData["updated_input"] = req.UpdatedInput
+	// Feedback is a refusal's payload; an approval carrying it would send Claude
+	// a complaint about work it was just cleared to do.
+	answer := req.permissionAnswer
+	answer.Feedback = ""
+	if answer.empty() {
+		return notifications.Decision{Status: "approved"}, nil
 	}
-	if req.ApplyPermission != nil {
-		respData["apply_permission"] = *req.ApplyPermission
+	response, err := json.Marshal(answer)
+	if err != nil {
+		return notifications.Decision{}, fmt.Errorf("encode response: %w", err)
 	}
-	var response json.RawMessage
-	if len(respData) > 0 {
-		response, _ = json.Marshal(respData)
-	}
-
 	return notifications.Decision{Status: "approved", Response: response}, nil
 }
 

--- a/internal/provider/claude/actions.go
+++ b/internal/provider/claude/actions.go
@@ -23,7 +23,7 @@ func SetBackend(b backend.Backend) {
 // handlePermissionAction turns a remote surface's answer into a decision.
 //
 // The body is a permissionAnswer plus the action, so a phone can send anything
-// the terminal can: the mode to continue a plan in, or the words to send it
+// the terminal can: which way to say yes to a plan, or the words to send it
 // back with.
 func handlePermissionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -339,20 +339,24 @@ const (
 
 // showPermissionPrompt paints the approval over the session's terminal so the
 // person sitting at it can answer, and returns the function that takes it down.
+//
+// A plan gets no box. The CLI draws its own dialog for one — the mode rows, the
+// feedback row and all — and painting over it cost more than it gave: the two
+// boxes composite into one unreadable screen, which is also the screen helios
+// reads back when it presses a row for the phone. The person at the keyboard
+// answers the CLI directly; the phone still gets its card.
 func showPermissionPrompt(ctx *provider.HookContext, input *hookInput, notifID string) func() {
+	if input.ToolName == exitPlanModeTool {
+		return func() {}
+	}
 	p := permissionPrompt(input)
 	return showPrompt(ctx, input.SessionID, p, func(a hitl.Answer) {
 		resolvePermissionFromTerminal(ctx, notifID, p.Choices, a)
 	})
 }
 
-// permissionPrompt is the box a tool's approval gets. A plan is asking
-// something else than "may I run this", so it gets its own; see planPrompt.
+// permissionPrompt is the box a tool's approval gets.
 func permissionPrompt(input *hookInput) hitl.Prompt {
-	if input.ToolName == exitPlanModeTool {
-		return planPrompt(input)
-	}
-
 	choices := []string{allowOnce, denyChoice}
 	// "Don't ask again" is only offerable when the CLI told us what rule it
 	// would write; there is nothing to apply otherwise.
@@ -418,8 +422,6 @@ func terminalDecision(choices []string, a hitl.Answer) notifications.Decision {
 			Status:   "approved",
 			Response: json.RawMessage(`{"apply_permission":0}`),
 		}
-	case planAutoMode, planManualEdits:
-		return approvedWithPlanChoice(planChoiceOf(choices[a.Index]))
 	}
 	return notifications.Decision{Status: "denied"}
 }

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -175,13 +175,37 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 
 	if decision.Status == "approved" {
 		resp.HookSpecificOutput.Decision.Behavior = "allow"
-		applyApproval(ctx, &input, payloadJSON, decision, &resp)
+		applyApproval(&input, payloadJSON, decision, &resp)
 	} else {
 		resp.HookSpecificOutput.Decision.Behavior = "deny"
 		resp.HookSpecificOutput.Decision.Message = denyMessage(&input, decision)
 	}
 
+	// An approved plan is not settled by this reply; see answerPlanDialog. The
+	// keystroke has to follow the reply rather than accompany it, because the
+	// CLI draws the dialog it lands on only once the hook has answered.
+	if choice := approvedPlanChoice(&input, decision); choice != "" {
+		resp.HookSpecificOutput.Decision.Behavior = "ask"
+		recordPlanMode(ctx, input.SessionID, choice)
+		go answerPlanDialog(ctx.Terminal, input.SessionID, choice)
+	}
+
 	writePermResponse(w, resp)
+}
+
+// approvedPlanChoice returns the plan row a surface picked, or "" when this
+// decision is not an approved plan.
+func approvedPlanChoice(input *hookInput, decision *notifications.Decision) string {
+	if input.ToolName != exitPlanModeTool || decision.Status != "approved" ||
+		len(decision.Response) == 0 {
+		return ""
+	}
+	var answer permissionAnswer
+	if err := json.Unmarshal(decision.Response, &answer); err != nil {
+		log.Printf("hook: read plan answer for %s: %v", input.SessionID, err)
+		return ""
+	}
+	return answer.PlanChoice
 }
 
 // permissionAnswer is what a surface sends back for an approval, whichever
@@ -192,19 +216,19 @@ type permissionAnswer struct {
 	// ApplyPermission indexes the CLI's own permission_suggestions, and means
 	// "don't ask again".
 	ApplyPermission *int `json:"apply_permission,omitempty"`
-	// PermissionUpdates are permission changes helios composed itself rather
-	// than picked from a suggestion — a plan's setMode, for one.
-	PermissionUpdates json.RawMessage `json:"permission_updates,omitempty"`
+	// PlanChoice is the way a plan was approved: which mode the session
+	// continues in. Empty for every tool but ExitPlanMode.
+	PlanChoice string `json:"plan_choice,omitempty"`
 	// Feedback is what the user wrote when they refused. Claude reads it in
 	// place of the tool's result.
 	Feedback string `json:"feedback,omitempty"`
 }
 
 // empty reports whether the answer says nothing beyond yes or no. Written out
-// because the struct holds a map and a slice, so == does not apply.
+// because the struct holds a map, so == does not apply.
 func (a permissionAnswer) empty() bool {
 	return a.UpdatedInput == nil && a.ApplyPermission == nil &&
-		len(a.PermissionUpdates) == 0 && a.Feedback == ""
+		a.PlanChoice == "" && a.Feedback == ""
 }
 
 // answerJSON encodes an answer helios composed itself. The value is built from
@@ -220,8 +244,8 @@ func answerJSON(a permissionAnswer) json.RawMessage {
 }
 
 // applyApproval folds whatever the answering surface sent into the reply the
-// CLI gets: an edited input, a rule to remember, or the mode to continue in.
-func applyApproval(ctx *provider.HookContext, input *hookInput, payloadJSON []byte,
+// CLI gets: an edited input, or a rule to remember.
+func applyApproval(input *hookInput, payloadJSON []byte,
 	decision *notifications.Decision, resp *permResponse) {
 	if len(decision.Response) == 0 {
 		return
@@ -239,12 +263,6 @@ func applyApproval(ctx *provider.HookContext, input *hookInput, payloadJSON []by
 		if rule := suggestedRule(payloadJSON, *answer.ApplyPermission); rule != nil {
 			resp.HookSpecificOutput.Decision.UpdatedPermissions = rule
 		}
-	}
-	// Composed updates win over a suggestion index: only one of the two is ever
-	// sent, and this one names the change outright rather than pointing at it.
-	if len(answer.PermissionUpdates) > 0 {
-		resp.HookSpecificOutput.Decision.UpdatedPermissions = answer.PermissionUpdates
-		recordSessionMode(ctx, input.SessionID, answer.PermissionUpdates)
 	}
 }
 
@@ -400,10 +418,8 @@ func terminalDecision(choices []string, a hitl.Answer) notifications.Decision {
 			Status:   "approved",
 			Response: json.RawMessage(`{"apply_permission":0}`),
 		}
-	case planAcceptEdits:
-		return approvedWithMode(modeAcceptEdits)
-	case planManualEdits:
-		return approvedWithMode(modeDefault)
+	case planAutoMode, planManualEdits:
+		return approvedWithPlanChoice(planChoiceOf(choices[a.Index]))
 	}
 	return notifications.Decision{Status: "denied"}
 }

--- a/internal/provider/claude/hooks.go
+++ b/internal/provider/claude/hooks.go
@@ -175,39 +175,139 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 
 	if decision.Status == "approved" {
 		resp.HookSpecificOutput.Decision.Behavior = "allow"
-
-		if len(decision.Response) > 0 {
-			var respData struct {
-				UpdatedInput    map[string]interface{} `json:"updated_input,omitempty"`
-				ApplyPermission *int                   `json:"apply_permission,omitempty"`
-			}
-			if json.Unmarshal(decision.Response, &respData) == nil {
-				if respData.UpdatedInput != nil {
-					resp.HookSpecificOutput.Decision.UpdatedInput = respData.UpdatedInput
-				}
-				if respData.ApplyPermission != nil {
-					var p map[string]json.RawMessage
-					if json.Unmarshal(payloadJSON, &p) == nil {
-						if sugRaw, ok := p["permission_suggestions"]; ok {
-							var suggestions []json.RawMessage
-							if json.Unmarshal(sugRaw, &suggestions) == nil {
-								idx := *respData.ApplyPermission
-								if idx >= 0 && idx < len(suggestions) {
-									resp.HookSpecificOutput.Decision.UpdatedPermissions =
-										json.RawMessage("[" + string(suggestions[idx]) + "]")
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+		applyApproval(ctx, &input, payloadJSON, decision, &resp)
 	} else {
 		resp.HookSpecificOutput.Decision.Behavior = "deny"
-		resp.HookSpecificOutput.Decision.Message = "Denied via helios"
+		resp.HookSpecificOutput.Decision.Message = denyMessage(&input, decision)
 	}
 
 	writePermResponse(w, resp)
+}
+
+// permissionAnswer is what a surface sends back for an approval, whichever
+// surface it was. Every field is optional: a plain "Allow once" carries none.
+type permissionAnswer struct {
+	// UpdatedInput replaces the tool's arguments with the ones the user edited.
+	UpdatedInput map[string]interface{} `json:"updated_input,omitempty"`
+	// ApplyPermission indexes the CLI's own permission_suggestions, and means
+	// "don't ask again".
+	ApplyPermission *int `json:"apply_permission,omitempty"`
+	// PermissionUpdates are permission changes helios composed itself rather
+	// than picked from a suggestion — a plan's setMode, for one.
+	PermissionUpdates json.RawMessage `json:"permission_updates,omitempty"`
+	// Feedback is what the user wrote when they refused. Claude reads it in
+	// place of the tool's result.
+	Feedback string `json:"feedback,omitempty"`
+}
+
+// empty reports whether the answer says nothing beyond yes or no. Written out
+// because the struct holds a map and a slice, so == does not apply.
+func (a permissionAnswer) empty() bool {
+	return a.UpdatedInput == nil && a.ApplyPermission == nil &&
+		len(a.PermissionUpdates) == 0 && a.Feedback == ""
+}
+
+// answerJSON encodes an answer helios composed itself. The value is built from
+// known fields, so an error is a bug rather than bad input, and the decision
+// still stands without the detail.
+func answerJSON(a permissionAnswer) json.RawMessage {
+	raw, err := json.Marshal(a)
+	if err != nil {
+		log.Printf("hook: encode permission answer: %v", err)
+		return nil
+	}
+	return raw
+}
+
+// applyApproval folds whatever the answering surface sent into the reply the
+// CLI gets: an edited input, a rule to remember, or the mode to continue in.
+func applyApproval(ctx *provider.HookContext, input *hookInput, payloadJSON []byte,
+	decision *notifications.Decision, resp *permResponse) {
+	if len(decision.Response) == 0 {
+		return
+	}
+	var answer permissionAnswer
+	if err := json.Unmarshal(decision.Response, &answer); err != nil {
+		log.Printf("hook: read permission answer for %s: %v", input.SessionID, err)
+		return
+	}
+
+	if answer.UpdatedInput != nil {
+		resp.HookSpecificOutput.Decision.UpdatedInput = answer.UpdatedInput
+	}
+	if answer.ApplyPermission != nil {
+		if rule := suggestedRule(payloadJSON, *answer.ApplyPermission); rule != nil {
+			resp.HookSpecificOutput.Decision.UpdatedPermissions = rule
+		}
+	}
+	// Composed updates win over a suggestion index: only one of the two is ever
+	// sent, and this one names the change outright rather than pointing at it.
+	if len(answer.PermissionUpdates) > 0 {
+		resp.HookSpecificOutput.Decision.UpdatedPermissions = answer.PermissionUpdates
+		recordSessionMode(ctx, input.SessionID, answer.PermissionUpdates)
+	}
+}
+
+// suggestedRule returns the rule at idx of the CLI's own suggestions, wrapped
+// as the one-entry list updatedPermissions takes.
+func suggestedRule(payloadJSON []byte, idx int) json.RawMessage {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+		return nil
+	}
+	raw, ok := payload["permission_suggestions"]
+	if !ok {
+		return nil
+	}
+	var suggestions []json.RawMessage
+	if err := json.Unmarshal(raw, &suggestions); err != nil {
+		return nil
+	}
+	if idx < 0 || idx >= len(suggestions) {
+		return nil
+	}
+	return json.RawMessage("[" + string(suggestions[idx]) + "]")
+}
+
+// What Claude reads in place of the tool's result when it is refused.
+//
+// A denied tool call reaches the model as "Error: <message>", so a bare
+// instruction there reads as something that went wrong rather than as someone
+// talking. Each of these says who is speaking.
+const (
+	deniedReason   = "Denied via helios"
+	deniedFeedback = "The user denied this in helios and said:"
+	planFeedbacked = "The user reviewed this plan in helios and asked for changes:"
+	// planRejected covers the plan refused without a word. A plan is how Claude
+	// asks to start work, so a bare no has to say what happens next, or it
+	// reads as "stop".
+	planRejected = "The user rejected this plan in helios without saying why. " +
+		"Stay in plan mode, ask them what to change, and call ExitPlanMode again."
+)
+
+// denyMessage renders a refusal as the text Claude receives.
+func denyMessage(input *hookInput, decision *notifications.Decision) string {
+	text := ""
+	if len(decision.Response) > 0 {
+		var answer permissionAnswer
+		if err := json.Unmarshal(decision.Response, &answer); err != nil {
+			log.Printf("hook: read denial for %s: %v", input.SessionID, err)
+		} else {
+			text = strings.TrimSpace(answer.Feedback)
+		}
+	}
+
+	plan := input.ToolName == exitPlanModeTool
+	switch {
+	case text != "" && plan:
+		return planFeedbacked + "\n" + text
+	case text != "":
+		return deniedFeedback + "\n" + text
+	case plan:
+		return planRejected
+	default:
+		return deniedReason
+	}
 }
 
 // The approval choices helios draws over the terminal. They are compared by
@@ -222,20 +322,30 @@ const (
 // showPermissionPrompt paints the approval over the session's terminal so the
 // person sitting at it can answer, and returns the function that takes it down.
 func showPermissionPrompt(ctx *provider.HookContext, input *hookInput, notifID string) func() {
+	p := permissionPrompt(input)
+	return showPrompt(ctx, input.SessionID, p, func(a hitl.Answer) {
+		resolvePermissionFromTerminal(ctx, notifID, p.Choices, a)
+	})
+}
+
+// permissionPrompt is the box a tool's approval gets. A plan is asking
+// something else than "may I run this", so it gets its own; see planPrompt.
+func permissionPrompt(input *hookInput) hitl.Prompt {
+	if input.ToolName == exitPlanModeTool {
+		return planPrompt(input)
+	}
+
 	choices := []string{allowOnce, denyChoice}
 	// "Don't ask again" is only offerable when the CLI told us what rule it
 	// would write; there is nothing to apply otherwise.
 	if len(input.PermissionSuggestions) > 0 {
 		choices = []string{allowOnce, allowAlways, denyChoice}
 	}
-
-	return showPrompt(ctx, input.SessionID, hitl.Prompt{
+	return hitl.Prompt{
 		Title:   input.ToolName,
 		Body:    []string{summarizeToolInput(input.ToolInput)},
 		Choices: choices,
-	}, func(a hitl.Answer) {
-		resolvePermissionFromTerminal(ctx, notifID, choices, a)
-	})
+	}
 }
 
 // showPrompt paints a helios modal over a session's terminal and returns the
@@ -260,22 +370,42 @@ func showPrompt(ctx *provider.HookContext, sessionID string, p hitl.Prompt, onAn
 // phone would have produced and resolves it through the manager, so which
 // surface won is decided in exactly one place.
 func resolvePermissionFromTerminal(ctx *provider.HookContext, notifID string, choices []string, a hitl.Answer) {
-	decision := notifications.Decision{Status: "denied"}
-	if !a.Cancelled() && a.Index < len(choices) {
-		switch choices[a.Index] {
-		case allowOnce:
-			decision.Status = "approved"
-		case allowAlways:
-			decision.Status = "approved"
-			// The suggestions are a list, and the CLI puts the one it would
-			// apply first. Same index the phone's "don't ask again" sends.
-			decision.Response = json.RawMessage(`{"apply_permission":0}`)
-		}
-	}
+	decision := terminalDecision(choices, a)
 	if err := ctx.Mgr.Resolve(notifID, decision, "terminal"); err != nil &&
 		!errors.Is(err, store.ErrAlreadyResolved) {
 		log.Printf("hook: resolve permission %s from the terminal: %v", notifID, err)
 	}
+}
+
+// terminalDecision reads an answer off the overlay. Anything it does not
+// recognise — escape, a row that is gone, a prompt that changed under it —
+// denies, because the safe reading of an unclear answer is no.
+func terminalDecision(choices []string, a hitl.Answer) notifications.Decision {
+	// Text first: a typed answer carries Index -1, so indexing choices with it
+	// would read off the front of the list.
+	if text := strings.TrimSpace(a.Text); text != "" {
+		return deniedWithFeedback(text)
+	}
+	if a.Cancelled() || a.Index < 0 || a.Index >= len(choices) {
+		return notifications.Decision{Status: "denied"}
+	}
+
+	switch choices[a.Index] {
+	case allowOnce:
+		return notifications.Decision{Status: "approved"}
+	case allowAlways:
+		// The suggestions are a list, and the CLI puts the one it would apply
+		// first. Same index the phone's "don't ask again" sends.
+		return notifications.Decision{
+			Status:   "approved",
+			Response: json.RawMessage(`{"apply_permission":0}`),
+		}
+	case planAcceptEdits:
+		return approvedWithMode(modeAcceptEdits)
+	case planManualEdits:
+		return approvedWithMode(modeDefault)
+	}
+	return notifications.Decision{Status: "denied"}
 }
 
 // ==================== AskUserQuestion Hook ====================
@@ -1301,6 +1431,11 @@ func summarizeToolInput(raw json.RawMessage) string {
 			return cmd[:100] + "..."
 		}
 		return cmd
+	}
+	// A plan is markdown, and its first heading is the title someone reading a
+	// push notification needs. Raw JSON cut at 100 characters is not.
+	if plan, ok := m["plan"].(string); ok {
+		return planHeadline(plan)
 	}
 	if len(raw) > 100 {
 		return string(raw[:100]) + "..."

--- a/internal/provider/claude/hooks_test.go
+++ b/internal/provider/claude/hooks_test.go
@@ -45,6 +45,7 @@ type fakeBackend struct {
 	keys    []string // "sessionID:key"
 	texts   []string // "sessionID:text"
 	evicted map[string]bool
+	screen  string
 }
 
 func newFakeBackend() *fakeBackend {
@@ -115,7 +116,37 @@ func (f *fakeBackend) SendKey(sessionID string, k backend.Key) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.keys = append(f.keys, sessionID+":"+string(k))
+	if k == backend.KeyUp || k == backend.KeyDown {
+		f.screen = moveHighlight(f.screen, k)
+	}
 	return nil
+}
+
+// moveHighlight walks the ❯ marker one row, so a fake screen answers arrows the
+// way a real dialog does. A picker that reads the screen between keystrokes
+// arrows forever without it.
+func moveHighlight(screen string, k backend.Key) string {
+	lines := strings.Split(screen, "\n")
+	at := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "❯") {
+			at = i
+			break
+		}
+	}
+	if at < 0 {
+		return screen
+	}
+	to := at + 1
+	if k == backend.KeyUp {
+		to = at - 1
+	}
+	if to < 0 || to >= len(lines) || strings.TrimSpace(lines[to]) == "" {
+		return screen
+	}
+	lines[at] = strings.Replace(lines[at], "❯ ", "  ", 1)
+	lines[to] = "❯ " + strings.TrimLeft(lines[to], " ")
+	return strings.Join(lines, "\n")
 }
 
 // sentKeys returns a copy of the recorded keystrokes.
@@ -133,9 +164,19 @@ func (f *fakeBackend) Kill(sessionID string) error {
 	return nil
 }
 
-// Capture reports an empty screen: nothing in this package reads a session's
-// screen any more.
-func (f *fakeBackend) Capture(sessionID string) (string, error) { return "", nil }
+// Capture reports whatever the test put on the session's screen. An approved
+// plan is answered on the CLI's own dialog, which means reading it first.
+func (f *fakeBackend) Capture(sessionID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.screen, nil
+}
+
+func (f *fakeBackend) setScreen(text string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.screen = text
+}
 
 func (f *fakeBackend) Rename(sessionID, name string) error {
 	f.renames = append(f.renames, sessionID+":"+name)

--- a/internal/provider/claude/plan.go
+++ b/internal/provider/claude/plan.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/hitl"
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/provider"
@@ -19,30 +21,22 @@ import (
 // back with a reason. See docs/specs/57-plan-approval.md.
 const exitPlanModeTool = "ExitPlanMode"
 
-// The rows helios draws for a plan, in the CLI's own words. The first two
+// The rows helios draws for a plan, worded as the CLI words them. The first two
 // differ only in the mode they leave the session in. The third is not a choice
 // at all: it labels the row that opens the answer field.
 const (
-	planAcceptEdits = "Yes, auto-accept edits"
+	planAutoMode    = "Yes, and use auto mode"
 	planManualEdits = "Yes, manually approve edits"
 	planFeedback    = "Tell Claude what to change"
 )
 
 const (
-	planAcceptEditsDetail = "Claude edits files without asking for the rest of this session"
+	planAutoModeDetail    = "Claude edits and runs commands without asking, for the rest of this session"
 	planManualEditsDetail = "Claude asks before each edit, as it does now"
 )
 
-// The permission modes the two "Yes" rows switch a session to, spelled the way
-// the CLI's setMode update spells them. Note that these are not the names
-// helios stores; see heliosMode.
-const (
-	modeAcceptEdits = "acceptEdits"
-	modeDefault     = "default"
-)
-
-// planTitle names the box after the decision rather than after the tool. A
-// tool name is the right label for Bash. Here it would name the mechanism.
+// planTitle names the box after the decision rather than after the tool. A tool
+// name is the right label for Bash. Here it would name the mechanism.
 const planTitle = "Ready to code?"
 
 // planPrompt is the approval a plan gets.
@@ -50,8 +44,8 @@ func planPrompt(input *hookInput) hitl.Prompt {
 	return hitl.Prompt{
 		Title:     planTitle,
 		Body:      planBody(input.ToolInput),
-		Choices:   []string{planAcceptEdits, planManualEdits},
-		Details:   []string{planAcceptEditsDetail, planManualEditsDetail},
+		Choices:   []string{planAutoMode, planManualEdits},
+		Details:   []string{planAutoModeDetail, planManualEditsDetail},
 		AllowText: true,
 		TextLabel: planFeedback,
 	}
@@ -126,22 +120,32 @@ func planHeadline(plan string) string {
 	return ""
 }
 
-// setModeUpdate is the permission update that leaves the session in mode.
-//
-// The shape is the CLI's own: its plan dialog sends exactly this through
-// permissionUpdates when the user picks one of the "Yes" rows. Measured against
-// Claude Code 2.1.259.
-func setModeUpdate(mode string) json.RawMessage {
-	return json.RawMessage(fmt.Sprintf(
-		`[{"type":"setMode","destination":"session","mode":%q}]`, mode))
+// The two ways to say yes to a plan, as they travel between surfaces. Short
+// names rather than the row labels, because the labels are the CLI's copy and
+// change with its releases.
+const (
+	planChoiceAuto   = "auto"
+	planChoiceManual = "manual"
+)
+
+// planChoiceOf names the answer a row stands for, or "" for a row that is not
+// one of the two ways to say yes.
+func planChoiceOf(choice string) string {
+	switch choice {
+	case planAutoMode:
+		return planChoiceAuto
+	case planManualEdits:
+		return planChoiceManual
+	}
+	return ""
 }
 
-// approvedWithMode is a "Yes" row: the plan is approved, and the session
-// continues in mode rather than in the mode plan mode was entered from.
-func approvedWithMode(mode string) notifications.Decision {
+// approvedWithPlanChoice is a "Yes" row. The mode rides along because the CLI
+// does not take it from the hook; see answerPlanDialog.
+func approvedWithPlanChoice(choice string) notifications.Decision {
 	return notifications.Decision{
 		Status:   "approved",
-		Response: answerJSON(permissionAnswer{PermissionUpdates: setModeUpdate(mode)}),
+		Response: answerJSON(permissionAnswer{PlanChoice: choice}),
 	}
 }
 
@@ -153,53 +157,70 @@ func deniedWithFeedback(text string) notifications.Decision {
 	}
 }
 
-// recordSessionMode writes a mode switch back to the session record.
+// What each plan choice matches on the CLI's own dialog, and the permission
+// mode helios records for it.
 //
-// The CLI applies a setMode update to the running process only. Helios repeats
-// --permission-mode from the record on every resume (see ResumeArgs), so
-// without this a session that left plan mode would wake back up inside it.
-func recordSessionMode(ctx *provider.HookContext, sessionID string, updates json.RawMessage) {
-	mode := heliosMode(setModeOf(updates))
-	if mode == "" {
+// The match is a substring of the CLI's row, kept to the words that carry the
+// meaning. Its full copy is "Yes, and use auto mode", and that wording is the
+// CLI's to change.
+var planChoices = map[string]struct {
+	dialogRow string
+	mode      string
+}{
+	planChoiceAuto:   {dialogRow: "auto mode", mode: "auto"},
+	planChoiceManual: {dialogRow: "manually approve", mode: "manual"},
+}
+
+// planDialogWait is how long helios keeps looking for the CLI's dialog.
+//
+// The hook has to answer before the dialog is drawn — the CLI holds it back
+// until the hook replies — so the reply and the keystroke cannot be sent
+// together. Measured at well under a second; the rest is slack.
+const (
+	planDialogWait = 15 * time.Second
+	planDialogPoll = 150 * time.Millisecond
+)
+
+// answerPlanDialog picks a row on the CLI's own plan dialog.
+//
+// A plan is the one permission the CLI will not let a hook decide: an "allow"
+// for ExitPlanMode is ignored and the dialog is shown regardless. Measured
+// against Claude Code 2.1.259 — an allow, with and without a setMode permission
+// update, left the dialog up and the plan unstarted. So helios collects the
+// answer on its own overlay, replies "ask" to get out of the CLI's way, and
+// presses the row the user chose.
+//
+// Failing here is survivable and deliberately quiet: the CLI's dialog is on
+// screen, fully usable, and the person at the terminal can answer it. That is
+// also the behaviour if the CLI renames a row out from under the match.
+func answerPlanDialog(b backend.Backend, sessionID, choice string) {
+	row, ok := planChoices[choice]
+	if !ok {
 		return
 	}
-	if err := ctx.DB.UpdateSessionPermissionMode(sessionID, mode); err != nil {
-		log.Printf("hook: record permission mode %q for %s: %v", mode, sessionID, err)
-	}
-}
 
-// setModeOf returns the mode a set of permission updates switches to, or ""
-// when none of them does. Rules and directories are not a mode change.
-func setModeOf(updates json.RawMessage) string {
-	if len(updates) == 0 {
-		return ""
-	}
-	var list []struct {
-		Type string `json:"type"`
-		Mode string `json:"mode"`
-	}
-	if err := json.Unmarshal(updates, &list); err != nil {
-		return ""
-	}
-	for _, u := range list {
-		if u.Type == "setMode" && u.Mode != "" {
-			return u.Mode
+	deadline := time.Now().Add(planDialogWait)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if lastErr = provider.ConfirmChoice(b, sessionID, row.dialogRow); lastErr == nil {
+			return
 		}
+		time.Sleep(planDialogPoll)
 	}
-	return ""
+	log.Printf("hook: answer the plan dialog for %s with %q: %v", sessionID, row.dialogRow, lastErr)
 }
 
-// heliosMode maps the CLI's name for a permission mode onto the one helios
-// stores, and returns "" for a mode helios cannot launch with.
+// recordPlanMode writes an approved plan's mode to the session record.
 //
-// The two vocabularies agree on all but one name: setMode calls the
-// ask-each-time mode "default", and --permission-mode calls it "manual".
-func heliosMode(cliMode string) string {
-	if cliMode == modeDefault {
-		return "manual"
+// The CLI applies the mode to the running process only. Helios repeats
+// --permission-mode from the record on every resume (see ResumeArgs), so
+// without this a session that left plan mode would wake back up inside it.
+func recordPlanMode(ctx *provider.HookContext, sessionID, choice string) {
+	row, ok := planChoices[choice]
+	if !ok {
+		return
 	}
-	if ValidPermissionMode(cliMode) {
-		return cliMode
+	if err := ctx.DB.UpdateSessionPermissionMode(sessionID, row.mode); err != nil {
+		log.Printf("hook: record permission mode %q for %s: %v", row.mode, sessionID, err)
 	}
-	return ""
 }

--- a/internal/provider/claude/plan.go
+++ b/internal/provider/claude/plan.go
@@ -1,13 +1,12 @@
 package claude
 
 import (
-	"encoding/json"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/kamrul1157024/helios/internal/backend"
-	"github.com/kamrul1157024/helios/internal/hitl"
 	"github.com/kamrul1157024/helios/internal/notifications"
 	"github.com/kamrul1157024/helios/internal/provider"
 )
@@ -17,68 +16,9 @@ import (
 // On the wire its approval is a permission like any other, so helios used to
 // paint "Allow once" and "Deny" over it. It is not a yes-or-no question: the
 // CLI's own dialog offers the mode to continue in, and a way to send the plan
-// back with a reason. See docs/specs/57-plan-approval.md.
+// back with a reason. Helios leaves that dialog alone and answers it for a
+// remote surface. See docs/specs/57-plan-approval.md.
 const exitPlanModeTool = "ExitPlanMode"
-
-// The rows helios draws for a plan, worded as the CLI words them. The first two
-// differ only in the mode they leave the session in. The third is not a choice
-// at all: it labels the row that opens the answer field.
-const (
-	planAutoMode    = "Yes, and use auto mode"
-	planManualEdits = "Yes, manually approve edits"
-	planFeedback    = "Tell Claude what to change"
-)
-
-const (
-	planAutoModeDetail    = "Claude edits and runs commands without asking, for the rest of this session"
-	planManualEditsDetail = "Claude asks before each edit, as it does now"
-)
-
-// planTitle names the box after the decision rather than after the tool. A tool
-// name is the right label for Bash. Here it would name the mechanism.
-const planTitle = "Ready to code?"
-
-// planPrompt is the approval a plan gets.
-func planPrompt(input *hookInput) hitl.Prompt {
-	return hitl.Prompt{
-		Title:     planTitle,
-		Body:      planBody(input.ToolInput),
-		Choices:   []string{planAutoMode, planManualEdits},
-		Details:   []string{planAutoModeDetail, planManualEditsDetail},
-		AllowText: true,
-		TextLabel: planFeedback,
-	}
-}
-
-// planBody is what the box says above the rows: where the plan is written down,
-// and nothing else.
-//
-// The plan itself is not repeated. The CLI has already printed it into the
-// transcript immediately above — headings, tables, colour — and the overlay is
-// plain box-drawn text with no markdown renderer and nowhere to scroll. What it
-// drew was a worse second copy of a good first one: raw markdown, capped
-// mid-plan, and paid for in the rows it pushed off a short screen. The path is
-// kept because it is the one thing the transcript does not say.
-func planBody(toolInput json.RawMessage) []string {
-	var in struct {
-		Plan     string `json:"plan"`
-		FilePath string `json:"planFilePath"`
-	}
-	if len(toolInput) > 0 {
-		if err := json.Unmarshal(toolInput, &in); err != nil {
-			log.Printf("hook: parse plan: %v", err)
-		}
-	}
-	// No plan text means the CLI printed nothing to read either, so the box is
-	// the only place left to say what is being approved.
-	if strings.TrimSpace(in.Plan) == "" {
-		return []string{summarizeToolInput(toolInput)}
-	}
-	if in.FilePath == "" {
-		return nil
-	}
-	return []string{in.FilePath}
-}
 
 // planHeadlineMax keeps the one-line form short enough for a phone's push
 // notification, which shows a couple of lines at most.
@@ -108,27 +48,6 @@ const (
 	planChoiceManual = "manual"
 )
 
-// planChoiceOf names the answer a row stands for, or "" for a row that is not
-// one of the two ways to say yes.
-func planChoiceOf(choice string) string {
-	switch choice {
-	case planAutoMode:
-		return planChoiceAuto
-	case planManualEdits:
-		return planChoiceManual
-	}
-	return ""
-}
-
-// approvedWithPlanChoice is a "Yes" row. The mode rides along because the CLI
-// does not take it from the hook; see answerPlanDialog.
-func approvedWithPlanChoice(choice string) notifications.Decision {
-	return notifications.Decision{
-		Status:   "approved",
-		Response: answerJSON(permissionAnswer{PlanChoice: choice}),
-	}
-}
-
 // deniedWithFeedback sends the plan back with the user's own words.
 func deniedWithFeedback(text string) notifications.Decision {
 	return notifications.Decision{
@@ -141,14 +60,16 @@ func deniedWithFeedback(text string) notifications.Decision {
 // mode helios records for it.
 //
 // The match is a substring of the CLI's row, kept to the words that carry the
-// meaning. Its full copy is "Yes, and use auto mode", and that wording is the
-// CLI's to change.
+// meaning. There is more than one per row because the copy is the CLI's to
+// change and it has: 2.1.259 offers "Yes, and use auto mode", 2.1.126 offers
+// "Yes, auto-accept edits". Helios has to answer whichever is installed, so it
+// tries each in turn.
 var planChoices = map[string]struct {
-	dialogRow string
-	mode      string
+	dialogRows []string
+	mode       string
 }{
-	planChoiceAuto:   {dialogRow: "auto mode", mode: "auto"},
-	planChoiceManual: {dialogRow: "manually approve", mode: "manual"},
+	planChoiceAuto:   {dialogRows: []string{"auto-accept", "auto mode"}, mode: "auto"},
+	planChoiceManual: {dialogRows: []string{"manually approve"}, mode: "manual"},
 }
 
 // planDialogWait is how long helios keeps looking for the CLI's dialog.
@@ -161,14 +82,32 @@ const (
 	planDialogPoll = 150 * time.Millisecond
 )
 
+// planDialogSentinel is the CLI's own question, and the proof that its dialog
+// is the thing on screen. Nothing is pressed before it appears: a digit sent at
+// any other moment is a digit typed into the composer.
+const planDialogSentinel = "would you like to proceed"
+
+// planRowNumber reads the number off a numbered dialog row: "❯ 1. Yes, …" is
+// answered by pressing 1.
+var planRowNumber = regexp.MustCompile(`^[^0-9]*([1-9])\.`)
+
+// planDigits maps a row's number to the key that presses it. The CLI has never
+// offered a fourth row, and a plan whose rows ran past three would need reading
+// before it was answered anyway.
+var planDigits = map[string]backend.Key{"1": backend.Key1, "2": backend.Key2, "3": backend.Key3}
+
 // answerPlanDialog picks a row on the CLI's own plan dialog.
 //
 // A plan is the one permission the CLI will not let a hook decide: an "allow"
 // for ExitPlanMode is ignored and the dialog is shown regardless. Measured
 // against Claude Code 2.1.259 — an allow, with and without a setMode permission
-// update, left the dialog up and the plan unstarted. So helios collects the
-// answer on its own overlay, replies "ask" to get out of the CLI's way, and
-// presses the row the user chose.
+// update, left the dialog up and the plan unstarted. So helios replies "ask" to
+// get out of the CLI's way and presses the row the user chose.
+//
+// The row is pressed by its number rather than by walking the highlight onto
+// it. The composer's own "❯" sits below the dialog, and a highlight walk reads
+// that as the cursor: it then presses Up until it gives up, having moved the
+// selection somewhere nobody asked for.
 //
 // Failing here is survivable and deliberately quiet: the CLI's dialog is on
 // screen, fully usable, and the person at the terminal can answer it. That is
@@ -180,14 +119,67 @@ func answerPlanDialog(b backend.Backend, sessionID, choice string) {
 	}
 
 	deadline := time.Now().Add(planDialogWait)
-	var lastErr error
 	for time.Now().Before(deadline) {
-		if lastErr = provider.ConfirmChoice(b, sessionID, row.dialogRow); lastErr == nil {
+		if key, found := planRowKey(b, sessionID, row.dialogRows); found {
+			if err := b.SendKey(sessionID, key); err != nil {
+				log.Printf("hook: press %q on the plan dialog for %s: %v", key, sessionID, err)
+			}
 			return
 		}
 		time.Sleep(planDialogPoll)
 	}
-	log.Printf("hook: answer the plan dialog for %s with %q: %v", sessionID, row.dialogRow, lastErr)
+	// The screen goes in the log because without it a miss says only that the
+	// rows were not found, and every cause looks the same from there: a renamed
+	// row, a dialog that never came, a capture that read something else.
+	log.Printf("hook: answer the plan dialog for %s with %v: no row matched\nlast screen:\n%s",
+		sessionID, row.dialogRows, lastScreen(b, sessionID))
+}
+
+// planRowKey finds the digit that answers the wanted row, once the CLI's dialog
+// is the thing on screen.
+func planRowKey(b backend.Backend, sessionID string, want []string) (backend.Key, bool) {
+	screen, err := b.Capture(sessionID)
+	if err != nil {
+		return "", false
+	}
+	lower := strings.ToLower(screen)
+	if !strings.Contains(lower, planDialogSentinel) {
+		return "", false
+	}
+	for _, line := range strings.Split(lower, "\n") {
+		number := planRowNumber.FindStringSubmatch(strings.TrimSpace(line))
+		if number == nil {
+			continue
+		}
+		for _, w := range want {
+			if strings.Contains(line, w) {
+				key, ok := planDigits[number[1]]
+				return key, ok
+			}
+		}
+	}
+	return "", false
+}
+
+// planScreenLines is how much of the screen a failure is worth. The rows sit at
+// the bottom, so the tail is the part that would have carried them.
+const planScreenLines = 15
+
+func lastScreen(b backend.Backend, sessionID string) string {
+	screen, err := b.Capture(sessionID)
+	if err != nil {
+		return "unavailable: " + err.Error()
+	}
+	var kept []string
+	for _, line := range strings.Split(screen, "\n") {
+		if strings.TrimSpace(line) != "" {
+			kept = append(kept, strings.TrimRight(line, " "))
+		}
+	}
+	if len(kept) > planScreenLines {
+		kept = kept[len(kept)-planScreenLines:]
+	}
+	return strings.Join(kept, "\n")
 }
 
 // recordPlanMode writes an approved plan's mode to the session record.

--- a/internal/provider/claude/plan.go
+++ b/internal/provider/claude/plan.go
@@ -2,7 +2,6 @@ package claude
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -51,16 +50,15 @@ func planPrompt(input *hookInput) hitl.Prompt {
 	}
 }
 
-// planBodyMaxLines caps how much of the plan the box shows. The overlay is
-// anchored to the bottom of the viewport and clips from the top, so an uncapped
-// plan pushes the rows themselves off the screen.
-const planBodyMaxLines = 14
-
-// planBody renders the plan for the overlay, one entry per line of markdown.
+// planBody is what the box says above the rows: where the plan is written down,
+// and nothing else.
 //
-// The line-per-entry part is not cosmetic: the box wraps on words and would
-// reflow a whole plan passed as one entry into a single paragraph, taking the
-// headings with it.
+// The plan itself is not repeated. The CLI has already printed it into the
+// transcript immediately above — headings, tables, colour — and the overlay is
+// plain box-drawn text with no markdown renderer and nowhere to scroll. What it
+// drew was a worse second copy of a good first one: raw markdown, capped
+// mid-plan, and paid for in the rows it pushed off a short screen. The path is
+// kept because it is the one thing the transcript does not say.
 func planBody(toolInput json.RawMessage) []string {
 	var in struct {
 		Plan     string `json:"plan"`
@@ -71,33 +69,15 @@ func planBody(toolInput json.RawMessage) []string {
 			log.Printf("hook: parse plan: %v", err)
 		}
 	}
+	// No plan text means the CLI printed nothing to read either, so the box is
+	// the only place left to say what is being approved.
 	if strings.TrimSpace(in.Plan) == "" {
 		return []string{summarizeToolInput(toolInput)}
 	}
-
-	lines := strings.Split(strings.TrimRight(in.Plan, "\n"), "\n")
-	hidden := 0
-	if len(lines) > planBodyMaxLines {
-		hidden = len(lines) - planBodyMaxLines
-		lines = lines[:planBodyMaxLines]
+	if in.FilePath == "" {
+		return nil
 	}
-	if tail := planTail(hidden, in.FilePath); tail != "" {
-		lines = append(lines, tail)
-	}
-	return lines
-}
-
-// planTail says what was cut and where the whole plan lives, so a box that
-// shows part of a plan is not the only copy the reader can reach.
-func planTail(hidden int, path string) string {
-	switch {
-	case hidden > 0 && path != "":
-		return fmt.Sprintf("…%d more lines · %s", hidden, path)
-	case hidden > 0:
-		return fmt.Sprintf("…%d more lines", hidden)
-	default:
-		return path
-	}
+	return []string{in.FilePath}
 }
 
 // planHeadlineMax keeps the one-line form short enough for a phone's push

--- a/internal/provider/claude/plan.go
+++ b/internal/provider/claude/plan.go
@@ -1,0 +1,205 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/provider"
+)
+
+// exitPlanModeTool is the tool Claude calls to leave plan mode.
+//
+// On the wire its approval is a permission like any other, so helios used to
+// paint "Allow once" and "Deny" over it. It is not a yes-or-no question: the
+// CLI's own dialog offers the mode to continue in, and a way to send the plan
+// back with a reason. See docs/specs/57-plan-approval.md.
+const exitPlanModeTool = "ExitPlanMode"
+
+// The rows helios draws for a plan, in the CLI's own words. The first two
+// differ only in the mode they leave the session in. The third is not a choice
+// at all: it labels the row that opens the answer field.
+const (
+	planAcceptEdits = "Yes, auto-accept edits"
+	planManualEdits = "Yes, manually approve edits"
+	planFeedback    = "Tell Claude what to change"
+)
+
+const (
+	planAcceptEditsDetail = "Claude edits files without asking for the rest of this session"
+	planManualEditsDetail = "Claude asks before each edit, as it does now"
+)
+
+// The permission modes the two "Yes" rows switch a session to, spelled the way
+// the CLI's setMode update spells them. Note that these are not the names
+// helios stores; see heliosMode.
+const (
+	modeAcceptEdits = "acceptEdits"
+	modeDefault     = "default"
+)
+
+// planTitle names the box after the decision rather than after the tool. A
+// tool name is the right label for Bash. Here it would name the mechanism.
+const planTitle = "Ready to code?"
+
+// planPrompt is the approval a plan gets.
+func planPrompt(input *hookInput) hitl.Prompt {
+	return hitl.Prompt{
+		Title:     planTitle,
+		Body:      planBody(input.ToolInput),
+		Choices:   []string{planAcceptEdits, planManualEdits},
+		Details:   []string{planAcceptEditsDetail, planManualEditsDetail},
+		AllowText: true,
+		TextLabel: planFeedback,
+	}
+}
+
+// planBodyMaxLines caps how much of the plan the box shows. The overlay is
+// anchored to the bottom of the viewport and clips from the top, so an uncapped
+// plan pushes the rows themselves off the screen.
+const planBodyMaxLines = 14
+
+// planBody renders the plan for the overlay, one entry per line of markdown.
+//
+// The line-per-entry part is not cosmetic: the box wraps on words and would
+// reflow a whole plan passed as one entry into a single paragraph, taking the
+// headings with it.
+func planBody(toolInput json.RawMessage) []string {
+	var in struct {
+		Plan     string `json:"plan"`
+		FilePath string `json:"planFilePath"`
+	}
+	if len(toolInput) > 0 {
+		if err := json.Unmarshal(toolInput, &in); err != nil {
+			log.Printf("hook: parse plan: %v", err)
+		}
+	}
+	if strings.TrimSpace(in.Plan) == "" {
+		return []string{summarizeToolInput(toolInput)}
+	}
+
+	lines := strings.Split(strings.TrimRight(in.Plan, "\n"), "\n")
+	hidden := 0
+	if len(lines) > planBodyMaxLines {
+		hidden = len(lines) - planBodyMaxLines
+		lines = lines[:planBodyMaxLines]
+	}
+	if tail := planTail(hidden, in.FilePath); tail != "" {
+		lines = append(lines, tail)
+	}
+	return lines
+}
+
+// planTail says what was cut and where the whole plan lives, so a box that
+// shows part of a plan is not the only copy the reader can reach.
+func planTail(hidden int, path string) string {
+	switch {
+	case hidden > 0 && path != "":
+		return fmt.Sprintf("…%d more lines · %s", hidden, path)
+	case hidden > 0:
+		return fmt.Sprintf("…%d more lines", hidden)
+	default:
+		return path
+	}
+}
+
+// planHeadlineMax keeps the one-line form short enough for a phone's push
+// notification, which shows a couple of lines at most.
+const planHeadlineMax = 100
+
+// planHeadline reduces a plan to one line: its first non-blank line, with the
+// markdown heading marks taken off.
+func planHeadline(plan string) string {
+	for _, line := range strings.Split(plan, "\n") {
+		line = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(line), "#"))
+		if line == "" {
+			continue
+		}
+		if len(line) > planHeadlineMax {
+			return line[:planHeadlineMax] + "..."
+		}
+		return line
+	}
+	return ""
+}
+
+// setModeUpdate is the permission update that leaves the session in mode.
+//
+// The shape is the CLI's own: its plan dialog sends exactly this through
+// permissionUpdates when the user picks one of the "Yes" rows. Measured against
+// Claude Code 2.1.259.
+func setModeUpdate(mode string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(
+		`[{"type":"setMode","destination":"session","mode":%q}]`, mode))
+}
+
+// approvedWithMode is a "Yes" row: the plan is approved, and the session
+// continues in mode rather than in the mode plan mode was entered from.
+func approvedWithMode(mode string) notifications.Decision {
+	return notifications.Decision{
+		Status:   "approved",
+		Response: answerJSON(permissionAnswer{PermissionUpdates: setModeUpdate(mode)}),
+	}
+}
+
+// deniedWithFeedback sends the plan back with the user's own words.
+func deniedWithFeedback(text string) notifications.Decision {
+	return notifications.Decision{
+		Status:   "denied",
+		Response: answerJSON(permissionAnswer{Feedback: text}),
+	}
+}
+
+// recordSessionMode writes a mode switch back to the session record.
+//
+// The CLI applies a setMode update to the running process only. Helios repeats
+// --permission-mode from the record on every resume (see ResumeArgs), so
+// without this a session that left plan mode would wake back up inside it.
+func recordSessionMode(ctx *provider.HookContext, sessionID string, updates json.RawMessage) {
+	mode := heliosMode(setModeOf(updates))
+	if mode == "" {
+		return
+	}
+	if err := ctx.DB.UpdateSessionPermissionMode(sessionID, mode); err != nil {
+		log.Printf("hook: record permission mode %q for %s: %v", mode, sessionID, err)
+	}
+}
+
+// setModeOf returns the mode a set of permission updates switches to, or ""
+// when none of them does. Rules and directories are not a mode change.
+func setModeOf(updates json.RawMessage) string {
+	if len(updates) == 0 {
+		return ""
+	}
+	var list []struct {
+		Type string `json:"type"`
+		Mode string `json:"mode"`
+	}
+	if err := json.Unmarshal(updates, &list); err != nil {
+		return ""
+	}
+	for _, u := range list {
+		if u.Type == "setMode" && u.Mode != "" {
+			return u.Mode
+		}
+	}
+	return ""
+}
+
+// heliosMode maps the CLI's name for a permission mode onto the one helios
+// stores, and returns "" for a mode helios cannot launch with.
+//
+// The two vocabularies agree on all but one name: setMode calls the
+// ask-each-time mode "default", and --permission-mode calls it "manual".
+func heliosMode(cliMode string) string {
+	if cliMode == modeDefault {
+		return "manual"
+	}
+	if ValidPermissionMode(cliMode) {
+		return cliMode
+	}
+	return ""
+}

--- a/internal/provider/claude/plan_test.go
+++ b/internal/provider/claude/plan_test.go
@@ -2,13 +2,15 @@ package claude
 
 import (
 	"encoding/json"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/provider"
 	"github.com/kamrul1157024/helios/internal/store"
-	"github.com/kamrul1157024/helios/internal/terminal"
 )
 
 // samplePlan is what the CLI puts in tool_input.plan: markdown, several lines.
@@ -35,12 +37,28 @@ func planHook(plan string) hookInput {
 // cliPlanDialog is the dialog Claude Code 2.1.259 draws for a plan, which
 // helios answers with a keystroke because the CLI ignores an allow for
 // ExitPlanMode. Copied from a real session.
+//
+// The composer sits under it, carrying a cursor mark of its own. That mark is
+// why the row is pressed by number: a highlight walk reads the lowest "❯" on
+// the screen as the dialog's selection and marches away from the rows.
 const cliPlanDialog = `Claude has written up a plan and is ready to execute. Would you like to proceed?
 ❯ 1. Yes, and use auto mode
   2. Yes, manually approve edits
   3. Tell Claude what to change
       shift+tab to approve with this feedback
-  ctrl+g to edit in Vim · ~/.claude/plans/rows.md`
+  ctrl+g to edit in Vim · ~/.claude/plans/rows.md
+────────────────────────────────────────────────
+❯ what shall we do next
+────────────────────────────────────────────────`
+
+// The same dialog on Claude Code 2.1.126, which words the first row
+// differently. Approving was a no-op against this build: the match looked for
+// "auto mode" and the row says "auto-accept edits".
+const cliPlanDialogAutoAccept = `Claude has written up a plan and is ready to execute. Would you like to proceed?
+❯ 1. Yes, auto-accept edits
+  2. Yes, manually approve edits
+  3. Tell Claude what to change
+      shift+tab to approve with this feedback`
 
 // awaitKeys waits for the handoff goroutine to finish pressing rows.
 func awaitKeys(t *testing.T, f *fakeBackend, want int) []string {
@@ -69,61 +87,79 @@ func sessionMode(t *testing.T, db *store.Store, sessionID string) string {
 	return *sess.PermissionMode
 }
 
-// The bug this closes: a plan is not a yes-or-no question, but helios painted
-// Allow once / Deny over it, so neither mode could be picked and disagreeing
-// meant a bare no.
-func TestPlan_PaintsTheModeRowsAndTheFeedbackRow(t *testing.T) {
+// answerFromPhone runs the permission hook and resolves its notification the
+// way a remote surface does. A plan has no terminal box to answer any more, so
+// this is the only way in besides the CLI's own dialog.
+func answerFromPhone(t *testing.T, ctx *provider.HookContext, input hookInput,
+	decision notifications.Decision) permResponse {
+	t.Helper()
+	ids := captureNotifIDs(ctx)
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- callHook(handlePermission, ctx, input) }()
+
+	if err := ctx.Mgr.Resolve(awaitNotifID(t, ids), decision, "mobile"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return permDecision(t, awaitResponse(t, done))
+}
+
+// The bug this closes: helios drew its own approval box over the dialog the CLI
+// draws for a plan. The two composite into one unreadable screen — which is
+// also the screen helios reads back when it presses a row for the phone.
+func TestPlan_PaintsNoBoxOverTheCLIsOwnDialog(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, _ := withTerminal(ctx)
+	terminalOf(ctx).setScreen(cliPlanDialog)
+
+	answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "denied"})
+
+	select {
+	case o := <-overlays.painted:
+		t.Errorf("helios painted %q over the CLI's own plan dialog", o.Title)
+	default:
+	}
+}
+
+// An ordinary tool keeps its box: only a plan has a dialog of the CLI's own to
+// leave alone.
+func TestPlan_OrdinaryToolsKeepTheirBox(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 	overlays, hitlCtl := withTerminal(ctx)
 
-	done, o := askPermission(t, ctx, overlays, planHook(samplePlan))
-
-	if o.Title != planTitle {
-		t.Errorf("title = %q, want %q — the tool name names the mechanism, not the decision", o.Title, planTitle)
+	done, o := askPermission(t, ctx, overlays, hookInput{
+		SessionID: "sess-1", CWD: "/tmp/proj", ToolName: "Bash",
+		ToolInput: json.RawMessage(`{"command":"ls"}`),
+	})
+	if o.Title != "Bash" {
+		t.Errorf("title = %q, want the tool name", o.Title)
 	}
-	want := []string{planAutoMode, planManualEdits}
-	if len(o.Options) != len(want) || o.Options[0] != want[0] || o.Options[1] != want[1] {
-		t.Errorf("options = %v, want %v", o.Options, want)
-	}
-	if len(o.Details) != 2 || o.Details[0] == "" || o.Details[1] == "" {
-		t.Errorf("details = %v, want a line under each mode", o.Details)
-	}
-	if o.Input == nil || o.Input.Label != planFeedback {
-		t.Errorf("input row = %v, want one labelled %q", o.Input, planFeedback)
-	}
-
-	// The plan is not repeated over the CLI's own rendering of it. All the box
-	// adds above the rows is where the plan is written down.
-	if len(o.Body) != 1 || o.Body[0] != "~/.claude/plans/rows.md" {
-		t.Errorf("body = %v, want the plan's path and nothing else", o.Body)
-	}
-
 	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
 	awaitResponse(t, done)
 }
 
 // The CLI will not let a hook approve a plan: an allow for ExitPlanMode is
 // ignored and its own dialog is shown regardless. So helios answers "ask" and
-// presses the row the user picked.
-func TestPlan_AutoModeIsPressedOnTheCLIsOwnDialog(t *testing.T) {
+// presses the row the phone picked.
+func TestPlan_AutoModePressesTheFirstRow(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
+	withTerminal(ctx)
 	terminalOf(ctx).setScreen(cliPlanDialog)
 
-	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
-	hitlCtl.HandleInput("sess-1", []byte("\r")) // the first row is preselected
+	resp := answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "approved",
+			Response: json.RawMessage(`{"plan_choice":"auto"}`)})
 
-	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
 	// Not "allow": the CLI ignores that here, and claiming it would hide the
 	// keystroke that does the work.
-	if decision.Behavior != "ask" {
-		t.Fatalf("behavior = %q, want ask", decision.Behavior)
+	if got := resp.HookSpecificOutput.Decision.Behavior; got != "ask" {
+		t.Fatalf("behavior = %q, want ask", got)
 	}
-	// Row one is already highlighted, so Enter is the whole answer.
-	if got := awaitKeys(t, terminalOf(ctx), 1); got[0] != "sess-1:enter" {
-		t.Errorf("keys = %v, want Enter on the highlighted row", got)
+	if got := awaitKeys(t, terminalOf(ctx), 1); got[0] != "sess-1:1" {
+		t.Errorf("keys = %v, want the first row pressed by number", got)
 	}
 	// The CLI applies the mode to itself. Helios repeats --permission-mode from
 	// the record on resume, so it has to know too, or the session wakes back up
@@ -133,24 +169,39 @@ func TestPlan_AutoModeIsPressedOnTheCLIsOwnDialog(t *testing.T) {
 	}
 }
 
-func TestPlan_ManualApprovalWalksToTheSecondRow(t *testing.T) {
+// The row's copy belongs to the CLI and has already moved once.
+func TestPlan_AutoModeIsPressedWhateverTheCLICallsIt(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
+	withTerminal(ctx)
+	terminalOf(ctx).setScreen(cliPlanDialogAutoAccept)
+
+	answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "approved",
+			Response: json.RawMessage(`{"plan_choice":"auto"}`)})
+
+	if got := awaitKeys(t, terminalOf(ctx), 1); got[0] != "sess-1:1" {
+		t.Errorf("keys = %v, want the first row pressed by number", got)
+	}
+	if got := sessionMode(t, db, "sess-1"); got != "auto" {
+		t.Errorf("recorded mode = %q, want auto", got)
+	}
+}
+
+func TestPlan_ManualApprovalPressesTheSecondRow(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	withTerminal(ctx)
 	terminalOf(ctx).setScreen(cliPlanDialog)
 
-	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
-	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
-	awaitOverlay(t, overlays)
-	hitlCtl.HandleInput("sess-1", []byte("\r"))
+	answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "approved",
+			Response: json.RawMessage(`{"plan_choice":"manual"}`)})
 
-	if got := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision.Behavior; got != "ask" {
-		t.Fatalf("behavior = %q, want ask", got)
-	}
-	// The highlight starts on row one, so row two is a Down and then Enter.
-	got := awaitKeys(t, terminalOf(ctx), 2)
-	if got[0] != "sess-1:down" || got[1] != "sess-1:enter" {
-		t.Errorf("keys = %v, want the highlight walked down, then Enter", got)
+	// Two, not "one Down then Enter": the highlight is not walked, so the
+	// composer's own cursor mark cannot be mistaken for the dialog's.
+	if got := awaitKeys(t, terminalOf(ctx), 1); got[0] != "sess-1:2" {
+		t.Errorf("keys = %v, want the second row pressed by number", got)
 	}
 	if got := sessionMode(t, db, "sess-1"); got != "manual" {
 		t.Errorf("recorded mode = %q, want manual", got)
@@ -163,13 +214,14 @@ func TestPlan_ManualApprovalWalksToTheSecondRow(t *testing.T) {
 func TestPlan_AnUnreachableDialogLeavesTheSessionAnswerable(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
+	withTerminal(ctx)
 	terminalOf(ctx).setScreen("a screen with no plan dialog on it")
 
-	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
-	hitlCtl.HandleInput("sess-1", []byte("\r"))
+	resp := answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "approved",
+			Response: json.RawMessage(`{"plan_choice":"auto"}`)})
 
-	if got := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision.Behavior; got != "ask" {
+	if got := resp.HookSpecificOutput.Decision.Behavior; got != "ask" {
 		t.Errorf("behavior = %q, want ask so the CLI keeps its own dialog", got)
 	}
 	if got := terminalOf(ctx).sentKeys(); len(got) != 0 {
@@ -177,29 +229,34 @@ func TestPlan_AnUnreachableDialogLeavesTheSessionAnswerable(t *testing.T) {
 	}
 }
 
-// Disagreeing with a plan is the point of the feedback row: Claude re-plans
+// The rows alone are not enough to press one: a numbered list is an ordinary
+// shape, and a digit typed into the composer is a digit in the next prompt.
+func TestPlan_RowsWithoutTheCLIsQuestionArePressedNothing(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	withTerminal(ctx)
+	terminalOf(ctx).setScreen("1. Yes, and use auto mode\n2. Yes, manually approve edits")
+
+	answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "approved",
+			Response: json.RawMessage(`{"plan_choice":"auto"}`)})
+
+	if got := terminalOf(ctx).sentKeys(); len(got) != 0 {
+		t.Errorf("keys = %v, want nothing pressed without the CLI's own question", got)
+	}
+}
+
+// Disagreeing with a plan is the point of the feedback field: Claude re-plans
 // from the words rather than stopping.
 func TestPlan_TypedFeedbackReachesClaude(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
+	withTerminal(ctx)
 
-	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+	resp := answerFromPhone(t, ctx, planHook(samplePlan),
+		deniedWithFeedback("split the plan on newlines"))
 
-	// Down past both modes onto the feedback row, Enter to open the field.
-	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
-	awaitOverlay(t, overlays)
-	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
-	awaitOverlay(t, overlays)
-	hitlCtl.HandleInput("sess-1", []byte("\r"))
-	if o := awaitOverlay(t, overlays); o.Input == nil || !o.Input.Active {
-		t.Fatalf("input = %v, want the field open after Enter on its row", o.Input)
-	}
-	hitlCtl.HandleInput("sess-1", []byte("split the plan on newlines"))
-	awaitOverlay(t, overlays)
-	hitlCtl.HandleInput("sess-1", []byte("\r"))
-
-	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	decision := resp.HookSpecificOutput.Decision
 	if decision.Behavior != "deny" {
 		t.Fatalf("behavior = %q, want deny — feedback sends the plan back", decision.Behavior)
 	}
@@ -216,90 +273,22 @@ func TestPlan_TypedFeedbackReachesClaude(t *testing.T) {
 	}
 }
 
-// Escape on a plan is a refusal without a word. A bare "Denied via helios"
-// reads as stop; the plan is how Claude asks to start.
-func TestPlan_EscapeAsksClaudeWhatToChange(t *testing.T) {
+// A refusal without a word. A bare "Denied via helios" reads as stop; the plan
+// is how Claude asks to start.
+func TestPlan_ABareRefusalAsksClaudeWhatToChange(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
+	withTerminal(ctx)
 
-	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
-	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
+	resp := answerFromPhone(t, ctx, planHook(samplePlan),
+		notifications.Decision{Status: "denied"})
 
-	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	decision := resp.HookSpecificOutput.Decision
 	if decision.Behavior != "deny" {
 		t.Fatalf("behavior = %q, want deny", decision.Behavior)
 	}
 	if !strings.Contains(decision.Message, exitPlanModeTool) {
 		t.Errorf("message = %q, want it to name the way back", decision.Message)
-	}
-}
-
-// An ordinary tool keeps the rows it had; only ExitPlanMode changes.
-func TestPlan_OrdinaryToolsKeepAllowAndDeny(t *testing.T) {
-	p := permissionPrompt(&hookInput{
-		ToolName:  "Bash",
-		ToolInput: json.RawMessage(`{"command":"ls"}`),
-	})
-	if p.Title != "Bash" || p.AllowText {
-		t.Errorf("prompt = %+v, want the tool name and no answer field", p)
-	}
-	if len(p.Choices) != 2 || p.Choices[0] != allowOnce || p.Choices[1] != denyChoice {
-		t.Errorf("choices = %v, want allow/deny", p.Choices)
-	}
-}
-
-// The box used to reprint the plan the CLI had just rendered above it, in raw
-// markdown and cut off partway. However long the plan, the box says where it
-// lives and leaves the reading to the transcript.
-func TestPlan_ThePlanIsNotReprintedOverTheCLIsOwnCopy(t *testing.T) {
-	long := strings.Repeat("a line of the plan\n", 40)
-	body := planBody(planInput(long, "~/.claude/plans/rows.md"))
-
-	if len(body) != 1 || body[0] != "~/.claude/plans/rows.md" {
-		t.Fatalf("body = %v, want the path alone", body)
-	}
-	if strings.Contains(body[0], "a line of the plan") {
-		t.Errorf("body = %v, want none of the plan's own text", body)
-	}
-}
-
-// A plan the CLI wrote nowhere leaves the box with nothing to point at, and a
-// path is not worth inventing.
-func TestPlan_APlanWithNoFileShowsNoBody(t *testing.T) {
-	if body := planBody(planInput("# Small\n", "")); len(body) != 0 {
-		t.Errorf("body = %v, want nothing above the rows", body)
-	}
-}
-
-// The rows are the point of the box, and they are checked on the screen: it is
-// anchored to the bottom of the viewport and clipped from the top, so anything
-// above them that grows with the plan would push them off.
-func TestPlan_TheRowsSurviveALongPlanOnASmallScreen(t *testing.T) {
-	ctx, db, _ := setupCtx(t)
-	seedSession(t, db, "sess-1", "/tmp/proj", "active")
-	overlays, hitlCtl := withTerminal(ctx)
-
-	long := "# Plan\n" + strings.Repeat("a line of the plan\n", 60)
-	done, o := askPermission(t, ctx, overlays, planHook(long))
-
-	// 80x24 is the small end of a real terminal, not a corner case.
-	painted := string(terminal.RenderOverlay(o, 80, 24))
-	for _, want := range []string{planAutoMode, planManualEdits, planFeedback} {
-		if !strings.Contains(painted, want) {
-			t.Errorf("the row %q was clipped off an 80x24 screen:\n%s", want, painted)
-		}
-	}
-
-	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
-	awaitResponse(t, done)
-}
-
-// A plan with no text at all still has to paint something.
-func TestPlan_WithoutAPlanFallsBackToTheToolInput(t *testing.T) {
-	body := planBody(json.RawMessage(`{"other":"field"}`))
-	if len(body) != 1 || body[0] == "" {
-		t.Errorf("body = %v, want a single summary line", body)
 	}
 }
 
@@ -313,11 +302,10 @@ func TestPlan_NotificationDetailReadsAsThePlansTitle(t *testing.T) {
 }
 
 // A typed answer carries Index -1, so indexing the choices with it would read
-// off the front of the list. Nothing set AllowText on a permission before, so
-// this was latent until the feedback row.
+// off the front of the list.
 func TestPlan_ATypedAnswerDoesNotIndexTheChoices(t *testing.T) {
-	choices := []string{planAutoMode, planManualEdits}
-	got := terminalDecision(choices, hitl.Answer{Index: -1, Text: "  change it  "})
+	got := terminalDecision([]string{allowOnce, denyChoice},
+		hitl.Answer{Index: -1, Text: "  change it  "})
 
 	if got.Status != "denied" {
 		t.Fatalf("status = %q, want denied", got.Status)
@@ -339,24 +327,8 @@ func TestPlan_AnAnswerOffTheEndDenies(t *testing.T) {
 	}
 }
 
-// A row's label is the CLI's copy and changes with its releases, so what
-// travels between surfaces is the short name.
-func TestPlan_PlanChoiceNames(t *testing.T) {
-	cases := map[string]string{
-		planAutoMode:    planChoiceAuto,
-		planManualEdits: planChoiceManual,
-		planFeedback:    "",
-		allowOnce:       "",
-	}
-	for row, want := range cases {
-		if got := planChoiceOf(row); got != want {
-			t.Errorf("planChoiceOf(%q) = %q, want %q", row, got, want)
-		}
-	}
-}
-
-// The phone answers over the same contract as the terminal, so it can pick a
-// mode or send the plan back in words.
+// The phone answers over the same contract as before, so it can pick a mode or
+// send the plan back in words.
 func TestPlan_ThePhoneCanAnswerAPlan(t *testing.T) {
 	approve, err := handlePermissionAction(nil, json.RawMessage(
 		`{"action":"approve","plan_choice":"auto"}`))

--- a/internal/provider/claude/plan_test.go
+++ b/internal/provider/claude/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kamrul1157024/helios/internal/hitl"
 	"github.com/kamrul1157024/helios/internal/store"
@@ -29,6 +30,30 @@ func planHook(plan string) hookInput {
 		PermissionMode: "plan",
 		ToolInput:      planInput(plan, "~/.claude/plans/rows.md"),
 	}
+}
+
+// cliPlanDialog is the dialog Claude Code 2.1.259 draws for a plan, which
+// helios answers with a keystroke because the CLI ignores an allow for
+// ExitPlanMode. Copied from a real session.
+const cliPlanDialog = `Claude has written up a plan and is ready to execute. Would you like to proceed?
+❯ 1. Yes, and use auto mode
+  2. Yes, manually approve edits
+  3. Tell Claude what to change
+      shift+tab to approve with this feedback
+  ctrl+g to edit in Vim · ~/.claude/plans/rows.md`
+
+// awaitKeys waits for the handoff goroutine to finish pressing rows.
+func awaitKeys(t *testing.T, f *fakeBackend, want int) []string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := f.sentKeys(); len(got) >= want {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("only %v reached the CLI's dialog, want %d keystrokes", f.sentKeys(), want)
+	return nil
 }
 
 // sessionMode reads back the mode helios would resume the session with.
@@ -57,7 +82,7 @@ func TestPlan_PaintsTheModeRowsAndTheFeedbackRow(t *testing.T) {
 	if o.Title != planTitle {
 		t.Errorf("title = %q, want %q — the tool name names the mechanism, not the decision", o.Title, planTitle)
 	}
-	want := []string{planAcceptEdits, planManualEdits}
+	want := []string{planAutoMode, planManualEdits}
 	if len(o.Options) != len(want) || o.Options[0] != want[0] || o.Options[1] != want[1] {
 		t.Errorf("options = %v, want %v", o.Options, want)
 	}
@@ -81,45 +106,77 @@ func TestPlan_PaintsTheModeRowsAndTheFeedbackRow(t *testing.T) {
 	awaitResponse(t, done)
 }
 
-func TestPlan_AutoAcceptEditsSwitchesTheSessionMode(t *testing.T) {
+// The CLI will not let a hook approve a plan: an allow for ExitPlanMode is
+// ignored and its own dialog is shown regardless. So helios answers "ask" and
+// presses the row the user picked.
+func TestPlan_AutoModeIsPressedOnTheCLIsOwnDialog(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 	overlays, hitlCtl := withTerminal(ctx)
+	terminalOf(ctx).setScreen(cliPlanDialog)
 
 	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
 	hitlCtl.HandleInput("sess-1", []byte("\r")) // the first row is preselected
 
 	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
-	if decision.Behavior != "allow" {
-		t.Fatalf("behavior = %q, want allow", decision.Behavior)
+	// Not "allow": the CLI ignores that here, and claiming it would hide the
+	// keystroke that does the work.
+	if decision.Behavior != "ask" {
+		t.Fatalf("behavior = %q, want ask", decision.Behavior)
 	}
-	if !strings.Contains(string(decision.UpdatedPermissions), `"mode":"acceptEdits"`) {
-		t.Errorf("updatedPermissions = %s, want a setMode to acceptEdits", decision.UpdatedPermissions)
+	// Row one is already highlighted, so Enter is the whole answer.
+	if got := awaitKeys(t, terminalOf(ctx), 1); got[0] != "sess-1:enter" {
+		t.Errorf("keys = %v, want Enter on the highlighted row", got)
 	}
-	// setMode reaches the running CLI only. Helios repeats --permission-mode
-	// from the record on resume, so without this the session wakes in plan mode.
-	if got := sessionMode(t, db, "sess-1"); got != "acceptEdits" {
-		t.Errorf("recorded mode = %q, want acceptEdits", got)
+	// The CLI applies the mode to itself. Helios repeats --permission-mode from
+	// the record on resume, so it has to know too, or the session wakes back up
+	// in plan mode.
+	if got := sessionMode(t, db, "sess-1"); got != "auto" {
+		t.Errorf("recorded mode = %q, want auto", got)
 	}
 }
 
-func TestPlan_ManualApprovalLeavesPlanModeForManual(t *testing.T) {
+func TestPlan_ManualApprovalWalksToTheSecondRow(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")
 	overlays, hitlCtl := withTerminal(ctx)
+	terminalOf(ctx).setScreen(cliPlanDialog)
 
 	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
 	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
 	awaitOverlay(t, overlays)
 	hitlCtl.HandleInput("sess-1", []byte("\r"))
 
-	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
-	if !strings.Contains(string(decision.UpdatedPermissions), `"mode":"default"`) {
-		t.Errorf("updatedPermissions = %s, want a setMode to default", decision.UpdatedPermissions)
+	if got := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision.Behavior; got != "ask" {
+		t.Fatalf("behavior = %q, want ask", got)
 	}
-	// The two vocabularies differ: the CLI's "default" is helios's "manual".
+	// The highlight starts on row one, so row two is a Down and then Enter.
+	got := awaitKeys(t, terminalOf(ctx), 2)
+	if got[0] != "sess-1:down" || got[1] != "sess-1:enter" {
+		t.Errorf("keys = %v, want the highlight walked down, then Enter", got)
+	}
 	if got := sessionMode(t, db, "sess-1"); got != "manual" {
 		t.Errorf("recorded mode = %q, want manual", got)
+	}
+}
+
+// A dialog that never appears, or a row the CLI has renamed, must not hang the
+// session or fake an answer: the CLI's dialog is on screen and answerable by
+// hand.
+func TestPlan_AnUnreachableDialogLeavesTheSessionAnswerable(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+	terminalOf(ctx).setScreen("a screen with no plan dialog on it")
+
+	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+	hitlCtl.HandleInput("sess-1", []byte("\r"))
+
+	if got := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision.Behavior; got != "ask" {
+		t.Errorf("behavior = %q, want ask so the CLI keeps its own dialog", got)
+	}
+	if got := terminalOf(ctx).sentKeys(); len(got) != 0 {
+		t.Errorf("keys = %v, want nothing pressed into a screen we did not recognise", got)
 	}
 }
 
@@ -234,7 +291,7 @@ func TestPlan_TheRowsSurviveALongPlanOnASmallScreen(t *testing.T) {
 
 	// 80x24 is the small end of a real terminal, not a corner case.
 	painted := string(terminal.RenderOverlay(o, 80, 24))
-	for _, want := range []string{planAcceptEdits, planManualEdits, planFeedback} {
+	for _, want := range []string{planAutoMode, planManualEdits, planFeedback} {
 		if !strings.Contains(painted, want) {
 			t.Errorf("the row %q was clipped off an 80x24 screen:\n%s", want, painted)
 		}
@@ -265,7 +322,7 @@ func TestPlan_NotificationDetailReadsAsThePlansTitle(t *testing.T) {
 // off the front of the list. Nothing set AllowText on a permission before, so
 // this was latent until the feedback row.
 func TestPlan_ATypedAnswerDoesNotIndexTheChoices(t *testing.T) {
-	choices := []string{planAcceptEdits, planManualEdits}
+	choices := []string{planAutoMode, planManualEdits}
 	got := terminalDecision(choices, hitl.Answer{Index: -1, Text: "  change it  "})
 
 	if got.Status != "denied" {
@@ -288,17 +345,18 @@ func TestPlan_AnAnswerOffTheEndDenies(t *testing.T) {
 	}
 }
 
-// The names helios stores and the names setMode uses agree everywhere but one.
-func TestPlan_HeliosModeNames(t *testing.T) {
+// A row's label is the CLI's copy and changes with its releases, so what
+// travels between surfaces is the short name.
+func TestPlan_PlanChoiceNames(t *testing.T) {
 	cases := map[string]string{
-		modeDefault:     "manual",
-		modeAcceptEdits: "acceptEdits",
-		"plan":          "plan",
-		"nonsense":      "",
+		planAutoMode:    planChoiceAuto,
+		planManualEdits: planChoiceManual,
+		planFeedback:    "",
+		allowOnce:       "",
 	}
-	for cli, want := range cases {
-		if got := heliosMode(cli); got != want {
-			t.Errorf("heliosMode(%q) = %q, want %q", cli, got, want)
+	for row, want := range cases {
+		if got := planChoiceOf(row); got != want {
+			t.Errorf("planChoiceOf(%q) = %q, want %q", row, got, want)
 		}
 	}
 }
@@ -307,12 +365,12 @@ func TestPlan_HeliosModeNames(t *testing.T) {
 // mode or send the plan back in words.
 func TestPlan_ThePhoneCanAnswerAPlan(t *testing.T) {
 	approve, err := handlePermissionAction(nil, json.RawMessage(
-		`{"action":"approve","permission_updates":[{"type":"setMode","destination":"session","mode":"acceptEdits"}]}`))
+		`{"action":"approve","plan_choice":"auto"}`))
 	if err != nil {
 		t.Fatalf("approve: %v", err)
 	}
-	if approve.Status != "approved" || !strings.Contains(string(approve.Response), "acceptEdits") {
-		t.Errorf("approve = %+v, want the mode carried through", approve)
+	if approve.Status != "approved" || !strings.Contains(string(approve.Response), `"plan_choice":"auto"`) {
+		t.Errorf("approve = %+v, want the chosen mode carried through", approve)
 	}
 
 	deny, err := handlePermissionAction(nil, json.RawMessage(

--- a/internal/provider/claude/plan_test.go
+++ b/internal/provider/claude/plan_test.go
@@ -1,0 +1,339 @@
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/terminal"
+)
+
+// samplePlan is what the CLI puts in tool_input.plan: markdown, several lines.
+const samplePlan = "# Plan: give plan approval its own rows\n\n" +
+	"## Context\nThe terminal only offers Allow once and Deny.\n\n" +
+	"## Steps\n1. Name the rows.\n2. Collect the feedback.\n"
+
+func planInput(plan, path string) json.RawMessage {
+	raw, err := json.Marshal(map[string]string{"plan": plan, "planFilePath": path})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func planHook(plan string) hookInput {
+	return hookInput{
+		SessionID: "sess-1", CWD: "/tmp/proj", ToolName: exitPlanModeTool,
+		PermissionMode: "plan",
+		ToolInput:      planInput(plan, "~/.claude/plans/rows.md"),
+	}
+}
+
+// sessionMode reads back the mode helios would resume the session with.
+func sessionMode(t *testing.T, db *store.Store, sessionID string) string {
+	t.Helper()
+	sess, err := db.GetSession(sessionID)
+	if err != nil || sess == nil {
+		t.Fatalf("GetSession(%q): %v", sessionID, err)
+	}
+	if sess.PermissionMode == nil {
+		return ""
+	}
+	return *sess.PermissionMode
+}
+
+// The bug this closes: a plan is not a yes-or-no question, but helios painted
+// Allow once / Deny over it, so neither mode could be picked and disagreeing
+// meant a bare no.
+func TestPlan_PaintsTheModeRowsAndTheFeedbackRow(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	done, o := askPermission(t, ctx, overlays, planHook(samplePlan))
+
+	if o.Title != planTitle {
+		t.Errorf("title = %q, want %q — the tool name names the mechanism, not the decision", o.Title, planTitle)
+	}
+	want := []string{planAcceptEdits, planManualEdits}
+	if len(o.Options) != len(want) || o.Options[0] != want[0] || o.Options[1] != want[1] {
+		t.Errorf("options = %v, want %v", o.Options, want)
+	}
+	if len(o.Details) != 2 || o.Details[0] == "" || o.Details[1] == "" {
+		t.Errorf("details = %v, want a line under each mode", o.Details)
+	}
+	if o.Input == nil || o.Input.Label != planFeedback {
+		t.Errorf("input row = %v, want one labelled %q", o.Input, planFeedback)
+	}
+
+	// The plan is one body entry per line. Passed whole it would be reflowed
+	// into a single paragraph and the headings would vanish.
+	if len(o.Body) < 5 {
+		t.Errorf("body = %v, want the plan split across lines", o.Body)
+	}
+	if o.Body[0] != "# Plan: give plan approval its own rows" {
+		t.Errorf("body[0] = %q, want the plan's first line", o.Body[0])
+	}
+
+	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
+	awaitResponse(t, done)
+}
+
+func TestPlan_AutoAcceptEditsSwitchesTheSessionMode(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+	hitlCtl.HandleInput("sess-1", []byte("\r")) // the first row is preselected
+
+	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	if decision.Behavior != "allow" {
+		t.Fatalf("behavior = %q, want allow", decision.Behavior)
+	}
+	if !strings.Contains(string(decision.UpdatedPermissions), `"mode":"acceptEdits"`) {
+		t.Errorf("updatedPermissions = %s, want a setMode to acceptEdits", decision.UpdatedPermissions)
+	}
+	// setMode reaches the running CLI only. Helios repeats --permission-mode
+	// from the record on resume, so without this the session wakes in plan mode.
+	if got := sessionMode(t, db, "sess-1"); got != "acceptEdits" {
+		t.Errorf("recorded mode = %q, want acceptEdits", got)
+	}
+}
+
+func TestPlan_ManualApprovalLeavesPlanModeForManual(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
+	awaitOverlay(t, overlays)
+	hitlCtl.HandleInput("sess-1", []byte("\r"))
+
+	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	if !strings.Contains(string(decision.UpdatedPermissions), `"mode":"default"`) {
+		t.Errorf("updatedPermissions = %s, want a setMode to default", decision.UpdatedPermissions)
+	}
+	// The two vocabularies differ: the CLI's "default" is helios's "manual".
+	if got := sessionMode(t, db, "sess-1"); got != "manual" {
+		t.Errorf("recorded mode = %q, want manual", got)
+	}
+}
+
+// Disagreeing with a plan is the point of the feedback row: Claude re-plans
+// from the words rather than stopping.
+func TestPlan_TypedFeedbackReachesClaude(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+
+	// Down past both modes onto the feedback row, Enter to open the field.
+	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
+	awaitOverlay(t, overlays)
+	hitlCtl.HandleInput("sess-1", []byte("\x1b[B"))
+	awaitOverlay(t, overlays)
+	hitlCtl.HandleInput("sess-1", []byte("\r"))
+	if o := awaitOverlay(t, overlays); o.Input == nil || !o.Input.Active {
+		t.Fatalf("input = %v, want the field open after Enter on its row", o.Input)
+	}
+	hitlCtl.HandleInput("sess-1", []byte("split the plan on newlines"))
+	awaitOverlay(t, overlays)
+	hitlCtl.HandleInput("sess-1", []byte("\r"))
+
+	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny — feedback sends the plan back", decision.Behavior)
+	}
+	if !strings.Contains(decision.Message, "split the plan on newlines") {
+		t.Errorf("message = %q, want the typed words", decision.Message)
+	}
+	// A denied tool reaches the model as "Error: <message>", so the words need
+	// someone attached to them or they read as a malfunction.
+	if !strings.Contains(decision.Message, planFeedbacked) {
+		t.Errorf("message = %q, want it to say who is speaking", decision.Message)
+	}
+	if got := sessionMode(t, db, "sess-1"); got != "" {
+		t.Errorf("recorded mode = %q, want plan mode left alone on a refusal", got)
+	}
+}
+
+// Escape on a plan is a refusal without a word. A bare "Denied via helios"
+// reads as stop; the plan is how Claude asks to start.
+func TestPlan_EscapeAsksClaudeWhatToChange(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	done, _ := askPermission(t, ctx, overlays, planHook(samplePlan))
+	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
+
+	decision := permDecision(t, awaitResponse(t, done)).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny", decision.Behavior)
+	}
+	if !strings.Contains(decision.Message, exitPlanModeTool) {
+		t.Errorf("message = %q, want it to name the way back", decision.Message)
+	}
+}
+
+// An ordinary tool keeps the rows it had; only ExitPlanMode changes.
+func TestPlan_OrdinaryToolsKeepAllowAndDeny(t *testing.T) {
+	p := permissionPrompt(&hookInput{
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"ls"}`),
+	})
+	if p.Title != "Bash" || p.AllowText {
+		t.Errorf("prompt = %+v, want the tool name and no answer field", p)
+	}
+	if len(p.Choices) != 2 || p.Choices[0] != allowOnce || p.Choices[1] != denyChoice {
+		t.Errorf("choices = %v, want allow/deny", p.Choices)
+	}
+}
+
+func TestPlan_LongPlanIsCappedAndPointsAtTheFile(t *testing.T) {
+	long := strings.Repeat("a line of the plan\n", planBodyMaxLines+6)
+	body := planBody(planInput(long, "~/.claude/plans/rows.md"))
+
+	// One line over the cap: the cap line itself.
+	if len(body) != planBodyMaxLines+1 {
+		t.Fatalf("body has %d lines, want %d plus the cap line", len(body), planBodyMaxLines)
+	}
+	tail := body[len(body)-1]
+	if !strings.Contains(tail, "6 more lines") {
+		t.Errorf("tail = %q, want the count of what was cut", tail)
+	}
+	// The overlay clips from the bottom of the viewport upwards, so a capped
+	// plan has to say where the whole one lives.
+	if !strings.Contains(tail, "~/.claude/plans/rows.md") {
+		t.Errorf("tail = %q, want the plan's path", tail)
+	}
+}
+
+func TestPlan_ShortPlanShowsThePathAlone(t *testing.T) {
+	body := planBody(planInput("# Small\n", "~/.claude/plans/small.md"))
+	if got := body[len(body)-1]; got != "~/.claude/plans/small.md" {
+		t.Errorf("tail = %q, want the path with no cut-count", got)
+	}
+}
+
+// The cap exists for the screen, so it is checked on the screen: the box is
+// anchored to the bottom of the viewport and clipped from the top, and a plan
+// long enough to push the rows off would leave nothing to answer with.
+func TestPlan_TheRowsSurviveALongPlanOnASmallScreen(t *testing.T) {
+	ctx, db, _ := setupCtx(t)
+	seedSession(t, db, "sess-1", "/tmp/proj", "active")
+	overlays, hitlCtl := withTerminal(ctx)
+
+	long := "# Plan\n" + strings.Repeat("a line of the plan\n", 60)
+	done, o := askPermission(t, ctx, overlays, planHook(long))
+
+	// 80x24 is the small end of a real terminal, not a corner case.
+	painted := string(terminal.RenderOverlay(o, 80, 24))
+	for _, want := range []string{planAcceptEdits, planManualEdits, planFeedback} {
+		if !strings.Contains(painted, want) {
+			t.Errorf("the row %q was clipped off an 80x24 screen:\n%s", want, painted)
+		}
+	}
+
+	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
+	awaitResponse(t, done)
+}
+
+// A plan with no text at all still has to paint something.
+func TestPlan_WithoutAPlanFallsBackToTheToolInput(t *testing.T) {
+	body := planBody(json.RawMessage(`{"other":"field"}`))
+	if len(body) != 1 || body[0] == "" {
+		t.Errorf("body = %v, want a single summary line", body)
+	}
+}
+
+// The push notification a phone shows used to be raw JSON cut at 100
+// characters.
+func TestPlan_NotificationDetailReadsAsThePlansTitle(t *testing.T) {
+	got := summarizeToolInput(planInput(samplePlan, ""))
+	if got != "Plan: give plan approval its own rows" {
+		t.Errorf("summary = %q, want the plan's heading without the marks", got)
+	}
+}
+
+// A typed answer carries Index -1, so indexing the choices with it would read
+// off the front of the list. Nothing set AllowText on a permission before, so
+// this was latent until the feedback row.
+func TestPlan_ATypedAnswerDoesNotIndexTheChoices(t *testing.T) {
+	choices := []string{planAcceptEdits, planManualEdits}
+	got := terminalDecision(choices, hitl.Answer{Index: -1, Text: "  change it  "})
+
+	if got.Status != "denied" {
+		t.Fatalf("status = %q, want denied", got.Status)
+	}
+	var answer permissionAnswer
+	if err := json.Unmarshal(got.Response, &answer); err != nil {
+		t.Fatalf("decode %s: %v", got.Response, err)
+	}
+	if answer.Feedback != "change it" {
+		t.Errorf("feedback = %q, want the trimmed text", answer.Feedback)
+	}
+}
+
+func TestPlan_AnAnswerOffTheEndDenies(t *testing.T) {
+	for _, a := range []hitl.Answer{{Index: 9}, {Index: -1}, {Index: -3, Text: "   "}} {
+		if got := terminalDecision([]string{allowOnce, denyChoice}, a); got.Status != "denied" {
+			t.Errorf("terminalDecision(%+v) = %q, want denied", a, got.Status)
+		}
+	}
+}
+
+// The names helios stores and the names setMode uses agree everywhere but one.
+func TestPlan_HeliosModeNames(t *testing.T) {
+	cases := map[string]string{
+		modeDefault:     "manual",
+		modeAcceptEdits: "acceptEdits",
+		"plan":          "plan",
+		"nonsense":      "",
+	}
+	for cli, want := range cases {
+		if got := heliosMode(cli); got != want {
+			t.Errorf("heliosMode(%q) = %q, want %q", cli, got, want)
+		}
+	}
+}
+
+// The phone answers over the same contract as the terminal, so it can pick a
+// mode or send the plan back in words.
+func TestPlan_ThePhoneCanAnswerAPlan(t *testing.T) {
+	approve, err := handlePermissionAction(nil, json.RawMessage(
+		`{"action":"approve","permission_updates":[{"type":"setMode","destination":"session","mode":"acceptEdits"}]}`))
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if approve.Status != "approved" || !strings.Contains(string(approve.Response), "acceptEdits") {
+		t.Errorf("approve = %+v, want the mode carried through", approve)
+	}
+
+	deny, err := handlePermissionAction(nil, json.RawMessage(
+		`{"action":"deny","feedback":"use a queue instead"}`))
+	if err != nil {
+		t.Fatalf("deny: %v", err)
+	}
+	if deny.Status != "denied" || !strings.Contains(string(deny.Response), "use a queue instead") {
+		t.Errorf("deny = %+v, want the feedback carried through", deny)
+	}
+}
+
+// An approval says yes. Feedback riding along with one would reach Claude as a
+// complaint about work it was just cleared to do.
+func TestPlan_AnApprovalDropsAnyFeedback(t *testing.T) {
+	got, err := handlePermissionAction(nil, json.RawMessage(
+		`{"action":"approve","feedback":"ignore me"}`))
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if len(got.Response) != 0 {
+		t.Errorf("response = %s, want nothing beyond the yes", got.Response)
+	}
+}

--- a/internal/provider/claude/plan_test.go
+++ b/internal/provider/claude/plan_test.go
@@ -93,13 +93,10 @@ func TestPlan_PaintsTheModeRowsAndTheFeedbackRow(t *testing.T) {
 		t.Errorf("input row = %v, want one labelled %q", o.Input, planFeedback)
 	}
 
-	// The plan is one body entry per line. Passed whole it would be reflowed
-	// into a single paragraph and the headings would vanish.
-	if len(o.Body) < 5 {
-		t.Errorf("body = %v, want the plan split across lines", o.Body)
-	}
-	if o.Body[0] != "# Plan: give plan approval its own rows" {
-		t.Errorf("body[0] = %q, want the plan's first line", o.Body[0])
+	// The plan is not repeated over the CLI's own rendering of it. All the box
+	// adds above the rows is where the plan is written down.
+	if len(o.Body) != 1 || o.Body[0] != "~/.claude/plans/rows.md" {
+		t.Errorf("body = %v, want the plan's path and nothing else", o.Body)
 	}
 
 	hitlCtl.HandleInput("sess-1", []byte("\x1b"))
@@ -252,35 +249,32 @@ func TestPlan_OrdinaryToolsKeepAllowAndDeny(t *testing.T) {
 	}
 }
 
-func TestPlan_LongPlanIsCappedAndPointsAtTheFile(t *testing.T) {
-	long := strings.Repeat("a line of the plan\n", planBodyMaxLines+6)
+// The box used to reprint the plan the CLI had just rendered above it, in raw
+// markdown and cut off partway. However long the plan, the box says where it
+// lives and leaves the reading to the transcript.
+func TestPlan_ThePlanIsNotReprintedOverTheCLIsOwnCopy(t *testing.T) {
+	long := strings.Repeat("a line of the plan\n", 40)
 	body := planBody(planInput(long, "~/.claude/plans/rows.md"))
 
-	// One line over the cap: the cap line itself.
-	if len(body) != planBodyMaxLines+1 {
-		t.Fatalf("body has %d lines, want %d plus the cap line", len(body), planBodyMaxLines)
+	if len(body) != 1 || body[0] != "~/.claude/plans/rows.md" {
+		t.Fatalf("body = %v, want the path alone", body)
 	}
-	tail := body[len(body)-1]
-	if !strings.Contains(tail, "6 more lines") {
-		t.Errorf("tail = %q, want the count of what was cut", tail)
-	}
-	// The overlay clips from the bottom of the viewport upwards, so a capped
-	// plan has to say where the whole one lives.
-	if !strings.Contains(tail, "~/.claude/plans/rows.md") {
-		t.Errorf("tail = %q, want the plan's path", tail)
+	if strings.Contains(body[0], "a line of the plan") {
+		t.Errorf("body = %v, want none of the plan's own text", body)
 	}
 }
 
-func TestPlan_ShortPlanShowsThePathAlone(t *testing.T) {
-	body := planBody(planInput("# Small\n", "~/.claude/plans/small.md"))
-	if got := body[len(body)-1]; got != "~/.claude/plans/small.md" {
-		t.Errorf("tail = %q, want the path with no cut-count", got)
+// A plan the CLI wrote nowhere leaves the box with nothing to point at, and a
+// path is not worth inventing.
+func TestPlan_APlanWithNoFileShowsNoBody(t *testing.T) {
+	if body := planBody(planInput("# Small\n", "")); len(body) != 0 {
+		t.Errorf("body = %v, want nothing above the rows", body)
 	}
 }
 
-// The cap exists for the screen, so it is checked on the screen: the box is
-// anchored to the bottom of the viewport and clipped from the top, and a plan
-// long enough to push the rows off would leave nothing to answer with.
+// The rows are the point of the box, and they are checked on the screen: it is
+// anchored to the bottom of the viewport and clipped from the top, so anything
+// above them that grows with the plan would push them off.
 func TestPlan_TheRowsSurviveALongPlanOnASmallScreen(t *testing.T) {
 	ctx, db, _ := setupCtx(t)
 	seedSession(t, db, "sess-1", "/tmp/proj", "active")

--- a/internal/provider/codex/actions.go
+++ b/internal/provider/codex/actions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/notifications"
@@ -42,9 +43,15 @@ func (p *Provider) ActionRoutes() map[string]provider.ActionRoute {
 	}
 }
 
+// handlePermissionAction turns a remote surface's answer into a decision.
+//
+// A refusal may carry words, the way the terminal overlay's text field does.
+// An approval that carried them would send Codex a complaint about work it was
+// just cleared to do, so they are read on the deny path only.
 func handlePermissionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {
 		Action string `json:"action"`
+		permissionAnswer
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return notifications.Decision{}, fmt.Errorf("invalid body: %w", err)
@@ -53,6 +60,9 @@ func handlePermissionAction(notif *store.Notification, body json.RawMessage) (no
 	case "approve":
 		return notifications.Decision{Status: "approved"}, nil
 	case "deny":
+		if text := strings.TrimSpace(req.Feedback); text != "" {
+			return deniedWithFeedback(text), nil
+		}
 		return notifications.Decision{Status: "denied"}, nil
 	default:
 		return notifications.Decision{}, fmt.Errorf("action must be approve/deny")

--- a/internal/provider/codex/hooks.go
+++ b/internal/provider/codex/hooks.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -372,7 +373,75 @@ func writePermResponse(w http.ResponseWriter, behavior, message string) {
 const (
 	allowOnce  = "Allow once"
 	denyChoice = "Deny"
+
+	// Codex's own approval dialog offers "No, and tell Codex what to do
+	// differently". Helios paints over that dialog, so it has to offer the row
+	// too or the only refusal it leaves the user is a bare no.
+	feedbackLabel = "Tell Codex what to do differently"
 )
+
+// What Codex reads in place of the tool's result when it is refused.
+//
+// A denied call comes back to the model as an error, so bare text there reads
+// as a malfunction rather than as a person talking. Each of these says who is
+// speaking. Codex honours a deny message; see docs/specs/46-codex-provider.md.
+const (
+	deniedReason   = "Denied via helios"
+	deniedFeedback = "The user denied this in helios and said:"
+)
+
+// permissionAnswer is what a surface sends back beyond approve or deny. Only
+// the words matter here: Codex cannot write a permission rule and cannot take
+// an edited input, so there is nothing else to carry.
+type permissionAnswer struct {
+	Feedback string `json:"feedback,omitempty"`
+}
+
+// deniedWithFeedback refuses the tool in the user's own words.
+func deniedWithFeedback(text string) notifications.Decision {
+	response, err := json.Marshal(permissionAnswer{Feedback: text})
+	if err != nil {
+		log.Printf("codex: encode denial feedback: %v", err)
+		return notifications.Decision{Status: "denied"}
+	}
+	return notifications.Decision{Status: "denied", Response: response}
+}
+
+// denyMessage is the sentence Codex reads for a refusal, whichever surface
+// refused. Unreadable feedback degrades to the bare reason rather than to a
+// tool that hangs.
+func denyMessage(sessionID string, decision *notifications.Decision) string {
+	if len(decision.Response) == 0 {
+		return deniedReason
+	}
+	var answer permissionAnswer
+	if err := json.Unmarshal(decision.Response, &answer); err != nil {
+		log.Printf("codex: read denial for %s: %v", sessionID, err)
+		return deniedReason
+	}
+	if text := strings.TrimSpace(answer.Feedback); text != "" {
+		return deniedFeedback + "\n" + text
+	}
+	return deniedReason
+}
+
+// terminalDecision reads an answer off the overlay. Anything it does not
+// recognise — escape, a row that is gone, a prompt that changed under it —
+// denies, because the safe reading of an unclear answer is no.
+func terminalDecision(choices []string, a hitl.Answer) notifications.Decision {
+	// Text first: a typed answer carries Index -1, so indexing choices with it
+	// would read off the front of the list.
+	if text := strings.TrimSpace(a.Text); text != "" {
+		return deniedWithFeedback(text)
+	}
+	if a.Cancelled() || a.Index < 0 || a.Index >= len(choices) {
+		return notifications.Decision{Status: "denied"}
+	}
+	if choices[a.Index] == allowOnce {
+		return notifications.Decision{Status: "approved"}
+	}
+	return notifications.Decision{Status: "denied"}
+}
 
 func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	in, ok := decode(w, raw)
@@ -423,18 +492,17 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 	// matter which of them settled it.
 	//
 	// Only two choices: Codex cannot write a permission rule, so there is
-	// nothing for "don't ask again" to apply.
+	// nothing for "don't ask again" to apply. The third row is not a choice —
+	// it is the text field, and the words it takes become the deny message.
 	choices := []string{allowOnce, denyChoice}
 	defer showPrompt(ctx, key, hitl.Prompt{
-		Title:   in.ToolName,
-		Body:    []string{summarize(in.ToolInput)},
-		Choices: choices,
+		Title:     in.ToolName,
+		Body:      []string{summarize(in.ToolInput)},
+		Choices:   choices,
+		AllowText: true,
+		TextLabel: feedbackLabel,
 	}, func(a hitl.Answer) {
-		decision := notifications.Decision{Status: "denied"}
-		if !a.Cancelled() && a.Index < len(choices) && choices[a.Index] == allowOnce {
-			decision.Status = "approved"
-		}
-		if err := ctx.Mgr.Resolve(notifID, decision, "terminal"); err != nil &&
+		if err := ctx.Mgr.Resolve(notifID, terminalDecision(choices, a), "terminal"); err != nil &&
 			!errors.Is(err, store.ErrAlreadyResolved) {
 			log.Printf("codex: resolve permission %s from the terminal: %v", notifID, err)
 		}
@@ -452,7 +520,7 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 		writePermResponse(w, "allow", "")
 		return
 	}
-	writePermResponse(w, "deny", "Denied via helios")
+	writePermResponse(w, "deny", denyMessage(key, decision))
 }
 
 // ==================== Compaction and subagents ====================

--- a/internal/provider/codex/permission_test.go
+++ b/internal/provider/codex/permission_test.go
@@ -1,0 +1,262 @@
+package codex
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/provider"
+	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/terminal"
+)
+
+// The bug these close: Codex's own approval dialog offers "No, and tell Codex
+// what to do differently", and helios painted a bare Deny over it. Every
+// refusal reached the model as "Denied via helios", whoever refused and
+// whatever they meant.
+
+const codexSession = "01a04dee-183a-7461-9bef-5f05c0aa510a"
+
+// codexOverlays stands in for a session's terminal, recording what helios drew
+// over it. Painting happens on the hook's goroutine while the test drives keys
+// from its own, so both directions travel by channel.
+type codexOverlays struct {
+	painted chan terminal.Overlay
+	cleared chan string
+}
+
+func (p *codexOverlays) SetOverlay(sessionID string, o terminal.Overlay) error {
+	p.painted <- o
+	return nil
+}
+
+func (p *codexOverlays) ClearOverlay(sessionID string) error {
+	p.cleared <- sessionID
+	return nil
+}
+
+// OverlayProtocol reports a host of this build, so the answer field is painted
+// rather than dropped and left to the phone.
+func (p *codexOverlays) OverlayProtocol(sessionID string) int {
+	return terminal.HostProtocol
+}
+
+func permCtx(t *testing.T) (*provider.HookContext, *codexOverlays, *hitl.Controller) {
+	t.Helper()
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	overlays := &codexOverlays{
+		painted: make(chan terminal.Overlay, 8),
+		cleared: make(chan string, 8),
+	}
+	ctl := hitl.NewController(overlays)
+	ctx := &provider.HookContext{
+		DB:             db,
+		Mgr:            notifications.NewManager(db),
+		HITL:           ctl,
+		Notify:         func(string, interface{}) {},
+		Report:         func(provider.ReportEvent) {},
+		SessionStarted: func(string) {},
+	}
+	return ctx, overlays, ctl
+}
+
+// askPerm runs the permission hook and waits for its overlay to land.
+func askPerm(t *testing.T, ctx *provider.HookContext, p *codexOverlays,
+	tool string) (<-chan *httptest.ResponseRecorder, terminal.Overlay) {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"session_id": codexSession,
+		"cwd":        "/tmp/proj",
+		"tool_name":  tool,
+		"tool_input": map[string]string{"command": "rm -rf build"},
+	})
+	if err != nil {
+		t.Fatalf("encode hook input: %v", err)
+	}
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		handlePermission(ctx, w, httptest.NewRequest("POST", "/hooks/codex/permission", nil), body)
+		done <- w
+	}()
+	return done, awaitPainted(t, p)
+}
+
+func awaitPainted(t *testing.T, p *codexOverlays) terminal.Overlay {
+	t.Helper()
+	select {
+	case o := <-p.painted:
+		return o
+	case <-time.After(5 * time.Second):
+		t.Fatal("nothing was painted on the terminal")
+		return terminal.Overlay{}
+	}
+}
+
+func awaitPermResponse(t *testing.T, done <-chan *httptest.ResponseRecorder) permResponse {
+	t.Helper()
+	select {
+	case w := <-done:
+		var resp permResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response %q: %v", w.Body.String(), err)
+		}
+		return resp
+	case <-time.After(5 * time.Second):
+		t.Fatal("the hook never answered Codex")
+		return permResponse{}
+	}
+}
+
+func TestPermission_TheOverlayOffersAWayToDisagree(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, o := askPerm(t, ctx, overlays, "shell")
+
+	if len(o.Options) != 2 {
+		t.Errorf("choices = %v, want allow and deny only", o.Options)
+	}
+	if o.Input == nil || o.Input.Label != feedbackLabel {
+		t.Errorf("input row = %v, want one labelled %q", o.Input, feedbackLabel)
+	}
+
+	ctl.HandleInput(codexSession, []byte("\x1b"))
+	awaitPermResponse(t, done)
+}
+
+// The words are the point: Codex reads them and picks a different way rather
+// than stopping.
+func TestPermission_TypedWordsReachCodex(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+
+	// Down past both choices onto the feedback row, Enter to open the field.
+	ctl.HandleInput(codexSession, []byte("\x1b[B"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\x1b[B"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\r"))
+	if o := awaitPainted(t, overlays); o.Input == nil || !o.Input.Active {
+		t.Fatalf("input = %v, want the field open after Enter on its row", o.Input)
+	}
+	ctl.HandleInput(codexSession, []byte("delete the directory, do not rm it"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\r"))
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny — words refuse the tool", decision.Behavior)
+	}
+	if !strings.Contains(decision.Message, "delete the directory, do not rm it") {
+		t.Errorf("message = %q, want the typed words", decision.Message)
+	}
+	// A refused call comes back as an error, so the words need someone
+	// attached to them or they read as a malfunction.
+	if !strings.Contains(decision.Message, deniedFeedback) {
+		t.Errorf("message = %q, want it to say who is speaking", decision.Message)
+	}
+}
+
+func TestPermission_EscapeStillDeniesWithoutWords(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+	ctl.HandleInput(codexSession, []byte("\x1b"))
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny", decision.Behavior)
+	}
+	if decision.Message != deniedReason {
+		t.Errorf("message = %q, want %q", decision.Message, deniedReason)
+	}
+}
+
+func TestPermission_AllowOnceStillAllows(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+	ctl.HandleInput(codexSession, []byte("\r")) // "Allow once" is preselected
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "allow" {
+		t.Errorf("behavior = %q, want allow", decision.Behavior)
+	}
+	if decision.Message != "" {
+		t.Errorf("message = %q, want none on an approval", decision.Message)
+	}
+}
+
+// The phone sends the same words the overlay's field takes, and the daemon
+// cannot tell which surface answered.
+func TestPermission_ThePhoneCanSayWhatToDoDifferently(t *testing.T) {
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"deny","feedback":"use git clean instead"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if decision.Status != "denied" {
+		t.Fatalf("status = %q, want denied", decision.Status)
+	}
+	msg := denyMessage(codexSession, &decision)
+	if !strings.Contains(msg, "use git clean instead") {
+		t.Errorf("message = %q, want the phone's words", msg)
+	}
+}
+
+func TestPermission_AnApprovalDropsAnyWordsSentWithIt(t *testing.T) {
+	// Feedback is a refusal's payload. Carried onto an approval it would send
+	// Codex a complaint about work it was just cleared to do.
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"approve","feedback":"use git clean instead"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if decision.Status != "approved" {
+		t.Fatalf("status = %q, want approved", decision.Status)
+	}
+	if len(decision.Response) != 0 {
+		t.Errorf("response = %s, want nothing carried onto an approval", decision.Response)
+	}
+}
+
+func TestPermission_ABareNoKeepsItsOldWords(t *testing.T) {
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"deny"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if got := denyMessage(codexSession, &decision); got != deniedReason {
+		t.Errorf("message = %q, want %q", got, deniedReason)
+	}
+}
+
+// An answer helios cannot read is a no, not a crash and not a yes.
+func TestPermission_AnUnreadableAnswerDenies(t *testing.T) {
+	choices := []string{allowOnce, denyChoice}
+	for name, a := range map[string]hitl.Answer{
+		"cancelled":     {Index: -1},
+		"row that went": {Index: 7},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := terminalDecision(choices, a).Status; got != "denied" {
+				t.Errorf("status = %q, want denied", got)
+			}
+		})
+	}
+
+	broken := notifications.Decision{Status: "denied", Response: json.RawMessage(`{`)}
+	if got := denyMessage(codexSession, &broken); got != deniedReason {
+		t.Errorf("message = %q, want the bare reason for unreadable feedback", got)
+	}
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -129,9 +129,7 @@ class _AuthGateState extends State<AuthGate> {
               child: Column(
                 children: [
                   const SizedBox(height: 60),
-                  for (int i = 0; i < 4; i++) ...[
-                    const SessionCardSkeleton(),
-                  ],
+                  for (int i = 0; i < 4; i++) ...[const SessionCardSkeleton()],
                 ],
               ),
             ),
@@ -175,15 +173,15 @@ class _PendingApprovalScreen extends StatelessWidget {
                   Text(
                     'helios',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     'Waiting for approval...',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: 24),
                   const CircularProgressIndicator(),
@@ -192,20 +190,30 @@ class _PendingApprovalScreen extends StatelessWidget {
                     Container(
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Icon(Icons.key, size: 16, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                          Icon(
+                            Icons.key,
+                            size: 16,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurfaceVariant,
+                          ),
                           const SizedBox(width: 8),
                           Text(
                             'Device ID: $shortId...',
                             style: TextStyle(
                               fontFamily: 'monospace',
                               fontSize: 12,
-                              color: Theme.of(context).colorScheme.onSurfaceVariant,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
                             ),
                           ),
                         ],
@@ -221,13 +229,21 @@ class _PendingApprovalScreen extends StatelessWidget {
                     ),
                     child: Row(
                       children: [
-                        Icon(Icons.terminal, color: Theme.of(context).colorScheme.onPrimaryContainer, size: 20),
+                        Icon(
+                          Icons.terminal,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onPrimaryContainer,
+                          size: 20,
+                        ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
                             'Press "y" in the terminal to approve this device.',
                             style: TextStyle(
-                              color: Theme.of(context).colorScheme.onPrimaryContainer,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onPrimaryContainer,
                               fontSize: 13,
                             ),
                           ),

--- a/mobile/lib/models/host_connection.dart
+++ b/mobile/lib/models/host_connection.dart
@@ -32,14 +32,14 @@ class HostConnection {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'label': label,
-        'serverUrl': serverUrl,
-        'deviceId': deviceId,
-        'colorIndex': colorIndex,
-        'hostname': hostname,
-        'addedAt': addedAt.toIso8601String(),
-      };
+    'id': id,
+    'label': label,
+    'serverUrl': serverUrl,
+    'deviceId': deviceId,
+    'colorIndex': colorIndex,
+    'hostname': hostname,
+    'addedAt': addedAt.toIso8601String(),
+  };
 
   factory HostConnection.fromJson(Map<String, dynamic> json) {
     return HostConnection(

--- a/mobile/lib/models/message.dart
+++ b/mobile/lib/models/message.dart
@@ -42,8 +42,9 @@ class Message {
 
   String get timeAgo {
     try {
-      final normalized =
-          timestamp.contains('T') ? timestamp : '${timestamp.replaceAll(' ', 'T')}Z';
+      final normalized = timestamp.contains('T')
+          ? timestamp
+          : '${timestamp.replaceAll(' ', 'T')}Z';
       final d = DateTime.parse(normalized);
       final diff = DateTime.now().toUtc().difference(d);
       if (diff.inSeconds < 60) return 'just now';
@@ -89,7 +90,9 @@ class TranscriptResult {
   factory TranscriptResult.fromJson(Map<String, dynamic> json) {
     final list = (json['messages'] as List?) ?? [];
     return TranscriptResult(
-      messages: list.map((m) => Message.fromJson(m as Map<String, dynamic>)).toList(),
+      messages: list
+          .map((m) => Message.fromJson(m as Map<String, dynamic>))
+          .toList(),
       total: json['total'] as int? ?? 0,
       returned: json['returned'] as int? ?? 0,
       offset: json['offset'] as int? ?? 0,

--- a/mobile/lib/models/notification.dart
+++ b/mobile/lib/models/notification.dart
@@ -51,7 +51,10 @@ class HeliosNotification {
     return i < 0 ? '' : type.substring(i + 1);
   }
 
-  factory HeliosNotification.fromJson(Map<String, dynamic> json, {String hostId = ''}) {
+  factory HeliosNotification.fromJson(
+    Map<String, dynamic> json, {
+    String hostId = '',
+  }) {
     Map<String, dynamic>? parseJson(dynamic raw) {
       if (raw == null) return null;
       if (raw is Map<String, dynamic>) return raw;
@@ -112,6 +115,7 @@ class HeliosNotification {
         return type;
     }
   }
+
   String get displayDetail => detail ?? 'No details';
 
   String get timeAgo {

--- a/mobile/lib/models/schedule.dart
+++ b/mobile/lib/models/schedule.dart
@@ -150,9 +150,18 @@ class Schedule {
     if (RegExp(r'^\d+$').hasMatch(min) && RegExp(r'^\d+$').hasMatch(hour)) {
       final time = '${hour.padLeft(2, '0')}:${min.padLeft(2, '0')}';
       if (everyDay) return 'every day at $time';
-      if (dom == '*' && month == '*' && dow == '1-5') return 'weekdays at $time';
+      if (dom == '*' && month == '*' && dow == '1-5')
+        return 'weekdays at $time';
       if (dom == '*' && month == '*' && RegExp(r'^\d$').hasMatch(dow)) {
-        const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        const days = [
+          'Sunday',
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+        ];
         return '${days[int.parse(dow)]}s at $time';
       }
     }
@@ -200,7 +209,8 @@ String untilWords(String stamp) {
   if (until.isNegative) return 'due';
   if (until.inMinutes < 1) return 'in ${until.inSeconds}s';
   if (until.inMinutes < 60) return 'in ${until.inMinutes}m';
-  if (until.inHours < 12) return 'in ${until.inHours}h ${until.inMinutes % 60}m';
+  if (until.inHours < 12)
+    return 'in ${until.inHours}h ${until.inMinutes % 60}m';
   return '${_weekday(at)} ${at.hour.toString().padLeft(2, '0')}:'
       '${at.minute.toString().padLeft(2, '0')}';
 }
@@ -239,10 +249,10 @@ class CheckResult {
   });
 
   factory CheckResult.fromJson(Map<String, dynamic> json) => CheckResult(
-        exit: json['exit'] as int? ?? 0,
-        output: (json['output'] as String?) ?? '',
-        matched: json['matched'] as bool? ?? false,
-        failed: json['failed'] as bool? ?? false,
-        error: (json['error'] as String?) ?? '',
-      );
+    exit: json['exit'] as int? ?? 0,
+    output: (json['output'] as String?) ?? '',
+    matched: json['matched'] as bool? ?? false,
+    failed: json['failed'] as bool? ?? false,
+    error: (json['error'] as String?) ?? '',
+  );
 }

--- a/mobile/lib/providers/cache_effects.dart
+++ b/mobile/lib/providers/cache_effects.dart
@@ -211,7 +211,13 @@ List<CacheEffect> effectsFor(String hostId, String type, dynamic data) {
       final sessionId = _text(map['session_id']);
       return sessionId.isEmpty
           ? const []
-          : [InvalidateTarget(CacheTarget.subagents, hostId, sessionId: sessionId)];
+          : [
+              InvalidateTarget(
+                CacheTarget.subagents,
+                hostId,
+                sessionId: sessionId,
+              ),
+            ];
 
     case 'session_evicted':
       // A session going cold invalidates everything about it, and the payload

--- a/mobile/lib/providers/card_registry.dart
+++ b/mobile/lib/providers/card_registry.dart
@@ -5,12 +5,13 @@ import 'cards.dart';
 import 'notification_ext.dart';
 
 /// Signature for a notification card builder.
-typedef CardBuilder = Widget Function({
-  required HeliosNotification notification,
-  required DaemonAPIService sse,
-  required Set<String> selected,
-  required VoidCallback onSelectionChanged,
-});
+typedef CardBuilder =
+    Widget Function({
+      required HeliosNotification notification,
+      required DaemonAPIService sse,
+      required Set<String> selected,
+      required VoidCallback onSelectionChanged,
+    });
 
 /// Maps a notification to the card that renders it.
 ///
@@ -35,30 +36,15 @@ Widget? buildCardForType({
         onSelectionChanged: onSelectionChanged,
       );
     case 'question':
-      return QuestionCard(
-        notification: notification,
-        sse: sse,
-      );
+      return QuestionCard(notification: notification, sse: sse);
     case 'elicitation.form':
-      return ElicitationFormCard(
-        notification: notification,
-        sse: sse,
-      );
+      return ElicitationFormCard(notification: notification, sse: sse);
     case 'elicitation.url':
-      return ElicitationUrlCard(
-        notification: notification,
-        sse: sse,
-      );
+      return ElicitationUrlCard(notification: notification, sse: sse);
     case 'trust':
-      return TrustCard(
-        notification: notification,
-        sse: sse,
-      );
+      return TrustCard(notification: notification, sse: sse);
     case 'error':
-      return ErrorCard(
-        notification: notification,
-        sse: sse,
-      );
+      return ErrorCard(notification: notification, sse: sse);
     default:
       return null;
   }

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -25,10 +25,32 @@ class PermissionCard extends StatefulWidget {
   State<PermissionCard> createState() => _PermissionCardState();
 }
 
+/// The two ways to say yes to a plan, worded as the CLI words them, and the
+/// name each one travels under. The daemon presses the matching row on the
+/// CLI's own dialog, so the phone sends the name and not the label.
+const _planRows = [
+  (
+    choice: 'auto',
+    label: 'Yes, and use auto mode',
+    detail:
+        'Claude edits and runs commands without asking, '
+        'for the rest of this session',
+  ),
+  (
+    choice: 'manual',
+    label: 'Yes, manually approve edits',
+    detail: 'Claude asks before each edit, as it does now',
+  ),
+];
+
 class _PermissionCardState extends State<PermissionCard> {
   final Map<String, TextEditingController> _editControllers = {};
+  final TextEditingController _feedback = TextEditingController();
   bool _isEditing = false;
   int? _selectedPermissionIdx;
+
+  /// Which way to say yes to a plan, or null while nothing is picked.
+  String? _planChoice;
 
   HeliosNotification get n => widget.notification;
 
@@ -37,12 +59,15 @@ class _PermissionCardState extends State<PermissionCard> {
     for (final c in _editControllers.values) {
       c.dispose();
     }
+    _feedback.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final suggestions = n.permissionSuggestions;
+    // A plan gets neither the quick rules nor the edit field: there is no
+    // command to edit, and the CLI sends no suggestions for this tool.
+    final suggestions = n.isPlan ? null : n.permissionSuggestions;
 
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
@@ -88,7 +113,9 @@ class _PermissionCardState extends State<PermissionCard> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    n.displayTitle,
+                    // A tool name is the right label for Bash. For this tool
+                    // it names the mechanism, not the decision.
+                    n.isPlan ? 'Ready to code?' : n.displayTitle,
                     style: const TextStyle(
                       fontWeight: FontWeight.w600,
                       fontSize: 14,
@@ -106,7 +133,9 @@ class _PermissionCardState extends State<PermissionCard> {
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(8),
               ),
-              constraints: const BoxConstraints(maxHeight: 160),
+              // A plan is meant to be read before it is answered, so it gets
+              // more of the card than a command does.
+              constraints: BoxConstraints(maxHeight: n.isPlan ? 280 : 160),
               child: SingleChildScrollView(
                 child: Text(
                   _displayInput(),
@@ -202,8 +231,27 @@ class _PermissionCardState extends State<PermissionCard> {
                 ),
               ),
             ],
+            // How to say yes to a plan, and how to disagree with one
+            if (n.isPlan) ...[
+              const SizedBox(height: 12),
+              ..._planRows.map(_planRow),
+              const SizedBox(height: 4),
+              TextField(
+                controller: _feedback,
+                maxLines: 3,
+                minLines: 1,
+                style: const TextStyle(fontSize: 13),
+                decoration: const InputDecoration(
+                  isDense: true,
+                  labelText: 'Tell Claude what to change',
+                  hintText: 'Send the plan back in your own words',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (_) => setState(() {}),
+              ),
+            ],
             // Edit input
-            if (_isEditing) ...[
+            if (_isEditing && !n.isPlan) ...[
               const SizedBox(height: 8),
               TextField(
                 controller: _editControllers.putIfAbsent(
@@ -226,36 +274,87 @@ class _PermissionCardState extends State<PermissionCard> {
               children: [
                 Expanded(
                   child: FilledButton(
-                    onPressed: _approve,
+                    // A plan cannot be approved without saying which way, so
+                    // the button waits for a row.
+                    onPressed: n.isPlan && _planChoice == null
+                        ? null
+                        : _approve,
                     child: const Text('Approve'),
                   ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: FilledButton(
-                    onPressed: () =>
-                        widget.sse.sendAction(n.id, {'action': 'deny'}),
+                    onPressed: _deny,
                     style: FilledButton.styleFrom(
                       backgroundColor: Theme.of(context).colorScheme.error,
                       foregroundColor: Theme.of(context).colorScheme.onError,
                     ),
-                    child: const Text('Deny'),
+                    // Words turn a refusal into a re-plan, so the button says
+                    // what it will do with them.
+                    child: Text(
+                      n.isPlan && _feedback.text.trim().isNotEmpty
+                          ? 'Send back'
+                          : 'Deny',
+                    ),
                   ),
                 ),
               ],
             ),
-            const SizedBox(height: 4),
-            Center(
-              child: TextButton(
-                onPressed: () {
-                  setState(() {
-                    _isEditing = !_isEditing;
-                  });
-                },
-                child: Text(
-                  _isEditing ? 'Cancel editing' : 'Edit before approving',
-                  style: const TextStyle(fontSize: 12),
+            if (!n.isPlan) ...[
+              const SizedBox(height: 4),
+              Center(
+                child: TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _isEditing = !_isEditing;
+                    });
+                  },
+                  child: Text(
+                    _isEditing ? 'Cancel editing' : 'Edit before approving',
+                    style: const TextStyle(fontSize: 12),
+                  ),
                 ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// One way of saying yes to a plan, with the mode it leaves behind spelled
+  /// out under it.
+  Widget _planRow(({String choice, String label, String detail}) row) {
+    final selected = _planChoice == row.choice;
+    return InkWell(
+      onTap: () => setState(() => _planChoice = row.choice),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 3),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              selected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 20,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(row.label, style: const TextStyle(fontSize: 13)),
+                  Text(
+                    row.detail,
+                    style: TextStyle(
+                      fontSize: 11.5,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
               ),
             ),
           ],
@@ -264,8 +363,21 @@ class _PermissionCardState extends State<PermissionCard> {
     );
   }
 
+  /// Refuse, with the user's words when they wrote any. Claude re-plans from
+  /// them rather than stopping.
+  void _deny() {
+    final body = <String, dynamic>{'action': 'deny'};
+    final text = _feedback.text.trim();
+    if (text.isNotEmpty) body['feedback'] = text;
+    widget.sse.sendAction(n.id, body);
+  }
+
   void _approve() {
     final body = <String, dynamic>{'action': 'approve'};
+
+    if (_planChoice != null) {
+      body['plan_choice'] = _planChoice;
+    }
 
     if (_isEditing && _editControllers.containsKey(n.id)) {
       final edited = _editControllers[n.id]!.text;
@@ -294,6 +406,11 @@ class _PermissionCardState extends State<PermissionCard> {
   /// is shown as it is, and any other input as one field per block with its
   /// multi-line values printed as the lines they are.
   String _displayInput() {
+    // A plan is prose. Showing it under a "plan:" key, or as JSON, would put
+    // escapes through the one thing on the card meant to be read.
+    final plan = n.planText;
+    if (plan != null && plan.trim().isNotEmpty) return plan.trimRight();
+
     final ti = n.payload?['tool_input'];
     if (ti is String && ti.isNotEmpty) return ti;
     if (ti is Map) {

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -231,21 +231,24 @@ class _PermissionCardState extends State<PermissionCard> {
                 ),
               ),
             ],
-            // How to say yes to a plan, and how to disagree with one
+            // How to say yes to a plan
             if (n.isPlan) ...[
               const SizedBox(height: 12),
               ..._planRows.map(_planRow),
-              const SizedBox(height: 4),
+            ],
+            // How to disagree in words rather than with a bare no
+            if (_takesFeedback) ...[
+              SizedBox(height: n.isPlan ? 4 : 12),
               TextField(
                 controller: _feedback,
                 maxLines: 3,
                 minLines: 1,
                 style: const TextStyle(fontSize: 13),
-                decoration: const InputDecoration(
+                decoration: InputDecoration(
                   isDense: true,
-                  labelText: 'Tell Claude what to change',
-                  hintText: 'Send the plan back in your own words',
-                  border: OutlineInputBorder(),
+                  labelText: _feedbackLabel,
+                  hintText: _feedbackHint,
+                  border: const OutlineInputBorder(),
                 ),
                 onChanged: (_) => setState(() {}),
               ),
@@ -290,10 +293,10 @@ class _PermissionCardState extends State<PermissionCard> {
                       backgroundColor: Theme.of(context).colorScheme.error,
                       foregroundColor: Theme.of(context).colorScheme.onError,
                     ),
-                    // Words turn a refusal into a re-plan, so the button says
-                    // what it will do with them.
+                    // Words turn a refusal into another attempt, so the button
+                    // says what it will do with them.
                     child: Text(
-                      n.isPlan && _feedback.text.trim().isNotEmpty
+                      _takesFeedback && _feedback.text.trim().isNotEmpty
                           ? 'Send back'
                           : 'Deny',
                     ),
@@ -322,6 +325,21 @@ class _PermissionCardState extends State<PermissionCard> {
       ),
     );
   }
+
+  /// Whether this card takes words as well as a yes or a no.
+  ///
+  /// A plan is not a yes-or-no question. Neither is a Codex approval: the
+  /// dialog Codex draws under helios offers "No, and tell Codex what to do
+  /// differently", so the card has to offer it too.
+  bool get _takesFeedback => n.isPlan || n.isCodex;
+
+  String get _feedbackLabel => n.isPlan
+      ? 'Tell Claude what to change'
+      : 'Tell Codex what to do differently';
+
+  String get _feedbackHint => n.isPlan
+      ? 'Send the plan back in your own words'
+      : 'Say what to do instead';
 
   /// One way of saying yes to a plan, with the mode it leaves behind spelled
   /// out under it.

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../models/notification.dart';
+import '../screens/file_browser_screen.dart';
 import '../services/daemon_api_service.dart';
 import 'notification_ext.dart';
 
@@ -126,27 +127,7 @@ class _PermissionCardState extends State<PermissionCard> {
               ],
             ),
             const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(10),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              // A plan is meant to be read before it is answered, so it gets
-              // more of the card than a command does.
-              constraints: BoxConstraints(maxHeight: n.isPlan ? 280 : 160),
-              child: SingleChildScrollView(
-                child: Text(
-                  _displayInput(),
-                  style: TextStyle(
-                    fontFamily: 'monospace',
-                    fontSize: 12,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
-              ),
-            ),
+            _whatIsBeingApproved(context),
             const SizedBox(height: 8),
             Row(
               children: [
@@ -414,6 +395,111 @@ class _PermissionCardState extends State<PermissionCard> {
     }
 
     widget.sse.sendAction(n.id, body);
+  }
+
+  /// The block above the rows: what the card is asking about.
+  ///
+  /// A plan the CLI wrote to a file is named and pointed at, not printed. The
+  /// whole plan in a scroll box took the phone's screen before the rows that
+  /// answer it, and it arrived as raw markdown — `#` and backticks and all —
+  /// because a monospace `Text` renders none of it. The viewer does, and it is
+  /// one tap away.
+  ///
+  /// Everything else is shown in full: a command is short, and a plan with no
+  /// file behind it has nowhere else to be read.
+  Widget _whatIsBeingApproved(BuildContext context) {
+    final path = n.isPlan ? n.planFilePath?.trim() : null;
+    if (path != null && path.isNotEmpty) return _planSummary(context, path);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      constraints: BoxConstraints(maxHeight: n.isPlan ? 280 : 160),
+      child: SingleChildScrollView(
+        child: Text(
+          _displayInput(),
+          style: TextStyle(
+            fontFamily: 'monospace',
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// A plan in two lines and a way to open it.
+  Widget _planSummary(BuildContext context, String path) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(10, 10, 10, 4),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            n.planHeadline ?? 'A plan is ready',
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 2),
+          Row(
+            children: [
+              Expanded(
+                // The name, not the path: the directory is the same one every
+                // time, and the viewer says where the file is anyway.
+                child: Text(
+                  path.split('/').last,
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              TextButton.icon(
+                onPressed: () => _openPlanFile(context, path),
+                icon: const Icon(Icons.description_outlined, size: 16),
+                label: const Text('View plan', style: TextStyle(fontSize: 12)),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Opens the plan in the file viewer, which renders the markdown.
+  ///
+  /// Rooted at the plan's own directory rather than the session's: the file
+  /// lives under ~/.claude/plans, so "show in folder" pointed at the project
+  /// would offer a folder the plan is not in.
+  void _openPlanFile(BuildContext context, String path) {
+    final cut = path.lastIndexOf('/');
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        settings: const RouteSettings(name: '/file-viewer'),
+        builder: (_) => FileViewerScreen(
+          hostId: n.hostId,
+          path: path,
+          rootPath: cut > 0 ? path.substring(0, cut) : path,
+        ),
+      ),
+    );
   }
 
   /// What the tool will actually do, laid out to be read.

--- a/mobile/lib/providers/daemon_providers.dart
+++ b/mobile/lib/providers/daemon_providers.dart
@@ -24,7 +24,8 @@ import '../services/host_manager.dart';
 /// it from. So the single instance built in `main` is handed to both trees, and
 /// this is overridden at the `ProviderScope` that wraps the app.
 final hostManagerProvider = Provider<HostManager>(
-  (ref) => throw UnimplementedError('override hostManagerProvider in ProviderScope'),
+  (ref) =>
+      throw UnimplementedError('override hostManagerProvider in ProviderScope'),
 );
 
 final serviceProvider = Provider.family<DaemonAPIService?, String>(
@@ -34,7 +35,10 @@ final serviceProvider = Provider.family<DaemonAPIService?, String>(
 // ─── Schedules ──────────────────────────────────────────────────────────────
 
 /// A host's schedules, parents before children so the tree renders in one pass.
-final schedulesProvider = FutureProvider.family<List<Schedule>, String>((ref, hostId) async {
+final schedulesProvider = FutureProvider.family<List<Schedule>, String>((
+  ref,
+  hostId,
+) async {
   final service = ref.watch(serviceProvider(hostId));
   if (service == null) return const [];
   return service.listSchedules();
@@ -46,11 +50,11 @@ final schedulesProvider = FutureProvider.family<List<Schedule>, String>((ref, ho
 /// second list widget anywhere: the runs list is the session list.
 final scheduleRunsProvider =
     FutureProvider.family<List<Session>, (String, String)>((ref, arg) async {
-  final (hostId, scheduleId) = arg;
-  final service = ref.watch(serviceProvider(hostId));
-  if (service == null) return const [];
-  return service.listSessions(SessionQuery(scheduleId: scheduleId));
-});
+      final (hostId, scheduleId) = arg;
+      final service = ref.watch(serviceProvider(hostId));
+      if (service == null) return const [];
+      return service.listSessions(SessionQuery(scheduleId: scheduleId));
+    });
 
 // ─── Sessions and notifications ─────────────────────────────────────────────
 
@@ -85,7 +89,10 @@ class SessionsNotifier
     return service.listSessions(query);
   }
 
-  Future<void> _refreshBehind(DaemonAPIService service, SessionQuery query) async {
+  Future<void> _refreshBehind(
+    DaemonAPIService service,
+    SessionQuery query,
+  ) async {
     try {
       final fresh = await service.listSessions(query);
       state = AsyncData(fresh);
@@ -172,28 +179,38 @@ class SessionsNotifier
   }
 }
 
-final sessionsProvider = AsyncNotifierProvider.family<SessionsNotifier,
-    List<Session>, (String, SessionQuery)>(SessionsNotifier.new);
+final sessionsProvider =
+    AsyncNotifierProvider.family<
+      SessionsNotifier,
+      List<Session>,
+      (String, SessionQuery)
+    >(SessionsNotifier.new);
 
 /// The unfiltered list — what most screens want, and the one the disk cache
 /// seeds.
 ///
 /// An alias, not a second provider: it resolves to the same family entry, so
 /// the whole list is never held twice.
-AsyncNotifierProviderFamily<SessionsNotifier, List<Session>,
-        (String, SessionQuery)>
-    get allSessions => sessionsProvider;
+AsyncNotifierProviderFamily<
+  SessionsNotifier,
+  List<Session>,
+  (String, SessionQuery)
+>
+get allSessions => sessionsProvider;
 
 /// The key for a host's unfiltered list.
 (String, SessionQuery) allSessionsKey(String hostId) =>
     (hostId, SessionQuery.all);
 
 final notificationsProvider =
-    FutureProvider.family<List<HeliosNotification>, String>((ref, hostId) async {
-  final service = ref.watch(serviceProvider(hostId));
-  if (service == null) return const [];
-  return service.listNotifications();
-});
+    FutureProvider.family<List<HeliosNotification>, String>((
+      ref,
+      hostId,
+    ) async {
+      final service = ref.watch(serviceProvider(hostId));
+      if (service == null) return const [];
+      return service.listNotifications();
+    });
 
 // ─── Across hosts ───────────────────────────────────────────────────────────
 
@@ -215,9 +232,9 @@ final allHostSessionsProvider = Provider<AsyncValue<List<Session>>>((ref) {
 /// Every host's pending notifications, merged.
 final allHostNotificationsProvider =
     Provider<AsyncValue<List<HeliosNotification>>>((ref) {
-  final hosts = ref.watch(hostManagerProvider).hosts;
-  return _merge(hosts.map((h) => ref.watch(notificationsProvider(h.id))));
-});
+      final hosts = ref.watch(hostManagerProvider).hosts;
+      return _merge(hosts.map((h) => ref.watch(notificationsProvider(h.id))));
+    });
 
 /// The sessions under one query: from the checked-out host, or merged across
 /// all of them.
@@ -226,11 +243,13 @@ final allHostNotificationsProvider =
 /// the filters of the last fetch in order to repeat it.
 final visibleSessionsForProvider =
     Provider.family<AsyncValue<List<Session>>, SessionQuery>((ref, query) {
-  final active = ref.watch(hostManagerProvider).activeHostId;
-  if (active != null) return ref.watch(sessionsProvider((active, query)));
-  final hosts = ref.watch(hostManagerProvider).hosts;
-  return _merge(hosts.map((h) => ref.watch(sessionsProvider((h.id, query)))));
-});
+      final active = ref.watch(hostManagerProvider).activeHostId;
+      if (active != null) return ref.watch(sessionsProvider((active, query)));
+      final hosts = ref.watch(hostManagerProvider).hosts;
+      return _merge(
+        hosts.map((h) => ref.watch(sessionsProvider((h.id, query)))),
+      );
+    });
 
 /// The unfiltered list for the current filter.
 final visibleSessionsProvider = Provider<AsyncValue<List<Session>>>(
@@ -240,10 +259,10 @@ final visibleSessionsProvider = Provider<AsyncValue<List<Session>>>(
 /// The notifications for the current filter.
 final visibleNotificationsProvider =
     Provider<AsyncValue<List<HeliosNotification>>>((ref) {
-  final active = ref.watch(hostManagerProvider).activeHostId;
-  if (active == null) return ref.watch(allHostNotificationsProvider);
-  return ref.watch(notificationsProvider(active));
-});
+      final active = ref.watch(hostManagerProvider).activeHostId;
+      if (active == null) return ref.watch(allHostNotificationsProvider);
+      return ref.watch(notificationsProvider(active));
+    });
 
 /// Flattens per-host answers into one.
 ///
@@ -264,8 +283,10 @@ AsyncValue<List<T>> _merge<T>(Iterable<AsyncValue<List<T>>> parts) {
 
 // ─── Providers, models, directories, settings ───────────────────────────────
 
-final providersProvider =
-    FutureProvider.family<List<ProviderInfo>, String>((ref, hostId) async {
+final providersProvider = FutureProvider.family<List<ProviderInfo>, String>((
+  ref,
+  hostId,
+) async {
   final service = ref.watch(serviceProvider(hostId));
   if (service == null) return const [];
   return service.listProviders();
@@ -277,21 +298,24 @@ final providersProvider =
 /// runs and is never heard from, which reads as a hang.
 final readyProvidersProvider =
     FutureProvider.family<List<ProviderInfo>, String>((ref, hostId) async {
-  final all = await ref.watch(providersProvider(hostId).future);
-  return all.where((p) => p.ready).toList(growable: false);
-});
+      final all = await ref.watch(providersProvider(hostId).future);
+      return all.where((p) => p.ready).toList(growable: false);
+    });
 
-final modelsProvider =
-    FutureProvider.family<List<ModelInfo>, (String, String)>((ref, key) async {
-  final (hostId, providerId) = key;
-  if (providerId.isEmpty) return const [];
-  final service = ref.watch(serviceProvider(hostId));
-  if (service == null) return const [];
-  return service.fetchModels(providerId);
-});
+final modelsProvider = FutureProvider.family<List<ModelInfo>, (String, String)>(
+  (ref, key) async {
+    final (hostId, providerId) = key;
+    if (providerId.isEmpty) return const [];
+    final service = ref.watch(serviceProvider(hostId));
+    if (service == null) return const [];
+    return service.fetchModels(providerId);
+  },
+);
 
-final directoriesProvider =
-    FutureProvider.family<List<DirectoryInfo>, String>((ref, hostId) async {
+final directoriesProvider = FutureProvider.family<List<DirectoryInfo>, String>((
+  ref,
+  hostId,
+) async {
   final service = ref.watch(serviceProvider(hostId));
   if (service == null) return const [];
   return service.fetchDirectories();
@@ -328,22 +352,22 @@ class HostSettingsNotifier extends FamilyAsyncNotifier<HostSettings, String> {
   }
 
   Future<bool> setAutoTitleEnabled(bool value) => _write(
-        DaemonAPIService.settingAutoTitle,
-        value ? 'true' : 'false',
-        (s) => s.copyWith(autoTitleEnabled: value),
-      );
+    DaemonAPIService.settingAutoTitle,
+    value ? 'true' : 'false',
+    (s) => s.copyWith(autoTitleEnabled: value),
+  );
 
   Future<bool> setAutoTitleEmoji(bool value) => _write(
-        DaemonAPIService.settingAutoTitleEmoji,
-        value ? 'true' : 'false',
-        (s) => s.copyWith(autoTitleEmoji: value),
-      );
+    DaemonAPIService.settingAutoTitleEmoji,
+    value ? 'true' : 'false',
+    (s) => s.copyWith(autoTitleEmoji: value),
+  );
 
   Future<bool> setEvictEnabled(bool value) => _write(
-        DaemonAPIService.settingEvict,
-        value ? 'true' : 'false',
-        (s) => s.copyWith(evictEnabled: value),
-      );
+    DaemonAPIService.settingEvict,
+    value ? 'true' : 'false',
+    (s) => s.copyWith(evictEnabled: value),
+  );
 
   Future<bool> setBudgetFraction(double value) {
     final clamped = value.clamp(
@@ -358,14 +382,16 @@ class HostSettingsNotifier extends FamilyAsyncNotifier<HostSettings, String> {
   }
 
   Future<bool> setManualOrder(bool value) => _write(
-        DaemonAPIService.settingSortMode,
-        value ? 'manual' : 'activity',
-        (s) => s.copyWith(manualOrder: value),
-      );
+    DaemonAPIService.settingSortMode,
+    value ? 'manual' : 'activity',
+    (s) => s.copyWith(manualOrder: value),
+  );
 }
 
-final hostSettingsProvider = AsyncNotifierProvider.family<HostSettingsNotifier,
-    HostSettings, String>(HostSettingsNotifier.new);
+final hostSettingsProvider =
+    AsyncNotifierProvider.family<HostSettingsNotifier, HostSettings, String>(
+      HostSettingsNotifier.new,
+    );
 
 /// Whether any host is sorting by hand.
 ///
@@ -374,14 +400,17 @@ final hostSettingsProvider = AsyncNotifierProvider.family<HostSettingsNotifier,
 final manualOrderProvider = Provider<bool>((ref) {
   final hosts = ref.watch(hostManagerProvider).hosts;
   return hosts.any(
-    (h) => ref.watch(hostSettingsProvider(h.id)).valueOrNull?.manualOrder ?? false,
+    (h) =>
+        ref.watch(hostSettingsProvider(h.id)).valueOrNull?.manualOrder ?? false,
   );
 });
 
 // ─── Git ────────────────────────────────────────────────────────────────────
 
-final gitStatusProvider =
-    FutureProvider.family<GitStatus?, (String, String)>((ref, key) async {
+final gitStatusProvider = FutureProvider.family<GitStatus?, (String, String)>((
+  ref,
+  key,
+) async {
   final (hostId, cwd) = key;
   if (cwd.isEmpty) return null;
   return ref.watch(serviceProvider(hostId))?.gitStatus(cwd);
@@ -389,12 +418,12 @@ final gitStatusProvider =
 
 final gitWorktreesProvider =
     FutureProvider.family<List<Worktree>, (String, String)>((ref, key) async {
-  final (hostId, cwd) = key;
-  if (cwd.isEmpty) return const [];
-  final service = ref.watch(serviceProvider(hostId));
-  if (service == null) return const [];
-  return service.gitWorktrees(cwd);
-});
+      final (hostId, cwd) = key;
+      if (cwd.isEmpty) return const [];
+      final service = ref.watch(serviceProvider(hostId));
+      if (service == null) return const [];
+      return service.gitWorktrees(cwd);
+    });
 
 /// What a log read varies by. Part of the key, because two different logs are
 /// two different answers and cannot share an entry.
@@ -429,9 +458,14 @@ class GitLogKey {
   int get hashCode => Object.hash(hostId, cwd, base, all, limit, skip);
 }
 
-final gitLogProvider = FutureProvider.family<GitLog?, GitLogKey>((ref, key) async {
+final gitLogProvider = FutureProvider.family<GitLog?, GitLogKey>((
+  ref,
+  key,
+) async {
   if (key.cwd.isEmpty) return null;
-  return ref.watch(serviceProvider(key.hostId))?.gitLog(
+  return ref
+      .watch(serviceProvider(key.hostId))
+      ?.gitLog(
         key.cwd,
         base: key.base,
         all: key.all,
@@ -475,9 +509,14 @@ class GitDiffKey {
       Object.hash(hostId, cwd, file, staged, from, to, untracked);
 }
 
-final gitDiffProvider = FutureProvider.family<GitDiff?, GitDiffKey>((ref, key) async {
+final gitDiffProvider = FutureProvider.family<GitDiff?, GitDiffKey>((
+  ref,
+  key,
+) async {
   if (key.cwd.isEmpty || key.file.isEmpty) return null;
-  return ref.watch(serviceProvider(key.hostId))?.gitDiff(
+  return ref
+      .watch(serviceProvider(key.hostId))
+      ?.gitDiff(
         key.cwd,
         key.file,
         staged: key.staged,
@@ -507,8 +546,10 @@ class GitChangesKey {
   int get hashCode => Object.hash(hostId, cwd, to, from);
 }
 
-final gitChangesProvider =
-    FutureProvider.family<GitChanges?, GitChangesKey>((ref, key) async {
+final gitChangesProvider = FutureProvider.family<GitChanges?, GitChangesKey>((
+  ref,
+  key,
+) async {
   if (key.cwd.isEmpty || key.to.isEmpty) return null;
   return ref
       .watch(serviceProvider(key.hostId))
@@ -517,12 +558,13 @@ final gitChangesProvider =
 
 // ─── Files ──────────────────────────────────────────────────────────────────
 
-final listFilesProvider =
-    FutureProvider.family<FileListing?, (String, String)>((ref, key) async {
-  final (hostId, path) = key;
-  if (path.isEmpty) return null;
-  return ref.watch(serviceProvider(hostId))?.listFiles(path);
-});
+final listFilesProvider = FutureProvider.family<FileListing?, (String, String)>(
+  (ref, key) async {
+    final (hostId, path) = key;
+    if (path.isEmpty) return null;
+    return ref.watch(serviceProvider(hostId))?.listFiles(path);
+  },
+);
 
 /// A file's contents.
 ///
@@ -532,21 +574,21 @@ final listFilesProvider =
 /// explicit reload.
 final readFileProvider =
     FutureProvider.family<FileReadResult?, (String, String)>((ref, key) async {
-  final (hostId, path) = key;
-  if (path.isEmpty) return null;
-  return ref.watch(serviceProvider(hostId))?.readFile(path);
-});
+      final (hostId, path) = key;
+      if (path.isEmpty) return null;
+      return ref.watch(serviceProvider(hostId))?.readFile(path);
+    });
 
 // ─── Subagents ──────────────────────────────────────────────────────────────
 
 final subagentsProvider =
     FutureProvider.family<List<Subagent>, (String, String)>((ref, key) async {
-  final (hostId, sessionId) = key;
-  if (sessionId.isEmpty) return const [];
-  final service = ref.watch(serviceProvider(hostId));
-  if (service == null) return const [];
-  return service.fetchSubagents(sessionId);
-});
+      final (hostId, sessionId) = key;
+      if (sessionId.isEmpty) return const [];
+      final service = ref.watch(serviceProvider(hostId));
+      if (service == null) return const [];
+      return service.fetchSubagents(sessionId);
+    });
 
 // ─── Refreshing by hand ─────────────────────────────────────────────────────
 
@@ -565,6 +607,6 @@ extension RefreshHosts on WidgetRef {
   }
 
   Future<void> refreshAllHosts() => Future.wait(
-        read(hostManagerProvider).hosts.map((h) => refreshHost(h.id)),
-      );
+    read(hostManagerProvider).hosts.map((h) => refreshHost(h.id)),
+  );
 }

--- a/mobile/lib/providers/notification_ext.dart
+++ b/mobile/lib/providers/notification_ext.dart
@@ -79,6 +79,18 @@ extension NotificationPayload on HeliosNotification {
     return null;
   }
 
+  /// What to call the plan in one line: its first heading, marks taken off.
+  ///
+  /// Read from the plan rather than from the notification's own detail, which
+  /// is written by the daemon and so is missing from a card built by hand.
+  String? get planHeadline {
+    for (final line in (planText ?? '').split('\n')) {
+      final text = line.replaceFirst(RegExp(r'^\s*#+\s*'), '').trim();
+      if (text.isNotEmpty) return text;
+    }
+    return null;
+  }
+
   // Payload accessors for a question
   List<dynamic>? get questions => payload?['questions'] as List?;
 

--- a/mobile/lib/providers/notification_ext.dart
+++ b/mobile/lib/providers/notification_ext.dart
@@ -56,6 +56,10 @@ extension NotificationPayload on HeliosNotification {
   List<dynamic>? get permissionSuggestions =>
       payload?['permission_suggestions'] as List?;
 
+  /// Whether Codex raised this. The card is the same card whoever raised it,
+  /// but the words on it name the agent the user is talking to.
+  bool get isCodex => source == 'codex';
+
   /// A plan waiting for approval. On the wire it is a permission like any
   /// other, but it is not a yes-or-no question: the answer picks the mode the
   /// session continues in, or sends the plan back in words.

--- a/mobile/lib/providers/notification_ext.dart
+++ b/mobile/lib/providers/notification_ext.dart
@@ -56,6 +56,25 @@ extension NotificationPayload on HeliosNotification {
   List<dynamic>? get permissionSuggestions =>
       payload?['permission_suggestions'] as List?;
 
+  /// A plan waiting for approval. On the wire it is a permission like any
+  /// other, but it is not a yes-or-no question: the answer picks the mode the
+  /// session continues in, or sends the plan back in words.
+  bool get isPlan => toolName == 'ExitPlanMode';
+
+  /// The plan as Claude wrote it, markdown and all.
+  String? get planText {
+    final ti = payload?['tool_input'];
+    if (ti is Map) return ti['plan'] as String?;
+    return null;
+  }
+
+  /// Where the whole plan lives on the machine running the agent.
+  String? get planFilePath {
+    final ti = payload?['tool_input'];
+    if (ti is Map) return ti['planFilePath'] as String?;
+    return null;
+  }
+
   // Payload accessors for a question
   List<dynamic>? get questions => payload?['questions'] as List?;
 

--- a/mobile/lib/providers/transcript.dart
+++ b/mobile/lib/providers/transcript.dart
@@ -50,11 +50,11 @@ Transcript appendDelta(Transcript held, TranscriptResult delta) {
 
 /// Adds the page before the oldest message held, for a reader scrolling back.
 Transcript prependPage(Transcript held, TranscriptResult older) => Transcript(
-      messages: [...older.messages, ...held.messages],
-      total: older.total,
-      hasMore: older.hasMore,
-      epoch: held.epoch,
-    );
+  messages: [...older.messages, ...held.messages],
+  total: older.total,
+  hasMore: older.hasMore,
+  epoch: held.epoch,
+);
 
 /// One session's conversation, paged backwards from the newest message.
 ///
@@ -182,5 +182,9 @@ class TranscriptNotifier
   }
 }
 
-final transcriptProvider = AsyncNotifierProvider.family<TranscriptNotifier,
-    Transcript, (String, String)>(TranscriptNotifier.new);
+final transcriptProvider =
+    AsyncNotifierProvider.family<
+      TranscriptNotifier,
+      Transcript,
+      (String, String)
+    >(TranscriptNotifier.new);

--- a/mobile/lib/screens/dashboard_screen.dart
+++ b/mobile/lib/screens/dashboard_screen.dart
@@ -51,7 +51,9 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
           }
         }
 
-        if (pendingActions.isEmpty && activeStatuses.isEmpty && resolved.isEmpty) {
+        if (pendingActions.isEmpty &&
+            activeStatuses.isEmpty &&
+            resolved.isEmpty) {
           return _buildEmptyState();
         }
 
@@ -62,7 +64,8 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
           child: ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              if (pendingActions.isNotEmpty) _buildBatchActions(pendingActions, hm),
+              if (pendingActions.isNotEmpty)
+                _buildBatchActions(pendingActions, hm),
               if (pendingActions.isNotEmpty) ...[
                 _sectionHeader('Pending (${pendingActions.length})'),
                 ...pendingActions.map((n) => _buildNotificationCard(n, hm)),
@@ -91,7 +94,9 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
     final match = held.where((s) => s.sessionId == sourceSession);
     if (match.isEmpty) return;
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => SessionDetailScreen(session: match.first)),
+      MaterialPageRoute(
+        builder: (_) => SessionDetailScreen(session: match.first),
+      ),
     );
   }
 
@@ -107,7 +112,12 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
     return _wrapWithHostBar(n, hm, card ?? _buildStatusCard(n, hm));
   }
 
-  Widget _wrapWithHostBar(HeliosNotification n, HostManager hm, Widget child, {double opacity = 0.4}) {
+  Widget _wrapWithHostBar(
+    HeliosNotification n,
+    HostManager hm,
+    Widget child, {
+    double opacity = 0.4,
+  }) {
     final host = hm.hostById(n.hostId);
     final hostColor = host?.color ?? Theme.of(context).colorScheme.primary;
 
@@ -135,21 +145,25 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
           Icon(
             Icons.notifications_none,
             size: 48,
-            color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            color: Theme.of(
+              context,
+            ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
           ),
           const SizedBox(height: 16),
           Text(
             'No notifications yet.',
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 4),
           Text(
             'Start a Claude session with helios hooks installed.',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-                ),
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+            ),
           ),
         ],
       ),
@@ -162,8 +176,8 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
       child: Text(
         title,
         style: Theme.of(context).textTheme.labelMedium?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
       ),
     );
   }
@@ -184,7 +198,9 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
                   byHost.putIfAbsent(n.hostId, () => []).add(n.id);
                 }
                 for (final entry in byHost.entries) {
-                  hm.serviceFor(entry.key)?.batchAction(entry.value, {'action': 'approve'});
+                  hm.serviceFor(entry.key)?.batchAction(entry.value, {
+                    'action': 'approve',
+                  });
                 }
               },
               child: Text('Approve All (${permissionIds.length})'),
@@ -202,7 +218,9 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
                   }
                 }
                 for (final entry in byHost.entries) {
-                  hm.serviceFor(entry.key)?.batchAction(entry.value, {'action': 'approve'});
+                  hm.serviceFor(entry.key)?.batchAction(entry.value, {
+                    'action': 'approve',
+                  });
                 }
                 setState(() => _selected.clear());
               },
@@ -284,7 +302,11 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
                 ),
                 Text(
                   hostLabel,
-                  style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: hostColor),
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: hostColor,
+                  ),
                 ),
               ],
             ),
@@ -330,30 +352,46 @@ class _DashboardScreenState extends rp.ConsumerState<DashboardScreen> {
                   title: Row(
                     children: [
                       Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 1,
+                        ),
                         decoration: BoxDecoration(
                           color: badgeColor.withValues(alpha: 0.15),
                           borderRadius: BorderRadius.circular(4),
                         ),
-                        child: Text(n.status, style: TextStyle(fontSize: 11, color: badgeColor)),
+                        child: Text(
+                          n.status,
+                          style: TextStyle(fontSize: 11, color: badgeColor),
+                        ),
                       ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
                           n.displayTitle,
-                          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+                          style: const TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w500,
+                          ),
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       Text(
                         hostLabel,
-                        style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: hostColor),
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: hostColor,
+                        ),
                       ),
                     ],
                   ),
                   subtitle: Text(
                     '${n.displayDetail}  ${n.timeAgo}${n.resolvedSource != null ? '  via ${n.resolvedSource}' : ''}',
-                    style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/mobile/lib/screens/file_browser_screen.dart
+++ b/mobile/lib/screens/file_browser_screen.dart
@@ -34,7 +34,8 @@ class FileBrowserScreen extends rp.ConsumerStatefulWidget {
   });
 
   @override
-  rp.ConsumerState<FileBrowserScreen> createState() => _FileBrowserScreenState();
+  rp.ConsumerState<FileBrowserScreen> createState() =>
+      _FileBrowserScreenState();
 }
 
 class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
@@ -102,7 +103,9 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
   Future<void> _pickRoot() async {
     if (_svc == null) return;
     final worktrees = sortWorktreesByLastTouched(
-      await ref.read(gitWorktreesProvider((widget.hostId, _currentPath)).future),
+      await ref.read(
+        gitWorktreesProvider((widget.hostId, _currentPath)).future,
+      ),
     );
     if (!mounted) return;
     if (worktrees.isEmpty) {
@@ -139,17 +142,26 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
                 final selected = wt.path == _rootPath;
                 return ListTile(
                   leading: Icon(
-                    selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                    selected
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
                     size: 22,
-                    color: selected ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+                    color: selected
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.onSurfaceVariant,
                   ),
                   title: Text(
                     wt.branch.isEmpty ? '(detached)' : wt.branch,
-                    style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontFamily: 'monospace',
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                   subtitle: Text(
-                    wt.date.isEmpty ? wt.shortPath : '${wt.shortPath} · ${wt.timeAgo}',
+                    wt.date.isEmpty
+                        ? wt.shortPath
+                        : '${wt.shortPath} · ${wt.timeAgo}',
                     style: const TextStyle(fontSize: 12),
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -230,9 +242,9 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
             IconButton(
               icon: const Icon(Icons.chat_bubble_outline),
               tooltip: 'Back to chat',
-              onPressed: () => Navigator.of(context).popUntil(
-                (route) => route.settings.name != '/file-browser',
-              ),
+              onPressed: () => Navigator.of(
+                context,
+              ).popUntil((route) => route.settings.name != '/file-browser'),
             ),
           ],
           bottom: PreferredSize(
@@ -241,7 +253,10 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
               height: 36,
               child: ListView.separated(
                 scrollDirection: Axis.horizontal,
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
                 itemCount: crumbs.length,
                 separatorBuilder: (_, i) => Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 2),
@@ -264,7 +279,9 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
                         color: isLast
                             ? theme.colorScheme.onSurface
                             : theme.colorScheme.primary,
-                        fontWeight: isLast ? FontWeight.w600 : FontWeight.normal,
+                        fontWeight: isLast
+                            ? FontWeight.w600
+                            : FontWeight.normal,
                       ),
                     ),
                   );
@@ -286,7 +303,8 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
     // reader is looking at and redraw it. The skeleton is a first-load
     // affordance. Same guard as the transcript's (spec 52,
     // session_detail_screen.dart:460).
-    if (listing.isLoading && !listing.hasValue) return const _FileListSkeleton();
+    if (listing.isLoading && !listing.hasValue)
+      return const _FileListSkeleton();
 
     final failed = listing.hasError || listing.valueOrNull == null;
     if (failed) {
@@ -349,17 +367,26 @@ class _EntryTile extends StatelessWidget {
       leading: Icon(
         entry.isDir ? Icons.folder : _iconForFile(entry.name),
         size: 28,
-        color: entry.isDir ? Colors.amber.shade700 : theme.colorScheme.onSurfaceVariant,
+        color: entry.isDir
+            ? Colors.amber.shade700
+            : theme.colorScheme.onSurfaceVariant,
       ),
       title: Text(
         entry.name,
         style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
       ),
       trailing: entry.isDir
-          ? Icon(Icons.chevron_right, size: 24, color: theme.colorScheme.onSurfaceVariant)
+          ? Icon(
+              Icons.chevron_right,
+              size: 24,
+              color: theme.colorScheme.onSurfaceVariant,
+            )
           : Text(
               entry.formattedSize,
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
       onTap: onTap,
       dense: true,
@@ -438,7 +465,9 @@ class _ScriptsSwitch extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: value ? FontWeight.w700 : FontWeight.w500,
-                  color: value ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+                  color: value
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurfaceVariant,
                 ),
               ),
               Transform.scale(
@@ -496,6 +525,7 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
   bool _runScripts = false;
 
   FileReadResult? get _result => _file.valueOrNull;
+
   /// Whether there is nothing to show yet.
   ///
   /// Not a bare `isLoading`: an agent editing this file invalidates the entry,
@@ -523,13 +553,15 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) ref.invalidate(readFileProvider(_fileKey));
+    if (state == AppLifecycleState.resumed)
+      ref.invalidate(readFileProvider(_fileKey));
   }
 
   /// What a preview may read from, and what "show in folder" browses.
   String get _root => widget.rootPath ?? _directory;
 
-  String get _directory => widget.path.substring(0, widget.path.lastIndexOf('/'));
+  String get _directory =>
+      widget.path.substring(0, widget.path.lastIndexOf('/'));
 
   /// Whether what is on screen is text the reader can point at.
   bool get _showsText {
@@ -543,7 +575,8 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
   /// the stack does not grow a second browser every time.
   void _showInFolder() {
     final nav = Navigator.of(context);
-    if (nav.canPop() && ModalRoute.of(context)?.settings.name == '/file-viewer') {
+    if (nav.canPop() &&
+        ModalRoute.of(context)?.settings.name == '/file-viewer') {
       nav.pop(_directory);
       return;
     }
@@ -563,7 +596,7 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
   bool _userConfirmedLarge = false;
   static const _softLimit = 1024 * 1024; // 1 MB
   int? _selStart; // 1-based line number
-  int? _selEnd;   // 1-based line number
+  int? _selEnd; // 1-based line number
 
   bool get _hasSelection => _selStart != null;
   String get _selLabel {
@@ -571,6 +604,7 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
     if (_selEnd == null || _selStart == _selEnd) return 'L$_selStart';
     return 'L$_selStart-$_selEnd';
   }
+
   int get _selCount {
     if (_selStart == null) return 0;
     if (_selEnd == null) return 1;
@@ -631,18 +665,28 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
   @override
   Widget build(BuildContext context) {
     _file = ref.watch(readFileProvider(_fileKey));
-    ref.listen(readFileProvider(_fileKey), (_, next) => _redirectIfDirectory(next));
+    ref.listen(
+      readFileProvider(_fileKey),
+      (_, next) => _redirectIfDirectory(next),
+    );
     final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(_fileName, style: const TextStyle(fontSize: 15), overflow: TextOverflow.ellipsis),
+            Text(
+              _fileName,
+              style: const TextStyle(fontSize: 15),
+              overflow: TextOverflow.ellipsis,
+            ),
             if (_result != null)
               Text(
                 _result!.formattedSize,
-                style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
           ],
         ),
@@ -697,15 +741,21 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
 
   Widget _buildAskAIBar(ThemeData theme) {
     final isDark = theme.brightness == Brightness.dark;
-    final accentColor = isDark ? const Color(0xFF58A6FF) : const Color(0xFF0969DA);
+    final accentColor = isDark
+        ? const Color(0xFF58A6FF)
+        : const Color(0xFF0969DA);
     return Container(
       padding: EdgeInsets.only(
-        left: 12, right: 8, top: 8,
+        left: 12,
+        right: 8,
+        top: 8,
         bottom: MediaQuery.of(context).padding.bottom + 8,
       ),
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        border: Border(top: BorderSide(color: theme.colorScheme.outlineVariant)),
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
       ),
       child: Row(
         children: [
@@ -714,17 +764,31 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
           if (_hasSelection) ...[
             Text(
               '$_selLabel · $_selCount ${_selCount == 1 ? 'line' : 'lines'}',
-              style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+              style: TextStyle(
+                fontSize: 12,
+                fontFamily: 'monospace',
+                color: theme.colorScheme.onSurface,
+              ),
             ),
             const SizedBox(width: 8),
             GestureDetector(
-              onTap: () => setState(() { _selStart = null; _selEnd = null; }),
-              child: Icon(Icons.close, size: 18, color: theme.colorScheme.onSurfaceVariant),
+              onTap: () => setState(() {
+                _selStart = null;
+                _selEnd = null;
+              }),
+              child: Icon(
+                Icons.close,
+                size: 18,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ] else
             Text(
               'Tap lines to select',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           const Spacer(),
           FilledButton.tonalIcon(
@@ -744,14 +808,18 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
   void _showAskAISheet(ThemeData theme) {
     final controller = TextEditingController();
     final isDark = theme.brightness == Brightness.dark;
-    final accentColor = isDark ? const Color(0xFF58A6FF) : const Color(0xFF0969DA);
+    final accentColor = isDark
+        ? const Color(0xFF58A6FF)
+        : const Color(0xFF0969DA);
     final label = _hasSelection ? '$_fileName:$_selLabel' : widget.path;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (ctx) {
         return Padding(
-          padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(ctx).viewInsets.bottom,
+          ),
           child: SafeArea(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
@@ -761,13 +829,18 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.insert_drive_file, size: 20, color: accentColor),
+                      Icon(
+                        Icons.insert_drive_file,
+                        size: 20,
+                        color: accentColor,
+                      ),
                       const SizedBox(width: 6),
                       Flexible(
                         child: Text(
                           label,
                           style: TextStyle(
-                            fontSize: 13, fontFamily: 'monospace',
+                            fontSize: 13,
+                            fontFamily: 'monospace',
                             fontWeight: FontWeight.w600,
                             color: accentColor,
                           ),
@@ -784,10 +857,20 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
                     maxLines: 4,
                     style: const TextStyle(fontSize: 14),
                     decoration: InputDecoration(
-                      hintText: _hasSelection ? 'Ask about this code...' : 'Ask about this file...',
-                      hintStyle: TextStyle(fontSize: 14, color: theme.colorScheme.onSurfaceVariant),
-                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
-                      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                      hintText: _hasSelection
+                          ? 'Ask about this code...'
+                          : 'Ask about this file...',
+                      hintStyle: TextStyle(
+                        fontSize: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
                       suffixIcon: IconButton(
                         icon: const Icon(Icons.send, size: 20),
                         onPressed: () => _sendAskAI(ctx, controller.text),
@@ -815,9 +898,13 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
       final lines = content.split('\n');
       final start = (_selStart ?? 1) - 1;
       final end = (_selEnd ?? _selStart ?? 1);
-      final selected = lines.sublist(start.clamp(0, lines.length), end.clamp(0, lines.length));
+      final selected = lines.sublist(
+        start.clamp(0, lines.length),
+        end.clamp(0, lines.length),
+      );
       final ext = _fileName.contains('.') ? _fileName.split('.').last : '';
-      prompt = 'Regarding `${widget.path}` $_selLabel:\n```$ext\n${selected.join('\n')}\n```\n${question.trim()}';
+      prompt =
+          'Regarding `${widget.path}` $_selLabel:\n```$ext\n${selected.join('\n')}\n```\n${question.trim()}';
     } else {
       prompt = 'Regarding file `${widget.path}`:\n${question.trim()}';
     }
@@ -828,7 +915,9 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
     await svc.sendSessionPrompt(widget.sessionId!, prompt);
     if (!mounted) return;
     nav.popUntil(
-      (route) => route.settings.name != '/file-browser' && route.settings.name != '/git-status',
+      (route) =>
+          route.settings.name != '/file-browser' &&
+          route.settings.name != '/git-status',
     );
   }
 
@@ -851,7 +940,10 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
 
     // Server hard limit exceeded
     if (_result!.isTooLarge) {
-      return _buildTooLargeView(theme, '${_result!.formattedSize} — exceeds 10 MB server limit');
+      return _buildTooLargeView(
+        theme,
+        '${_result!.formattedSize} — exceeds 10 MB server limit',
+      );
     }
 
     // Client soft limit: warn before showing large files
@@ -908,10 +1000,25 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
               borderRadius: BorderRadius.circular(8),
             ),
             codeblockPadding: const EdgeInsets.all(0),
-            h1: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: theme.colorScheme.onSurface),
-            h2: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: theme.colorScheme.onSurface),
-            h3: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: theme.colorScheme.onSurface),
-            listBullet: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+            h1: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.onSurface,
+            ),
+            h2: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.onSurface,
+            ),
+            h3: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: theme.colorScheme.onSurface,
+            ),
+            listBullet: TextStyle(
+              fontSize: 14,
+              color: theme.colorScheme.onSurface,
+            ),
           ),
         ),
       );
@@ -924,14 +1031,25 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
     return _buildLineListView(theme, lines, language, isDark);
   }
 
-  Widget _buildLineListView(ThemeData theme, List<String> lines, String? language, bool isDark) {
+  Widget _buildLineListView(
+    ThemeData theme,
+    List<String> lines,
+    String? language,
+    bool isDark,
+  ) {
     // Syntax highlight all lines together for context
     List<List<TextSpan>>? highlightedLines;
     if (language != null) {
-      highlightedLines = _highlightCodeLines(lines.join('\n'), language, isDark);
+      highlightedLines = _highlightCodeLines(
+        lines.join('\n'),
+        language,
+        isDark,
+      );
     }
 
-    final selectedBg = isDark ? const Color(0xFF1A3A5C) : const Color(0xFFD4E8FC);
+    final selectedBg = isDark
+        ? const Color(0xFF1A3A5C)
+        : const Color(0xFFD4E8FC);
     final gutterColor = theme.colorScheme.onSurfaceVariant.withAlpha(120);
 
     return ListView.builder(
@@ -951,7 +1069,11 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
         } else {
           textWidget = Text(
             lines[i],
-            style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: 'monospace',
+              color: theme.colorScheme.onSurface,
+            ),
             maxLines: 1,
             overflow: TextOverflow.clip,
           );
@@ -969,7 +1091,11 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
                   child: Text(
                     '$lineNum',
                     textAlign: TextAlign.right,
-                    style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: selected ? theme.colorScheme.primary : gutterColor),
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontFamily: 'monospace',
+                      color: selected ? theme.colorScheme.primary : gutterColor,
+                    ),
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -982,10 +1108,15 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
     );
   }
 
-  List<List<TextSpan>> _highlightCodeLines(String code, String language, bool isDark) {
+  List<List<TextSpan>> _highlightCodeLines(
+    String code,
+    String language,
+    bool isDark,
+  ) {
     final themeMap = isDark ? atomOneDarkTheme : atomOneLightTheme;
     final defaultStyle = TextStyle(
-      fontSize: 12, fontFamily: 'monospace',
+      fontSize: 12,
+      fontFamily: 'monospace',
       color: isDark ? Colors.white70 : Colors.black87,
     );
     try {
@@ -1009,11 +1140,19 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
       }
       return lines;
     } catch (_) {
-      return code.split('\n').map((l) => [TextSpan(text: l, style: defaultStyle)]).toList();
+      return code
+          .split('\n')
+          .map((l) => [TextSpan(text: l, style: defaultStyle)])
+          .toList();
     }
   }
 
-  void _buildHighlightSpans(List<dynamic> nodes, Map<String, TextStyle> themeMap, TextStyle defaultStyle, List<TextSpan> out) {
+  void _buildHighlightSpans(
+    List<dynamic> nodes,
+    Map<String, TextStyle> themeMap,
+    TextStyle defaultStyle,
+    List<TextSpan> out,
+  ) {
     for (final node in nodes) {
       if (node.value != null) {
         TextStyle style = defaultStyle;
@@ -1024,45 +1163,82 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
         }
         out.add(TextSpan(text: node.value as String, style: style));
       } else if (node.children != null) {
-        _buildHighlightSpans(node.children as List<dynamic>, themeMap, defaultStyle, out);
+        _buildHighlightSpans(
+          node.children as List<dynamic>,
+          themeMap,
+          defaultStyle,
+          out,
+        );
       }
     }
   }
 
   String? _languageForExt(String ext) {
     switch (ext) {
-      case 'dart': return 'dart';
-      case 'go': return 'go';
-      case 'py': return 'python';
-      case 'js': return 'javascript';
-      case 'ts': return 'typescript';
-      case 'tsx': return 'typescript';
-      case 'jsx': return 'javascript';
-      case 'java': return 'java';
-      case 'kt': return 'kotlin';
-      case 'swift': return 'swift';
-      case 'rs': return 'rust';
-      case 'c': return 'c';
-      case 'cpp': return 'cpp';
-      case 'h': return 'cpp';
-      case 'cs': return 'cs';
-      case 'rb': return 'ruby';
-      case 'sh': return 'bash';
-      case 'bash': return 'bash';
-      case 'zsh': return 'bash';
-      case 'json': return 'json';
-      case 'yaml': return 'yaml';
-      case 'yml': return 'yaml';
-      case 'toml': return 'ini';
-      case 'xml': return 'xml';
-      case 'html': return 'html';
-      case 'css': return 'css';
-      case 'scss': return 'scss';
-      case 'sql': return 'sql';
-      case 'dockerfile': return 'dockerfile';
-      case 'tf': return 'hcl';
-      case 'proto': return 'protobuf';
-      default: return null;
+      case 'dart':
+        return 'dart';
+      case 'go':
+        return 'go';
+      case 'py':
+        return 'python';
+      case 'js':
+        return 'javascript';
+      case 'ts':
+        return 'typescript';
+      case 'tsx':
+        return 'typescript';
+      case 'jsx':
+        return 'javascript';
+      case 'java':
+        return 'java';
+      case 'kt':
+        return 'kotlin';
+      case 'swift':
+        return 'swift';
+      case 'rs':
+        return 'rust';
+      case 'c':
+        return 'c';
+      case 'cpp':
+        return 'cpp';
+      case 'h':
+        return 'cpp';
+      case 'cs':
+        return 'cs';
+      case 'rb':
+        return 'ruby';
+      case 'sh':
+        return 'bash';
+      case 'bash':
+        return 'bash';
+      case 'zsh':
+        return 'bash';
+      case 'json':
+        return 'json';
+      case 'yaml':
+        return 'yaml';
+      case 'yml':
+        return 'yaml';
+      case 'toml':
+        return 'ini';
+      case 'xml':
+        return 'xml';
+      case 'html':
+        return 'html';
+      case 'css':
+        return 'css';
+      case 'scss':
+        return 'scss';
+      case 'sql':
+        return 'sql';
+      case 'dockerfile':
+        return 'dockerfile';
+      case 'tf':
+        return 'hcl';
+      case 'proto':
+        return 'protobuf';
+      default:
+        return null;
     }
   }
 
@@ -1082,7 +1258,10 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
             const SizedBox(height: 8),
             Text(
               'Loading may be slow or cause performance issues.',
-              style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
@@ -1112,7 +1291,10 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
             const SizedBox(height: 8),
             Text(
               detail,
-              style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               textAlign: TextAlign.center,
             ),
           ],
@@ -1147,7 +1329,11 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.do_not_disturb, size: 48, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.do_not_disturb,
+              size: 48,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             const SizedBox(height: 16),
             const Text(
               'Binary file',
@@ -1156,7 +1342,10 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
             const SizedBox(height: 8),
             Text(
               '${_result!.formattedSize} — cannot display',
-              style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),
@@ -1179,7 +1368,11 @@ class _FileListSkeleton extends StatelessWidget {
           for (int i = 0; i < 10; i++) ...[
             Row(
               children: [
-                const Skeleton(width: 24, height: 24, borderRadius: BorderRadius.all(Radius.circular(4))),
+                const Skeleton(
+                  width: 24,
+                  height: 24,
+                  borderRadius: BorderRadius.all(Radius.circular(4)),
+                ),
                 const SizedBox(width: 12),
                 Skeleton(width: 80.0 + (i * 31 % 120), height: 16),
                 const Spacer(),
@@ -1243,10 +1436,18 @@ class _SyntaxHighlightBuilder extends MarkdownElementBuilder {
       language: lang.isNotEmpty ? lang : 'plaintext',
       theme: isDark ? atomOneDarkTheme : atomOneLightTheme,
       padding: const EdgeInsets.all(12),
-      textStyle: const TextStyle(fontSize: 12, fontFamily: 'monospace', height: 1.5),
+      textStyle: const TextStyle(
+        fontSize: 12,
+        fontFamily: 'monospace',
+        height: 1.5,
+      ),
     );
     if (lang == 'mermaid') {
-      return MermaidDiagram(source: code.trimRight(), isDark: isDark, fallback: block);
+      return MermaidDiagram(
+        source: code.trimRight(),
+        isDark: isDark,
+        fallback: block,
+      );
     }
     return block;
   }

--- a/mobile/lib/screens/file_browser_screen.dart
+++ b/mobile/lib/screens/file_browser_screen.dart
@@ -44,12 +44,32 @@ class _FileBrowserScreenState extends rp.ConsumerState<FileBrowserScreen>
   late String _rootPath;
   final List<String> _history = [];
 
+  /// Whether the read that [didChangeDependencies] owes the first build is done.
+  bool _readOnOpen = false;
+
   @override
   void initState() {
     super.initState();
     _currentPath = widget.startPath ?? widget.rootPath;
     _rootPath = widget.rootPath;
     WidgetsBinding.instance.addObserver(this);
+  }
+
+  /// The first read, from the earliest place `ref` is allowed to work.
+  ///
+  /// Not `initState`. Riverpod resolves the enclosing scope lazily, on the
+  /// first `ref` call, through `dependOnInheritedWidgetOfExactType` — and
+  /// Flutter forbids that until `initState` has returned. The check is an
+  /// `assert`, so this throws a red screen in debug and passes silently in
+  /// release, which is how it survived being shipped.
+  ///
+  /// `didChangeDependencies` still runs before the first build, which is what
+  /// `_reread` needs.
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_readOnOpen) return;
+    _readOnOpen = true;
     _reread();
   }
 
@@ -537,11 +557,22 @@ class _FileViewerScreenState extends rp.ConsumerState<FileViewerScreen>
 
   (String, String) get _fileKey => (widget.hostId, widget.path);
 
+  /// Whether the read that [didChangeDependencies] owes the first build is done.
+  bool _readOnOpen = false;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    // Same reasoning as the listing's: see _FileBrowserScreenState._reread.
+  }
+
+  /// Why the read waits for dependencies, and why it happens at all: see
+  /// `_FileBrowserScreenState.didChangeDependencies` and `_reread`.
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_readOnOpen) return;
+    _readOnOpen = true;
     ref.invalidate(readFileProvider(_fileKey));
   }
 

--- a/mobile/lib/screens/git_status_screen.dart
+++ b/mobile/lib/screens/git_status_screen.dart
@@ -17,7 +17,12 @@ class GitStatusScreen extends rp.ConsumerStatefulWidget {
   final String cwd;
   final String? sessionId;
 
-  const GitStatusScreen({super.key, required this.hostId, required this.cwd, this.sessionId});
+  const GitStatusScreen({
+    super.key,
+    required this.hostId,
+    required this.cwd,
+    this.sessionId,
+  });
 
   @override
   rp.ConsumerState<GitStatusScreen> createState() => _GitStatusScreenState();
@@ -45,7 +50,9 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final status = await ref.read(gitStatusProvider((widget.hostId, _root)).future);
+    final status = await ref.read(
+      gitStatusProvider((widget.hostId, _root)).future,
+    );
     if (!mounted) return;
     setState(() {
       _status = status;
@@ -112,9 +119,18 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: SegmentedButton<_GitView>(
               segments: const [
-                ButtonSegment(value: _GitView.changes, label: Text('Changes', style: TextStyle(fontSize: 12))),
-                ButtonSegment(value: _GitView.commits, label: Text('Commits', style: TextStyle(fontSize: 12))),
-                ButtonSegment(value: _GitView.worktrees, label: Text('Worktrees', style: TextStyle(fontSize: 12))),
+                ButtonSegment(
+                  value: _GitView.changes,
+                  label: Text('Changes', style: TextStyle(fontSize: 12)),
+                ),
+                ButtonSegment(
+                  value: _GitView.commits,
+                  label: Text('Commits', style: TextStyle(fontSize: 12)),
+                ),
+                ButtonSegment(
+                  value: _GitView.worktrees,
+                  label: Text('Worktrees', style: TextStyle(fontSize: 12)),
+                ),
               ],
               selected: {_view},
               onSelectionChanged: (s) => setState(() => _view = s.first),
@@ -129,18 +145,18 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
       body: switch (_view) {
         _GitView.changes => _buildChanges(theme),
         _GitView.commits => _CommitsTab(
-            key: ValueKey('commits:$_root:$_reload'),
-            hostId: widget.hostId,
-            root: _root,
-            sessionId: widget.sessionId,
-          ),
+          key: ValueKey('commits:$_root:$_reload'),
+          hostId: widget.hostId,
+          root: _root,
+          sessionId: widget.sessionId,
+        ),
         _GitView.worktrees => _WorktreesTab(
-            key: ValueKey('worktrees:$_root:$_reload'),
-            hostId: widget.hostId,
-            root: _root,
-            active: _root,
-            onPick: _scopeTo,
-          ),
+          key: ValueKey('worktrees:$_root:$_reload'),
+          hostId: widget.hostId,
+          root: _root,
+          active: _root,
+          onPick: _scopeTo,
+        ),
       },
     );
   }
@@ -179,7 +195,11 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
             children: [
               Row(
                 children: [
-                  Icon(Icons.fork_right, size: 20, color: theme.colorScheme.primary),
+                  Icon(
+                    Icons.fork_right,
+                    size: 20,
+                    color: theme.colorScheme.primary,
+                  ),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -194,12 +214,22 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
                   ),
                   if (!s.dirty)
                     Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
                       decoration: BoxDecoration(
                         color: Colors.green.withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(4),
                       ),
-                      child: const Text('clean', style: TextStyle(fontSize: 11, color: Colors.green, fontWeight: FontWeight.w600)),
+                      child: const Text(
+                        'clean',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: Colors.green,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
                     ),
                 ],
               ),
@@ -208,15 +238,35 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
                 Row(
                   children: [
                     if (s.ahead > 0) ...[
-                      Icon(Icons.arrow_upward, size: 14, color: Colors.green.shade400),
+                      Icon(
+                        Icons.arrow_upward,
+                        size: 14,
+                        color: Colors.green.shade400,
+                      ),
                       const SizedBox(width: 2),
-                      Text('${ s.ahead} ahead', style: TextStyle(fontSize: 12, color: Colors.green.shade400)),
+                      Text(
+                        '${s.ahead} ahead',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.green.shade400,
+                        ),
+                      ),
                       const SizedBox(width: 12),
                     ],
                     if (s.behind > 0) ...[
-                      Icon(Icons.arrow_downward, size: 14, color: Colors.orange.shade400),
+                      Icon(
+                        Icons.arrow_downward,
+                        size: 14,
+                        color: Colors.orange.shade400,
+                      ),
                       const SizedBox(width: 2),
-                      Text('${s.behind} behind', style: TextStyle(fontSize: 12, color: Colors.orange.shade400)),
+                      Text(
+                        '${s.behind} behind',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.orange.shade400,
+                        ),
+                      ),
                     ],
                   ],
                 ),
@@ -240,7 +290,10 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
             child: Center(
               child: Text(
                 'Working tree clean',
-                style: TextStyle(fontSize: 14, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 14,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ),
@@ -248,7 +301,13 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
     );
   }
 
-  Widget _buildSection(ThemeData theme, String title, List<GitChange> changes, Color color, bool staged) {
+  Widget _buildSection(
+    ThemeData theme,
+    String title,
+    List<GitChange> changes,
+    Color color,
+    bool staged,
+  ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -268,18 +327,23 @@ class _GitStatusScreenState extends rp.ConsumerState<GitStatusScreen> {
               const SizedBox(width: 6),
               Text(
                 '(${changes.length})',
-                style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),
         ),
-        ...changes.map((c) => _ChangeTile(
-          change: c,
-          color: color,
-          onTap: c.status == '?'
-              ? () => _openFile(c.path)
-              : () => _openDiff(c, staged),
-        )),
+        ...changes.map(
+          (c) => _ChangeTile(
+            change: c,
+            color: color,
+            onTap: c.status == '?'
+                ? () => _openFile(c.path)
+                : () => _openDiff(c, staged),
+          ),
+        ),
         const SizedBox(height: 16),
       ],
     );
@@ -319,7 +383,11 @@ class _ChangeTile extends StatelessWidget {
   final Color color;
   final VoidCallback onTap;
 
-  const _ChangeTile({required this.change, required this.color, required this.onTap});
+  const _ChangeTile({
+    required this.change,
+    required this.color,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -356,7 +424,11 @@ class _ChangeTile extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-            Icon(Icons.chevron_right, size: 16, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ],
         ),
       ),
@@ -412,13 +484,21 @@ List<Widget> _statChips(int insertions, int deletions) {
     if (insertions > 0)
       Text(
         '+$insertions',
-        style: const TextStyle(fontSize: 11, fontFamily: 'monospace', color: Colors.green),
+        style: const TextStyle(
+          fontSize: 11,
+          fontFamily: 'monospace',
+          color: Colors.green,
+        ),
       ),
     if (insertions > 0 && deletions > 0) const SizedBox(width: 6),
     if (deletions > 0)
       Text(
         '-$deletions',
-        style: const TextStyle(fontSize: 11, fontFamily: 'monospace', color: Colors.red),
+        style: const TextStyle(
+          fontSize: 11,
+          fontFamily: 'monospace',
+          color: Colors.red,
+        ),
       ),
   ];
 }
@@ -434,7 +514,12 @@ class _CommitsTab extends rp.ConsumerStatefulWidget {
   final String root;
   final String? sessionId;
 
-  const _CommitsTab({super.key, required this.hostId, required this.root, this.sessionId});
+  const _CommitsTab({
+    super.key,
+    required this.hostId,
+    required this.root,
+    this.sessionId,
+  });
 
   @override
   rp.ConsumerState<_CommitsTab> createState() => _CommitsTabState();
@@ -460,7 +545,8 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
       _compareFrom = null;
     });
     final log = await ref.read(
-        gitLogProvider(GitLogKey(widget.hostId, widget.root, all: _all)).future);
+      gitLogProvider(GitLogKey(widget.hostId, widget.root, all: _all)).future,
+    );
     if (!mounted) return;
     setState(() {
       _log = log;
@@ -474,9 +560,11 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
   Future<void> _loadMore() async {
     if (_loadingMore) return;
     setState(() => _loadingMore = true);
-    final next = await ref.read(gitLogProvider(
-            GitLogKey(widget.hostId, widget.root, all: _all, skip: _commits.length))
-        .future);
+    final next = await ref.read(
+      gitLogProvider(
+        GitLogKey(widget.hostId, widget.root, all: _all, skip: _commits.length),
+      ).future,
+    );
     if (!mounted) return;
     setState(() {
       if (next != null) {
@@ -568,11 +656,16 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
                                 ? const SizedBox(
                                     width: 18,
                                     height: 18,
-                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
                                   )
                                 : TextButton(
                                     onPressed: _loadMore,
-                                    child: const Text('Load more', style: TextStyle(fontSize: 13)),
+                                    child: const Text(
+                                      'Load more',
+                                      style: TextStyle(fontSize: 13),
+                                    ),
                                   ),
                           ),
                         );
@@ -602,7 +695,9 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant)),
+        border: Border(
+          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
       ),
       child: Row(
         children: [
@@ -624,15 +719,24 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
           Flexible(
             child: Text(
               label,
-              style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 11,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               overflow: TextOverflow.ellipsis,
             ),
           ),
           const Spacer(),
           SegmentedButton<bool>(
             segments: const [
-              ButtonSegment(value: false, label: Text('Branch', style: TextStyle(fontSize: 11))),
-              ButtonSegment(value: true, label: Text('All', style: TextStyle(fontSize: 11))),
+              ButtonSegment(
+                value: false,
+                label: Text('Branch', style: TextStyle(fontSize: 11)),
+              ),
+              ButtonSegment(
+                value: true,
+                label: Text('All', style: TextStyle(fontSize: 11)),
+              ),
             ],
             selected: {_all},
             onSelectionChanged: (s) {
@@ -657,17 +761,28 @@ class _CommitsTabState extends rp.ConsumerState<_CommitsTab> {
       color: theme.colorScheme.primaryContainer,
       child: Row(
         children: [
-          Icon(Icons.compare_arrows, size: 16, color: theme.colorScheme.onPrimaryContainer),
+          Icon(
+            Icons.compare_arrows,
+            size: 16,
+            color: theme.colorScheme.onPrimaryContainer,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               'Comparing from $short — tap another commit',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onPrimaryContainer),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
             ),
           ),
           GestureDetector(
             onTap: () => setState(() => _compareFrom = null),
-            child: Icon(Icons.close, size: 16, color: theme.colorScheme.onPrimaryContainer),
+            child: Icon(
+              Icons.close,
+              size: 16,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
           ),
         ],
       ),
@@ -697,15 +812,24 @@ class _CommitTile extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         decoration: BoxDecoration(
-          color: marked ? theme.colorScheme.primaryContainer.withValues(alpha: 0.4) : null,
-          border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5))),
+          color: marked
+              ? theme.colorScheme.primaryContainer.withValues(alpha: 0.4)
+              : null,
+          border: Border(
+            bottom: BorderSide(
+              color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+            ),
+          ),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               commit.subject,
-              style: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+              style: TextStyle(
+                fontSize: 14,
+                color: theme.colorScheme.onSurface,
+              ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
@@ -724,14 +848,20 @@ class _CommitTile extends StatelessWidget {
                 Flexible(
                   child: Text(
                     commit.author,
-                    style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 const SizedBox(width: 8),
                 Text(
                   commit.timeAgo,
-                  style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
                 const Spacer(),
                 ..._statChips(commit.insertions, commit.deletions),
@@ -764,7 +894,8 @@ class CommitDetailScreen extends rp.ConsumerStatefulWidget {
   });
 
   @override
-  rp.ConsumerState<CommitDetailScreen> createState() => _CommitDetailScreenState();
+  rp.ConsumerState<CommitDetailScreen> createState() =>
+      _CommitDetailScreenState();
 }
 
 class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
@@ -779,9 +910,11 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final changes = await ref.read(gitChangesProvider(
-            GitChangesKey(widget.hostId, widget.root, widget.to, from: widget.from))
-        .future);
+    final changes = await ref.read(
+      gitChangesProvider(
+        GitChangesKey(widget.hostId, widget.root, widget.to, from: widget.from),
+      ).future,
+    );
     if (!mounted) return;
     setState(() {
       _changes = changes;
@@ -812,7 +945,9 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          changes?.single == true && changes!.subject.isNotEmpty ? changes.subject : widget.title,
+          changes?.single == true && changes!.subject.isNotEmpty
+              ? changes.subject
+              : widget.title,
           style: const TextStyle(fontSize: 15),
           overflow: TextOverflow.ellipsis,
         ),
@@ -821,7 +956,9 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
             icon: const Icon(Icons.chat_bubble_outline),
             tooltip: 'Back to chat',
             onPressed: () => Navigator.of(context).popUntil(
-              (route) => route.settings.name != '/file-browser' && route.settings.name != '/git-status',
+              (route) =>
+                  route.settings.name != '/file-browser' &&
+                  route.settings.name != '/git-status',
             ),
           ),
         ],
@@ -829,17 +966,21 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
       body: _loading
           ? const _GitStatusSkeleton()
           : changes == null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
-                      const SizedBox(height: 12),
-                      const Text('Failed to load commit'),
-                    ],
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    size: 40,
+                    color: theme.colorScheme.error,
                   ),
-                )
-              : _buildBody(theme, changes),
+                  const SizedBox(height: 12),
+                  const Text('Failed to load commit'),
+                ],
+              ),
+            )
+          : _buildBody(theme, changes),
     );
   }
 
@@ -859,7 +1000,9 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
               Row(
                 children: [
                   Text(
-                    changes.single ? changes.shortTo : '${changes.shortFrom}...${changes.shortTo}',
+                    changes.single
+                        ? changes.shortTo
+                        : '${changes.shortFrom}...${changes.shortTo}',
                     style: TextStyle(
                       fontSize: 12,
                       fontFamily: 'monospace',
@@ -871,7 +1014,10 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
                     Flexible(
                       child: Text(
                         changes.author,
-                        style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
@@ -880,7 +1026,10 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
                     const SizedBox(width: 8),
                     Text(
                       changes.timeAgo,
-                      style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ],
                   const Spacer(),
@@ -920,17 +1069,25 @@ class _CommitDetailScreenState extends rp.ConsumerState<CommitDetailScreen> {
             child: Center(
               child: Text(
                 'No files — a merge commit',
-                style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 13,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ),
-        ...changes.files.map((file) => _CommitFileTile(file: file, onTap: () => _openFile(file))),
+        ...changes.files.map(
+          (file) => _CommitFileTile(file: file, onTap: () => _openFile(file)),
+        ),
         if (changes.truncated)
           Padding(
             padding: const EdgeInsets.only(top: 12),
             child: Text(
               'Showing the first ${changes.files.length} files.',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
       ],
@@ -974,13 +1131,21 @@ class _CommitFileTile extends StatelessWidget {
                 children: [
                   Text(
                     file.path,
-                    style: TextStyle(fontSize: 13, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontFamily: 'monospace',
+                      color: theme.colorScheme.onSurface,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                   if (file.from.isNotEmpty)
                     Text(
                       'was ${file.from}',
-                      style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurfaceVariant),
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                       overflow: TextOverflow.ellipsis,
                     ),
                 ],
@@ -988,7 +1153,11 @@ class _CommitFileTile extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             ..._statChips(file.insertions, file.deletions),
-            Icon(Icons.chevron_right, size: 16, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ],
         ),
       ),
@@ -1036,8 +1205,9 @@ class _WorktreesTabState extends rp.ConsumerState<_WorktreesTab> {
   }
 
   Future<void> _load() async {
-    final worktrees =
-        await ref.read(gitWorktreesProvider((widget.hostId, widget.root)).future);
+    final worktrees = await ref.read(
+      gitWorktreesProvider((widget.hostId, widget.root)).future,
+    );
     if (!mounted) return;
     setState(() => _worktrees = sortWorktreesByLastTouched(worktrees));
   }
@@ -1049,7 +1219,10 @@ class _WorktreesTabState extends rp.ConsumerState<_WorktreesTab> {
     if (worktrees == null) return const _GitStatusSkeleton();
     if (worktrees.isEmpty) {
       return Center(
-        child: Text('No worktrees', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
+        child: Text(
+          'No worktrees',
+          style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+        ),
       );
     }
     final matches = filterWorktrees(worktrees, _query);
@@ -1064,9 +1237,15 @@ class _WorktreesTabState extends rp.ConsumerState<_WorktreesTab> {
             decoration: InputDecoration(
               isDense: true,
               hintText: 'Search branch, path or subject',
-              hintStyle: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
+              hintStyle: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
               prefixIcon: const Icon(Icons.search, size: 18),
-              prefixIconConstraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+              prefixIconConstraints: const BoxConstraints(
+                minWidth: 36,
+                minHeight: 36,
+              ),
               suffixIcon: _query.isEmpty
                   ? null
                   : IconButton(
@@ -1077,7 +1256,10 @@ class _WorktreesTabState extends rp.ConsumerState<_WorktreesTab> {
                       },
                     ),
               border: const OutlineInputBorder(),
-              contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 10,
+              ),
             ),
           ),
         ),
@@ -1110,10 +1292,12 @@ List<Worktree> filterWorktrees(List<Worktree> worktrees, String query) {
   final needle = query.trim().toLowerCase();
   if (needle.isEmpty) return worktrees;
   return worktrees
-      .where((w) =>
-          w.branch.toLowerCase().contains(needle) ||
-          w.path.toLowerCase().contains(needle) ||
-          w.subject.toLowerCase().contains(needle))
+      .where(
+        (w) =>
+            w.branch.toLowerCase().contains(needle) ||
+            w.path.toLowerCase().contains(needle) ||
+            w.subject.toLowerCase().contains(needle),
+      )
       .toList();
 }
 
@@ -1122,7 +1306,11 @@ class _WorktreeTile extends StatelessWidget {
   final bool selected;
   final VoidCallback onTap;
 
-  const _WorktreeTile({required this.worktree, required this.selected, required this.onTap});
+  const _WorktreeTile({
+    required this.worktree,
+    required this.selected,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1132,8 +1320,14 @@ class _WorktreeTile extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         decoration: BoxDecoration(
-          color: selected ? theme.colorScheme.primaryContainer.withValues(alpha: 0.35) : null,
-          border: Border(bottom: BorderSide(color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5))),
+          color: selected
+              ? theme.colorScheme.primaryContainer.withValues(alpha: 0.35)
+              : null,
+          border: Border(
+            bottom: BorderSide(
+              color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+            ),
+          ),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -1141,9 +1335,13 @@ class _WorktreeTile extends StatelessWidget {
             Row(
               children: [
                 Icon(
-                  selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+                  selected
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked,
                   size: 16,
-                  color: selected ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+                  color: selected
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(width: 8),
                 Flexible(
@@ -1152,7 +1350,9 @@ class _WorktreeTile extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 13,
                       fontFamily: 'monospace',
-                      fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+                      fontWeight: selected
+                          ? FontWeight.w600
+                          : FontWeight.normal,
                       color: theme.colorScheme.onSurface,
                     ),
                     overflow: TextOverflow.ellipsis,
@@ -1161,8 +1361,10 @@ class _WorktreeTile extends StatelessWidget {
                 const SizedBox(width: 6),
                 if (worktree.isMain) const _Pill(text: 'main'),
                 if (worktree.locked) const _Pill(text: 'locked'),
-                if (worktree.ahead > 0) _Pill(text: '↑${worktree.ahead}', color: Colors.green),
-                if (worktree.behind > 0) _Pill(text: '↓${worktree.behind}', color: Colors.orange),
+                if (worktree.ahead > 0)
+                  _Pill(text: '↑${worktree.ahead}', color: Colors.green),
+                if (worktree.behind > 0)
+                  _Pill(text: '↓${worktree.behind}', color: Colors.orange),
                 if (worktree.dirty > 0)
                   _Pill(text: '●${worktree.dirty}', color: Colors.orange)
                 else
@@ -1173,7 +1375,10 @@ class _WorktreeTile extends StatelessWidget {
               const SizedBox(height: 4),
               Text(
                 worktree.subject,
-                style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 12,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -1186,7 +1391,9 @@ class _WorktreeTile extends StatelessWidget {
               style: TextStyle(
                 fontSize: 11,
                 fontFamily: 'monospace',
-                color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
+                color: theme.colorScheme.onSurfaceVariant.withValues(
+                  alpha: 0.8,
+                ),
               ),
               overflow: TextOverflow.ellipsis,
             ),
@@ -1216,7 +1423,11 @@ class _Pill extends StatelessWidget {
       ),
       child: Text(
         text,
-        style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: tint),
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: tint,
+        ),
       ),
     );
   }
@@ -1267,6 +1478,7 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
     if (_selEnd == null || _selStart == _selEnd) return 'L$_selStart';
     return 'L$_selStart-$_selEnd';
   }
+
   int get _selCount {
     if (_selStart == null) return 0;
     if (_selEnd == null) return 1;
@@ -1326,7 +1538,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
     // is the current file, which is not what an old commit changed.
     if (_atRevision) return;
     final fullPath = '${widget.cwd}/${widget.change.path}';
-    final file = await ref.read(readFileProvider((widget.hostId, fullPath)).future);
+    final file = await ref.read(
+      readFileProvider((widget.hostId, fullPath)).future,
+    );
     if (mounted && file != null) {
       setState(() => _fullFile = file);
     }
@@ -1342,14 +1556,21 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(widget.change.fileName, style: const TextStyle(fontSize: 15), overflow: TextOverflow.ellipsis),
+            Text(
+              widget.change.fileName,
+              style: const TextStyle(fontSize: 15),
+              overflow: TextOverflow.ellipsis,
+            ),
             if (_diff?.stat.isNotEmpty == true || _atRevision)
               Text(
                 [
                   if (_diff?.stat.isNotEmpty == true) _diff!.stat,
                   if (_atRevision) 'at ${_shortSha(widget.to!)}',
                 ].join(' · '),
-                style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
           ],
         ),
@@ -1362,7 +1583,11 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
                 Clipboard.setData(ClipboardData(text: _diff!.diff));
                 HapticFeedback.lightImpact();
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Diff copied'), duration: Duration(seconds: 1), behavior: SnackBarBehavior.floating),
+                  const SnackBar(
+                    content: Text('Diff copied'),
+                    duration: Duration(seconds: 1),
+                    behavior: SnackBarBehavior.floating,
+                  ),
                 );
               },
             ),
@@ -1370,7 +1595,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
             icon: const Icon(Icons.chat_bubble_outline),
             tooltip: 'Back to chat',
             onPressed: () => Navigator.of(context).popUntil(
-              (route) => route.settings.name != '/file-browser' && route.settings.name != '/git-status',
+              (route) =>
+                  route.settings.name != '/file-browser' &&
+                  route.settings.name != '/git-status',
             ),
           ),
         ],
@@ -1380,12 +1607,21 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: SegmentedButton<DiffViewMode>(
               segments: [
-                const ButtonSegment(value: DiffViewMode.diff, label: Text('Diff', style: TextStyle(fontSize: 12))),
-                const ButtonSegment(value: DiffViewMode.unified, label: Text('Unified', style: TextStyle(fontSize: 12))),
+                const ButtonSegment(
+                  value: DiffViewMode.diff,
+                  label: Text('Diff', style: TextStyle(fontSize: 12)),
+                ),
+                const ButtonSegment(
+                  value: DiffViewMode.unified,
+                  label: Text('Unified', style: TextStyle(fontSize: 12)),
+                ),
                 // The file on disk is the current one, so "full" only makes
                 // sense for a working-tree diff.
                 if (!_atRevision)
-                  const ButtonSegment(value: DiffViewMode.full, label: Text('Full', style: TextStyle(fontSize: 12))),
+                  const ButtonSegment(
+                    value: DiffViewMode.full,
+                    label: Text('Full', style: TextStyle(fontSize: 12)),
+                  ),
               ],
               selected: {_mode},
               onSelectionChanged: (s) => setState(() => _mode = s.first),
@@ -1400,17 +1636,21 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
       body: _loading
           ? const _DiffSkeleton()
           : _diff == null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
-                      const SizedBox(height: 12),
-                      const Text('Failed to load diff'),
-                    ],
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    size: 40,
+                    color: theme.colorScheme.error,
                   ),
-                )
-              : _buildDiffView(theme),
+                  const SizedBox(height: 12),
+                  const Text('Failed to load diff'),
+                ],
+              ),
+            )
+          : _buildDiffView(theme),
       bottomNavigationBar: widget.sessionId != null
           ? _buildAskAIBar(theme)
           : null,
@@ -1419,15 +1659,21 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
 
   Widget _buildAskAIBar(ThemeData theme) {
     final isDark = theme.brightness == Brightness.dark;
-    final accentColor = isDark ? const Color(0xFF58A6FF) : const Color(0xFF0969DA);
+    final accentColor = isDark
+        ? const Color(0xFF58A6FF)
+        : const Color(0xFF0969DA);
     return Container(
       padding: EdgeInsets.only(
-        left: 12, right: 8, top: 8,
+        left: 12,
+        right: 8,
+        top: 8,
         bottom: MediaQuery.of(context).padding.bottom + 8,
       ),
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        border: Border(top: BorderSide(color: theme.colorScheme.outlineVariant)),
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
       ),
       child: Row(
         children: [
@@ -1436,17 +1682,31 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
           if (_hasSelection) ...[
             Text(
               '$_selLabel · $_selCount ${_selCount == 1 ? 'line' : 'lines'}',
-              style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+              style: TextStyle(
+                fontSize: 12,
+                fontFamily: 'monospace',
+                color: theme.colorScheme.onSurface,
+              ),
             ),
             const SizedBox(width: 8),
             GestureDetector(
-              onTap: () => setState(() { _selStart = null; _selEnd = null; }),
-              child: Icon(Icons.close, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              onTap: () => setState(() {
+                _selStart = null;
+                _selEnd = null;
+              }),
+              child: Icon(
+                Icons.close,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ] else
             Text(
               'Tap lines to select',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           const Spacer(),
           FilledButton.tonalIcon(
@@ -1466,14 +1726,20 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
   void _showAskAISheet(ThemeData theme) {
     final controller = TextEditingController();
     final isDark = theme.brightness == Brightness.dark;
-    final accentColor = isDark ? const Color(0xFF58A6FF) : const Color(0xFF0969DA);
-    final label = _hasSelection ? '${widget.change.fileName}:$_selLabel' : widget.change.path;
+    final accentColor = isDark
+        ? const Color(0xFF58A6FF)
+        : const Color(0xFF0969DA);
+    final label = _hasSelection
+        ? '${widget.change.fileName}:$_selLabel'
+        : widget.change.path;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (ctx) {
         return Padding(
-          padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(ctx).viewInsets.bottom,
+          ),
           child: SafeArea(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
@@ -1483,13 +1749,18 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.insert_drive_file, size: 16, color: accentColor),
+                      Icon(
+                        Icons.insert_drive_file,
+                        size: 16,
+                        color: accentColor,
+                      ),
                       const SizedBox(width: 6),
                       Flexible(
                         child: Text(
                           label,
                           style: TextStyle(
-                            fontSize: 13, fontFamily: 'monospace',
+                            fontSize: 13,
+                            fontFamily: 'monospace',
                             fontWeight: FontWeight.w600,
                             color: accentColor,
                           ),
@@ -1506,10 +1777,20 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
                     maxLines: 4,
                     style: const TextStyle(fontSize: 14),
                     decoration: InputDecoration(
-                      hintText: _hasSelection ? 'Ask about this code...' : 'Ask about this diff...',
-                      hintStyle: TextStyle(fontSize: 14, color: theme.colorScheme.onSurfaceVariant),
-                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
-                      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                      hintText: _hasSelection
+                          ? 'Ask about this code...'
+                          : 'Ask about this diff...',
+                      hintStyle: TextStyle(
+                        fontSize: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
                       suffixIcon: IconButton(
                         icon: const Icon(Icons.send, size: 20),
                         onPressed: () => _sendAskAI(ctx, controller.text),
@@ -1535,22 +1816,31 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
     final at = !_atRevision
         ? ''
         : widget.from == null || widget.from!.isEmpty
-            ? ' at ${_shortSha(widget.to!)}'
-            : ' between ${_shortSha(widget.from!)} and ${_shortSha(widget.to!)}';
+        ? ' at ${_shortSha(widget.to!)}'
+        : ' between ${_shortSha(widget.from!)} and ${_shortSha(widget.to!)}';
 
     String prompt;
     if (_hasSelection) {
       final allLines = _parseDiff(_diff!.diff);
       final start = (_selStart ?? 0).clamp(0, allLines.length);
       final end = ((_selEnd ?? _selStart ?? 0) + 1).clamp(0, allLines.length);
-      final selectedTexts = allLines.sublist(start, end).map((l) {
-        final prefix = l.type == _DiffLineType.added ? '+' : l.type == _DiffLineType.removed ? '-' : ' ';
-        return '$prefix${l.text}';
-      }).join('\n');
+      final selectedTexts = allLines
+          .sublist(start, end)
+          .map((l) {
+            final prefix = l.type == _DiffLineType.added
+                ? '+'
+                : l.type == _DiffLineType.removed
+                ? '-'
+                : ' ';
+            return '$prefix${l.text}';
+          })
+          .join('\n');
       final ext = _diff?.language ?? '';
-      prompt = 'Regarding diff of `${widget.change.path}`$at $_selLabel:\n```$ext\n$selectedTexts\n```\n${question.trim()}';
+      prompt =
+          'Regarding diff of `${widget.change.path}`$at $_selLabel:\n```$ext\n$selectedTexts\n```\n${question.trim()}';
     } else {
-      prompt = 'Regarding diff of `${widget.change.path}`$at:\n${question.trim()}';
+      prompt =
+          'Regarding diff of `${widget.change.path}`$at:\n${question.trim()}';
     }
 
     final nav = Navigator.of(context);
@@ -1558,7 +1848,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
     await svc.sendSessionPrompt(widget.sessionId!, prompt);
     if (!mounted) return;
     nav.popUntil(
-      (route) => route.settings.name != '/file-browser' && route.settings.name != '/git-status',
+      (route) =>
+          route.settings.name != '/file-browser' &&
+          route.settings.name != '/git-status',
     );
   }
 
@@ -1595,7 +1887,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
   // Diff mode: only show changed lines + hunk headers
   Widget _buildChangesOnly(ThemeData theme) {
     final lines = _parseDiff(_diff!.diff);
-    final filtered = lines.where((l) => l.type != _DiffLineType.context).toList();
+    final filtered = lines
+        .where((l) => l.type != _DiffLineType.context)
+        .toList();
     return _buildDiffListView(theme, filtered);
   }
 
@@ -1608,7 +1902,10 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
   Widget _buildDiffListView(ThemeData theme, List<_DiffLine> lines) {
     if (lines.isEmpty) {
       return Center(
-        child: Text('No changes', style: TextStyle(color: theme.colorScheme.onSurfaceVariant)),
+        child: Text(
+          'No changes',
+          style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+        ),
       );
     }
 
@@ -1628,7 +1925,11 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
     // Syntax highlight the combined code.
     List<List<TextSpan>>? highlightedLines;
     if (language != null && codeTexts.isNotEmpty) {
-      highlightedLines = _highlightLines(codeTexts.join('\n'), language, isDark);
+      highlightedLines = _highlightLines(
+        codeTexts.join('\n'),
+        language,
+        isDark,
+      );
     }
 
     return ListView.builder(
@@ -1654,24 +1955,31 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         final prefix = line.type == _DiffLineType.added
             ? '+'
             : line.type == _DiffLineType.removed
-                ? '-'
-                : ' ';
+            ? '-'
+            : ' ';
         final prefixColor = line.type == _DiffLineType.added
             ? Colors.green
             : line.type == _DiffLineType.removed
-                ? Colors.red
-                : theme.colorScheme.onSurfaceVariant;
+            ? Colors.red
+            : theme.colorScheme.onSurfaceVariant;
 
         // Find highlighted spans for this line.
         final codeIdx = codeLines.indexOf(i);
         Widget textWidget;
-        if (highlightedLines != null && codeIdx >= 0 && codeIdx < highlightedLines.length) {
+        if (highlightedLines != null &&
+            codeIdx >= 0 &&
+            codeIdx < highlightedLines.length) {
           textWidget = RichText(
             text: TextSpan(
               children: [
                 TextSpan(
                   text: '$prefix ',
-                  style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: prefixColor, fontWeight: FontWeight.w700),
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    color: prefixColor,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
                 ...highlightedLines[codeIdx],
               ],
@@ -1683,11 +1991,20 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
               children: [
                 TextSpan(
                   text: '$prefix ',
-                  style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: prefixColor, fontWeight: FontWeight.w700),
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    color: prefixColor,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
                 TextSpan(
                   text: line.text,
-                  style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.onSurface,
+                  ),
                 ),
               ],
             ),
@@ -1695,7 +2012,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         }
 
         final selected = _isLineSelected(i);
-        final selectedBg = isDark ? const Color(0xFF1A3A5C) : const Color(0xFFD4E8FC);
+        final selectedBg = isDark
+            ? const Color(0xFF1A3A5C)
+            : const Color(0xFFD4E8FC);
 
         return GestureDetector(
           onTap: widget.sessionId != null ? () => _onLineTap(i) : null,
@@ -1703,7 +2022,14 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 1),
             decoration: BoxDecoration(
               color: selected ? selectedBg : bgColor,
-              border: selected ? Border(left: BorderSide(color: theme.colorScheme.primary, width: 3)) : null,
+              border: selected
+                  ? Border(
+                      left: BorderSide(
+                        color: theme.colorScheme.primary,
+                        width: 3,
+                      ),
+                    )
+                  : null,
             ),
             child: textWidget,
           ),
@@ -1765,7 +2091,11 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         final firstChange = addedLines.reduce((a, b) => a < b ? a : b);
         final offset = (firstChange - 3).clamp(0, fileLines.length) * 18.0;
-        scrollController.animateTo(offset, duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+        scrollController.animateTo(
+          offset,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
       });
     }
 
@@ -1777,7 +2107,9 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         final lineNum = i + 1;
         final isChanged = addedLines.contains(lineNum);
         final bgColor = isChanged
-            ? (isDark ? Colors.green.withValues(alpha: 0.12) : Colors.green.withValues(alpha: 0.08))
+            ? (isDark
+                  ? Colors.green.withValues(alpha: 0.12)
+                  : Colors.green.withValues(alpha: 0.08))
             : null;
 
         Widget textWidget;
@@ -1790,14 +2122,20 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         } else {
           textWidget = Text(
             fileLines[i],
-            style: TextStyle(fontSize: 12, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: 'monospace',
+              color: theme.colorScheme.onSurface,
+            ),
             overflow: TextOverflow.clip,
             maxLines: 1,
           );
         }
 
         final selected = _isLineSelected(i);
-        final selectedBg = isDark ? const Color(0xFF1A3A5C) : const Color(0xFFD4E8FC);
+        final selectedBg = isDark
+            ? const Color(0xFF1A3A5C)
+            : const Color(0xFFD4E8FC);
 
         return GestureDetector(
           onTap: widget.sessionId != null ? () => _onLineTap(i) : null,
@@ -1806,10 +2144,17 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
             decoration: BoxDecoration(
               color: selected ? selectedBg : bgColor,
               border: selected
-                  ? Border(left: BorderSide(color: theme.colorScheme.primary, width: 3))
+                  ? Border(
+                      left: BorderSide(
+                        color: theme.colorScheme.primary,
+                        width: 3,
+                      ),
+                    )
                   : isChanged
-                      ? Border(left: BorderSide(color: Colors.green.shade400, width: 3))
-                      : null,
+                  ? Border(
+                      left: BorderSide(color: Colors.green.shade400, width: 3),
+                    )
+                  : null,
             ),
             child: Row(
               children: [
@@ -1817,7 +2162,15 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
                   width: 36,
                   child: Text(
                     '$lineNum',
-                    style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: selected ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5)),
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontFamily: 'monospace',
+                      color: selected
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant.withValues(
+                              alpha: 0.5,
+                            ),
+                    ),
                     textAlign: TextAlign.right,
                   ),
                 ),
@@ -1834,16 +2187,24 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
   Color? _bgColorForType(_DiffLineType type, bool isDark) {
     switch (type) {
       case _DiffLineType.added:
-        return isDark ? Colors.green.withValues(alpha: 0.12) : Colors.green.withValues(alpha: 0.08);
+        return isDark
+            ? Colors.green.withValues(alpha: 0.12)
+            : Colors.green.withValues(alpha: 0.08);
       case _DiffLineType.removed:
-        return isDark ? Colors.red.withValues(alpha: 0.12) : Colors.red.withValues(alpha: 0.08);
+        return isDark
+            ? Colors.red.withValues(alpha: 0.12)
+            : Colors.red.withValues(alpha: 0.08);
       default:
         return null;
     }
   }
 
   /// Syntax-highlights code and splits into per-line TextSpan lists.
-  List<List<TextSpan>> _highlightLines(String code, String language, bool isDark) {
+  List<List<TextSpan>> _highlightLines(
+    String code,
+    String language,
+    bool isDark,
+  ) {
     final themeMap = isDark ? atomOneDarkTheme : atomOneLightTheme;
     final defaultStyle = TextStyle(
       fontSize: 12,
@@ -1877,11 +2238,19 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
       return lines;
     } catch (_) {
       // Fallback: plain text per line.
-      return code.split('\n').map((l) => [TextSpan(text: l, style: defaultStyle)]).toList();
+      return code
+          .split('\n')
+          .map((l) => [TextSpan(text: l, style: defaultStyle)])
+          .toList();
     }
   }
 
-  void _buildSpans(List<dynamic> nodes, Map<String, TextStyle> themeMap, TextStyle defaultStyle, List<TextSpan> out) {
+  void _buildSpans(
+    List<dynamic> nodes,
+    Map<String, TextStyle> themeMap,
+    TextStyle defaultStyle,
+    List<TextSpan> out,
+  ) {
     for (final node in nodes) {
       if (node.value != null) {
         TextStyle style = defaultStyle;
@@ -1892,38 +2261,73 @@ class _GitDiffScreenState extends rp.ConsumerState<GitDiffScreen> {
         }
         out.add(TextSpan(text: node.value as String, style: style));
       } else if (node.children != null) {
-        _buildSpans(node.children as List<dynamic>, themeMap, defaultStyle, out);
+        _buildSpans(
+          node.children as List<dynamic>,
+          themeMap,
+          defaultStyle,
+          out,
+        );
       }
     }
   }
 
   String? _langForExt(String ext) {
     switch (ext) {
-      case 'dart': return 'dart';
-      case 'go': return 'go';
-      case 'py': return 'python';
-      case 'js': return 'javascript';
-      case 'ts': case 'tsx': return 'typescript';
-      case 'jsx': return 'javascript';
-      case 'java': return 'java';
-      case 'kt': return 'kotlin';
-      case 'swift': return 'swift';
-      case 'rs': return 'rust';
-      case 'c': case 'h': return 'c';
-      case 'cpp': return 'cpp';
-      case 'cs': return 'cs';
-      case 'rb': return 'ruby';
-      case 'sh': case 'bash': case 'zsh': return 'bash';
-      case 'json': return 'json';
-      case 'yaml': case 'yml': return 'yaml';
-      case 'toml': return 'ini';
-      case 'xml': return 'xml';
-      case 'html': return 'html';
-      case 'css': return 'css';
-      case 'scss': return 'scss';
-      case 'sql': return 'sql';
-      case 'md': return 'markdown';
-      default: return null;
+      case 'dart':
+        return 'dart';
+      case 'go':
+        return 'go';
+      case 'py':
+        return 'python';
+      case 'js':
+        return 'javascript';
+      case 'ts':
+      case 'tsx':
+        return 'typescript';
+      case 'jsx':
+        return 'javascript';
+      case 'java':
+        return 'java';
+      case 'kt':
+        return 'kotlin';
+      case 'swift':
+        return 'swift';
+      case 'rs':
+        return 'rust';
+      case 'c':
+      case 'h':
+        return 'c';
+      case 'cpp':
+        return 'cpp';
+      case 'cs':
+        return 'cs';
+      case 'rb':
+        return 'ruby';
+      case 'sh':
+      case 'bash':
+      case 'zsh':
+        return 'bash';
+      case 'json':
+        return 'json';
+      case 'yaml':
+      case 'yml':
+        return 'yaml';
+      case 'toml':
+        return 'ini';
+      case 'xml':
+        return 'xml';
+      case 'html':
+        return 'html';
+      case 'css':
+        return 'css';
+      case 'scss':
+        return 'scss';
+      case 'sql':
+        return 'sql';
+      case 'md':
+        return 'markdown';
+      default:
+        return null;
     }
   }
 }

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -29,7 +29,8 @@ class HomeScreen extends rp.ConsumerStatefulWidget {
   rp.ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingObserver {
+class _HomeScreenState extends rp.ConsumerState<HomeScreen>
+    with WidgetsBindingObserver {
   late HostManager _hm;
   final Map<String, StreamSubscription<SSEEvent>> _eventSubs = {};
   int _currentIndex = 0;
@@ -87,15 +88,18 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
       if (event.data is! Map) return;
       final id = (event.data as Map)['id']?.toString();
       if (id != null && id.isNotEmpty) {
-        NotificationService.instance
-            .cancel(NotificationService.notifKey(hostId, id));
+        NotificationService.instance.cancel(
+          NotificationService.notifKey(hostId, id),
+        );
       }
       return;
     }
 
     if (event.type != 'notification') return;
     if (event.data is! Map) {
-      debugPrint('[HomeScreen] notification data is not Map: ${event.data.runtimeType}');
+      debugPrint(
+        '[HomeScreen] notification data is not Map: ${event.data.runtimeType}',
+      );
       return;
     }
 
@@ -103,7 +107,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
     final type = data['type']?.toString() ?? '';
     final id = data['id']?.toString() ?? '';
     final status = data['status']?.toString();
-    debugPrint('[HomeScreen] notification: notifType=$type id=$id status=$status');
+    debugPrint(
+      '[HomeScreen] notification: notifType=$type id=$id status=$status',
+    );
 
     final key = NotificationService.notifKey(hostId, id);
     final shouldRaise = registry.shouldRaiseNotification(
@@ -176,8 +182,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
 
       // Answering from the notification's own buttons does not otherwise
       // retract it — the tray copy would sit there already answered.
-      NotificationService.instance
-          .cancel(NotificationService.notifKey(hostId, notificationId));
+      NotificationService.instance.cancel(
+        NotificationService.notifKey(hostId, notificationId),
+      );
 
       // Switch UI filter to this host
       _hm.setActiveHost(hostId);
@@ -277,19 +284,26 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                 child: Text(
                   'Select Host',
-                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
               // "All Hosts" option
               ListTile(
                 leading: Icon(
-                  _hm.activeHostId == null ? Icons.radio_button_checked : Icons.radio_button_off,
+                  _hm.activeHostId == null
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_off,
                   color: theme.colorScheme.primary,
                 ),
                 title: const Text('All Hosts'),
                 trailing: Text(
                   '${_hm.hosts.where((h) => _hm.serviceFor(h.id)?.connected == true).length}/${_hm.hosts.length}',
-                  style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 13),
+                  style: TextStyle(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontSize: 13,
+                  ),
                 ),
                 onTap: () {
                   Navigator.pop(ctx);
@@ -305,7 +319,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
 
                 return ListTile(
                   leading: Icon(
-                    isSelected ? Icons.radio_button_checked : Icons.radio_button_off,
+                    isSelected
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_off,
                     color: host.color,
                   ),
                   title: Row(
@@ -315,7 +331,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
                         height: 10,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          color: host.color.withValues(alpha: isConnected ? 1.0 : 0.3),
+                          color: host.color.withValues(
+                            alpha: isConnected ? 1.0 : 0.3,
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -324,7 +342,10 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
                   ),
                   subtitle: Text(
                     host.serverUrl,
-                    style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                   onTap: () {
@@ -384,7 +405,10 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(label, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+          Text(
+            label,
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          ),
           const SizedBox(width: 4),
           const Icon(Icons.arrow_drop_down, size: 20),
         ],
@@ -402,7 +426,8 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
           return Padding(
             padding: const EdgeInsets.only(left: 3),
             child: Tooltip(
-              message: '${host.label}: ${isConnected ? 'connected' : 'offline'}',
+              message:
+                  '${host.label}: ${isConnected ? 'connected' : 'offline'}',
               child: Icon(
                 Icons.circle,
                 size: 10,
@@ -430,7 +455,10 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
     if (!mounted) return;
     // Closing by any route counts as read: a dialog that comes back tomorrow
     // because it was dismissed with the back button is one nobody trusts.
-    await showDialog<void>(context: context, builder: (ctx) => _ReleaseNotesDialog(update: info));
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => _ReleaseNotesDialog(update: info),
+    );
     await UpdateService.instance.dismiss(info.latestVersion);
   }
 
@@ -442,12 +470,19 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
       color: theme.colorScheme.errorContainer,
       child: Row(
         children: [
-          Icon(Icons.notifications_off, size: 18, color: theme.colorScheme.onErrorContainer),
+          Icon(
+            Icons.notifications_off,
+            size: 18,
+            color: theme.colorScheme.onErrorContainer,
+          ),
           const SizedBox(width: 10),
           Expanded(
             child: Text(
               'Notifications are disabled — you won\'t hear permission requests.',
-              style: TextStyle(fontSize: 12, color: theme.colorScheme.onErrorContainer),
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onErrorContainer,
+              ),
             ),
           ),
           TextButton(
@@ -484,7 +519,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
             ref.watch(allHostNotificationsProvider).valueOrNull ?? const [];
         final allSessions =
             ref.watch(allHostSessionsProvider).valueOrNull ?? const [];
-        final pendingCount = allNotifications.where((n) => registry.needsAction(n)).length;
+        final pendingCount = allNotifications
+            .where((n) => registry.needsAction(n))
+            .length;
         final activeSessionCount = allSessions.where((s) => s.isActive).length;
 
         return Scaffold(
@@ -503,7 +540,9 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
                     tooltip: 'Settings',
                     onPressed: () {
                       Navigator.of(context).push(
-                        MaterialPageRoute(builder: (_) => const SettingsScreen()),
+                        MaterialPageRoute(
+                          builder: (_) => const SettingsScreen(),
+                        ),
                       );
                     },
                   ),
@@ -529,26 +568,27 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen> with WidgetsBindingO
           ),
           floatingActionButton: switch (_currentIndex) {
             0 => FloatingActionButton(
-                onPressed: _showNewSessionSheet,
-                tooltip: 'New Session',
-                child: const Icon(Icons.add),
-              ),
+              onPressed: _showNewSessionSheet,
+              tooltip: 'New Session',
+              child: const Icon(Icons.add),
+            ),
             1 => FloatingActionButton(
-                onPressed: () {
-                  final hosts = ref.read(hostManagerProvider).hosts;
-                  if (hosts.isEmpty) return;
-                  // The fork: describe it and let an agent build it, or fill in
-                  // the form. Most people want the first.
-                  showNewScheduleSheet(context, hosts.first.id);
-                },
-                tooltip: 'New schedule',
-                child: const Icon(Icons.add_alarm),
-              ),
+              onPressed: () {
+                final hosts = ref.read(hostManagerProvider).hosts;
+                if (hosts.isEmpty) return;
+                // The fork: describe it and let an agent build it, or fill in
+                // the form. Most people want the first.
+                showNewScheduleSheet(context, hosts.first.id);
+              },
+              tooltip: 'New schedule',
+              child: const Icon(Icons.add_alarm),
+            ),
             _ => null,
           },
           bottomNavigationBar: NavigationBar(
             selectedIndex: _currentIndex,
-            onDestinationSelected: (index) => setState(() => _currentIndex = index),
+            onDestinationSelected: (index) =>
+                setState(() => _currentIndex = index),
             destinations: [
               NavigationDestination(
                 icon: Badge(
@@ -624,7 +664,10 @@ class _ReleaseNotesDialog extends StatelessWidget {
         ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Got it')),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Got it'),
+        ),
         FilledButton(
           onPressed: () {
             Navigator.pop(context);

--- a/mobile/lib/screens/host_detail_screen.dart
+++ b/mobile/lib/screens/host_detail_screen.dart
@@ -68,7 +68,8 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
                 spacing: 12,
                 children: List.generate(HostConnection.hostColors.length, (i) {
                   final color = HostConnection.hostColors[i];
-                  final isSelected = host.colorIndex % HostConnection.hostColors.length == i;
+                  final isSelected =
+                      host.colorIndex % HostConnection.hostColors.length == i;
                   return GestureDetector(
                     onTap: () => hm.updateHostColor(host.id, i),
                     child: Container(
@@ -78,11 +79,18 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
                         shape: BoxShape.circle,
                         color: color,
                         border: isSelected
-                            ? Border.all(color: theme.colorScheme.onSurface, width: 3)
+                            ? Border.all(
+                                color: theme.colorScheme.onSurface,
+                                width: 3,
+                              )
                             : null,
                       ),
                       child: isSelected
-                          ? const Icon(Icons.check, color: Colors.white, size: 18)
+                          ? const Icon(
+                              Icons.check,
+                              color: Colors.white,
+                              size: 18,
+                            )
                           : null,
                     ),
                   );
@@ -151,15 +159,24 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
                   padding: const EdgeInsets.only(top: 4),
                   child: Text(
                     'Tailnet address — reachable only while Tailscale is connected.',
-                    style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ),
               const SizedBox(height: 16),
 
               // Info fields
               _infoRow('Device ID', host.deviceId, theme),
-              _infoRow('Status', isConnected ? 'Connected' : 'Offline', theme,
-                  valueColor: isConnected ? Colors.green : theme.colorScheme.onSurfaceVariant),
+              _infoRow(
+                'Status',
+                isConnected ? 'Connected' : 'Offline',
+                theme,
+                valueColor: isConnected
+                    ? Colors.green
+                    : theme.colorScheme.onSurfaceVariant,
+              ),
               _infoRow('Paired', _formatDate(host.addedAt), theme),
 
               const SizedBox(height: 24),
@@ -208,7 +225,11 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
         if (isConnected)
           const Row(
             children: [
-              SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)),
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
               SizedBox(width: 12),
               Text('Loading…'),
             ],
@@ -216,7 +237,10 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
         else
           Text(
             'Offline — settings unavailable until this host reconnects.',
-            style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+            style: TextStyle(
+              fontSize: 12,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ),
       ];
     }
@@ -232,7 +256,10 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
           padding: const EdgeInsets.only(top: 4),
           child: Text(
             'Offline — showing the last known values. Reconnect to change them.',
-            style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurfaceVariant),
+            style: TextStyle(
+              fontSize: 12,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
       const SizedBox(height: 8),
@@ -244,9 +271,9 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
         value: settings.autoTitleEnabled,
         onChanged: isConnected
             ? (value) => _saveHostSetting(
-                  () => writer.setAutoTitleEnabled(value),
-                  'Auto title',
-                )
+                () => writer.setAutoTitleEnabled(value),
+                'Auto title',
+              )
             : null,
       ),
       if (settings.autoTitleEnabled)
@@ -258,9 +285,9 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
           value: settings.autoTitleEmoji,
           onChanged: isConnected
               ? (value) => _saveHostSetting(
-                    () => writer.setAutoTitleEmoji(value),
-                    'Title icon',
-                  )
+                  () => writer.setAutoTitleEmoji(value),
+                  'Title icon',
+                )
               : null,
         ),
       SwitchListTile(
@@ -274,9 +301,9 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
         value: settings.evictEnabled,
         onChanged: isConnected
             ? (value) => _saveHostSetting(
-                  () => writer.setEvictEnabled(value),
-                  'Save memory',
-                )
+                () => writer.setEvictEnabled(value),
+                'Save memory',
+              )
             : null,
       ),
       if (settings.evictEnabled)
@@ -293,12 +320,17 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
             ],
           ),
           subtitle: Slider(
-            value: fraction.clamp(DaemonAPIService.budgetMin, DaemonAPIService.budgetMax),
+            value: fraction.clamp(
+              DaemonAPIService.budgetMin,
+              DaemonAPIService.budgetMax,
+            ),
             min: DaemonAPIService.budgetMin,
             max: DaemonAPIService.budgetMax,
             divisions: 17,
             label: '${(fraction * 100).round()}%',
-            onChanged: isConnected ? (value) => setState(() => _budgetDrag = value) : null,
+            onChanged: isConnected
+                ? (value) => setState(() => _budgetDrag = value)
+                : null,
             onChangeEnd: isConnected
                 ? (value) async {
                     await _saveHostSetting(
@@ -316,11 +348,16 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
   /// Writes one setting and says so when it fails. The cache puts the old
   /// value back on its own; without a message the control would flick back
   /// with no reason given.
-  Future<void> _saveHostSetting(Future<bool> Function() write, String label) async {
+  Future<void> _saveHostSetting(
+    Future<bool> Function() write,
+    String label,
+  ) async {
     final ok = await write();
     if (!mounted || ok) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Could not save $label — the host did not answer')),
+      SnackBar(
+        content: Text('Could not save $label — the host did not answer'),
+      ),
     );
   }
 
@@ -330,13 +367,16 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
   Future<void> _saveUrl(HostManager hm, String value) async {
     final trimmed = value.trim();
     final uri = Uri.tryParse(trimmed);
-    final valid = uri != null &&
+    final valid =
+        uri != null &&
         (uri.scheme == 'http' || uri.scheme == 'https') &&
         uri.host.isNotEmpty;
 
     if (!valid) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Enter a full URL, e.g. https://host.tailnet.ts.net')),
+        const SnackBar(
+          content: Text('Enter a full URL, e.g. https://host.tailnet.ts.net'),
+        ),
       );
       return;
     }
@@ -348,7 +388,12 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
     );
   }
 
-  Widget _infoRow(String label, String value, ThemeData theme, {Color? valueColor}) {
+  Widget _infoRow(
+    String label,
+    String value,
+    ThemeData theme, {
+    Color? valueColor,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
@@ -356,7 +401,13 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
         children: [
           SizedBox(
             width: 100,
-            child: Text(label, style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant)),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           ),
           Expanded(
             child: Text(
@@ -386,16 +437,23 @@ class _HostDetailScreenState extends rp.ConsumerState<HostDetailScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Disconnect host'),
-        content: Text('Remove "${host.label}" and delete stored credentials? You can re-pair later.'),
+        content: Text(
+          'Remove "${host.label}" and delete stored credentials? You can re-pair later.',
+        ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
           FilledButton(
             onPressed: () async {
               Navigator.pop(ctx);
               await hm.removeHost(host.id);
               if (mounted) Navigator.of(context).pop();
             },
-            style: FilledButton.styleFrom(backgroundColor: Theme.of(ctx).colorScheme.error),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
             child: const Text('Disconnect'),
           ),
         ],

--- a/mobile/lib/screens/new_schedule_sheet.dart
+++ b/mobile/lib/screens/new_schedule_sheet.dart
@@ -26,7 +26,8 @@ String schedulePrompt(String description, String cwd) {
     'Use the helios skill and the `helios schedule` CLI. Work out which kind it is —',
     'a timer, a one-shot, a monitor with a check, or a job that runs after another —',
     'and create it with a name that reads well in a list.',
-    if (cwd.isNotEmpty) 'Unless the description says otherwise, it should run in $cwd.',
+    if (cwd.isNotEmpty)
+      'Unless the description says otherwise, it should run in $cwd.',
     '',
     'Then run `helios schedule list` and tell me in one or two lines what you made,',
     'when it next fires, and anything you had to guess.',
@@ -39,7 +40,9 @@ Future<void> showNewScheduleSheet(BuildContext context, String hostId) {
     context: context,
     isScrollControlled: true,
     builder: (_) => Padding(
-      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       child: _NewScheduleSheet(hostId: hostId),
     ),
   );
@@ -74,7 +77,8 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
     final navigator = Navigator.of(context);
     final messenger = ScaffoldMessenger.of(context);
 
-    final ok = await service?.createSession(
+    final ok =
+        await service?.createSession(
           provider: _provider.isEmpty ? 'claude' : _provider,
           cwd: _cwd.text.trim(),
           prompt: schedulePrompt(_description.text, _cwd.text.trim()),
@@ -86,9 +90,11 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
     navigator.pop();
     messenger.showSnackBar(
       SnackBar(
-        content: Text(ok
-            ? 'An agent is writing it. Watch it in Sessions.'
-            : 'Could not start an agent on that machine.'),
+        content: Text(
+          ok
+              ? 'An agent is writing it. Watch it in Sessions.'
+              : 'Could not start an agent on that machine.',
+        ),
       ),
     );
   }
@@ -97,8 +103,12 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hosts = ref.watch(hostManagerProvider).hosts;
-    final providers = ref.watch(readyProvidersProvider(_hostId)).valueOrNull ?? const <ProviderInfo>[];
-    final agent = _provider.isEmpty ? (providers.isEmpty ? '' : providers.first.id) : _provider;
+    final providers =
+        ref.watch(readyProvidersProvider(_hostId)).valueOrNull ??
+        const <ProviderInfo>[];
+    final agent = _provider.isEmpty
+        ? (providers.isEmpty ? '' : providers.first.id)
+        : _provider;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
@@ -132,7 +142,8 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
             decoration: const InputDecoration(
               labelText: 'Describe it',
               alignLabelWithHint: true,
-              hintText: 'every 15 minutes, run the tests and if they fail, fix them',
+              hintText:
+                  'every 15 minutes, run the tests and if they fail, fix them',
             ),
           ),
           const SizedBox(height: 8),
@@ -149,7 +160,8 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
               initialValue: agent.isEmpty ? null : agent,
               decoration: const InputDecoration(labelText: 'Agent'),
               items: [
-                for (final p in providers) DropdownMenuItem(value: p.id, child: Text(p.name)),
+                for (final p in providers)
+                  DropdownMenuItem(value: p.id, child: Text(p.name)),
               ],
               onChanged: (v) => setState(() => _provider = v ?? ''),
             ),
@@ -177,7 +189,9 @@ class _NewScheduleSheetState extends rp.ConsumerState<_NewScheduleSheet> {
               ),
               const Spacer(),
               FilledButton(
-                onPressed: _starting || _description.text.trim().isEmpty ? null : _askAnAgent,
+                onPressed: _starting || _description.text.trim().isEmpty
+                    ? null
+                    : _askAnAgent,
                 child: Text(_starting ? 'Starting…' : 'Ask an agent'),
               ),
             ],

--- a/mobile/lib/screens/new_session_sheet.dart
+++ b/mobile/lib/screens/new_session_sheet.dart
@@ -78,7 +78,10 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
     final sse = _service;
     if (sse == null) return;
     setState(() => _refreshingModels = true);
-    final models = await sse.fetchModels(_selectedProvider!.id, forceRefresh: true);
+    final models = await sse.fetchModels(
+      _selectedProvider!.id,
+      forceRefresh: true,
+    );
     if (mounted) {
       setState(() {
         _models = models;
@@ -150,7 +153,9 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
               width: 36,
               height: 4,
               decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
+                color: theme.colorScheme.onSurfaceVariant.withValues(
+                  alpha: 0.3,
+                ),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -232,10 +237,11 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
       initialValue: _selectedHostId,
       decoration: InputDecoration(
         labelText: 'Host',
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 12,
         ),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
       ),
       items: hm.hosts.map((host) {
         final isConnected = hm.serviceFor(host.id)?.connected == true;
@@ -275,22 +281,20 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
     final providers = hostId == null
         ? const <ProviderInfo>[]
         : ref.watch(readyProvidersProvider(hostId)).valueOrNull ??
-            const <ProviderInfo>[];
+              const <ProviderInfo>[];
 
     return DropdownButtonFormField<String>(
       initialValue: _selectedProvider?.id,
       decoration: InputDecoration(
         labelText: 'Provider',
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 12,
         ),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
       ),
       items: providers.map((p) {
-        return DropdownMenuItem(
-          value: p.id,
-          child: Text(p.name),
-        );
+        return DropdownMenuItem(value: p.id, child: Text(p.name));
       }).toList(),
       onChanged: (value) {
         if (value == null) return;
@@ -388,7 +392,7 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
             final dirs = hostId == null
                 ? const <DirectoryInfo>[]
                 : ref.watch(directoriesProvider(hostId)).valueOrNull ??
-                    const <DirectoryInfo>[];
+                      const <DirectoryInfo>[];
             return Wrap(
               spacing: 6,
               runSpacing: 6,
@@ -400,12 +404,18 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
                         ? Container(
                             width: 8,
                             height: 8,
-                            decoration: const BoxDecoration(shape: BoxShape.circle, color: Colors.green),
+                            decoration: const BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.green,
+                            ),
                           )
                         : null,
                     label: Text(
                       d.project.isNotEmpty ? d.project : d.shortCwd,
-                      style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontFamily: 'monospace',
+                      ),
                     ),
                     selected: isSelected,
                     onSelected: (selected) {
@@ -421,7 +431,10 @@ class _NewSessionSheetState extends rp.ConsumerState<NewSessionSheet> {
                   );
                 }),
                 FilterChip(
-                  label: const Text('Custom...', style: TextStyle(fontSize: 12)),
+                  label: const Text(
+                    'Custom...',
+                    style: TextStyle(fontSize: 12),
+                  ),
                   selected: _showCustomCwd,
                   onSelected: (selected) {
                     setState(() {

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -17,7 +17,8 @@ class _NotificationSettingsScreenState
     _NotifType(
       kind: 'permission',
       label: 'Permission requests',
-      description: 'The agent is asking to use a tool that requires your approval.',
+      description:
+          'The agent is asking to use a tool that requires your approval.',
       blocking: true,
     ),
     _NotifType(
@@ -193,8 +194,8 @@ class _SectionHeader extends StatelessWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              color: Theme.of(context).colorScheme.primary,
-            ),
+          color: Theme.of(context).colorScheme.primary,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/schedule_detail_screen.dart
+++ b/mobile/lib/screens/schedule_detail_screen.dart
@@ -19,10 +19,15 @@ class ScheduleDetailScreen extends rp.ConsumerStatefulWidget {
   final String hostId;
   final String scheduleId;
 
-  const ScheduleDetailScreen({super.key, required this.hostId, required this.scheduleId});
+  const ScheduleDetailScreen({
+    super.key,
+    required this.hostId,
+    required this.scheduleId,
+  });
 
   @override
-  rp.ConsumerState<ScheduleDetailScreen> createState() => _ScheduleDetailScreenState();
+  rp.ConsumerState<ScheduleDetailScreen> createState() =>
+      _ScheduleDetailScreenState();
 }
 
 class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
@@ -43,7 +48,9 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
       await work();
     } catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('$error')));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('$error')));
       }
     } finally {
       ref.invalidate(schedulesProvider(widget.hostId));
@@ -53,12 +60,18 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
 
   @override
   Widget build(BuildContext context) {
-    final schedules = ref.watch(schedulesProvider(widget.hostId)).valueOrNull ?? const <Schedule>[];
-    final schedule = schedules.where((sc) => sc.id == widget.scheduleId).firstOrNull;
+    final schedules =
+        ref.watch(schedulesProvider(widget.hostId)).valueOrNull ??
+        const <Schedule>[];
+    final schedule = schedules
+        .where((sc) => sc.id == widget.scheduleId)
+        .firstOrNull;
     final service = ref.read(serviceProvider(widget.hostId));
 
     if (schedule == null) {
-      return const Scaffold(body: Center(child: Text('That schedule is gone.')));
+      return const Scaffold(
+        body: Center(child: Text('That schedule is gone.')),
+      );
     }
 
     return Scaffold(
@@ -78,16 +91,21 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
           TextButton(
             onPressed: _busy
                 ? null
-                : () => _act(() async => service?.saveSchedule(
-                      schedule.id,
-                      {'enabled': !schedule.enabled},
-                    )),
+                : () => _act(
+                    () async => service?.saveSchedule(schedule.id, {
+                      'enabled': !schedule.enabled,
+                    }),
+                  ),
             child: Text(schedule.enabled ? '● on' : '○ paused'),
           ),
         ],
         bottom: TabBar(
           controller: _tabs,
-          tabs: const [Tab(text: 'overview'), Tab(text: 'runs'), Tab(text: 'log')],
+          tabs: const [
+            Tab(text: 'overview'),
+            Tab(text: 'runs'),
+            Tab(text: 'log'),
+          ],
         ),
       ),
       body: TabBarView(
@@ -102,7 +120,9 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
         child: Row(
           children: [
             TextButton(
-              onPressed: _busy ? null : () => _act(() async => service?.runSchedule(schedule.id)),
+              onPressed: _busy
+                  ? null
+                  : () => _act(() async => service?.runSchedule(schedule.id)),
               child: const Text('Run now'),
             ),
             if (schedule.isMonitor)
@@ -110,7 +130,9 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
                 onPressed: _busy
                     ? null
                     : () => _act(() async {
-                        final result = await service?.checkSchedule(schedule.id);
+                        final result = await service?.checkSchedule(
+                          schedule.id,
+                        );
                         if (!mounted) return;
                         setState(() => _check = result);
                         _tabs.animateTo(0);
@@ -119,7 +141,11 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
               ),
             const Spacer(),
             TextButton(
-              onPressed: () => openScheduleEditor(context, widget.hostId, scheduleId: schedule.id),
+              onPressed: () => openScheduleEditor(
+                context,
+                widget.hostId,
+                scheduleId: schedule.id,
+              ),
               child: const Text('Edit'),
             ),
             IconButton(
@@ -142,18 +168,22 @@ class _ScheduleDetailScreenState extends rp.ConsumerState<ScheduleDetailScreen>
                           ),
                           actions: [
                             TextButton(
-                              onPressed: () => Navigator.pop(dialogContext, false),
+                              onPressed: () =>
+                                  Navigator.pop(dialogContext, false),
                               child: const Text('Cancel'),
                             ),
                             TextButton(
-                              onPressed: () => Navigator.pop(dialogContext, true),
+                              onPressed: () =>
+                                  Navigator.pop(dialogContext, true),
                               child: const Text('Delete'),
                             ),
                           ],
                         ),
                       );
                       if (ok != true) return;
-                      await _act(() async => service?.deleteSchedule(schedule.id));
+                      await _act(
+                        () async => service?.deleteSchedule(schedule.id),
+                      );
                       navigator.pop();
                     },
             ),
@@ -196,11 +226,14 @@ class _Overview extends StatelessWidget {
           const SizedBox(height: 16),
         ],
         _fact(theme, 'Runs', target),
-        _dim(theme, [
-          schedule.provider.isEmpty ? 'the default agent' : schedule.provider,
-          if (schedule.model.isNotEmpty) schedule.model,
-          if (schedule.permissionMode.isNotEmpty) schedule.permissionMode,
-        ].join(' · ')),
+        _dim(
+          theme,
+          [
+            schedule.provider.isEmpty ? 'the default agent' : schedule.provider,
+            if (schedule.model.isNotEmpty) schedule.model,
+            if (schedule.permissionMode.isNotEmpty) schedule.permissionMode,
+          ].join(' · '),
+        ),
         const SizedBox(height: 16),
         _fact(theme, 'Prompt', ''),
         Container(
@@ -226,7 +259,7 @@ class _Overview extends StatelessWidget {
               check!.failed
                   ? 'the check failed — ${check!.error}'
                   : 'exit ${check!.exit} — ${check!.matched ? 'MATCH, this would fire' : 'quiet, this would not fire'}'
-                      '${check!.output.isEmpty ? '' : '\n---\n${check!.output}'}',
+                        '${check!.output.isEmpty ? '' : '\n---\n${check!.output}'}',
               style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
             ),
           ),
@@ -236,32 +269,38 @@ class _Overview extends StatelessWidget {
   }
 
   Widget _fact(ThemeData theme, String label, String value) => Padding(
-        padding: const EdgeInsets.only(bottom: 4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label, style: theme.textTheme.labelSmall),
-            if (value.isNotEmpty) Text(value, style: theme.textTheme.bodyMedium),
-          ],
-        ),
-      );
+    padding: const EdgeInsets.only(bottom: 4),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: theme.textTheme.labelSmall),
+        if (value.isNotEmpty) Text(value, style: theme.textTheme.bodyMedium),
+      ],
+    ),
+  );
 
   Widget _dim(ThemeData theme, String text) => text.isEmpty
       ? const SizedBox.shrink()
       : Text(
           text,
-          style: theme.textTheme.labelSmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         );
 }
 
 String _footNote(Schedule sc) {
   final parts = <String>[];
   if (sc.nextRunAt.isNotEmpty && sc.enabled && sc.doneAt.isEmpty) {
-    parts.add('${sc.isMonitor ? 'next check' : 'next run'} ${untilWords(sc.nextRunAt)}');
+    parts.add(
+      '${sc.isMonitor ? 'next check' : 'next run'} ${untilWords(sc.nextRunAt)}',
+    );
   }
-  if (sc.lastFiredAt.isNotEmpty) parts.add('last ran ${agoWords(sc.lastFiredAt)}');
+  if (sc.lastFiredAt.isNotEmpty)
+    parts.add('last ran ${agoWords(sc.lastFiredAt)}');
   if (sc.firesToday > 0) parts.add('fired ${sc.firesToday}× today');
-  if (sc.failStreak > 1) parts.add('failing since ${agoWords(sc.failingSince)}');
+  if (sc.failStreak > 1)
+    parts.add('failing since ${agoWords(sc.failingSince)}');
   return parts.join(' · ');
 }
 
@@ -287,8 +326,16 @@ class _Runs extends rp.ConsumerWidget {
             final run = list[i];
             return ListTile(
               dense: true,
-              leading: Icon(Icons.circle, size: 8, color: _runColour(context, run.status)),
-              title: Text(run.displayTitle, maxLines: 1, overflow: TextOverflow.ellipsis),
+              leading: Icon(
+                Icons.circle,
+                size: 8,
+                color: _runColour(context, run.status),
+              ),
+              title: Text(
+                run.displayTitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
               subtitle: Text('${run.status} · ${agoWords(run.createdAt)}'),
               onTap: () => Navigator.of(context).push(
                 MaterialPageRoute(
@@ -338,7 +385,10 @@ class _LogState extends rp.ConsumerState<_Log> {
   void initState() {
     super.initState();
     unawaited(_read());
-    _poll = Timer.periodic(const Duration(seconds: 2), (_) => unawaited(_read()));
+    _poll = Timer.periodic(
+      const Duration(seconds: 2),
+      (_) => unawaited(_read()),
+    );
   }
 
   @override
@@ -364,7 +414,11 @@ class _LogState extends rp.ConsumerState<_Log> {
       padding: const EdgeInsets.all(12),
       child: SelectableText(
         _lines.isEmpty ? '(nothing yet)' : _lines.join('\n'),
-        style: const TextStyle(fontFamily: 'monospace', fontSize: 11, height: 1.5),
+        style: const TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          height: 1.5,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/schedule_editor_screen.dart
+++ b/mobile/lib/screens/schedule_editor_screen.dart
@@ -16,13 +16,19 @@ class ScheduleEditorScreen extends rp.ConsumerStatefulWidget {
   /// Empty for a new one.
   final String scheduleId;
 
-  const ScheduleEditorScreen({super.key, required this.hostId, this.scheduleId = ''});
+  const ScheduleEditorScreen({
+    super.key,
+    required this.hostId,
+    this.scheduleId = '',
+  });
 
   @override
-  rp.ConsumerState<ScheduleEditorScreen> createState() => _ScheduleEditorScreenState();
+  rp.ConsumerState<ScheduleEditorScreen> createState() =>
+      _ScheduleEditorScreenState();
 }
 
-class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> {
+class _ScheduleEditorScreenState
+    extends rp.ConsumerState<ScheduleEditorScreen> {
   final _name = TextEditingController();
   final _cron = TextEditingController(text: '0 9 * * 1-5');
   final _runAt = TextEditingController();
@@ -81,8 +87,12 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
       'run_at': _kind == 'once' ? _runAt.text.trim() : '',
       'after_id': _kind == 'after' ? _afterId : '',
       'after_when': _kind == 'after' ? _afterWhen : '',
-      'check_cmd': _kind == 'monitor' && _checkSource == 'command' ? _check.text : '',
-      'check_file': _kind == 'monitor' && _checkSource == 'file' ? _check.text.trim() : '',
+      'check_cmd': _kind == 'monitor' && _checkSource == 'command'
+          ? _check.text
+          : '',
+      'check_file': _kind == 'monitor' && _checkSource == 'file'
+          ? _check.text.trim()
+          : '',
       'check_match': _kind == 'monitor' ? _match.text : '',
     };
 
@@ -93,7 +103,8 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
     } catch (error) {
       // The daemon refuses at save what would be found at 3am otherwise, and
       // says which — so its words go on screen rather than a generic failure.
-      if (mounted) setState(() => _error = '$error'.replaceFirst('Exception: ', ''));
+      if (mounted)
+        setState(() => _error = '$error'.replaceFirst('Exception: ', ''));
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -102,14 +113,18 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final schedules = ref.watch(schedulesProvider(widget.hostId)).valueOrNull ?? const <Schedule>[];
+    final schedules =
+        ref.watch(schedulesProvider(widget.hostId)).valueOrNull ??
+        const <Schedule>[];
     _load(schedules);
 
     final monitor = _kind == 'monitor';
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.scheduleId.isEmpty ? 'New schedule' : 'Edit schedule'),
+        title: Text(
+          widget.scheduleId.isEmpty ? 'New schedule' : 'Edit schedule',
+        ),
         actions: [
           TextButton(
             onPressed: _saving ? null : _save,
@@ -122,7 +137,10 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
         children: [
           TextField(
             controller: _name,
-            decoration: const InputDecoration(labelText: 'Name', hintText: 'build-watch'),
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'build-watch',
+            ),
           ),
           const SizedBox(height: 16),
 
@@ -183,7 +201,9 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
               initialValue: _afterId.isEmpty ? null : _afterId,
               decoration: const InputDecoration(labelText: 'After'),
               items: [
-                for (final sc in schedules.where((s) => s.id != widget.scheduleId))
+                for (final sc in schedules.where(
+                  (s) => s.id != widget.scheduleId,
+                ))
                   DropdownMenuItem(value: sc.id, child: Text(sc.name)),
               ],
               onChanged: (v) => setState(() => _afterId = v ?? ''),
@@ -193,7 +213,10 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
               initialValue: _afterWhen,
               decoration: const InputDecoration(labelText: 'Runs'),
               items: const [
-                DropdownMenuItem(value: 'success', child: Text('only if it succeeds')),
+                DropdownMenuItem(
+                  value: 'success',
+                  child: Text('only if it succeeds'),
+                ),
                 DropdownMenuItem(value: 'any', child: Text('either way')),
               ],
               onChanged: (v) => setState(() => _afterWhen = v ?? 'success'),
@@ -224,7 +247,9 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
             TextField(
               controller: _check,
               decoration: InputDecoration(
-                hintText: _checkSource == 'command' ? 'make test 2>&1' : '~/checks/queue.py',
+                hintText: _checkSource == 'command'
+                    ? 'make test 2>&1'
+                    : '~/checks/queue.py',
               ),
             ),
             const SizedBox(height: 8),
@@ -246,7 +271,8 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
             controller: _cwd,
             decoration: const InputDecoration(
               labelText: 'Where',
-              hintText: 'optional — empty for work that is not about a directory',
+              hintText:
+                  'optional — empty for work that is not about a directory',
             ),
           ),
           const SizedBox(height: 16),
@@ -257,7 +283,9 @@ class _ScheduleEditorScreenState extends rp.ConsumerState<ScheduleEditorScreen> 
             decoration: InputDecoration(
               labelText: 'Prompt',
               alignLabelWithHint: true,
-              helperText: monitor ? '{{output}} is replaced with what the check printed.' : null,
+              helperText: monitor
+                  ? '{{output}} is replaced with what the check printed.'
+                  : null,
               hintText: monitor
                   ? 'The check found something:\n\n{{output}}\n\nLook into it.'
                   : 'What to do',

--- a/mobile/lib/screens/schedules_screen.dart
+++ b/mobile/lib/screens/schedules_screen.dart
@@ -36,8 +36,8 @@ class SchedulesScreen extends rp.ConsumerWidget {
               child: Text(
                 host.label,
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           _HostSchedules(hostId: host.id),
@@ -137,14 +137,17 @@ class ScheduleTile extends rp.ConsumerWidget {
       child: InkWell(
         onTap: () => Navigator.of(context).push(
           MaterialPageRoute(
-            builder: (_) => ScheduleDetailScreen(hostId: hostId, scheduleId: schedule.id),
+            builder: (_) =>
+                ScheduleDetailScreen(hostId: hostId, scheduleId: schedule.id),
           ),
         ),
         child: Container(
           padding: EdgeInsets.fromLTRB(16.0 + depth * 16, 10, 16, 10),
           decoration: BoxDecoration(
             border: Border(
-              bottom: BorderSide(color: theme.colorScheme.outlineVariant.withValues(alpha: 0.4)),
+              bottom: BorderSide(
+                color: theme.colorScheme.outlineVariant.withValues(alpha: 0.4),
+              ),
             ),
           ),
           child: Column(
@@ -152,18 +155,25 @@ class ScheduleTile extends rp.ConsumerWidget {
             children: [
               Row(
                 children: [
-                  Text(kindGlyph(schedule), style: const TextStyle(fontSize: 12)),
+                  Text(
+                    kindGlyph(schedule),
+                    style: const TextStyle(fontSize: 12),
+                  ),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
                       schedule.name,
-                      style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
                   Text(
                     schedule.stateWord,
-                    style: theme.textTheme.labelSmall?.copyWith(color: stateColour(theme, schedule)),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: stateColour(theme, schedule),
+                    ),
                   ),
                 ],
               ),
@@ -179,7 +189,9 @@ class ScheduleTile extends rp.ConsumerWidget {
               if (schedule.lastError.isNotEmpty)
                 Text(
                   schedule.lastError,
-                  style: theme.textTheme.labelSmall?.copyWith(color: theme.colorScheme.error),
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -232,10 +244,15 @@ Color? stateColour(ThemeData theme, Schedule sc) {
 }
 
 /// The button the schedules tab floats: a new one starts in the editor.
-void openScheduleEditor(BuildContext context, String hostId, {String scheduleId = ''}) {
+void openScheduleEditor(
+  BuildContext context,
+  String hostId, {
+  String scheduleId = '',
+}) {
   Navigator.of(context).push(
     MaterialPageRoute(
-      builder: (_) => ScheduleEditorScreen(hostId: hostId, scheduleId: scheduleId),
+      builder: (_) =>
+          ScheduleEditorScreen(hostId: hostId, scheduleId: scheduleId),
     ),
   );
 }

--- a/mobile/lib/screens/sessions_screen.dart
+++ b/mobile/lib/screens/sessions_screen.dart
@@ -54,7 +54,8 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
 
   List<Session> _filterSessions(List<Session> sessions) {
     // When search or CWD filter is active, API already filtered — pass through.
-    if (_searchExpanded && _searchController.text.trim().isNotEmpty || _cwdFilter != null) {
+    if (_searchExpanded && _searchController.text.trim().isNotEmpty ||
+        _cwdFilter != null) {
       return sessions;
     }
     switch (_filter) {
@@ -95,7 +96,8 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
   DaemonAPIService? _orderableService(HostManager hm) {
     if (hm.activeHostId == null) return null;
     if (_cwdFilter != null) return null;
-    if (_searchExpanded && _searchController.text.trim().isNotEmpty) return null;
+    if (_searchExpanded && _searchController.text.trim().isNotEmpty)
+      return null;
     return hm.serviceFor(hm.activeHostId!);
   }
 
@@ -109,16 +111,27 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
       byHost.putIfAbsent(session.hostId, () => []).add(session.sessionId);
     }
     final manual = !ref.read(manualOrderProvider);
-    await Future.wait(hm.hosts.map((host) async {
-      final order = byHost[host.id] ?? const <String>[];
-      if (manual && order.isNotEmpty) {
-        await ref.read(sessionsProvider(allSessionsKey(host.id)).notifier).reorder(order);
-      }
-      await ref.read(hostSettingsProvider(host.id).notifier).setManualOrder(manual);
-    }));
+    await Future.wait(
+      hm.hosts.map((host) async {
+        final order = byHost[host.id] ?? const <String>[];
+        if (manual && order.isNotEmpty) {
+          await ref
+              .read(sessionsProvider(allSessionsKey(host.id)).notifier)
+              .reorder(order);
+        }
+        await ref
+            .read(hostSettingsProvider(host.id).notifier)
+            .setManualOrder(manual);
+      }),
+    );
   }
 
-  Future<void> _onReorder(DaemonAPIService service, List<Session> visible, int from, int to) async {
+  Future<void> _onReorder(
+    DaemonAPIService service,
+    List<Session> visible,
+    int from,
+    int to,
+  ) async {
     final ids = visible.map((s) => s.sessionId).toList();
     if (to > from) to -= 1;
     ids.insert(to, ids.removeAt(from));
@@ -138,7 +151,7 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
     }
   }
 
-    /// What the list is currently asking the daemon for. Also its cache key, so
+  /// What the list is currently asking the daemon for. Also its cache key, so
   /// changing the search re-reads under a different entry rather than
   /// overwriting the unfiltered one.
   SessionQuery get _query {
@@ -195,44 +208,62 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                 child: Text(
                   'Filter by directory',
-                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
               const Divider(height: 1),
-              ...dirs.map((d) => ListTile(
-                leading: const Icon(Icons.folder_outlined),
-                title: Text(d.project.isNotEmpty ? d.project : d.shortCwd),
-                subtitle: Text(
-                  d.shortCwd,
-                  style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurfaceVariant),
-                ),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (d.activeCount > 0)
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: Colors.green.withValues(alpha: 0.12),
-                          borderRadius: BorderRadius.circular(4),
+              ...dirs.map(
+                (d) => ListTile(
+                  leading: const Icon(Icons.folder_outlined),
+                  title: Text(d.project.isNotEmpty ? d.project : d.shortCwd),
+                  subtitle: Text(
+                    d.shortCwd,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontFamily: 'monospace',
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (d.activeCount > 0)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.green.withValues(alpha: 0.12),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            '${d.activeCount} active',
+                            style: const TextStyle(
+                              fontSize: 11,
+                              color: Colors.green,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
                         ),
-                        child: Text(
-                          '${d.activeCount} active',
-                          style: const TextStyle(fontSize: 11, color: Colors.green, fontWeight: FontWeight.w600),
+                      const SizedBox(width: 6),
+                      Text(
+                        '${d.sessionCount}',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ),
-                    const SizedBox(width: 6),
-                    Text(
-                      '${d.sessionCount}',
-                      style: TextStyle(fontSize: 13, color: theme.colorScheme.onSurfaceVariant),
-                    ),
-                  ],
+                    ],
+                  ),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _setCwdFilter(d.cwd, d.project);
+                  },
                 ),
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _setCwdFilter(d.cwd, d.project);
-                },
-              )),
+              ),
               const SizedBox(height: 8),
             ],
           ),
@@ -264,7 +295,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
     for (final key in _selected.toList()) {
       final parts = key.split(':');
       if (parts.length == 2) {
-        ref.read(sessionsProvider(allSessionsKey(parts[0])).notifier).patch(parts[1], pinned: pin);
+        ref
+            .read(sessionsProvider(allSessionsKey(parts[0])).notifier)
+            .patch(parts[1], pinned: pin);
       }
     }
     _exitMultiSelect();
@@ -284,8 +317,14 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
               : 'The agent is mid-turn. Terminating loses the work in flight. Resume starts it again.',
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Terminate')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Terminate'),
+          ),
         ],
       ),
     );
@@ -318,12 +357,19 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Delete sessions'),
-        content: Text('Delete ${_selected.length} session(s)? This cannot be undone.'),
+        content: Text(
+          'Delete ${_selected.length} session(s)? This cannot be undone.',
+        ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(backgroundColor: Theme.of(ctx).colorScheme.error),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
             child: const Text('Delete'),
           ),
         ],
@@ -334,7 +380,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
     for (final key in _selected.toList()) {
       final parts = key.split(':');
       if (parts.length == 2) {
-        ref.read(sessionsProvider(allSessionsKey(parts[0])).notifier).delete(parts[1]);
+        ref
+            .read(sessionsProvider(allSessionsKey(parts[0])).notifier)
+            .delete(parts[1]);
       }
     }
     _exitMultiSelect();
@@ -359,8 +407,12 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
           );
         }
 
-        final isSearchActive = _searchExpanded && _searchController.text.trim().isNotEmpty;
-        final isFilterActive = isSearchActive || _cwdFilter != null || _filter != SessionFilter.all;
+        final isSearchActive =
+            _searchExpanded && _searchController.text.trim().isNotEmpty;
+        final isFilterActive =
+            isSearchActive ||
+            _cwdFilter != null ||
+            _filter != SessionFilter.all;
 
         if (sessions.isEmpty && !isFilterActive) {
           return _buildEmptyState();
@@ -370,7 +422,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
         final orderable = manual ? _orderableService(hm) : null;
         final matching = _filterSessions(sessions);
         final filtered = _sortSessions(
-          _hidingTerminated ? matching.where((s) => !s.isTerminated).toList() : matching,
+          _hidingTerminated
+              ? matching.where((s) => !s.isTerminated).toList()
+              : matching,
           manual: manual,
         );
 
@@ -388,18 +442,27 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                           : ref.refreshAllHosts(),
                       child: manual && orderable != null
                           ? ReorderableListView.builder(
-                              padding: const EdgeInsets.symmetric(horizontal: 12),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                              ),
                               itemCount: filtered.length,
-                              onReorder: (from, to) => _onReorder(orderable, filtered, from, to),
+                              onReorder: (from, to) =>
+                                  _onReorder(orderable, filtered, from, to),
                               // The cards carry their own handle, so the list's
                               // long-press drag would only fight the options
                               // sheet that a long press already opens.
                               buildDefaultDragHandles: false,
                               itemBuilder: (context, index) =>
-                                  _buildSwipeableCard(filtered[index], hm, reorderIndex: index),
+                                  _buildSwipeableCard(
+                                    filtered[index],
+                                    hm,
+                                    reorderIndex: index,
+                                  ),
                             )
                           : ListView.builder(
-                              padding: const EdgeInsets.symmetric(horizontal: 12),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                              ),
                               itemCount: filtered.length,
                               itemBuilder: (context, index) =>
                                   _buildSwipeableCard(filtered[index], hm),
@@ -421,13 +484,27 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
       color: theme.colorScheme.surfaceContainerHighest,
       child: Row(
         children: [
-          IconButton(icon: const Icon(Icons.close), onPressed: _exitMultiSelect),
-          Text('${_selected.length} selected', style: const TextStyle(fontWeight: FontWeight.w600)),
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: _exitMultiSelect,
+          ),
+          Text(
+            '${_selected.length} selected',
+            style: const TextStyle(fontWeight: FontWeight.w600),
+          ),
           const Spacer(),
           if (!isTerminatedTab)
-            IconButton(icon: const Icon(Icons.push_pin_outlined), tooltip: 'Pin', onPressed: () => _batchPin(true)),
+            IconButton(
+              icon: const Icon(Icons.push_pin_outlined),
+              tooltip: 'Pin',
+              onPressed: () => _batchPin(true),
+            ),
           IconButton(
-            icon: Icon(isTerminatedTab ? Icons.play_arrow_outlined : Icons.stop_circle_outlined),
+            icon: Icon(
+              isTerminatedTab
+                  ? Icons.play_arrow_outlined
+                  : Icons.stop_circle_outlined,
+            ),
             tooltip: isTerminatedTab ? 'Resume' : 'Terminate',
             onPressed: () =>
                 isTerminatedTab ? _batchResume(hm) : _batchTerminate(hm),
@@ -442,19 +519,29 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
     );
   }
 
-  Widget _buildFilterRow(List<Session> allSessions, HostManager hm, List<Session> visible) {
+  Widget _buildFilterRow(
+    List<Session> allSessions,
+    HostManager hm,
+    List<Session> visible,
+  ) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
       child: AnimatedCrossFade(
         duration: const Duration(milliseconds: 200),
-        crossFadeState: _searchExpanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+        crossFadeState: _searchExpanded
+            ? CrossFadeState.showSecond
+            : CrossFadeState.showFirst,
         firstChild: _buildFilterChips(allSessions, hm, visible),
         secondChild: _buildSearchBar(),
       ),
     );
   }
 
-  Widget _buildFilterChips(List<Session> allSessions, HostManager hm, List<Session> visible) {
+  Widget _buildFilterChips(
+    List<Session> allSessions,
+    HostManager hm,
+    List<Session> visible,
+  ) {
     // Counting what the tab would show, not what exists: a chip reading 155
     // over a list of twelve is a chip that has to be explained. Terminated
     // sessions have their own tab, and it holds them on purpose.
@@ -581,7 +668,11 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
   /// [reorderIndex] is the card's place in a list arranged by hand, and null
   /// when the list sorts itself. The drag handle needs it to say which card is
   /// being moved.
-  Widget _buildSwipeableCard(Session session, HostManager hm, {int? reorderIndex}) {
+  Widget _buildSwipeableCard(
+    Session session,
+    HostManager hm, {
+    int? reorderIndex,
+  }) {
     final theme = Theme.of(context);
     // Terminated is the archival state: putting a session away is ending it,
     // and the way back out is Resume rather than an unarchive.
@@ -600,24 +691,39 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
         padding: const EdgeInsets.only(left: 20),
         child: Row(
           children: [
-            Icon(isTerminated ? Icons.play_arrow : Icons.stop_circle_outlined, color: Colors.white),
+            Icon(
+              isTerminated ? Icons.play_arrow : Icons.stop_circle_outlined,
+              color: Colors.white,
+            ),
             const SizedBox(width: 8),
             Text(
               isTerminated ? 'Resume' : 'Terminate',
-              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ],
         ),
       ),
       secondaryBackground: Container(
         margin: const EdgeInsets.only(bottom: 8),
-        decoration: BoxDecoration(color: theme.colorScheme.error, borderRadius: BorderRadius.circular(12)),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.error,
+          borderRadius: BorderRadius.circular(12),
+        ),
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 20),
         child: const Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            Text('Delete', style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600)),
+            Text(
+              'Delete',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
             SizedBox(width: 8),
             Icon(Icons.delete, color: Colors.white),
           ],
@@ -636,19 +742,28 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
             context: context,
             builder: (ctx) => AlertDialog(
               title: const Text('Delete session'),
-              content: const Text('Delete this session? This cannot be undone.'),
+              content: const Text(
+                'Delete this session? This cannot be undone.',
+              ),
               actions: [
-                TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('Cancel'),
+                ),
                 FilledButton(
                   onPressed: () => Navigator.pop(ctx, true),
-                  style: FilledButton.styleFrom(backgroundColor: theme.colorScheme.error),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.error,
+                  ),
                   child: const Text('Delete'),
                 ),
               ],
             ),
           );
           if (confirmed == true) {
-            ref.read(sessionsProvider(allSessionsKey(session.hostId)).notifier).delete(session.sessionId);
+            ref
+                .read(sessionsProvider(allSessionsKey(session.hostId)).notifier)
+                .delete(session.sessionId);
           }
           return false;
         }
@@ -657,7 +772,11 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
     );
   }
 
-  Widget _buildSessionCard(Session session, HostManager hm, {int? reorderIndex}) {
+  Widget _buildSessionCard(
+    Session session,
+    HostManager hm, {
+    int? reorderIndex,
+  }) {
     final theme = Theme.of(context);
     final statusColor = _statusColor(session.status, theme);
     final statusIcon = _statusIcon(session.status);
@@ -674,8 +793,8 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
         side: isSelected
             ? BorderSide(color: theme.colorScheme.primary, width: 2)
             : session.isActive
-                ? BorderSide(color: statusColor.withValues(alpha: 0.4), width: 1.5)
-                : BorderSide.none,
+            ? BorderSide(color: statusColor.withValues(alpha: 0.4), width: 1.5)
+            : BorderSide.none,
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
@@ -684,7 +803,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
             _toggleSelection(session);
           } else {
             Navigator.of(context).push(
-              MaterialPageRoute(builder: (_) => SessionDetailScreen(session: session)),
+              MaterialPageRoute(
+                builder: (_) => SessionDetailScreen(session: session),
+              ),
             );
           }
         },
@@ -717,19 +838,34 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                             Row(
                               children: [
                                 if (session.isActive)
-                                  _PulsingIcon(icon: statusIcon, color: statusColor, size: 14)
+                                  _PulsingIcon(
+                                    icon: statusIcon,
+                                    color: statusColor,
+                                    size: 14,
+                                  )
                                 else
-                                  Icon(statusIcon, size: 14, color: statusColor),
+                                  Icon(
+                                    statusIcon,
+                                    size: 14,
+                                    color: statusColor,
+                                  ),
                                 const SizedBox(width: 6),
                                 Container(
-                                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
                                   decoration: BoxDecoration(
                                     color: statusColor.withValues(alpha: 0.12),
                                     borderRadius: BorderRadius.circular(4),
                                   ),
                                   child: Text(
                                     _statusLabel(session.status),
-                                    style: TextStyle(fontSize: 11, color: statusColor, fontWeight: FontWeight.w600),
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color: statusColor,
+                                      fontWeight: FontWeight.w600,
+                                    ),
                                   ),
                                 ),
                                 if (session.memoryLabel.isNotEmpty) ...[
@@ -746,17 +882,28 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                                   const SizedBox(width: 6),
                                   Tooltip(
                                     message: 'Cold — tap to resume',
-                                    child: Icon(Icons.link_off, size: 14, color: Colors.amber.shade700),
+                                    child: Icon(
+                                      Icons.link_off,
+                                      size: 14,
+                                      color: Colors.amber.shade700,
+                                    ),
                                   ),
                                 ],
                                 if (session.pinned) ...[
                                   const SizedBox(width: 6),
-                                  Icon(Icons.push_pin, size: 14, color: theme.colorScheme.primary),
+                                  Icon(
+                                    Icons.push_pin,
+                                    size: 14,
+                                    color: theme.colorScheme.primary,
+                                  ),
                                 ],
                                 const Spacer(),
                                 Text(
                                   session.timeAgo,
-                                  style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
                                 ),
                               ],
                             ),
@@ -791,13 +938,20 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                                 Flexible(
                                   child: Text(
                                     session.model ?? '',
-                                    style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                    ),
                                     overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                                 Text(
                                   hostLabel,
-                                  style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: hostColor),
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.w600,
+                                    color: hostColor,
+                                  ),
                                 ),
                               ],
                             ),
@@ -860,7 +1014,11 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                     ),
                     Text(
                       session.shortId,
-                      style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurfaceVariant),
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ],
                 ),
@@ -897,16 +1055,26 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                 },
               ),
               ListTile(
-                leading: Icon(session.pinned ? Icons.push_pin : Icons.push_pin_outlined),
+                leading: Icon(
+                  session.pinned ? Icons.push_pin : Icons.push_pin_outlined,
+                ),
                 title: Text(session.pinned ? 'Unpin' : 'Pin'),
                 onTap: () {
                   Navigator.pop(ctx);
-                  ref.read(sessionsProvider(allSessionsKey(session.hostId)).notifier).patch(sessionId, pinned: !session.pinned);
+                  ref
+                      .read(
+                        sessionsProvider(
+                          allSessionsKey(session.hostId),
+                        ).notifier,
+                      )
+                      .patch(sessionId, pinned: !session.pinned);
                 },
               ),
               ListTile(
                 leading: Icon(
-                  isTerminated ? Icons.play_arrow_outlined : Icons.stop_circle_outlined,
+                  isTerminated
+                      ? Icons.play_arrow_outlined
+                      : Icons.stop_circle_outlined,
                 ),
                 title: Text(isTerminated ? 'Resume' : 'Terminate'),
                 onTap: () async {
@@ -920,8 +1088,14 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                 },
               ),
               ListTile(
-                leading: Icon(Icons.delete_outline, color: theme.colorScheme.error),
-                title: Text('Delete', style: TextStyle(color: theme.colorScheme.error)),
+                leading: Icon(
+                  Icons.delete_outline,
+                  color: theme.colorScheme.error,
+                ),
+                title: Text(
+                  'Delete',
+                  style: TextStyle(color: theme.colorScheme.error),
+                ),
                 onTap: () async {
                   Navigator.pop(ctx);
                   if (!mounted) return;
@@ -929,23 +1103,38 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
                     context: context,
                     builder: (dCtx) => AlertDialog(
                       title: const Text('Delete session'),
-                      content: const Text('Delete this session? This cannot be undone.'),
+                      content: const Text(
+                        'Delete this session? This cannot be undone.',
+                      ),
                       actions: [
-                        TextButton(onPressed: () => Navigator.pop(dCtx, false), child: const Text('Cancel')),
+                        TextButton(
+                          onPressed: () => Navigator.pop(dCtx, false),
+                          child: const Text('Cancel'),
+                        ),
                         FilledButton(
                           onPressed: () => Navigator.pop(dCtx, true),
-                          style: FilledButton.styleFrom(backgroundColor: theme.colorScheme.error),
+                          style: FilledButton.styleFrom(
+                            backgroundColor: theme.colorScheme.error,
+                          ),
                           child: const Text('Delete'),
                         ),
                       ],
                     ),
                   );
                   if (confirmed == true) {
-                    ref.read(sessionsProvider(allSessionsKey(session.hostId)).notifier).delete(sessionId);
+                    ref
+                        .read(
+                          sessionsProvider(
+                            allSessionsKey(session.hostId),
+                          ).notifier,
+                        )
+                        .delete(sessionId);
                   }
                 },
               ),
-              if (session.canStop || session.canTerminate || session.canResume) ...[
+              if (session.canStop ||
+                  session.canTerminate ||
+                  session.canResume) ...[
                 const Divider(height: 1),
                 if (session.canStop)
                   ListTile(
@@ -998,7 +1187,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
             autofocus: true,
             decoration: InputDecoration(
               hintText: session.lastUserMessage ?? 'Session title',
-              border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
             ),
             onSubmitted: (value) => Navigator.pop(ctx, value.trim()),
           ),
@@ -1016,7 +1207,9 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
       },
     ).then((title) {
       if (title != null && title.isNotEmpty) {
-        ref.read(sessionsProvider(allSessionsKey(hostId)).notifier).patch(sessionId, title: title);
+        ref
+            .read(sessionsProvider(allSessionsKey(hostId)).notifier)
+            .patch(sessionId, title: title);
       }
     });
   }
@@ -1026,20 +1219,30 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.terminal, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.5)),
+          Icon(
+            Icons.terminal,
+            size: 48,
+            color: Theme.of(
+              context,
+            ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
           const SizedBox(height: 16),
           Text(
             'No sessions yet.',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 4),
           Text(
             'Start a Claude session:\nhelios new "your prompt"',
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-                  fontFamily: 'monospace',
-                ),
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+              fontFamily: 'monospace',
+            ),
           ),
         ],
       ),
@@ -1047,7 +1250,8 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
   }
 
   Widget _buildEmptyFilterState() {
-    final isSearchActive = _searchExpanded && _searchController.text.trim().isNotEmpty;
+    final isSearchActive =
+        _searchExpanded && _searchController.text.trim().isNotEmpty;
 
     final String label;
     final String hint;
@@ -1084,20 +1288,26 @@ class _SessionsScreenState extends rp.ConsumerState<SessionsScreen> {
           Icon(
             icon,
             size: 48,
-            color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            color: Theme.of(
+              context,
+            ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
           ),
           const SizedBox(height: 16),
           Text(
             label,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
           if (hint.isNotEmpty) ...[
             const SizedBox(height: 4),
             Text(
               hint,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-                  ),
+                color: Theme.of(
+                  context,
+                ).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+              ),
             ),
           ],
         ],
@@ -1174,13 +1384,18 @@ class _PulsingIcon extends StatefulWidget {
   final Color color;
   final double size;
 
-  const _PulsingIcon({required this.icon, required this.color, required this.size});
+  const _PulsingIcon({
+    required this.icon,
+    required this.color,
+    required this.size,
+  });
 
   @override
   State<_PulsingIcon> createState() => _PulsingIconState();
 }
 
-class _PulsingIconState extends State<_PulsingIcon> with SingleTickerProviderStateMixin {
+class _PulsingIconState extends State<_PulsingIcon>
+    with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
 
   @override
@@ -1207,7 +1422,11 @@ class _PulsingIconState extends State<_PulsingIcon> with SingleTickerProviderSta
         final scale = 1.0 + 0.15 * _controller.value;
         return Transform.scale(
           scale: scale,
-          child: Icon(widget.icon, size: widget.size, color: widget.color.withValues(alpha: opacity)),
+          child: Icon(
+            widget.icon,
+            size: widget.size,
+            color: widget.color.withValues(alpha: opacity),
+          ),
         );
       },
     );

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -60,9 +60,12 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
       _updateDownloading = true;
       _updateProgress = 0;
     });
-    await UpdateService.instance.install(info, onProgress: (p) {
-      if (mounted) setState(() => _updateProgress = p);
-    });
+    await UpdateService.instance.install(
+      info,
+      onProgress: (p) {
+        if (mounted) setState(() => _updateProgress = p);
+      },
+    );
     if (mounted) setState(() => _updateDownloading = false);
   }
 
@@ -79,7 +82,10 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
               const _SectionHeader('Hosts'),
               ...hm.hosts.map((host) => _buildHostTile(host, hm)),
               ListTile(
-                leading: Icon(Icons.add, color: Theme.of(context).colorScheme.primary),
+                leading: Icon(
+                  Icons.add,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
                 title: const Text('Add new host'),
                 onTap: () {
                   Navigator.of(context).push(
@@ -111,7 +117,9 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
               ListTile(
                 leading: const Icon(Icons.notifications_outlined),
                 title: const Text('Alert settings'),
-                subtitle: const Text('Choose which notifications buzz and play sound'),
+                subtitle: const Text(
+                  'Choose which notifications buzz and play sound',
+                ),
                 trailing: const Icon(Icons.chevron_right, size: 20),
                 onTap: () {
                   Navigator.of(context).push(
@@ -137,7 +145,9 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
       return ListTile(
         leading: const Icon(Icons.system_update),
         title: const Text('Downloading update...'),
-        subtitle: LinearProgressIndicator(value: _updateProgress > 0 ? _updateProgress : null),
+        subtitle: LinearProgressIndicator(
+          value: _updateProgress > 0 ? _updateProgress : null,
+        ),
       );
     }
 
@@ -151,11 +161,16 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
 
     if (hasUpdate) {
       return ListTile(
-        leading: Icon(Icons.system_update, color: Theme.of(context).colorScheme.primary),
+        leading: Icon(
+          Icons.system_update,
+          color: Theme.of(context).colorScheme.primary,
+        ),
         title: Text('Update available — v${_updateInfo!.latestVersion}'),
         subtitle: Text(
           'Current: v$_currentVersion  ·  Tap to ${_updateInfo!.canDirectInstall ? 'download & install' : 'open release page'}',
-          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
         trailing: FilledButton.tonal(
           onPressed: _doInstall,
@@ -181,15 +196,24 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
         tp.mode == ThemeMode.dark
             ? Icons.dark_mode
             : tp.mode == ThemeMode.light
-                ? Icons.light_mode
-                : Icons.brightness_auto,
+            ? Icons.light_mode
+            : Icons.brightness_auto,
       ),
       title: const Text('Theme'),
       trailing: SegmentedButton<ThemeMode>(
         segments: const [
-          ButtonSegment(value: ThemeMode.system, icon: Icon(Icons.brightness_auto, size: 18)),
-          ButtonSegment(value: ThemeMode.light, icon: Icon(Icons.light_mode, size: 18)),
-          ButtonSegment(value: ThemeMode.dark, icon: Icon(Icons.dark_mode, size: 18)),
+          ButtonSegment(
+            value: ThemeMode.system,
+            icon: Icon(Icons.brightness_auto, size: 18),
+          ),
+          ButtonSegment(
+            value: ThemeMode.light,
+            icon: Icon(Icons.light_mode, size: 18),
+          ),
+          ButtonSegment(
+            value: ThemeMode.dark,
+            icon: Icon(Icons.dark_mode, size: 18),
+          ),
         ],
         selected: {tp.mode},
         onSelectionChanged: (modes) => tp.setMode(modes.first),
@@ -208,7 +232,9 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
   String? _hostSettingsSummary(String hostId) {
     final settings = ref.watch(hostSettingsProvider(hostId)).valueOrNull;
     if (settings == null) return null;
-    final title = settings.autoTitleEnabled ? 'Auto title on' : 'Auto title off';
+    final title = settings.autoTitleEnabled
+        ? 'Auto title on'
+        : 'Auto title off';
     final memory = settings.evictEnabled
         ? 'Save memory ${(settings.budgetFraction * 100).round()}%'
         : 'Save memory off';
@@ -236,7 +262,10 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
         children: [
           Text(
             host.serverUrl,
-            style: TextStyle(fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant),
+            style: TextStyle(
+              fontSize: 11,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
             overflow: TextOverflow.ellipsis,
           ),
           if (summary != null)
@@ -244,9 +273,7 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
               summary,
               style: TextStyle(
                 fontSize: 11,
-                color: Theme.of(context)
-                    .colorScheme
-                    .onSurfaceVariant
+                color: Theme.of(context).colorScheme.onSurfaceVariant
                     .withValues(alpha: isConnected ? 1.0 : 0.5),
               ),
               overflow: TextOverflow.ellipsis,
@@ -260,7 +287,9 @@ class _SettingsScreenState extends rp.ConsumerState<SettingsScreen> {
             isConnected ? 'Connected' : 'Offline',
             style: TextStyle(
               fontSize: 12,
-              color: isConnected ? Colors.green : Theme.of(context).colorScheme.onSurfaceVariant,
+              color: isConnected
+                  ? Colors.green
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
             ),
           ),
           const SizedBox(width: 4),
@@ -287,8 +316,8 @@ class _SectionHeader extends StatelessWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              color: Theme.of(context).colorScheme.primary,
-            ),
+          color: Theme.of(context).colorScheme.primary,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/setup_screen.dart
+++ b/mobile/lib/screens/setup_screen.dart
@@ -8,8 +8,7 @@ import 'home_screen.dart';
 
 /// Whether QR scanning should be the default input mode.
 /// Disabled on web and desktop platforms where camera scanning is impractical.
-bool get _defaultToScanner =>
-    !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+bool get _defaultToScanner => !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
 class SetupScreen extends StatefulWidget {
   final String? deepLinkToken;
@@ -56,7 +55,10 @@ class _SetupScreenState extends State<SetupScreen> {
     if (input.isEmpty) return;
     final parsed = _parsePairingUrl(input);
     if (parsed == null) {
-      setState(() => _error = 'Invalid pairing URL. Scan the QR code from the terminal.');
+      setState(
+        () =>
+            _error = 'Invalid pairing URL. Scan the QR code from the terminal.',
+      );
       return;
     }
     await _doSetup(parsed.token, parsed.serverUrl);
@@ -106,10 +108,7 @@ class _SetupScreenState extends State<SetupScreen> {
     if (_error != null) return _buildError();
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('helios'),
-        centerTitle: true,
-      ),
+      appBar: AppBar(title: const Text('helios'), centerTitle: true),
       body: _scanning ? _buildScanner() : _buildManualInput(),
     );
   }
@@ -136,16 +135,26 @@ class _SetupScreenState extends State<SetupScreen> {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Icon(Icons.camera_alt_outlined, size: 48,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.5)),
+                      Icon(
+                        Icons.camera_alt_outlined,
+                        size: 48,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                      ),
                       const SizedBox(height: 16),
-                      Text('Camera unavailable',
-                          style: Theme.of(context).textTheme.bodyLarge),
+                      Text(
+                        'Camera unavailable',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
                       const SizedBox(height: 8),
-                      Text('Grant camera permission or paste the URL manually.',
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Theme.of(context).colorScheme.onSurfaceVariant),
-                          textAlign: TextAlign.center),
+                      Text(
+                        'Grant camera permission or paste the URL manually.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
                     ],
                   ),
                 ),
@@ -166,8 +175,8 @@ class _SetupScreenState extends State<SetupScreen> {
               Text(
                 'Run helios start in your terminal to generate a QR code',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
@@ -191,15 +200,17 @@ class _SetupScreenState extends State<SetupScreen> {
         children: [
           Text(
             'helios',
-            style: Theme.of(context).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+            style: Theme.of(
+              context,
+            ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
           Text(
             'Add Host',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 32),
@@ -247,53 +258,78 @@ class _SetupScreenState extends State<SetupScreen> {
                 children: [
                   Text(
                     'helios',
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    isPending ? 'Waiting for approval...' : 'Setting up device...',
+                    isPending
+                        ? 'Waiting for approval...'
+                        : 'Setting up device...',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: 16),
-                  ..._statusMessages.map((msg) => Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 2),
-                        child: Row(
-                          children: [
-                            Text('+',
-                                style: TextStyle(
-                                    color: Theme.of(context).colorScheme.primary, fontFamily: 'monospace')),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(msg,
-                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        fontFamily: 'monospace',
-                                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                                      )),
+                  ..._statusMessages.map(
+                    (msg) => Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2),
+                      child: Row(
+                        children: [
+                          Text(
+                            '+',
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.primary,
+                              fontFamily: 'monospace',
                             ),
-                          ],
-                        ),
-                      )),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              msg,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    fontFamily: 'monospace',
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                   if (isPending) ...[
                     const SizedBox(height: 16),
                     if (hm.pendingDeviceId != null) ...[
                       Container(
                         padding: const EdgeInsets.all(10),
                         decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
                           borderRadius: BorderRadius.circular(8),
                         ),
                         child: Row(
                           children: [
-                            Icon(Icons.key, size: 16, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                            Icon(
+                              Icons.key,
+                              size: 16,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
+                            ),
                             const SizedBox(width: 8),
                             Text(
                               'Device ID: ${hm.pendingDeviceId!.substring(0, 8)}...',
                               style: TextStyle(
                                 fontFamily: 'monospace',
                                 fontSize: 12,
-                                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
                               ),
                             ),
                           ],
@@ -309,14 +345,21 @@ class _SetupScreenState extends State<SetupScreen> {
                       ),
                       child: Row(
                         children: [
-                          Icon(Icons.terminal,
-                              color: Theme.of(context).colorScheme.onPrimaryContainer, size: 20),
+                          Icon(
+                            Icons.terminal,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onPrimaryContainer,
+                            size: 20,
+                          ),
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
                               'Press "y" in the terminal to approve this device.',
                               style: TextStyle(
-                                color: Theme.of(context).colorScheme.onPrimaryContainer,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onPrimaryContainer,
                                 fontSize: 13,
                               ),
                             ),
@@ -338,7 +381,8 @@ class _SetupScreenState extends State<SetupScreen> {
 
   Widget _buildError() {
     final isTokenExpired =
-        _error?.contains('expired') == true || _error?.contains('already been used') == true;
+        _error?.contains('expired') == true ||
+        _error?.contains('already been used') == true;
 
     return Scaffold(
       body: Center(
@@ -351,13 +395,19 @@ class _SetupScreenState extends State<SetupScreen> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('helios',
-                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
+                  Text(
+                    'helios',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                   const SizedBox(height: 4),
-                  Text('Setup Failed',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context).colorScheme.onSurfaceVariant,
-                          )),
+                  Text(
+                    'Setup Failed',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
                   const SizedBox(height: 16),
                   Container(
                     padding: const EdgeInsets.all(12),
@@ -365,43 +415,61 @@ class _SetupScreenState extends State<SetupScreen> {
                       color: Theme.of(context).colorScheme.errorContainer,
                       borderRadius: BorderRadius.circular(8),
                     ),
-                    child: Text(_error!,
-                        style: TextStyle(color: Theme.of(context).colorScheme.onErrorContainer, fontSize: 13)),
+                    child: Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onErrorContainer,
+                        fontSize: 13,
+                      ),
+                    ),
                   ),
                   if (isTokenExpired) ...[
                     const SizedBox(height: 12),
                     Container(
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: const Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text('What happened?',
-                              style: TextStyle(fontWeight: FontWeight.w600, fontSize: 13)),
+                          Text(
+                            'What happened?',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 13,
+                            ),
+                          ),
                           SizedBox(height: 4),
                           Text(
-                              'The pairing QR code has expired or was already used. Each QR code can only be scanned once and expires after 2 minutes.',
-                              style: TextStyle(fontSize: 13)),
+                            'The pairing QR code has expired or was already used. Each QR code can only be scanned once and expires after 2 minutes.',
+                            style: TextStyle(fontSize: 13),
+                          ),
                           SizedBox(height: 8),
                           Text(
-                              'A new QR code is automatically generated in the terminal. Scan the latest one.',
-                              style: TextStyle(fontSize: 13)),
+                            'A new QR code is automatically generated in the terminal. Scan the latest one.',
+                            style: TextStyle(fontSize: 13),
+                          ),
                         ],
                       ),
                     ),
                   ],
                   const SizedBox(height: 16),
-                  ..._statusMessages.map((msg) => Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 1),
-                        child: Text(msg,
-                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  fontFamily: 'monospace',
-                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                                )),
-                      )),
+                  ..._statusMessages.map(
+                    (msg) => Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 1),
+                      child: Text(
+                        msg,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
                   const SizedBox(height: 16),
                   SizedBox(
                     width: double.infinity,

--- a/mobile/lib/screens/terminal_screen.dart
+++ b/mobile/lib/screens/terminal_screen.dart
@@ -28,7 +28,8 @@ class TerminalScreen extends StatefulWidget {
   State<TerminalScreen> createState() => _TerminalScreenState();
 }
 
-class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObserver {
+class _TerminalScreenState extends State<TerminalScreen>
+    with WidgetsBindingObserver {
   final Map<String, _TerminalTab> _tabs = {};
   List<TerminalInfo> _terminals = [];
   String? _activeId;
@@ -51,7 +52,8 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
     // A shell is the session's, not this client's: one opened on the desktop
     // should appear here without a manual refresh.
     _eventSub = _sse?.events.listen((event) {
-      if (event.type != 'terminal_opened' && event.type != 'terminal_closed') return;
+      if (event.type != 'terminal_opened' && event.type != 'terminal_closed')
+        return;
       if (event.data is! Map) return;
       if ((event.data as Map)['session_id'] != widget.session.sessionId) return;
       _load();
@@ -97,7 +99,8 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
   }
 
   Future<void> _load() async {
-    final terminals = await _sse?.fetchTerminals(widget.session.sessionId) ?? [];
+    final terminals =
+        await _sse?.fetchTerminals(widget.session.sessionId) ?? [];
     if (!mounted) return;
 
     // Anything gone from the daemon's list is gone for good; keep the rest
@@ -194,8 +197,14 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
           'and anyone attached in a terminal.',
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Fit')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Fit'),
+          ),
         ],
       ),
     );
@@ -219,7 +228,10 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                 child: Row(
                   children: [
-                    Text('Text size', style: Theme.of(ctx).textTheme.titleSmall),
+                    Text(
+                      'Text size',
+                      style: Theme.of(ctx).textTheme.titleSmall,
+                    ),
                     const Spacer(),
                     Text('${_fontSize.toStringAsFixed(0)} pt'),
                   ],
@@ -264,13 +276,22 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
     final tab = _active;
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.session.displayTitle, overflow: TextOverflow.ellipsis),
+        title: Text(
+          widget.session.displayTitle,
+          overflow: TextOverflow.ellipsis,
+        ),
         actions: [
           if (tab != null)
             IconButton(
-              icon: Icon(tab.interactive ? Icons.fit_screen : Icons.fit_screen_outlined,
-                  color: tab.interactive ? Theme.of(context).colorScheme.primary : null),
-              tooltip: tab.interactive ? 'Hand the size back' : 'Fit to this screen',
+              icon: Icon(
+                tab.interactive ? Icons.fit_screen : Icons.fit_screen_outlined,
+                color: tab.interactive
+                    ? Theme.of(context).colorScheme.primary
+                    : null,
+              ),
+              tooltip: tab.interactive
+                  ? 'Hand the size back'
+                  : 'Fit to this screen',
               onPressed: _claimSize,
             ),
           IconButton(
@@ -280,7 +301,11 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
           ),
           IconButton(
             icon: _opening
-                ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
                 : const Icon(Icons.add),
             tooltip: 'Open a shell',
             onPressed: _opening ? null : _openShell,
@@ -290,43 +315,56 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _terminals.isEmpty
-              ? _buildCold()
-              : Column(
-                  children: [
-                    _buildTabs(),
-                    if (tab != null) _buildStatusLine(tab),
-                    Expanded(child: tab == null ? const SizedBox.shrink() : _buildTerminal(tab)),
-                    if (tab != null) _KeyBar(tab: tab),
-                  ],
+          ? _buildCold()
+          : Column(
+              children: [
+                _buildTabs(),
+                if (tab != null) _buildStatusLine(tab),
+                Expanded(
+                  child: tab == null
+                      ? const SizedBox.shrink()
+                      : _buildTerminal(tab),
                 ),
+                if (tab != null) _KeyBar(tab: tab),
+              ],
+            ),
     );
   }
 
   Widget _buildCold() => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.terminal, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
-              const SizedBox(height: 12),
-              const Text('This session has no live terminal.', textAlign: TextAlign.center),
-              const SizedBox(height: 4),
-              Text(
-                'Send it a prompt to wake it, or open a shell in its directory.',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
-              ),
-              const SizedBox(height: 16),
-              FilledButton.tonalIcon(
-                onPressed: _opening ? null : _openShell,
-                icon: const Icon(Icons.add),
-                label: const Text('Open a shell'),
-              ),
-            ],
+    child: Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.terminal,
+            size: 48,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
-        ),
-      );
+          const SizedBox(height: 12),
+          const Text(
+            'This session has no live terminal.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Send it a prompt to wake it, or open a shell in its directory.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton.tonalIcon(
+            onPressed: _opening ? null : _openShell,
+            icon: const Icon(Icons.add),
+            label: const Text('Open a shell'),
+          ),
+        ],
+      ),
+    ),
+  );
 
   Widget _buildTabs() {
     if (_terminals.length < 2) return const SizedBox.shrink();
@@ -344,9 +382,15 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
           return InputChip(
             selected: selected,
             showCheckmark: false,
-            avatar: Icon(terminal.isAgent ? Icons.smart_toy_outlined : Icons.terminal, size: 16),
+            avatar: Icon(
+              terminal.isAgent ? Icons.smart_toy_outlined : Icons.terminal,
+              size: 16,
+            ),
             label: Text(terminal.isAgent ? 'agent' : 'shell $index'),
-            labelStyle: TextStyle(fontSize: 12, color: selected ? theme.colorScheme.primary : null),
+            labelStyle: TextStyle(
+              fontSize: 12,
+              color: selected ? theme.colorScheme.primary : null,
+            ),
             onPressed: () {
               setState(() => _activeId = terminal.id);
               _tabFor(terminal.id);
@@ -368,11 +412,13 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
         LinkState.connecting => 'connecting',
         LinkState.reconnecting => 'reconnecting',
         LinkState.closed => tab.closeReason ?? 'closed',
-        LinkState.live => tab.interactive ? 'fitted to this screen' : 'watching',
+        LinkState.live =>
+          tab.interactive ? 'fitted to this screen' : 'watching',
       },
       if (status != null) '${status.cols}×${status.rows}',
       if (status != null && status.viewers > 1) '${status.viewers} viewers',
-      if (status?.writer != null && status!.writer!.isNotEmpty) 'typing: ${status.writer}',
+      if (status?.writer != null && status!.writer!.isNotEmpty)
+        'typing: ${status.writer}',
     ];
     return Container(
       width: double.infinity,
@@ -380,7 +426,10 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
       color: theme.colorScheme.surfaceContainerHighest,
       child: Text(
         parts.join(' · '),
-        style: TextStyle(fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+        style: TextStyle(
+          fontSize: 11,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
       ),
     );
   }
@@ -399,10 +448,14 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
           // Observing a desktop means inheriting its columns — 191 of them is
           // normal. Shrinking type until they fit produces something no one can
           // read, so the type stays legible and the screen pans instead.
-          final width = (tab.status?.cols ?? tab.cols) * _fontSize * _cellRatio + 12;
+          final width =
+              (tab.status?.cols ?? tab.cols) * _fontSize * _cellRatio + 12;
           return SingleChildScrollView(
             scrollDirection: Axis.horizontal,
-            child: _view(tab, width < constraints.maxWidth ? constraints.maxWidth : width),
+            child: _view(
+              tab,
+              width < constraints.maxWidth ? constraints.maxWidth : width,
+            ),
           );
         },
       ),
@@ -410,21 +463,21 @@ class _TerminalScreenState extends State<TerminalScreen> with WidgetsBindingObse
   }
 
   Widget _view(_TerminalTab tab, double width) => SizedBox(
-        width: width,
-        child: TerminalView(
-          tab.terminal,
-          controller: tab.controller,
-          textStyle: TerminalStyle(fontSize: _fontSize, fontFamily: _fontFamily),
-          padding: const EdgeInsets.all(6),
-          // Observing, the host owns the size and the view must not touch it;
-          // fitted, the view owns it and the host follows.
-          autoResize: tab.interactive,
-          // Android's IME sends no hardware delete event, so without this the
-          // backspace key does nothing at all.
-          deleteDetection: true,
-          backgroundOpacity: 0,
-        ),
-      );
+    width: width,
+    child: TerminalView(
+      tab.terminal,
+      controller: tab.controller,
+      textStyle: TerminalStyle(fontSize: _fontSize, fontFamily: _fontFamily),
+      padding: const EdgeInsets.all(6),
+      // Observing, the host owns the size and the view must not touch it;
+      // fitted, the view owns it and the host follows.
+      autoResize: tab.interactive,
+      // Android's IME sends no hardware delete event, so without this the
+      // backspace key does nothing at all.
+      deleteDetection: true,
+      backgroundOpacity: 0,
+    ),
+  );
 
   /// Bundled rather than the platform's "monospace": Android maps that to
   /// Droid Sans Mono, whose box-drawing characters do not join, and a TUI is
@@ -504,6 +557,7 @@ class _TerminalTab {
   LinkState state = LinkState.connecting;
   TerminalStatus? status;
   String? closeReason;
+
   /// Whether this viewer votes on the PTY size. On by default: a phone
   /// showing a desktop's 180 columns is unreadable, and the terminal is here
   /// to be used rather than watched. Handing it back leaves the phone an
@@ -580,10 +634,15 @@ class _TerminalTab {
     connect();
   }
 
-  void send(String data) => _connection?.send(Uint8List.fromList(utf8.encode(data)));
+  void send(String data) =>
+      _connection?.send(Uint8List.fromList(utf8.encode(data)));
 
-  void key(TerminalKey key, {bool ctrl = false, bool shift = false, bool alt = false}) =>
-      terminal.keyInput(key, ctrl: ctrl, shift: shift, alt: alt);
+  void key(
+    TerminalKey key, {
+    bool ctrl = false,
+    bool shift = false,
+    bool alt = false,
+  }) => terminal.keyInput(key, ctrl: ctrl, shift: shift, alt: alt);
 
   Future<void> pasteFromClipboard() async {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
@@ -698,7 +757,9 @@ class _KeyBarState extends State<_KeyBar> {
               _key('⇧tab', () => widget.tab.key(TerminalKey.tab, shift: true)),
               _key(
                 'ctrl',
-                () => setState(() => widget.tab.ctrlArmed = !widget.tab.ctrlArmed),
+                () => setState(
+                  () => widget.tab.ctrlArmed = !widget.tab.ctrlArmed,
+                ),
                 active: widget.tab.ctrlArmed,
               ),
               _key('^C', () => _chord(0x63)),
@@ -732,14 +793,18 @@ class _KeyBarState extends State<_KeyBar> {
           constraints: const BoxConstraints(minWidth: 44),
           padding: const EdgeInsets.symmetric(horizontal: 10),
           decoration: BoxDecoration(
-            color: active ? theme.colorScheme.primaryContainer : theme.colorScheme.surface,
+            color: active
+                ? theme.colorScheme.primaryContainer
+                : theme.colorScheme.surface,
             borderRadius: BorderRadius.circular(6),
           ),
           child: Text(
             label,
             style: TextStyle(
               fontSize: 13,
-              color: active ? theme.colorScheme.onPrimaryContainer : theme.colorScheme.onSurface,
+              color: active
+                  ? theme.colorScheme.onPrimaryContainer
+                  : theme.colorScheme.onSurface,
             ),
           ),
         ),

--- a/mobile/lib/services/api_client.dart
+++ b/mobile/lib/services/api_client.dart
@@ -63,16 +63,14 @@ class ApiClient {
   Future<String> _signJWT() async {
     final header = {'alg': 'EdDSA', 'typ': 'JWT', 'kid': deviceId};
     final now = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
-    final payload = {
-      'iat': now,
-      'exp': now + 3600,
-      'sub': 'helios-client',
-    };
+    final payload = {'iat': now, 'exp': now + 3600, 'sub': 'helios-client'};
 
     final encodedHeader = _base64urlEncode(
-        Uint8List.fromList(utf8.encode(jsonEncode(header))));
+      Uint8List.fromList(utf8.encode(jsonEncode(header))),
+    );
     final encodedPayload = _base64urlEncode(
-        Uint8List.fromList(utf8.encode(jsonEncode(payload))));
+      Uint8List.fromList(utf8.encode(jsonEncode(payload))),
+    );
     final signingInput = '$encodedHeader.$encodedPayload';
 
     final algorithm = Ed25519();
@@ -82,8 +80,9 @@ class ApiClient {
       keyPair: keyPair,
     );
 
-    final encodedSignature =
-        _base64urlEncode(Uint8List.fromList(signature.bytes));
+    final encodedSignature = _base64urlEncode(
+      Uint8List.fromList(signature.bytes),
+    );
     return '$signingInput.$encodedSignature';
   }
 
@@ -161,7 +160,10 @@ class ApiClient {
   /// builds a second one rather than replaying the first.
   Future<http.Response> postFiles(String path, List<UploadFile> files) async {
     Future<http.Response> attempt() async {
-      final request = http.MultipartRequest('POST', Uri.parse('$serverUrl$path'));
+      final request = http.MultipartRequest(
+        'POST',
+        Uri.parse('$serverUrl$path'),
+      );
       request.headers.addAll(await _authHeaders());
       for (final file in files) {
         request.files.add(

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -210,7 +210,9 @@ class DaemonAPIService extends ChangeNotifier {
       if (raw == null) return null;
       final list = (jsonDecode(raw) as List?) ?? [];
       return list
-          .map((s) => Session.fromJson(s as Map<String, dynamic>, hostId: hostId))
+          .map(
+            (s) => Session.fromJson(s as Map<String, dynamic>, hostId: hostId),
+          )
           .toList();
     } catch (_) {
       // Schema changed, corrupt cache, or no store at all. Either way the
@@ -500,7 +502,9 @@ class DaemonAPIService extends ChangeNotifier {
     }
     final data = jsonDecode(resp.body);
     final list = (data['schedules'] as List?) ?? [];
-    return list.map((s) => Schedule.fromJson(s as Map<String, dynamic>)).toList();
+    return list
+        .map((s) => Schedule.fromJson(s as Map<String, dynamic>))
+        .toList();
   }
 
   Future<Schedule> saveSchedule(String id, Map<String, dynamic> fields) async {
@@ -512,7 +516,9 @@ class DaemonAPIService extends ChangeNotifier {
       // The daemon refuses at save what would otherwise be found at 3am — a
       // cron that can never fire, a link that would close a loop — and says
       // which, so its message is worth more than the status.
-      throw Exception((data['message'] as String?) ?? 'could not save the schedule');
+      throw Exception(
+        (data['message'] as String?) ?? 'could not save the schedule',
+      );
     }
     return Schedule.fromJson(data['schedule'] as Map<String, dynamic>);
   }
@@ -569,8 +575,9 @@ class DaemonAPIService extends ChangeNotifier {
     final queryString = params.entries
         .map((e) => '${e.key}=${Uri.encodeComponent(e.value)}')
         .join('&');
-    final path =
-        queryString.isNotEmpty ? '/api/sessions?$queryString' : '/api/sessions';
+    final path = queryString.isNotEmpty
+        ? '/api/sessions?$queryString'
+        : '/api/sessions';
 
     final resp = await _api.get(path);
     if (resp.statusCode != 200) {
@@ -610,9 +617,7 @@ class DaemonAPIService extends ChangeNotifier {
       final query = afterSeq != null
           ? 'limit=$limit&after_seq=$afterSeq&epoch=${Uri.encodeQueryComponent(epoch ?? '')}'
           : 'limit=$limit&offset=$offset';
-      final resp = await _api.get(
-        '/api/sessions/$sessionId/transcript?$query',
-      );
+      final resp = await _api.get('/api/sessions/$sessionId/transcript?$query');
       debugPrint(
         '[$hostId] fetchTranscript[$sessionId] status=${resp.statusCode}',
       );
@@ -654,9 +659,14 @@ class DaemonAPIService extends ChangeNotifier {
   ) async {
     if (files.isEmpty) return const [];
     try {
-      final resp = await _api.postFiles('/api/sessions/$sessionId/files', files);
+      final resp = await _api.postFiles(
+        '/api/sessions/$sessionId/files',
+        files,
+      );
       if (resp.statusCode != 200) {
-        debugPrint('[$hostId] uploadSessionFiles: ${resp.statusCode} ${resp.body}');
+        debugPrint(
+          '[$hostId] uploadSessionFiles: ${resp.statusCode} ${resp.body}',
+        );
         return null;
       }
       final data = jsonDecode(resp.body);
@@ -810,11 +820,15 @@ class DaemonAPIService extends ChangeNotifier {
   /// The live terminals beside a session: its agent, then any shells.
   Future<List<TerminalInfo>> fetchTerminals(String sessionId) async {
     try {
-      final resp = await _api.get('/api/sessions/${Uri.encodeComponent(sessionId)}/terminals');
+      final resp = await _api.get(
+        '/api/sessions/${Uri.encodeComponent(sessionId)}/terminals',
+      );
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body);
         final list = (data['terminals'] as List?) ?? [];
-        return list.map((t) => TerminalInfo.fromJson(t as Map<String, dynamic>)).toList();
+        return list
+            .map((t) => TerminalInfo.fromJson(t as Map<String, dynamic>))
+            .toList();
       }
     } catch (e) {
       debugPrint('[$hostId] fetchTerminals error: $e');
@@ -827,9 +841,13 @@ class DaemonAPIService extends ChangeNotifier {
   /// something yourself.
   Future<TerminalInfo?> openShell(String sessionId) async {
     try {
-      final resp = await _api.post('/api/sessions/${Uri.encodeComponent(sessionId)}/terminals');
+      final resp = await _api.post(
+        '/api/sessions/${Uri.encodeComponent(sessionId)}/terminals',
+      );
       if (isSuccess(resp.statusCode)) {
-        return TerminalInfo.fromJson(jsonDecode(resp.body) as Map<String, dynamic>);
+        return TerminalInfo.fromJson(
+          jsonDecode(resp.body) as Map<String, dynamic>,
+        );
       }
       debugPrint('[$hostId] openShell failed: ${resp.statusCode} ${resp.body}');
     } catch (e) {
@@ -842,7 +860,9 @@ class DaemonAPIService extends ChangeNotifier {
   /// stop and terminate of its own.
   Future<bool> closeTerminal(String terminalId) async {
     try {
-      final resp = await _api.delete('/api/terminals/${Uri.encodeComponent(terminalId)}');
+      final resp = await _api.delete(
+        '/api/terminals/${Uri.encodeComponent(terminalId)}',
+      );
       return isSuccess(resp.statusCode);
     } catch (e) {
       debugPrint('[$hostId] closeTerminal error: $e');
@@ -918,7 +938,10 @@ class DaemonAPIService extends ChangeNotifier {
   /// Writes the arrangement. The cache paints it before this answers.
   Future<bool> setSessionOrder(List<String> sessionIds) async {
     try {
-      final resp = await _api.post('/api/sessions/order', body: {'order': sessionIds});
+      final resp = await _api.post(
+        '/api/sessions/order',
+        body: {'order': sessionIds},
+      );
       if (resp.statusCode == 200) return true;
     } catch (e) {
       debugPrint('[$hostId] setSessionOrder error: $e');
@@ -1085,7 +1108,8 @@ class DaemonAPIService extends ChangeNotifier {
         'file=${Uri.encodeComponent(file)}',
         if (staged) 'staged=true',
         if (untracked) 'untracked=true',
-        if (from != null && from.isNotEmpty) 'from=${Uri.encodeComponent(from)}',
+        if (from != null && from.isNotEmpty)
+          'from=${Uri.encodeComponent(from)}',
         if (to != null && to.isNotEmpty) 'to=${Uri.encodeComponent(to)}',
       ];
       final resp = await _api.get('/api/git/diff?${query.join('&')}');
@@ -1113,7 +1137,8 @@ class DaemonAPIService extends ChangeNotifier {
         'limit=$limit',
         if (skip > 0) 'skip=$skip',
         if (all) 'all=true',
-        if (base != null && base.isNotEmpty) 'base=${Uri.encodeComponent(base)}',
+        if (base != null && base.isNotEmpty)
+          'base=${Uri.encodeComponent(base)}',
       ];
       final resp = await _api.get('/api/git/log?${query.join('&')}');
       if (resp.statusCode == 200) {
@@ -1131,7 +1156,8 @@ class DaemonAPIService extends ChangeNotifier {
       final query = <String>[
         'path=${Uri.encodeComponent(path)}',
         'to=${Uri.encodeComponent(to)}',
-        if (from != null && from.isNotEmpty) 'from=${Uri.encodeComponent(from)}',
+        if (from != null && from.isNotEmpty)
+          'from=${Uri.encodeComponent(from)}',
       ];
       final resp = await _api.get('/api/git/changes?${query.join('&')}');
       if (resp.statusCode == 200) {
@@ -1225,7 +1251,8 @@ class HostSettings {
     return HostSettings(
       manualOrder: settings[DaemonAPIService.settingSortMode] == 'manual',
       autoTitleEnabled: settings[DaemonAPIService.settingAutoTitle] == 'true',
-      autoTitleEmoji: settings[DaemonAPIService.settingAutoTitleEmoji] == 'true',
+      autoTitleEmoji:
+          settings[DaemonAPIService.settingAutoTitleEmoji] == 'true',
       evictEnabled: settings[DaemonAPIService.settingEvict] == 'true',
       budgetFraction: budget == null
           ? DaemonAPIService.budgetDefault
@@ -1242,14 +1269,13 @@ class HostSettings {
     bool? autoTitleEmoji,
     bool? evictEnabled,
     double? budgetFraction,
-  }) =>
-      HostSettings(
-        manualOrder: manualOrder ?? this.manualOrder,
-        autoTitleEnabled: autoTitleEnabled ?? this.autoTitleEnabled,
-        autoTitleEmoji: autoTitleEmoji ?? this.autoTitleEmoji,
-        evictEnabled: evictEnabled ?? this.evictEnabled,
-        budgetFraction: budgetFraction ?? this.budgetFraction,
-      );
+  }) => HostSettings(
+    manualOrder: manualOrder ?? this.manualOrder,
+    autoTitleEnabled: autoTitleEnabled ?? this.autoTitleEnabled,
+    autoTitleEmoji: autoTitleEmoji ?? this.autoTitleEmoji,
+    evictEnabled: evictEnabled ?? this.evictEnabled,
+    budgetFraction: budgetFraction ?? this.budgetFraction,
+  );
 }
 
 /// The filters a session list is read under, and the key it is cached against.
@@ -1265,7 +1291,13 @@ class SessionQuery {
   /// Narrows to the runs of one schedule, which is what the runs list is.
   final String? scheduleId;
 
-  const SessionQuery({this.q, this.status, this.filter, this.cwd, this.scheduleId});
+  const SessionQuery({
+    this.q,
+    this.status,
+    this.filter,
+    this.cwd,
+    this.scheduleId,
+  });
 
   static const all = SessionQuery();
 
@@ -1286,7 +1318,8 @@ class SessionQuery {
   int get hashCode => Object.hash(q, status, filter, cwd, scheduleId);
 
   @override
-  String toString() => 'SessionQuery(q: $q, status: $status, filter: $filter, cwd: $cwd)';
+  String toString() =>
+      'SessionQuery(q: $q, status: $status, filter: $filter, cwd: $cwd)';
 }
 
 class FileEntry {
@@ -1433,11 +1466,11 @@ class TerminalInfo {
   });
 
   factory TerminalInfo.fromJson(Map<String, dynamic> json) => TerminalInfo(
-        id: json['id'] as String,
-        parent: json['parent'] as String? ?? '',
-        kind: json['kind'] as String? ?? 'shell',
-        cwd: json['cwd'] as String? ?? '',
-      );
+    id: json['id'] as String,
+    parent: json['parent'] as String? ?? '',
+    kind: json['kind'] as String? ?? 'shell',
+    cwd: json['cwd'] as String? ?? '',
+  );
 
   bool get isAgent => kind == 'agent';
 }
@@ -1811,7 +1844,9 @@ bool isSuccess(int statusCode) => statusCode >= 200 && statusCode < 300;
 /// Most recently committed first. Worktrees with no date — pruned, or past the
 /// detail cap the daemon enforces — keep their listing order at the end.
 List<Worktree> sortWorktreesByLastTouched(List<Worktree> worktrees) {
-  final order = {for (var i = 0; i < worktrees.length; i++) worktrees[i].path: i};
+  final order = {
+    for (var i = 0; i < worktrees.length; i++) worktrees[i].path: i,
+  };
   final sorted = [...worktrees];
   sorted.sort((a, b) {
     final da = DateTime.tryParse(a.date)?.toUtc();

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -29,7 +29,6 @@ class HostManager extends ChangeNotifier {
   static const _hostsKey = 'helios_hosts';
   static const _activeHostKey = 'helios_active_host_id';
 
-
   final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
 
   List<HostConnection> _hosts = [];
@@ -102,14 +101,18 @@ class HostManager extends ChangeNotifier {
       final raw = await _secureStorage.read(key: _hostsKey);
       if (raw != null) {
         final list = jsonDecode(raw) as List;
-        _hosts = list.map((h) => HostConnection.fromJson(h as Map<String, dynamic>)).toList();
+        _hosts = list
+            .map((h) => HostConnection.fromJson(h as Map<String, dynamic>))
+            .toList();
       }
 
       final prefs = await SharedPreferences.getInstance();
       _activeHostId = prefs.getString(_activeHostKey);
 
       // If active host was removed or never set, default to first host
-      if (_activeHostId == null || _activeHostId!.isEmpty || !_hosts.any((h) => h.id == _activeHostId)) {
+      if (_activeHostId == null ||
+          _activeHostId!.isEmpty ||
+          !_hosts.any((h) => h.id == _activeHostId)) {
         _activeHostId = _hosts.isNotEmpty ? _hosts.first.id : null;
         if (_activeHostId != null) {
           await prefs.setString(_activeHostKey, _activeHostId!);
@@ -128,7 +131,9 @@ class HostManager extends ChangeNotifier {
   }
 
   Future<void> _startServiceFor(HostConnection host) async {
-    final seedB64 = await _secureStorage.read(key: 'helios_host_${host.id}_key');
+    final seedB64 = await _secureStorage.read(
+      key: 'helios_host_${host.id}_key',
+    );
     if (seedB64 == null) return;
 
     final seed = _base64urlDecode(seedB64);
@@ -187,7 +192,9 @@ class HostManager extends ChangeNotifier {
 
       // 3. Get public key
       final publicKey = await keyPair.extractPublicKey();
-      final publicKeyB64 = _base64urlEncode(Uint8List.fromList(publicKey.bytes));
+      final publicKeyB64 = _base64urlEncode(
+        Uint8List.fromList(publicKey.bytes),
+      );
 
       // 4. Pair device
       onStatus?.call('Registering device...');
@@ -226,7 +233,9 @@ class HostManager extends ChangeNotifier {
             'Generate a new QR from the terminal with: helios start',
           );
         }
-        return SetupResult.error(pairData['message'] ?? 'Failed to register device');
+        return SetupResult.error(
+          pairData['message'] ?? 'Failed to register device',
+        );
       }
 
       // 5. Store private key seed
@@ -252,7 +261,10 @@ class HostManager extends ChangeNotifier {
       }
 
       // 8. Approved — now create and persist the host
-      final nextColorIndex = _hosts.isEmpty ? 0 : (_hosts.map((h) => h.colorIndex).reduce((a, b) => a > b ? a : b) + 1);
+      final nextColorIndex = _hosts.isEmpty
+          ? 0
+          : (_hosts.map((h) => h.colorIndex).reduce((a, b) => a > b ? a : b) +
+                1);
       final host = HostConnection(
         id: const Uuid().v4(),
         label: 'Host ${_hosts.length + 1}',
@@ -262,7 +274,10 @@ class HostManager extends ChangeNotifier {
         addedAt: DateTime.now(),
       );
 
-      await _secureStorage.write(key: 'helios_host_${host.id}_key', value: _base64urlEncode(seed));
+      await _secureStorage.write(
+        key: 'helios_host_${host.id}_key',
+        value: _base64urlEncode(seed),
+      );
       _hosts.add(host);
       await _saveHosts();
 
@@ -283,7 +298,9 @@ class HostManager extends ChangeNotifier {
       _pendingDeviceId = null;
       notifyListeners();
       final msg = e.toString();
-      if (msg.contains('SocketException') || msg.contains('ClientException') || msg.contains('Connection')) {
+      if (msg.contains('SocketException') ||
+          msg.contains('ClientException') ||
+          msg.contains('Connection')) {
         return SetupResult.error(_unreachableMessage(serverUrl));
       }
       return SetupResult.error('Setup failed: $e');
@@ -418,7 +435,10 @@ class HostManager extends ChangeNotifier {
       // Every host, not just the active one: a background host's approvals are
       // the ones most likely to have been answered elsewhere while the app was
       // suspended, and the reconcile sweep only runs on fetch.
-      _sseEvents.add((hostId: host.id, event: SSEEvent('notification_resolved', const {})));
+      _sseEvents.add((
+        hostId: host.id,
+        event: SSEEvent('notification_resolved', const {}),
+      ));
       final isActive = host.id == _activeHostId;
       await service.resume(asActiveHost: isActive);
     }
@@ -431,11 +451,18 @@ class HostManager extends ChangeNotifier {
     await _secureStorage.write(key: _hostsKey, value: json);
   }
 
-
-Future<bool> _waitForApproval(String serverUrl, SimpleKeyPair keyPair, String deviceId) async {
+  Future<bool> _waitForApproval(
+    String serverUrl,
+    SimpleKeyPair keyPair,
+    String deviceId,
+  ) async {
     final extractedSeed = await keyPair.extractPrivateKeyBytes();
     final seed = Uint8List.fromList(extractedSeed.sublist(0, 32));
-    final api = ApiClient(serverUrl: serverUrl, deviceId: deviceId, privateKeySeed: seed);
+    final api = ApiClient(
+      serverUrl: serverUrl,
+      deviceId: deviceId,
+      privateKeySeed: seed,
+    );
     const maxAttempts = 150; // 5 minutes at 2s intervals
     for (var i = 0; i < maxAttempts; i++) {
       await Future.delayed(const Duration(seconds: 2));
@@ -456,7 +483,11 @@ Future<bool> _waitForApproval(String serverUrl, SimpleKeyPair keyPair, String de
     return false;
   }
 
-  Future<void> _updateDeviceMetadata(String serverUrl, SimpleKeyPair keyPair, String deviceId) async {
+  Future<void> _updateDeviceMetadata(
+    String serverUrl,
+    SimpleKeyPair keyPair,
+    String deviceId,
+  ) async {
     String platform;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
@@ -474,12 +505,15 @@ Future<bool> _waitForApproval(String serverUrl, SimpleKeyPair keyPair, String de
     try {
       final extractedSeed = await keyPair.extractPrivateKeyBytes();
       final seed = Uint8List.fromList(extractedSeed.sublist(0, 32));
-      final api = ApiClient(serverUrl: serverUrl, deviceId: deviceId, privateKeySeed: seed);
-      await api.post('/api/auth/device/me', body: {
-        'name': name,
-        'platform': platform,
-        'browser': 'Helios App',
-      });
+      final api = ApiClient(
+        serverUrl: serverUrl,
+        deviceId: deviceId,
+        privateKeySeed: seed,
+      );
+      await api.post(
+        '/api/auth/device/me',
+        body: {'name': name, 'platform': platform, 'browser': 'Helios App'},
+      );
     } catch (_) {
       // Best effort
     }

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -5,7 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Callback for when a notification action (approve/deny) is tapped.
-typedef NotificationActionCallback = void Function(String notificationId, String action);
+typedef NotificationActionCallback =
+    void Function(String notificationId, String action);
 
 class NotificationService {
   NotificationService._();
@@ -29,13 +30,13 @@ class NotificationService {
   /// answer something — which is the same question whoever raised it. Keying
   /// on kind means a new provider needs no new rows and no new defaults.
   static const Map<String, bool> _defaultAlertTypes = {
-    'permission':       true,
-    'question':         true,
+    'permission': true,
+    'question': true,
     'elicitation.form': true,
-    'elicitation.url':  true,
-    'trust':            true,
-    'done':             true,
-    'error':            true,
+    'elicitation.url': true,
+    'trust': true,
+    'done': true,
+    'error': true,
   };
 
   bool _soundEnabled = true;
@@ -185,14 +186,18 @@ class NotificationService {
         final decoded = jsonDecode(alertJson) as Map<String, dynamic>;
         _alertTypes = {
           ..._defaultAlertTypes,
-          ...migrateLegacyAlertKeys(decoded.map((k, v) => MapEntry(k, v as bool))),
+          ...migrateLegacyAlertKeys(
+            decoded.map((k, v) => MapEntry(k, v as bool)),
+          ),
         };
       } catch (_) {
         _alertTypes = Map.of(_defaultAlertTypes);
       }
     }
 
-    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const androidSettings = AndroidInitializationSettings(
+      '@mipmap/ic_launcher',
+    );
     const darwinSettings = DarwinInitializationSettings(
       requestAlertPermission: true,
       requestBadgePermission: true,
@@ -208,17 +213,25 @@ class NotificationService {
       onDidReceiveNotificationResponse: _onResponse,
     );
 
-    final android = _plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
     if (android != null) {
       // Clean up all old channel IDs.
       for (final old in [
-        'helios_permissions', 'helios_general',
-        'helios_perm_v2', 'helios_general_v2',
-        'helios_perm_v3', 'helios_general_v3',
-        'helios_perm_v4', 'helios_general_v4',
-        'helios_perm_v5', 'helios_general_v5',
-        'helios_perm_v6', 'helios_general_v6',
+        'helios_permissions',
+        'helios_general',
+        'helios_perm_v2',
+        'helios_general_v2',
+        'helios_perm_v3',
+        'helios_general_v3',
+        'helios_perm_v4',
+        'helios_general_v4',
+        'helios_perm_v5',
+        'helios_general_v5',
+        'helios_perm_v6',
+        'helios_general_v6',
       ]) {
         await android.deleteNotificationChannel(old);
       }
@@ -245,51 +258,71 @@ class NotificationService {
       });
       debugPrint('[NotificationService] Native channels created');
     } on MissingPluginException {
-      debugPrint('[NotificationService] Native channel creation not available, using plugin');
+      debugPrint(
+        '[NotificationService] Native channel creation not available, using plugin',
+      );
       // Fallback to plugin-based channel creation.
       if (android != null) {
         await android.deleteNotificationChannel(_permChannel);
         await android.deleteNotificationChannel(_generalChannel);
 
-        await android.createNotificationChannel(AndroidNotificationChannel(
-          _permChannel,
-          'Permission Requests',
-          description: 'Claude tool permission requests',
-          importance: Importance.max,
-          playSound: false,
-          enableVibration: false,
-        ));
-        await android.createNotificationChannel(AndroidNotificationChannel(
-          _generalChannel,
-          'General',
-          description: 'General helios notifications',
-          importance: Importance.max,
-          playSound: false,
-          enableVibration: false,
-        ));
+        await android.createNotificationChannel(
+          AndroidNotificationChannel(
+            _permChannel,
+            'Permission Requests',
+            description: 'Claude tool permission requests',
+            importance: Importance.max,
+            playSound: false,
+            enableVibration: false,
+          ),
+        );
+        await android.createNotificationChannel(
+          AndroidNotificationChannel(
+            _generalChannel,
+            'General',
+            description: 'General helios notifications',
+            importance: Importance.max,
+            playSound: false,
+            enableVibration: false,
+          ),
+        );
       }
     }
   }
 
   Future<bool> requestPermission() async {
-    final android = _plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
     if (android != null) {
       final granted = await android.requestNotificationsPermission();
       return granted ?? false;
     }
 
-    final ios = _plugin.resolvePlatformSpecificImplementation<
-        IOSFlutterLocalNotificationsPlugin>();
+    final ios = _plugin
+        .resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin
+        >();
     if (ios != null) {
-      final granted = await ios.requestPermissions(alert: true, badge: true, sound: true);
+      final granted = await ios.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
       return granted ?? false;
     }
 
-    final macos = _plugin.resolvePlatformSpecificImplementation<
-        MacOSFlutterLocalNotificationsPlugin>();
+    final macos = _plugin
+        .resolvePlatformSpecificImplementation<
+          MacOSFlutterLocalNotificationsPlugin
+        >();
     if (macos != null) {
-      final granted = await macos.requestPermissions(alert: true, badge: true, sound: true);
+      final granted = await macos.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
       return granted ?? false;
     }
 
@@ -305,7 +338,9 @@ class NotificationService {
     bool silent = false,
   }) async {
     final nid = _notifId(id);
-    debugPrint('[NotificationService] showPermission id=$id nid=$nid tool=$toolName');
+    debugPrint(
+      '[NotificationService] showPermission id=$id nid=$nid tool=$toolName',
+    );
 
     final androidDetails = AndroidNotificationDetails(
       _permChannel,
@@ -318,8 +353,16 @@ class NotificationService {
       fullScreenIntent: true,
       category: AndroidNotificationCategory.alarm,
       actions: [
-        const AndroidNotificationAction('approve', 'Approve', showsUserInterface: true),
-        const AndroidNotificationAction('deny', 'Deny', showsUserInterface: true),
+        const AndroidNotificationAction(
+          'approve',
+          'Approve',
+          showsUserInterface: true,
+        ),
+        const AndroidNotificationAction(
+          'deny',
+          'Deny',
+          showsUserInterface: true,
+        ),
       ],
     );
 
@@ -355,7 +398,9 @@ class NotificationService {
     bool silent = false,
   }) async {
     final nid = _notifId(id);
-    debugPrint('[NotificationService] showNotification id=$id nid=$nid title=$title');
+    debugPrint(
+      '[NotificationService] showNotification id=$id nid=$nid title=$title',
+    );
 
     final androidDetails = AndroidNotificationDetails(
       _generalChannel,

--- a/mobile/lib/services/terminal/frames.dart
+++ b/mobile/lib/services/terminal/frames.dart
@@ -65,12 +65,12 @@ class TerminalStatus {
   });
 
   factory TerminalStatus.fromJson(Map<String, dynamic> json) => TerminalStatus(
-        state: json['state'] as String? ?? 'ready',
-        viewers: (json['viewers'] as num?)?.toInt() ?? 0,
-        cols: (json['cols'] as num?)?.toInt() ?? 0,
-        rows: (json['rows'] as num?)?.toInt() ?? 0,
-        writer: json['writer'] as String?,
-      );
+    state: json['state'] as String? ?? 'ready',
+    viewers: (json['viewers'] as num?)?.toInt() ?? 0,
+    cols: (json['cols'] as num?)?.toInt() ?? 0,
+    rows: (json['rows'] as num?)?.toInt() ?? 0,
+    writer: json['writer'] as String?,
+  );
 
   final String state;
   final int viewers;
@@ -103,14 +103,13 @@ Uint8List encodeHello({
   required int rows,
   int since = 0,
   String? name,
-}) =>
-    encodeJsonFrame(FrameType.hello, {
-      'role': role,
-      'cols': cols,
-      'rows': rows,
-      'since': since,
-      if (name != null && name.isNotEmpty) 'name': name,
-    });
+}) => encodeJsonFrame(FrameType.hello, {
+  'role': role,
+  'cols': cols,
+  'rows': rows,
+  'since': since,
+  if (name != null && name.isNotEmpty) 'name': name,
+});
 
 Uint8List encodeResize(int cols, int rows) {
   final out = Uint8List(4);
@@ -141,10 +140,7 @@ Uint8List encodeSnapshot(int seq, Uint8List ansi) {
     throw const FormatException('terminal: snapshot payload too short');
   }
   final view = ByteData.view(payload.buffer, payload.offsetInBytes);
-  return (
-    seq: view.getUint64(0),
-    ansi: Uint8List.sublistView(payload, 8),
-  );
+  return (seq: view.getUint64(0), ansi: Uint8List.sublistView(payload, 8));
 }
 
 int decodeExit(Uint8List payload) {
@@ -154,8 +150,9 @@ int decodeExit(Uint8List payload) {
   return ByteData.view(payload.buffer, payload.offsetInBytes).getInt32(0);
 }
 
-TerminalStatus decodeStatus(Uint8List payload) =>
-    TerminalStatus.fromJson(jsonDecode(utf8.decode(payload)) as Map<String, dynamic>);
+TerminalStatus decodeStatus(Uint8List payload) => TerminalStatus.fromJson(
+  jsonDecode(utf8.decode(payload)) as Map<String, dynamic>,
+);
 
 /// Reassembles frames from a byte stream, which arrives in whatever chunks the
 /// socket felt like: a frame can span several, and one chunk can hold many.
@@ -178,10 +175,12 @@ class FrameParser {
       final total = 4 + length;
       if (_buffer.length < total) break;
 
-      frames.add(Frame(
-        _buffer[4],
-        Uint8List.fromList(_buffer.sublist(headerSize, total)),
-      ));
+      frames.add(
+        Frame(
+          _buffer[4],
+          Uint8List.fromList(_buffer.sublist(headerSize, total)),
+        ),
+      );
       _buffer.removeRange(0, total);
     }
     return frames;

--- a/mobile/lib/services/terminal/terminal_connection.dart
+++ b/mobile/lib/services/terminal/terminal_connection.dart
@@ -120,13 +120,9 @@ class TerminalConnection {
   }
 
   void _sendHello() {
-    _write(encodeHello(
-      role: role,
-      cols: cols,
-      rows: rows,
-      since: _seq,
-      name: name,
-    ));
+    _write(
+      encodeHello(role: role, cols: cols, rows: rows, since: _seq, name: name),
+    );
     _sentCols = cols;
     _sentRows = rows;
   }
@@ -228,10 +224,14 @@ class TerminalConnection {
     if (_closed) return;
     _teardown();
     if (_reconnectTimer != null) return;
-    final delay = _reconnectDelays[
-        _attempt < _reconnectDelays.length ? _attempt : _reconnectDelays.length - 1];
+    final delay =
+        _reconnectDelays[_attempt < _reconnectDelays.length
+            ? _attempt
+            : _reconnectDelays.length - 1];
     _attempt++;
-    debugPrint('[Terminal] $terminalId dropped: $reason — retrying in ${delay.inMilliseconds}ms');
+    debugPrint(
+      '[Terminal] $terminalId dropped: $reason — retrying in ${delay.inMilliseconds}ms',
+    );
     _emitState(LinkState.reconnecting);
     _reconnectTimer = Timer(delay, () {
       _reconnectTimer = null;

--- a/mobile/lib/services/update_service.dart
+++ b/mobile/lib/services/update_service.dart
@@ -24,7 +24,11 @@ class ReleaseNote {
   final String body;
   final DateTime? publishedAt;
 
-  const ReleaseNote({required this.version, required this.body, this.publishedAt});
+  const ReleaseNote({
+    required this.version,
+    required this.body,
+    this.publishedAt,
+  });
 }
 
 class UpdateInfo {
@@ -75,14 +79,18 @@ class UpdateService {
   Future<UpdateInfo?> checkForUpdate() async {
     try {
       final res = await http
-          .get(Uri.parse(_apiUrl), headers: {'Accept': 'application/vnd.github+json'})
+          .get(
+            Uri.parse(_apiUrl),
+            headers: {'Accept': 'application/vnd.github+json'},
+          )
           .timeout(const Duration(seconds: 10));
       if (res.statusCode != 200) {
         debugPrint('[UpdateService] github said ${res.statusCode}');
         return null;
       }
 
-      final payload = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
+      final payload = (jsonDecode(res.body) as List)
+          .cast<Map<String, dynamic>>();
       // A draft is not published and a prerelease is not for everyone; neither
       // is news the reader can act on.
       final published = payload
@@ -122,15 +130,27 @@ class UpdateService {
 
   // Android: downloads APK to cache and opens system installer.
   // Desktop: opens releases page in browser.
-  Future<void> install(UpdateInfo info, {void Function(double)? onProgress}) async {
+  Future<void> install(
+    UpdateInfo info, {
+    void Function(double)? onProgress,
+  }) async {
     if (info.canDirectInstall) {
-      await _downloadAndInstallApk(info.apkDownloadUrl!, onProgress: onProgress);
+      await _downloadAndInstallApk(
+        info.apkDownloadUrl!,
+        onProgress: onProgress,
+      );
     } else {
-      await launchUrl(Uri.parse(info.releasesPageUrl), mode: LaunchMode.externalApplication);
+      await launchUrl(
+        Uri.parse(info.releasesPageUrl),
+        mode: LaunchMode.externalApplication,
+      );
     }
   }
 
-  Future<void> _downloadAndInstallApk(String url, {void Function(double)? onProgress}) async {
+  Future<void> _downloadAndInstallApk(
+    String url, {
+    void Function(double)? onProgress,
+  }) async {
     final dir = await getTemporaryDirectory();
     final file = File('${dir.path}/helios-update.apk');
 
@@ -186,7 +206,11 @@ class UpdateService {
     String current,
   ) {
     final newer = releases.where((r) => isNewer(_tagOf(r), current)).toList();
-    newer.sort((a, b) => isNewer(_tagOf(a), _tagOf(b)) ? -1 : (isNewer(_tagOf(b), _tagOf(a)) ? 1 : 0));
+    newer.sort(
+      (a, b) => isNewer(_tagOf(a), _tagOf(b))
+          ? -1
+          : (isNewer(_tagOf(b), _tagOf(a)) ? 1 : 0),
+    );
     return newer;
   }
 
@@ -202,6 +226,9 @@ class UpdateService {
   /// Leading digits of each dotted component; anything else counts as zero.
   List<int> _parts(String version) => version
       .split('.')
-      .map((part) => int.tryParse(RegExp(r'^\d+').firstMatch(part)?.group(0) ?? '') ?? 0)
+      .map(
+        (part) =>
+            int.tryParse(RegExp(r'^\d+').firstMatch(part)?.group(0) ?? '') ?? 0,
+      )
       .toList();
 }

--- a/mobile/lib/utils/large_paste.dart
+++ b/mobile/lib/utils/large_paste.dart
@@ -12,7 +12,8 @@ const int largePasteChars = 2000;
 const int largePasteLines = 50;
 
 bool isLargePaste(String text) =>
-    text.length >= largePasteChars || '\n'.allMatches(text).length + 1 >= largePasteLines;
+    text.length >= largePasteChars ||
+    '\n'.allMatches(text).length + 1 >= largePasteLines;
 
 /// The text inserted in one edit, or null when the change was not a single
 /// insertion.

--- a/mobile/lib/utils/preview_assets.dart
+++ b/mobile/lib/utils/preview_assets.dart
@@ -93,7 +93,11 @@ String? resolveAsset(String basePath, String href, String root) {
 
 /// Which references to read, in order, within the caps. Deduped by path: a page
 /// that uses one icon forty times is one read.
-List<PlannedAsset> planAssets(List<AssetRef> refs, String basePath, String root) {
+List<PlannedAsset> planAssets(
+  List<AssetRef> refs,
+  String basePath,
+  String root,
+) {
   final seen = <String>{};
   final planned = <PlannedAsset>[];
 

--- a/mobile/lib/widgets/html_preview.dart
+++ b/mobile/lib/widgets/html_preview.dart
@@ -69,7 +69,9 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
   @override
   void didUpdateWidget(HtmlPreview old) {
     super.didUpdateWidget(old);
-    if (old.html != widget.html || old.path != widget.path || old.scripts != widget.scripts) {
+    if (old.html != widget.html ||
+        old.path != widget.path ||
+        old.scripts != widget.scripts) {
       unawaited(_prepare());
     }
   }
@@ -85,7 +87,9 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
         // Off unless asked for. On, the page can compute and draw and has
         // nowhere to send anything — see the policy injected above.
         ..setJavaScriptMode(
-          widget.scripts ? JavaScriptMode.unrestricted : JavaScriptMode.disabled,
+          widget.scripts
+              ? JavaScriptMode.unrestricted
+              : JavaScriptMode.disabled,
         )
         ..setBackgroundColor(Colors.white)
         ..setNavigationDelegate(
@@ -110,11 +114,17 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
     final images = document.querySelectorAll('img[src]');
     final sheets = document
         .querySelectorAll('link[href]')
-        .where((el) => (el.attributes['rel'] ?? '').split(RegExp(r'\s+')).contains('stylesheet'))
+        .where(
+          (el) => (el.attributes['rel'] ?? '')
+              .split(RegExp(r'\s+'))
+              .contains('stylesheet'),
+        )
         .toList();
 
     // A local script is only worth fetching if it will be allowed to run.
-    final code = widget.scripts ? document.querySelectorAll('script[src]') : <dom.Element>[];
+    final code = widget.scripts
+        ? document.querySelectorAll('script[src]')
+        : <dom.Element>[];
 
     final refs = <AssetRef>[
       for (final el in images) AssetRef('img', el.attributes['src'] ?? ''),
@@ -128,7 +138,9 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
     final loaded = <String, FileReadResult>{};
     var spent = 0;
     for (final asset in planned) {
-      final file = await ref.read(readFileProvider((widget.hostId, asset.path)).future);
+      final file = await ref.read(
+        readFileProvider((widget.hostId, asset.path)).future,
+      );
       // A page that names a file the agent has since deleted still renders;
       // the reference simply goes unresolved.
       if (file?.content == null) continue;
@@ -146,7 +158,8 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
       final asset = matches.first;
 
       if (file.encoding == 'base64') {
-        el.attributes['src'] = 'data:${mimeForPath(asset.path)};base64,${file.content}';
+        el.attributes['src'] =
+            'data:${mimeForPath(asset.path)};base64,${file.content}';
       } else if (mimeForPath(asset.path) == 'image/svg+xml') {
         // An SVG is text and arrives as text; anything else that is not base64
         // came from a daemon too old to send bytes, and is already lost.
@@ -184,14 +197,18 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
     // The page's own <meta http-equiv> goes whatever happens: it could carry a
     // policy of its own, and the one this installs below has to be the only one.
     const always = 'iframe, object, embed, form, base, meta[http-equiv]';
-    for (final el in document.querySelectorAll(widget.scripts ? always : 'script, $always')) {
+    for (final el in document.querySelectorAll(
+      widget.scripts ? always : 'script, $always',
+    )) {
       el.remove();
     }
 
     // Anything still pointing at a scheme after the inlining above is remote:
     // an image on a CDN, a font, a tracking pixel. It is dropped rather than
     // left to be fetched the moment the page loads.
-    for (final el in document.querySelectorAll('[src], [href], [srcset], [poster], [data]')) {
+    for (final el in document.querySelectorAll(
+      '[src], [href], [srcset], [poster], [data]',
+    )) {
       for (final name in const ['src', 'href', 'srcset', 'poster', 'data']) {
         final value = el.attributes[name];
         if (value == null) continue;
@@ -248,10 +265,14 @@ class _HtmlPreviewState extends rp.ConsumerState<HtmlPreview> {
       );
     }
     final controller = _controller;
-    if (controller == null) return const Center(child: CircularProgressIndicator());
+    if (controller == null)
+      return const Center(child: CircularProgressIndicator());
 
     // White behind it, because a document assumes paper. A dark app around a
     // page written for a browser would misrepresent it.
-    return Container(color: Colors.white, child: WebViewWidget(controller: controller));
+    return Container(
+      color: Colors.white,
+      child: WebViewWidget(controller: controller),
+    );
   }
 }

--- a/mobile/lib/widgets/mermaid_diagram.dart
+++ b/mobile/lib/widgets/mermaid_diagram.dart
@@ -87,7 +87,9 @@ class _MermaidDiagramState extends State<MermaidDiagram> {
       ..setBackgroundColor(Colors.transparent)
       ..addJavaScriptChannel('HeliosMermaid', onMessageReceived: _onDrawn)
       ..setNavigationDelegate(
-        NavigationDelegate(onNavigationRequest: (_) => NavigationDecision.prevent),
+        NavigationDelegate(
+          onNavigationRequest: (_) => NavigationDecision.prevent,
+        ),
       )
       ..loadHtmlString(_document(library));
 

--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -55,7 +55,9 @@ class _UserMessageCard extends StatelessWidget {
       child: GestureDetector(
         onLongPress: () => _copyToClipboard(context, content),
         child: Container(
-          constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.8),
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width * 0.8,
+          ),
           margin: const EdgeInsets.only(bottom: 8),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
@@ -128,10 +130,15 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
       // If the first segment of the relative path matches the last segment of
       // sessionCwd (e.g. cwd=".../helios/mobile" and path="mobile/lib/..."),
       // strip that duplicate segment.
-      final cwdLastSegment = widget.sessionCwd.split('/').where((s) => s.isNotEmpty).lastOrNull ?? '';
+      final cwdLastSegment =
+          widget.sessionCwd.split('/').where((s) => s.isNotEmpty).lastOrNull ??
+          '';
       final firstSegment = path.split('/').first;
       if (cwdLastSegment.isNotEmpty && firstSegment == cwdLastSegment) {
-        final parent = widget.sessionCwd.substring(0, widget.sessionCwd.lastIndexOf('/'));
+        final parent = widget.sessionCwd.substring(
+          0,
+          widget.sessionCwd.lastIndexOf('/'),
+        );
         resolvedPath = '$parent/$path';
       } else {
         resolvedPath = '${widget.sessionCwd}/$path';
@@ -158,12 +165,16 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
     final content = widget.message.content ?? '';
     if (content.isEmpty) return const SizedBox.shrink();
 
-    final filePaths = widget.hostId.isNotEmpty ? _extractFilePaths(content) : <String>[];
+    final filePaths = widget.hostId.isNotEmpty
+        ? _extractFilePaths(content)
+        : <String>[];
 
     return Align(
       alignment: Alignment.centerLeft,
       child: Container(
-        constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.85),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.85,
+        ),
         margin: const EdgeInsets.only(bottom: 8),
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         decoration: BoxDecoration(
@@ -188,56 +199,80 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
                 ),
               },
               styleSheet: MarkdownStyleSheet(
-                  p: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
-                  a: TextStyle(
-                    fontSize: 14,
-                    color: theme.colorScheme.primary,
-                    decoration: TextDecoration.underline,
-                    decorationColor: theme.colorScheme.primary,
-                  ),
-                  code: TextStyle(
-                    fontSize: 12,
-                    fontFamily: 'monospace',
-                    color: theme.colorScheme.onSurface,
-                    backgroundColor: theme.colorScheme.surfaceContainerHigh,
-                  ),
-                  codeblockDecoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHigh,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  codeblockPadding: const EdgeInsets.all(10),
-                  blockquoteDecoration: BoxDecoration(
-                    border: Border(
-                      left: BorderSide(color: theme.colorScheme.primary, width: 3),
+                p: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+                a: TextStyle(
+                  fontSize: 14,
+                  color: theme.colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                  decorationColor: theme.colorScheme.primary,
+                ),
+                code: TextStyle(
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.onSurface,
+                  backgroundColor: theme.colorScheme.surfaceContainerHigh,
+                ),
+                codeblockDecoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHigh,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                codeblockPadding: const EdgeInsets.all(10),
+                blockquoteDecoration: BoxDecoration(
+                  border: Border(
+                    left: BorderSide(
+                      color: theme.colorScheme.primary,
+                      width: 3,
                     ),
                   ),
-                  blockquotePadding: const EdgeInsets.only(left: 12, top: 4, bottom: 4),
-                  h1: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: theme.colorScheme.onSurface),
-                  h2: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: theme.colorScheme.onSurface),
-                  h3: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: theme.colorScheme.onSurface),
-                  listBullet: TextStyle(fontSize: 14, color: theme.colorScheme.onSurface),
+                ),
+                blockquotePadding: const EdgeInsets.only(
+                  left: 12,
+                  top: 4,
+                  bottom: 4,
+                ),
+                h1: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.onSurface,
+                ),
+                h2: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.onSurface,
+                ),
+                h3: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurface,
+                ),
+                listBullet: TextStyle(
+                  fontSize: 14,
+                  color: theme.colorScheme.onSurface,
                 ),
               ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  GestureDetector(
-                    onTap: () => _copyToClipboard(context, content),
-                    child: Padding(
-                      padding: const EdgeInsets.only(top: 4, right: 8),
-                      child: Icon(
-                        Icons.copy,
-                        size: 14,
-                        color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                GestureDetector(
+                  onTap: () => _copyToClipboard(context, content),
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 4, right: 8),
+                    child: Icon(
+                      Icons.copy,
+                      size: 14,
+                      color: theme.colorScheme.onSurfaceVariant.withValues(
+                        alpha: 0.6,
                       ),
                     ),
                   ),
-                ],
-              ),
-              // File path chips — SelectionContainer.disabled so taps aren't absorbed by MarkdownBody's selection area
-              if (filePaths.isNotEmpty) ...[
-                const SizedBox(height: 8),
-                SelectionContainer.disabled(
+                ),
+              ],
+            ),
+            // File path chips — SelectionContainer.disabled so taps aren't absorbed by MarkdownBody's selection area
+            if (filePaths.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              SelectionContainer.disabled(
                 child: Wrap(
                   spacing: 6,
                   runSpacing: 4,
@@ -247,18 +282,30 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
                     return GestureDetector(
                       onTap: () => _openFilePath(path),
                       child: Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
                         decoration: BoxDecoration(
-                          color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.6),
+                          color: theme.colorScheme.secondaryContainer
+                              .withValues(alpha: 0.6),
                           borderRadius: BorderRadius.circular(6),
                           border: Border.all(
-                            color: theme.colorScheme.secondary.withValues(alpha: 0.3),
+                            color: theme.colorScheme.secondary.withValues(
+                              alpha: 0.3,
+                            ),
                           ),
                         ),
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Icon(isDir ? Icons.folder : Icons.insert_drive_file, size: 12, color: isDir ? Colors.amber.shade700 : theme.colorScheme.secondary),
+                            Icon(
+                              isDir ? Icons.folder : Icons.insert_drive_file,
+                              size: 12,
+                              color: isDir
+                                  ? Colors.amber.shade700
+                                  : theme.colorScheme.secondary,
+                            ),
                             const SizedBox(width: 4),
                             Flexible(
                               child: Text(
@@ -277,11 +324,11 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
                     );
                   }).toList(),
                 ),
-                ),
-              ],
+              ),
             ],
-          ),
+          ],
         ),
+      ),
     );
   }
 }
@@ -335,7 +382,8 @@ class _ToolUseCardState extends State<_ToolUseCard> {
                     color: theme.colorScheme.tertiary,
                   ),
                 ),
-                if (widget.message.summary != null && widget.message.summary!.isNotEmpty) ...[
+                if (widget.message.summary != null &&
+                    widget.message.summary!.isNotEmpty) ...[
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -367,7 +415,11 @@ class _ToolUseCardState extends State<_ToolUseCard> {
     );
   }
 
-  Widget _buildExpandedContent(BuildContext context, ThemeData theme, Map<String, dynamic> meta) {
+  Widget _buildExpandedContent(
+    BuildContext context,
+    ThemeData theme,
+    Map<String, dynamic> meta,
+  ) {
     final tool = widget.message.tool ?? '';
     final isDark = theme.brightness == Brightness.dark;
 
@@ -381,9 +433,19 @@ class _ToolUseCardState extends State<_ToolUseCard> {
       final widgets = <Widget>[];
 
       // Show non-content fields as plain text first (e.g. old_string label)
-      final contentKeys = {'content', 'new_string', 'old_string', 'new_content'};
+      final contentKeys = {
+        'content',
+        'new_string',
+        'old_string',
+        'new_content',
+      };
       final otherFields = meta.entries
-          .where((e) => !contentKeys.contains(e.key) && e.key != 'file_path' && e.key != 'path')
+          .where(
+            (e) =>
+                !contentKeys.contains(e.key) &&
+                e.key != 'file_path' &&
+                e.key != 'path',
+          )
           .toList();
       if (otherFields.isNotEmpty) {
         final plain = otherFields.map((e) => '${e.key}: ${e.value}').join('\n');
@@ -392,24 +454,41 @@ class _ToolUseCardState extends State<_ToolUseCard> {
             padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
             child: SelectableText(
               plain,
-              style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurfaceVariant),
+              style: TextStyle(
+                fontSize: 11,
+                fontFamily: 'monospace',
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         );
       }
 
       // Render each content field with syntax highlighting
-      for (final key in ['content', 'new_content', 'new_string', 'old_string']) {
+      for (final key in [
+        'content',
+        'new_content',
+        'new_string',
+        'old_string',
+      ]) {
         final value = meta[key];
         if (value is! String || value.isEmpty) continue;
-        final label = key == 'new_string' ? 'new' : key == 'old_string' ? 'old' : null;
+        final label = key == 'new_string'
+            ? 'new'
+            : key == 'old_string'
+            ? 'old'
+            : null;
         if (label != null) {
           widgets.add(
             Padding(
               padding: const EdgeInsets.fromLTRB(8, 4, 8, 0),
               child: Text(
                 label,
-                style: TextStyle(fontSize: 10, color: theme.colorScheme.onSurfaceVariant, fontWeight: FontWeight.w600),
+                style: TextStyle(
+                  fontSize: 10,
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           );
@@ -422,7 +501,11 @@ class _ToolUseCardState extends State<_ToolUseCard> {
               language: language ?? 'plaintext',
               theme: isDark ? atomOneDarkTheme : atomOneLightTheme,
               padding: const EdgeInsets.all(8),
-              textStyle: const TextStyle(fontSize: 11, fontFamily: 'monospace', height: 1.4),
+              textStyle: const TextStyle(
+                fontSize: 11,
+                fontFamily: 'monospace',
+                height: 1.4,
+              ),
             ),
           ),
         );
@@ -454,7 +537,11 @@ class _ToolUseCardState extends State<_ToolUseCard> {
             language: 'bash',
             theme: isDark ? atomOneDarkTheme : atomOneLightTheme,
             padding: const EdgeInsets.all(8),
-            textStyle: const TextStyle(fontSize: 11, fontFamily: 'monospace', height: 1.4),
+            textStyle: const TextStyle(
+              fontSize: 11,
+              fontFamily: 'monospace',
+              height: 1.4,
+            ),
           ),
         );
       }
@@ -464,7 +551,11 @@ class _ToolUseCardState extends State<_ToolUseCard> {
     final lines = <String>[];
     for (final MapEntry(:key, :value) in meta.entries) {
       if (value is String) {
-        lines.add(value.length > 500 ? '$key: ${value.substring(0, 500)}...' : '$key: $value');
+        lines.add(
+          value.length > 500
+              ? '$key: ${value.substring(0, 500)}...'
+              : '$key: $value',
+        );
       } else {
         lines.add('$key: $value');
       }
@@ -478,38 +569,72 @@ class _ToolUseCardState extends State<_ToolUseCard> {
       ),
       child: SelectableText(
         lines.join('\n'),
-        style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: theme.colorScheme.onSurface),
+        style: TextStyle(
+          fontSize: 11,
+          fontFamily: 'monospace',
+          color: theme.colorScheme.onSurface,
+        ),
       ),
     );
   }
 
   String? _langForExt(String ext) {
     switch (ext) {
-      case 'dart': return 'dart';
-      case 'go': return 'go';
-      case 'py': return 'python';
-      case 'js': return 'javascript';
-      case 'ts': case 'tsx': return 'typescript';
-      case 'jsx': return 'javascript';
-      case 'java': return 'java';
-      case 'kt': return 'kotlin';
-      case 'swift': return 'swift';
-      case 'rs': return 'rust';
-      case 'c': case 'h': return 'c';
-      case 'cpp': return 'cpp';
-      case 'cs': return 'cs';
-      case 'rb': return 'ruby';
-      case 'sh': case 'bash': case 'zsh': return 'bash';
-      case 'json': return 'json';
-      case 'yaml': case 'yml': return 'yaml';
-      case 'toml': return 'ini';
-      case 'xml': return 'xml';
-      case 'html': return 'html';
-      case 'css': return 'css';
-      case 'scss': return 'scss';
-      case 'sql': return 'sql';
-      case 'md': return 'markdown';
-      default: return null;
+      case 'dart':
+        return 'dart';
+      case 'go':
+        return 'go';
+      case 'py':
+        return 'python';
+      case 'js':
+        return 'javascript';
+      case 'ts':
+      case 'tsx':
+        return 'typescript';
+      case 'jsx':
+        return 'javascript';
+      case 'java':
+        return 'java';
+      case 'kt':
+        return 'kotlin';
+      case 'swift':
+        return 'swift';
+      case 'rs':
+        return 'rust';
+      case 'c':
+      case 'h':
+        return 'c';
+      case 'cpp':
+        return 'cpp';
+      case 'cs':
+        return 'cs';
+      case 'rb':
+        return 'ruby';
+      case 'sh':
+      case 'bash':
+      case 'zsh':
+        return 'bash';
+      case 'json':
+        return 'json';
+      case 'yaml':
+      case 'yml':
+        return 'yaml';
+      case 'toml':
+        return 'ini';
+      case 'xml':
+        return 'xml';
+      case 'html':
+        return 'html';
+      case 'css':
+        return 'css';
+      case 'scss':
+        return 'scss';
+      case 'sql':
+        return 'sql';
+      case 'md':
+        return 'markdown';
+      default:
+        return null;
     }
   }
 
@@ -567,7 +692,9 @@ class _ToolResultCard extends StatelessWidget {
           ),
           const SizedBox(width: 6),
           Text(
-            message.tool != null ? '${message.tool} ${success ? "done" : "failed"}' : (success ? 'done' : 'failed'),
+            message.tool != null
+                ? '${message.tool} ${success ? "done" : "failed"}'
+                : (success ? 'done' : 'failed'),
             style: TextStyle(
               fontSize: 11,
               color: theme.colorScheme.onSurfaceVariant,
@@ -602,10 +729,18 @@ class _SyntaxHighlightBuilder extends MarkdownElementBuilder {
       language: lang.isNotEmpty ? lang : 'plaintext',
       theme: isDark ? atomOneDarkTheme : atomOneLightTheme,
       padding: const EdgeInsets.all(10),
-      textStyle: const TextStyle(fontSize: 12, fontFamily: 'monospace', height: 1.5),
+      textStyle: const TextStyle(
+        fontSize: 12,
+        fontFamily: 'monospace',
+        height: 1.5,
+      ),
     );
     if (lang == 'mermaid') {
-      return MermaidDiagram(source: code.trimRight(), isDark: isDark, fallback: block);
+      return MermaidDiagram(
+        source: code.trimRight(),
+        isDark: isDark,
+        fallback: block,
+      );
     }
     return block;
   }

--- a/mobile/lib/widgets/skeleton.dart
+++ b/mobile/lib/widgets/skeleton.dart
@@ -17,7 +17,8 @@ class Skeleton extends StatefulWidget {
   State<Skeleton> createState() => _SkeletonState();
 }
 
-class _SkeletonState extends State<Skeleton> with SingleTickerProviderStateMixin {
+class _SkeletonState extends State<Skeleton>
+    with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _animation;
 
@@ -28,9 +29,10 @@ class _SkeletonState extends State<Skeleton> with SingleTickerProviderStateMixin
       vsync: this,
       duration: const Duration(milliseconds: 1200),
     )..repeat();
-    _animation = Tween<double>(begin: -1.0, end: 2.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
-    );
+    _animation = Tween<double>(
+      begin: -1.0,
+      end: 2.0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
   }
 
   @override
@@ -86,7 +88,11 @@ class SessionCardSkeleton extends StatelessWidget {
           children: [
             Row(
               children: [
-                const Skeleton(width: 14, height: 14, borderRadius: BorderRadius.all(Radius.circular(7))),
+                const Skeleton(
+                  width: 14,
+                  height: 14,
+                  borderRadius: BorderRadius.all(Radius.circular(7)),
+                ),
                 const SizedBox(width: 6),
                 const Skeleton(width: 70, height: 18),
                 const SizedBox(width: 8),

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -564,10 +564,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -580,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -1113,10 +1113,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -1230,5 +1230,5 @@ packages:
     source: hosted
     version: "0.0.6"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.4"

--- a/mobile/test/cache_effects_test.dart
+++ b/mobile/test/cache_effects_test.dart
@@ -16,7 +16,10 @@ void main() {
   group('session_status', () {
     test('patches the row and then refetches the list', () {
       expect(
-        effectsFor(host, 'session_status', {'session_id': 's1', 'status': 'active'}),
+        effectsFor(host, 'session_status', {
+          'session_id': 's1',
+          'status': 'active',
+        }),
         const [
           PatchSession(hostId: host, sessionId: 's1', status: 'active'),
           InvalidateTarget(CacheTarget.sessions, host),
@@ -27,18 +30,21 @@ void main() {
     // A resume carries the new host handle. Taking it matters: the session is
     // cold in this client's copy until something says otherwise.
     test('carries the terminal handle when the event has one', () {
-      final effects = effectsFor(
-        host,
-        'session_status',
-        {'session_id': 's1', 'status': 'active', 'terminal': 't-9'},
-      );
+      final effects = effectsFor(host, 'session_status', {
+        'session_id': 's1',
+        'status': 'active',
+        'terminal': 't-9',
+      });
       expect((effects.first as PatchSession).terminal, 't-9');
     });
 
     // Most session_status events say nothing about the terminal, and an absent
     // handle is no evidence the host went away.
     test('leaves the handle alone when the event omits it', () {
-      final effects = effectsFor(host, 'session_status', {'session_id': 's1', 'status': 'idle'});
+      final effects = effectsFor(host, 'session_status', {
+        'session_id': 's1',
+        'status': 'idle',
+      });
       expect((effects.first as PatchSession).terminal, isNull);
     });
 
@@ -50,28 +56,23 @@ void main() {
 
   test('session_updated and session_deleted refetch the list', () {
     for (final type in ['session_updated', 'session_deleted']) {
-      expect(
-        effectsFor(host, type, {'session_id': 's1'}),
-        const [InvalidateTarget(CacheTarget.sessions, host)],
-        reason: type,
-      );
+      expect(effectsFor(host, type, {'session_id': 's1'}), const [
+        InvalidateTarget(CacheTarget.sessions, host),
+      ], reason: type);
     }
   });
 
   // The socket was down and the daemon keeps no replay buffer, so anything that
   // changed in the gap was announced to nobody.
   test('a reconnect refetches what the stream could have missed', () {
-    expect(
-      effectsFor(host, 'stream_reconnected', const {}),
-      const [
-        InvalidateTarget(CacheTarget.sessions, host),
-        InvalidateTarget(CacheTarget.notifications, host),
-        // Files and git for a second reason: a path whose watch expired while
-        // a screen sat open is not being swept, and re-reading re-registers it.
-        InvalidateTarget(CacheTarget.files, host),
-        InvalidateTarget(CacheTarget.git, host),
-      ],
-    );
+    expect(effectsFor(host, 'stream_reconnected', const {}), const [
+      InvalidateTarget(CacheTarget.sessions, host),
+      InvalidateTarget(CacheTarget.notifications, host),
+      // Files and git for a second reason: a path whose watch expired while
+      // a screen sat open is not being swept, and re-reading re-registers it.
+      InvalidateTarget(CacheTarget.files, host),
+      InvalidateTarget(CacheTarget.git, host),
+    ]);
   });
 
   // Every path the daemon names has changed *content*, not merely a changed
@@ -79,18 +80,19 @@ void main() {
   group('file_changed', () {
     const named = {
       'paths': [
-        {'path': '/repo/a.go', 'kind': 'file', 'mod_time': '2026-09-01T04:03:11.204Z'},
+        {
+          'path': '/repo/a.go',
+          'kind': 'file',
+          'mod_time': '2026-09-01T04:03:11.204Z',
+        },
       ],
     };
 
     test('takes out the files and the git reads', () {
-      expect(
-        effectsFor(host, 'file_changed', named),
-        const [
-          InvalidateTarget(CacheTarget.files, host),
-          InvalidateTarget(CacheTarget.git, host),
-        ],
-      );
+      expect(effectsFor(host, 'file_changed', named), const [
+        InvalidateTarget(CacheTarget.files, host),
+        InvalidateTarget(CacheTarget.git, host),
+      ]);
     });
 
     // A working-tree write moves `git status`, and a repo entry is a commit or
@@ -118,44 +120,42 @@ void main() {
     });
 
     test('another host is not answered for', () {
-      expect(
-        effectsFor(other, 'file_changed', named),
-        const [
-          InvalidateTarget(CacheTarget.files, other),
-          InvalidateTarget(CacheTarget.git, other),
-        ],
-      );
+      expect(effectsFor(other, 'file_changed', named), const [
+        InvalidateTarget(CacheTarget.files, other),
+        InvalidateTarget(CacheTarget.git, other),
+      ]);
     });
 
     test('an event naming nothing does nothing', () {
       expect(effectsFor(host, 'file_changed', const {}), isEmpty);
       expect(effectsFor(host, 'file_changed', const {'paths': []}), isEmpty);
-      expect(effectsFor(host, 'file_changed', const {'paths': 'nonsense'}), isEmpty);
+      expect(
+        effectsFor(host, 'file_changed', const {'paths': 'nonsense'}),
+        isEmpty,
+      );
       expect(effectsFor(host, 'file_changed', null), isEmpty);
     });
   });
 
   // A permission request writes waiting_permission to the session and announces
   // only the notification, so the list is the one way the UI hears of it.
-  test('a notification takes out the sessions as well as the notifications', () {
-    for (final type in ['notification', 'notification_resolved']) {
-      expect(
-        effectsFor(host, type, const {}),
-        const [
+  test(
+    'a notification takes out the sessions as well as the notifications',
+    () {
+      for (final type in ['notification', 'notification_resolved']) {
+        expect(effectsFor(host, type, const {}), const [
           InvalidateTarget(CacheTarget.notifications, host),
           InvalidateTarget(CacheTarget.sessions, host),
-        ],
-        reason: type,
-      );
-    }
-  });
+        ], reason: type);
+      }
+    },
+  );
 
   group('subagent_status', () {
     test('narrows to the session it names', () {
-      expect(
-        effectsFor(host, 'subagent_status', {'session_id': 's1'}),
-        const [InvalidateTarget(CacheTarget.subagents, host, sessionId: 's1')],
-      );
+      expect(effectsFor(host, 'subagent_status', {'session_id': 's1'}), const [
+        InvalidateTarget(CacheTarget.subagents, host, sessionId: 's1'),
+      ]);
     });
 
     test('without a session id it touches nothing', () {
@@ -164,13 +164,10 @@ void main() {
   });
 
   test('session_evicted takes out the host-wide lists', () {
-    expect(
-      effectsFor(host, 'session_evicted', const {}),
-      const [
-        InvalidateTarget(CacheTarget.sessions, host),
-        InvalidateTarget(CacheTarget.notifications, host),
-      ],
-    );
+    expect(effectsFor(host, 'session_evicted', const {}), const [
+      InvalidateTarget(CacheTarget.sessions, host),
+      InvalidateTarget(CacheTarget.notifications, host),
+    ]);
   });
 
   // 'show' instructs the window; the terminal events move connections and the
@@ -191,15 +188,29 @@ void main() {
     });
 
     test('a per-session target separates by session as well as by host', () {
-      const one = InvalidateTarget(CacheTarget.subagents, host, sessionId: 's1');
-      const two = InvalidateTarget(CacheTarget.subagents, host, sessionId: 's2');
+      const one = InvalidateTarget(
+        CacheTarget.subagents,
+        host,
+        sessionId: 's1',
+      );
+      const two = InvalidateTarget(
+        CacheTarget.subagents,
+        host,
+        sessionId: 's2',
+      );
       expect(one, isNot(equals(two)));
-      expect(one, equals(const InvalidateTarget(CacheTarget.subagents, host, sessionId: 's1')));
+      expect(
+        one,
+        equals(
+          const InvalidateTarget(CacheTarget.subagents, host, sessionId: 's1'),
+        ),
+      );
     });
   });
 
   group('patching one row', () {
-    Session row(String id, {String status = 'idle', String? terminal}) => Session(
+    Session row(String id, {String status = 'idle', String? terminal}) =>
+        Session(
           sessionId: id,
           source: 'claude',
           cwd: '/tmp/p',
@@ -217,27 +228,45 @@ void main() {
     });
 
     test('keeps the order', () {
-      final next = patchSessionRow([row('a'), row('b'), row('c')], 'b', 'active', null);
+      final next = patchSessionRow(
+        [row('a'), row('b'), row('c')],
+        'b',
+        'active',
+        null,
+      );
       expect(next.map((s) => s.sessionId), ['a', 'b', 'c']);
     });
 
     // A resume carries a new handle, and taking it is how the client learns the
     // session is warm again.
     test('takes a new terminal handle when the event carries one', () {
-      final next = patchSessionRow([row('a', terminal: 'old')], 'a', 'active', 'new');
+      final next = patchSessionRow(
+        [row('a', terminal: 'old')],
+        'a',
+        'active',
+        'new',
+      );
       expect(next.single.terminal, 'new');
     });
 
     // Most events carry none, and an absent handle is no evidence it went away.
     test('keeps the existing handle when the event carries none', () {
-      final next = patchSessionRow([row('a', terminal: 'old')], 'a', 'active', null);
+      final next = patchSessionRow(
+        [row('a', terminal: 'old')],
+        'a',
+        'active',
+        null,
+      );
       expect(next.single.terminal, 'old');
     });
 
     // A filtered list legitimately does not hold every session.
     test('an absent row leaves the list untouched', () {
       final held = [row('a')];
-      expect(identical(patchSessionRow(held, 'zzz', 'active', null), held), isTrue);
+      expect(
+        identical(patchSessionRow(held, 'zzz', 'active', null), held),
+        isTrue,
+      );
     });
 
     test('an empty list is survivable', () {
@@ -255,7 +284,13 @@ void main() {
     });
 
     test('non-string fields are ignored rather than coerced', () {
-      expect(effectsFor(host, 'session_status', {'session_id': 7, 'status': 'active'}), isEmpty);
+      expect(
+        effectsFor(host, 'session_status', {
+          'session_id': 7,
+          'status': 'active',
+        }),
+        isEmpty,
+      );
     });
   });
 }

--- a/mobile/test/card_registry_test.dart
+++ b/mobile/test/card_registry_test.dart
@@ -5,14 +5,14 @@ import 'package:helios/providers/card_registry.dart';
 import 'package:helios/providers/notification_ext.dart';
 
 HeliosNotification _notif(String type, String status) => HeliosNotification(
-      id: 'n1',
-      source: 'claude',
-      sourceSession: 's1',
-      cwd: '/tmp',
-      type: type,
-      status: status,
-      createdAt: '2026-01-01T00:00:00Z',
-    );
+  id: 'n1',
+  source: 'claude',
+  sourceSession: 's1',
+  cwd: '/tmp',
+  type: type,
+  status: status,
+  createdAt: '2026-01-01T00:00:00Z',
+);
 
 const _allTypes = [
   'claude.permission',

--- a/mobile/test/codex_permission_card_test.dart
+++ b/mobile/test/codex_permission_card_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:helios/models/notification.dart';
+import 'package:helios/providers/cards.dart';
+import 'package:helios/services/api_client.dart';
+import 'package:helios/services/daemon_api_service.dart';
+
+/// Codex's own approval dialog offers "No, and tell Codex what to do
+/// differently". The phone painted a bare Deny over it. These pin the words
+/// that replaced it.
+
+HeliosNotification _permission(String source) => HeliosNotification(
+      id: 'n1',
+      source: source,
+      sourceSession: 's1',
+      cwd: '/tmp/proj',
+      type: '$source.permission',
+      status: 'pending',
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+      payload: {
+        'tool_name': 'shell',
+        'tool_input': {'command': 'rm -rf build'},
+      },
+    );
+
+/// A service whose action posts land in [sent] instead of on a daemon.
+DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {
+  final client = MockClient((req) async {
+    if (req.url.path.contains('/auth/')) {
+      return http.Response(
+        jsonEncode({
+          'token': 't',
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
+        }),
+        200,
+      );
+    }
+    if (req.url.path.endsWith('/action')) {
+      sent.add(jsonDecode(req.body) as Map<String, dynamic>);
+      return http.Response('{}', 200);
+    }
+    return http.Response('{}', 200);
+  });
+  return DaemonAPIService(
+    hostId: 'h1',
+    serverUrl: 'http://localhost:1',
+    api: ApiClient(
+      serverUrl: 'http://localhost:1',
+      deviceId: 'd1',
+      privateKeySeed: Uint8List(32),
+      client: client,
+    ),
+  );
+}
+
+Future<void> _pumpCard(
+  WidgetTester tester,
+  HeliosNotification n,
+  DaemonAPIService sse,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: PermissionCard(
+            notification: n,
+            sse: sse,
+            selected: <String>{},
+            onSelectionChanged: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a Codex approval can be refused in words', (tester) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _permission('codex'), _serviceRecording(sent));
+
+    expect(find.text('Tell Codex what to do differently'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'use git clean instead');
+    await tester.pump();
+
+    // The refusal button says what the words will do with it.
+    expect(find.widgetWithText(FilledButton, 'Send back'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Send back'));
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first['action'], 'deny');
+    expect(sent.first['feedback'], 'use git clean instead');
+  });
+
+  testWidgets('a Codex approval is still one tap to say yes', (tester) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _permission('codex'), _serviceRecording(sent));
+
+    // Nothing to pick first: Codex has no mode rows, only the words.
+    expect(find.text('Yes, and use auto mode'), findsNothing);
+
+    final approve = find.widgetWithText(FilledButton, 'Approve');
+    expect(tester.widget<FilledButton>(approve).onPressed, isNotNull);
+    await tester.tap(approve);
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first, {'action': 'approve'});
+  });
+
+  testWidgets('an ordinary Claude tool keeps its bare Deny', (tester) async {
+    await _pumpCard(tester, _permission('claude'), _serviceRecording([]));
+
+    // Claude writes a rule for a tool it is allowed, and the feedback row
+    // belongs to the plan card. Only Codex refuses in words on every tool.
+    expect(find.text('Tell Codex what to do differently'), findsNothing);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Deny'), findsOneWidget);
+  });
+}

--- a/mobile/test/codex_permission_card_test.dart
+++ b/mobile/test/codex_permission_card_test.dart
@@ -16,18 +16,18 @@ import 'package:helios/services/daemon_api_service.dart';
 /// that replaced it.
 
 HeliosNotification _permission(String source) => HeliosNotification(
-      id: 'n1',
-      source: source,
-      sourceSession: 's1',
-      cwd: '/tmp/proj',
-      type: '$source.permission',
-      status: 'pending',
-      createdAt: DateTime.now().toUtc().toIso8601String(),
-      payload: {
-        'tool_name': 'shell',
-        'tool_input': {'command': 'rm -rf build'},
-      },
-    );
+  id: 'n1',
+  source: source,
+  sourceSession: 's1',
+  cwd: '/tmp/proj',
+  type: '$source.permission',
+  status: 'pending',
+  createdAt: DateTime.now().toUtc().toIso8601String(),
+  payload: {
+    'tool_name': 'shell',
+    'tool_input': {'command': 'rm -rf build'},
+  },
+);
 
 /// A service whose action posts land in [sent] instead of on a daemon.
 DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {

--- a/mobile/test/connection_resilience_test.dart
+++ b/mobile/test/connection_resilience_test.dart
@@ -5,13 +5,13 @@ import 'package:helios/services/daemon_api_service.dart';
 import 'package:helios/services/host_manager.dart';
 
 HostConnection host(String id) => HostConnection(
-      id: id,
-      label: id,
-      serverUrl: 'http://$id.local:7655',
-      deviceId: 'device-$id',
-      colorIndex: 0,
-      addedAt: DateTime.utc(2026, 1, 1),
-    );
+  id: id,
+  label: id,
+  serverUrl: 'http://$id.local:7655',
+  deviceId: 'device-$id',
+  colorIndex: 0,
+  addedAt: DateTime.utc(2026, 1, 1),
+);
 
 void main() {
   group('offlineHostsForFilter', () {

--- a/mobile/test/error_notification_test.dart
+++ b/mobile/test/error_notification_test.dart
@@ -5,21 +5,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:helios/models/notification.dart';
 import 'package:helios/providers/notification_ext.dart';
 
-HeliosNotification errorNotif(Map<String, dynamic> payload,
-        {String status = 'pending'}) =>
-    HeliosNotification.fromJson({
-      'id': 'n1',
-      'source': 'claude',
-      'source_session': 'sess-1',
-      'cwd': '/tmp/proj',
-      'type': 'claude.error',
-      'status': status,
-      'title': 'Session error',
-      'detail': 'API Error: Response stalled mid-stream.',
-      // The daemon stores the payload as a JSON string.
-      'payload': jsonEncode(payload),
-      'created_at': '2026-01-01T00:00:00Z',
-    });
+HeliosNotification errorNotif(
+  Map<String, dynamic> payload, {
+  String status = 'pending',
+}) => HeliosNotification.fromJson({
+  'id': 'n1',
+  'source': 'claude',
+  'source_session': 'sess-1',
+  'cwd': '/tmp/proj',
+  'type': 'claude.error',
+  'status': status,
+  'title': 'Session error',
+  'detail': 'API Error: Response stalled mid-stream.',
+  // The daemon stores the payload as a JSON string.
+  'payload': jsonEncode(payload),
+  'created_at': '2026-01-01T00:00:00Z',
+});
 
 void main() {
   group('error payload accessors', () {
@@ -32,7 +33,10 @@ void main() {
       });
 
       expect(n.errorSessionId, 'sess-1');
-      expect(n.errorText, 'API Error: Stream idle timeout - no chunks received');
+      expect(
+        n.errorText,
+        'API Error: Stream idle timeout - no chunks received',
+      );
       expect(n.isRateLimit, isFalse);
       expect(n.isRetryable, isTrue);
       expect(n.rateLimitResetAt, isNull);

--- a/mobile/test/host_connection_test.dart
+++ b/mobile/test/host_connection_test.dart
@@ -5,14 +5,23 @@ import 'package:helios/models/host_connection.dart';
 void main() {
   group('isTailnetUrl', () {
     test('matches MagicDNS names', () {
-      expect(HostConnection.isTailnetUrl('http://box.tail1234.ts.net:7655'), isTrue);
-      expect(HostConnection.isTailnetUrl('https://box.tail1234.ts.net'), isTrue);
+      expect(
+        HostConnection.isTailnetUrl('http://box.tail1234.ts.net:7655'),
+        isTrue,
+      );
+      expect(
+        HostConnection.isTailnetUrl('https://box.tail1234.ts.net'),
+        isTrue,
+      );
       expect(HostConnection.isTailnetUrl('HTTP://BOX.TAIL1234.TS.NET'), isTrue);
     });
 
     test('does not match lookalike hosts', () {
       expect(HostConnection.isTailnetUrl('https://example.com'), isFalse);
-      expect(HostConnection.isTailnetUrl('https://ts.net.example.com'), isFalse);
+      expect(
+        HostConnection.isTailnetUrl('https://ts.net.example.com'),
+        isFalse,
+      );
       expect(HostConnection.isTailnetUrl('https://notts.net'), isFalse);
       expect(HostConnection.isTailnetUrl(''), isFalse);
     });
@@ -21,8 +30,14 @@ void main() {
     // not a tailnet address — treating it as one would tell people to switch
     // on a VPN that has nothing to do with their problem.
     test('ignores ts.net outside the host component', () {
-      expect(HostConnection.isTailnetUrl('https://example.com/box.ts.net'), isFalse);
-      expect(HostConnection.isTailnetUrl('https://example.com?h=box.ts.net'), isFalse);
+      expect(
+        HostConnection.isTailnetUrl('https://example.com/box.ts.net'),
+        isFalse,
+      );
+      expect(
+        HostConnection.isTailnetUrl('https://example.com?h=box.ts.net'),
+        isFalse,
+      );
     });
   });
 

--- a/mobile/test/large_paste_test.dart
+++ b/mobile/test/large_paste_test.dart
@@ -41,7 +41,10 @@ void main() {
 
   group('removeFirst', () {
     test('takes only the pasted block out', () {
-      expect(removeFirst('look at this: LOG here', 'LOG'), 'look at this:  here');
+      expect(
+        removeFirst('look at this: LOG here', 'LOG'),
+        'look at this:  here',
+      );
     });
 
     // An identical block pasted earlier on purpose is not the one being filed.
@@ -56,11 +59,18 @@ void main() {
 
   group('pastedTextFile', () {
     test('names by UTC stamp and carries the bytes', () {
-      final file = pastedTextFile('hello', at: DateTime.utc(2026, 8, 15, 4, 5, 6));
+      final file = pastedTextFile(
+        'hello',
+        at: DateTime.utc(2026, 8, 15, 4, 5, 6),
+      );
       expect(file.name, 'pasted-20260815T040506.txt');
       expect(file.size, 5);
       expect(utf8.decode(file.bytes), 'hello');
-      expect(file.storedPath, isNull, reason: 'not stored until the send uploads it');
+      expect(
+        file.storedPath,
+        isNull,
+        reason: 'not stored until the send uploads it',
+      );
     });
   });
 }

--- a/mobile/test/notification_service_test.dart
+++ b/mobile/test/notification_service_test.dart
@@ -6,7 +6,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:helios/services/notification_service.dart';
 
 /// The channel flutter_local_notifications talks to.
-const _pluginChannel = MethodChannel('dexterous.com/flutter/local_notifications');
+const _pluginChannel = MethodChannel(
+  'dexterous.com/flutter/local_notifications',
+);
 
 /// Helios' own channel for sound/vibration and channel creation.
 const _nativeChannel = MethodChannel('com.helios.helios/notifications');
@@ -110,9 +112,19 @@ void main() {
 
   test('cancelling one key leaves the other posted', () async {
     await NotificationService.instance.showNotification(
-      id: 'p1', key: 'host-a:n1', title: 'a', body: 'a', silent: true);
+      id: 'p1',
+      key: 'host-a:n1',
+      title: 'a',
+      body: 'a',
+      silent: true,
+    );
     await NotificationService.instance.showNotification(
-      id: 'p2', key: 'host-b:n2', title: 'b', body: 'b', silent: true);
+      id: 'p2',
+      key: 'host-b:n2',
+      title: 'b',
+      body: 'b',
+      silent: true,
+    );
 
     await NotificationService.instance.cancel('host-a:n1');
 
@@ -122,9 +134,19 @@ void main() {
 
   test('cancelAll retracts everything and clears tracking', () async {
     await NotificationService.instance.showNotification(
-      id: 'p1', key: 'host-a:n1', title: 'a', body: 'a', silent: true);
+      id: 'p1',
+      key: 'host-a:n1',
+      title: 'a',
+      body: 'a',
+      silent: true,
+    );
     await NotificationService.instance.showNotification(
-      id: 'p2', key: 'host-b:n2', title: 'b', body: 'b', silent: true);
+      id: 'p2',
+      key: 'host-b:n2',
+      title: 'b',
+      body: 'b',
+      silent: true,
+    );
 
     calls.clear();
     await NotificationService.instance.cancelAll();
@@ -179,16 +201,18 @@ void main() {
       expect(calls.where((c) => c.method == 'cancel').length, 2);
     });
 
-    test('everything still pending is left posted and nothing is cancelled',
-        () async {
-      await post('host-a', 'n1');
-      calls.clear();
+    test(
+      'everything still pending is left posted and nothing is cancelled',
+      () async {
+        await post('host-a', 'n1');
+        calls.clear();
 
-      await NotificationService.instance.retainOnly('host-a', {'n1'});
+        await NotificationService.instance.retainOnly('host-a', {'n1'});
 
-      expect(calls.where((c) => c.method == 'cancel'), isEmpty);
-      expect(NotificationService.instance.isPosted('host-a:n1'), isTrue);
-    });
+        expect(calls.where((c) => c.method == 'cancel'), isEmpty);
+        expect(NotificationService.instance.isPosted('host-a:n1'), isTrue);
+      },
+    );
 
     test('a host with nothing posted is a no-op', () async {
       await NotificationService.instance.retainOnly('host-z', {'n1'});

--- a/mobile/test/optimistic_write_test.dart
+++ b/mobile/test/optimistic_write_test.dart
@@ -21,15 +21,15 @@ import 'package:helios/services/daemon_api_service.dart';
 /// green.
 
 DaemonAPIService serviceReturning(MockClient client) => DaemonAPIService(
-      hostId: 'h1',
-      serverUrl: 'http://localhost:1',
-      api: ApiClient(
-        serverUrl: 'http://localhost:1',
-        deviceId: 'd1',
-        privateKeySeed: Uint8List(32),
-        client: client,
-      ),
-    );
+  hostId: 'h1',
+  serverUrl: 'http://localhost:1',
+  api: ApiClient(
+    serverUrl: 'http://localhost:1',
+    deviceId: 'd1',
+    privateKeySeed: Uint8List(32),
+    client: client,
+  ),
+);
 
 /// Answers the token handshake, then defers to [onWrite] for everything else.
 MockClient clientWhere(http.Response Function(http.Request) onWrite) {
@@ -38,8 +38,10 @@ MockClient clientWhere(http.Response Function(http.Request) onWrite) {
       return http.Response(
         jsonEncode({
           'token': 't',
-          'expires_at':
-              DateTime.now().toUtc().add(const Duration(hours: 1)).toIso8601String(),
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
         }),
         200,
       );
@@ -48,17 +50,22 @@ MockClient clientWhere(http.Response Function(http.Request) onWrite) {
   });
 }
 
-Map<String, dynamic> sessionJson(String id, {int order = 0, bool pinned = false, String? title}) => {
-      'session_id': id,
-      'source': 'claude',
-      'cwd': '/tmp/p',
-      'project': 'p',
-      'status': 'idle',
-      'created_at': '2026-01-01T00:00:00Z',
-      'sort_order': order,
-      'pinned': pinned,
-      'title': ?title,
-    };
+Map<String, dynamic> sessionJson(
+  String id, {
+  int order = 0,
+  bool pinned = false,
+  String? title,
+}) => {
+  'session_id': id,
+  'source': 'claude',
+  'cwd': '/tmp/p',
+  'project': 'p',
+  'status': 'idle',
+  'created_at': '2026-01-01T00:00:00Z',
+  'sort_order': order,
+  'pinned': pinned,
+  'title': ?title,
+};
 
 /// A container whose session list has loaded with [sessions], and whose writes
 /// are answered by [onWrite].
@@ -66,12 +73,14 @@ Future<ProviderContainer> containerHolding(
   List<Map<String, dynamic>> sessions,
   http.Response Function(http.Request) onWrite,
 ) async {
-  final svc = serviceReturning(clientWhere((req) {
-    if (req.method == 'GET' && req.url.path == '/api/sessions') {
-      return http.Response(jsonEncode({'sessions': sessions}), 200);
-    }
-    return onWrite(req);
-  }));
+  final svc = serviceReturning(
+    clientWhere((req) {
+      if (req.method == 'GET' && req.url.path == '/api/sessions') {
+        return http.Response(jsonEncode({'sessions': sessions}), 200);
+      }
+      return onWrite(req);
+    }),
+  );
   final container = ProviderContainer(
     overrides: [serviceProvider('h1').overrideWithValue(svc)],
   );
@@ -94,10 +103,10 @@ void main() {
 
   group('reorder', () {
     test('paints the new order before the daemon answers', () async {
-      final c = await containerHolding(
-        [sessionJson('a', order: 0), sessionJson('b', order: 1)],
-        (_) => http.Response('{}', 200),
-      );
+      final c = await containerHolding([
+        sessionJson('a', order: 0),
+        sessionJson('b', order: 1),
+      ], (_) => http.Response('{}', 200));
 
       final write = writerOf(c).reorder(['b', 'a']);
 
@@ -107,10 +116,10 @@ void main() {
     });
 
     test('puts the old order back when the daemon refuses', () async {
-      final c = await containerHolding(
-        [sessionJson('a', order: 0), sessionJson('b', order: 1)],
-        (_) => http.Response('nope', 500),
-      );
+      final c = await containerHolding([
+        sessionJson('a', order: 0),
+        sessionJson('b', order: 1),
+      ], (_) => http.Response('nope', 500));
 
       expect(await writerOf(c).reorder(['b', 'a']), isFalse);
       expect(rowsOf(c).firstWhere((s) => s.sessionId == 'a').sortOrder, 0);
@@ -120,12 +129,14 @@ void main() {
 
   group('patch', () {
     test('puts the original row back when the daemon refuses', () async {
-      final c = await containerHolding(
-        [sessionJson('a', title: 'before')],
-        (_) => http.Response('nope', 500),
-      );
+      final c = await containerHolding([
+        sessionJson('a', title: 'before'),
+      ], (_) => http.Response('nope', 500));
 
-      expect(await writerOf(c).patch('a', title: 'after', pinned: true), isFalse);
+      expect(
+        await writerOf(c).patch('a', title: 'after', pinned: true),
+        isFalse,
+      );
       final row = rowsOf(c).single;
       expect(row.title, 'before');
       expect(row.pinned, isFalse);
@@ -135,26 +146,32 @@ void main() {
     // finishes popping first — rebuilding its dependents inside that transition
     // trips the framework's _dependents.isEmpty assertion.
     test('defers the paint past the current synchronous turn', () async {
-      final c = await containerHolding(
-        [sessionJson('a', title: 'before')],
-        (_) => http.Response(jsonEncode({'ok': true}), 200),
-      );
+      final c = await containerHolding([
+        sessionJson('a', title: 'before'),
+      ], (_) => http.Response(jsonEncode({'ok': true}), 200));
 
       final write = writerOf(c).patch('a', title: 'after');
-      expect(rowsOf(c).single.title, 'before',
-          reason: 'must not repaint synchronously');
+      expect(
+        rowsOf(c).single.title,
+        'before',
+        reason: 'must not repaint synchronously',
+      );
 
       await write;
-      expect(rowsOf(c).single.title, 'after', reason: 'the paint still arrives');
+      expect(
+        rowsOf(c).single.title,
+        'after',
+        reason: 'the paint still arrives',
+      );
     });
   });
 
   group('delete', () {
     test('drops the row, and puts it back when the daemon refuses', () async {
-      final c = await containerHolding(
-        [sessionJson('a'), sessionJson('b')],
-        (_) => http.Response('nope', 500),
-      );
+      final c = await containerHolding([
+        sessionJson('a'),
+        sessionJson('b'),
+      ], (_) => http.Response('nope', 500));
 
       expect(await writerOf(c).delete('a'), isFalse);
       expect(rowsOf(c).map((s) => s.sessionId), ['a', 'b']);
@@ -165,20 +182,22 @@ void main() {
     /// A container wired to one host, whose settings read succeeds and whose
     /// writes are refused.
     ProviderContainer containerRefusingWrites() {
-      final svc = serviceReturning(clientWhere((req) {
-        if (req.method == 'GET') {
-          return http.Response(
-            jsonEncode({
-              'settings': {
-                DaemonAPIService.settingAutoTitle: 'true',
-                DaemonAPIService.settingEvict: 'true',
-              },
-            }),
-            200,
-          );
-        }
-        return http.Response('nope', 500);
-      }));
+      final svc = serviceReturning(
+        clientWhere((req) {
+          if (req.method == 'GET') {
+            return http.Response(
+              jsonEncode({
+                'settings': {
+                  DaemonAPIService.settingAutoTitle: 'true',
+                  DaemonAPIService.settingEvict: 'true',
+                },
+              }),
+              200,
+            );
+          }
+          return http.Response('nope', 500);
+        }),
+      );
       final container = ProviderContainer(
         overrides: [serviceProvider('h1').overrideWithValue(svc)],
       );
@@ -199,7 +218,11 @@ void main() {
 
       final after = container.read(hostSettingsProvider('h1')).valueOrNull!;
       expect(after.evictEnabled, isTrue, reason: 'the refused write reverts');
-      expect(after.autoTitleEnabled, isTrue, reason: 'its neighbour is untouched');
+      expect(
+        after.autoTitleEnabled,
+        isTrue,
+        reason: 'its neighbour is untouched',
+      );
     });
 
     // The daemon merges by key, so the cache has to merge by field. Replacing

--- a/mobile/test/plan_card_test.dart
+++ b/mobile/test/plan_card_test.dart
@@ -2,12 +2,14 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' as rp;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 import 'package:helios/models/notification.dart';
 import 'package:helios/providers/cards.dart';
+import 'package:helios/providers/daemon_providers.dart';
 import 'package:helios/screens/file_browser_screen.dart';
 import 'package:helios/services/api_client.dart';
 import 'package:helios/services/daemon_api_service.dart';
@@ -161,6 +163,52 @@ void main() {
     // Rooted where the plan lives, not at the project: "show in folder" from
     // the viewer has to land on a folder the file is in.
     expect(viewer.rootPath, '~/.claude/plans');
+  });
+
+  // The test above reads the route without running it, so it never caught
+  // that opening the viewer threw. This one builds the screen.
+  //
+  // What it threw: `ref` in `initState` resolves the ProviderScope through
+  // `dependOnInheritedWidgetOfExactType`, which Flutter forbids there. The
+  // check is an assert, so only a debug build shows the red screen.
+  testWidgets('the viewer the button opens actually builds', (tester) async {
+    await tester.pumpWidget(
+      rp.ProviderScope(
+        overrides: [
+          readFileProvider.overrideWith(
+            (ref, key) async => FileReadResult(
+              path: key.$2,
+              size: _plan.length,
+              content: _plan,
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: PermissionCard(
+                notification: _planNotification(),
+                sse: _serviceRecording([]),
+                selected: const <String>{},
+                onSelectionChanged: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('View plan'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // The plan is on screen as rendered markdown, which is the whole point of
+    // sending the reader here instead of printing it on the card.
+    expect(find.byType(FileViewerScreen), findsOneWidget);
+    expect(
+      find.textContaining('give plan approval its own rows'),
+      findsWidgets,
+    );
   });
 
   // A plan the CLI wrote nowhere leaves the card as the only copy, so it

--- a/mobile/test/plan_card_test.dart
+++ b/mobile/test/plan_card_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:helios/models/notification.dart';
+import 'package:helios/providers/cards.dart';
+import 'package:helios/services/api_client.dart';
+import 'package:helios/services/daemon_api_service.dart';
+
+/// A plan is not a yes-or-no question, and the phone asked it as one: Approve
+/// or Deny, over a body of raw JSON. These pin the rows that replaced them.
+
+const _plan = '# Plan: give plan approval its own rows\n\n'
+    '## Context\nThe card only offers Approve and Deny.\n';
+
+HeliosNotification _planNotification() => HeliosNotification(
+      id: 'n1',
+      source: 'claude',
+      sourceSession: 's1',
+      cwd: '/tmp/proj',
+      type: 'claude.permission',
+      status: 'pending',
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+      payload: {
+        'tool_name': 'ExitPlanMode',
+        'tool_input': {
+          'plan': _plan,
+          'planFilePath': '~/.claude/plans/rows.md',
+        },
+      },
+    );
+
+HeliosNotification _bashNotification() => HeliosNotification(
+      id: 'n2',
+      source: 'claude',
+      sourceSession: 's1',
+      cwd: '/tmp/proj',
+      type: 'claude.permission',
+      status: 'pending',
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+      payload: {
+        'tool_name': 'Bash',
+        'tool_input': {'command': 'ls -la'},
+      },
+    );
+
+/// A service whose action posts land in [sent] instead of on a daemon.
+DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {
+  final client = MockClient((req) async {
+    if (req.url.path.contains('/auth/')) {
+      return http.Response(
+        jsonEncode({
+          'token': 't',
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
+        }),
+        200,
+      );
+    }
+    if (req.url.path.endsWith('/action')) {
+      sent.add(jsonDecode(req.body) as Map<String, dynamic>);
+      return http.Response('{}', 200);
+    }
+    return http.Response('{}', 200);
+  });
+  return DaemonAPIService(
+    hostId: 'h1',
+    serverUrl: 'http://localhost:1',
+    api: ApiClient(
+      serverUrl: 'http://localhost:1',
+      deviceId: 'd1',
+      privateKeySeed: Uint8List(32),
+      client: client,
+    ),
+  );
+}
+
+Future<void> _pumpCard(
+  WidgetTester tester,
+  HeliosNotification n,
+  DaemonAPIService sse,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: PermissionCard(
+            notification: n,
+            sse: sse,
+            selected: <String>{},
+            onSelectionChanged: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a plan gets the mode rows and a way to disagree', (
+    tester,
+  ) async {
+    await _pumpCard(tester, _planNotification(), _serviceRecording([]));
+
+    expect(find.text('Ready to code?'), findsOneWidget);
+    expect(find.text('Yes, and use auto mode'), findsOneWidget);
+    expect(find.text('Yes, manually approve edits'), findsOneWidget);
+    expect(find.text('Tell Claude what to change'), findsOneWidget);
+
+    // The plan itself, not the JSON it arrived in.
+    expect(find.textContaining('## Context'), findsOneWidget);
+
+    // There is no command to edit and the CLI sends no rule suggestions for
+    // this tool, so the row that offers both would lead nowhere.
+    expect(find.text('Edit before approving'), findsNothing);
+  });
+
+  testWidgets('approving a plan waits for a mode, then sends it', (
+    tester,
+  ) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _planNotification(), _serviceRecording(sent));
+
+    final approve = find.widgetWithText(FilledButton, 'Approve');
+    expect(
+      tester.widget<FilledButton>(approve).onPressed,
+      isNull,
+      reason: 'a plan cannot be approved without saying which way',
+    );
+
+    await tester.tap(find.text('Yes, manually approve edits'));
+    await tester.pump();
+    await tester.tap(approve);
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first['action'], 'approve');
+    expect(sent.first['plan_choice'], 'manual');
+  });
+
+  testWidgets('typed words send the plan back rather than stopping it', (
+    tester,
+  ) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _planNotification(), _serviceRecording(sent));
+
+    await tester.enterText(find.byType(TextField), 'use a queue instead');
+    await tester.pump();
+
+    // The refusal button says what the words will do with it.
+    expect(find.widgetWithText(FilledButton, 'Send back'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Send back'));
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first['action'], 'deny');
+    expect(sent.first['feedback'], 'use a queue instead');
+  });
+
+  testWidgets('an ordinary tool keeps Approve and Deny', (tester) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _bashNotification(), _serviceRecording(sent));
+
+    expect(find.text('Yes, and use auto mode'), findsNothing);
+    expect(find.text('Edit before approving'), findsOneWidget);
+
+    final approve = find.widgetWithText(FilledButton, 'Approve');
+    expect(tester.widget<FilledButton>(approve).onPressed, isNotNull);
+    await tester.tap(approve);
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first, {'action': 'approve'});
+  });
+}

--- a/mobile/test/plan_card_test.dart
+++ b/mobile/test/plan_card_test.dart
@@ -8,45 +8,44 @@ import 'package:http/testing.dart';
 
 import 'package:helios/models/notification.dart';
 import 'package:helios/providers/cards.dart';
+import 'package:helios/screens/file_browser_screen.dart';
 import 'package:helios/services/api_client.dart';
 import 'package:helios/services/daemon_api_service.dart';
 
 /// A plan is not a yes-or-no question, and the phone asked it as one: Approve
 /// or Deny, over a body of raw JSON. These pin the rows that replaced them.
 
-const _plan = '# Plan: give plan approval its own rows\n\n'
+const _plan =
+    '# Plan: give plan approval its own rows\n\n'
     '## Context\nThe card only offers Approve and Deny.\n';
 
 HeliosNotification _planNotification() => HeliosNotification(
-      id: 'n1',
-      source: 'claude',
-      sourceSession: 's1',
-      cwd: '/tmp/proj',
-      type: 'claude.permission',
-      status: 'pending',
-      createdAt: DateTime.now().toUtc().toIso8601String(),
-      payload: {
-        'tool_name': 'ExitPlanMode',
-        'tool_input': {
-          'plan': _plan,
-          'planFilePath': '~/.claude/plans/rows.md',
-        },
-      },
-    );
+  id: 'n1',
+  source: 'claude',
+  sourceSession: 's1',
+  cwd: '/tmp/proj',
+  type: 'claude.permission',
+  status: 'pending',
+  createdAt: DateTime.now().toUtc().toIso8601String(),
+  payload: {
+    'tool_name': 'ExitPlanMode',
+    'tool_input': {'plan': _plan, 'planFilePath': '~/.claude/plans/rows.md'},
+  },
+);
 
 HeliosNotification _bashNotification() => HeliosNotification(
-      id: 'n2',
-      source: 'claude',
-      sourceSession: 's1',
-      cwd: '/tmp/proj',
-      type: 'claude.permission',
-      status: 'pending',
-      createdAt: DateTime.now().toUtc().toIso8601String(),
-      payload: {
-        'tool_name': 'Bash',
-        'tool_input': {'command': 'ls -la'},
-      },
-    );
+  id: 'n2',
+  source: 'claude',
+  sourceSession: 's1',
+  cwd: '/tmp/proj',
+  type: 'claude.permission',
+  status: 'pending',
+  createdAt: DateTime.now().toUtc().toIso8601String(),
+  payload: {
+    'tool_name': 'Bash',
+    'tool_input': {'command': 'ls -la'},
+  },
+);
 
 /// A service whose action posts land in [sent] instead of on a daemon.
 DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {
@@ -81,13 +80,26 @@ DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {
   );
 }
 
+/// Records what the card pushes, so a screen that wants a daemon behind it can
+/// be inspected without being built.
+class _Pushes extends NavigatorObserver {
+  final List<Route<dynamic>> routes = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previous) {
+    routes.add(route);
+  }
+}
+
 Future<void> _pumpCard(
   WidgetTester tester,
   HeliosNotification n,
-  DaemonAPIService sse,
-) async {
+  DaemonAPIService sse, {
+  NavigatorObserver? observer,
+}) async {
   await tester.pumpWidget(
     MaterialApp(
+      navigatorObservers: observer == null ? const [] : [observer],
       home: Scaffold(
         body: SingleChildScrollView(
           child: PermissionCard(
@@ -113,12 +125,66 @@ void main() {
     expect(find.text('Yes, manually approve edits'), findsOneWidget);
     expect(find.text('Tell Claude what to change'), findsOneWidget);
 
-    // The plan itself, not the JSON it arrived in.
-    expect(find.textContaining('## Context'), findsOneWidget);
+    // The plan is named and left in its file. Printed in full it filled the
+    // screen before the rows that answer it, and as raw markdown at that.
+    expect(find.text('Plan: give plan approval its own rows'), findsOneWidget);
+    expect(find.text('rows.md'), findsOneWidget);
+    expect(find.text('View plan'), findsOneWidget);
+    expect(find.textContaining('## Context'), findsNothing);
 
     // There is no command to edit and the CLI sends no rule suggestions for
     // this tool, so the row that offers both would lead nowhere.
     expect(find.text('Edit before approving'), findsNothing);
+  });
+
+  // The plan has to be readable from the phone, and the viewer renders the
+  // markdown the card would have shown as characters.
+  testWidgets('View plan opens the file the CLI wrote', (tester) async {
+    final pushes = _Pushes();
+    await _pumpCard(
+      tester,
+      _planNotification(),
+      _serviceRecording([]),
+      observer: pushes,
+    );
+
+    await tester.tap(find.text('View plan'));
+
+    // The route is read rather than run: the viewer reads the file off the
+    // host, which is not what this test is about.
+    final route = pushes.routes.last as MaterialPageRoute;
+    expect(route.settings.name, '/file-viewer');
+    final viewer =
+        route.builder(tester.element(find.byType(PermissionCard)))
+            as FileViewerScreen;
+    expect(viewer.path, '~/.claude/plans/rows.md');
+    // Rooted where the plan lives, not at the project: "show in folder" from
+    // the viewer has to land on a folder the file is in.
+    expect(viewer.rootPath, '~/.claude/plans');
+  });
+
+  // A plan the CLI wrote nowhere leaves the card as the only copy, so it
+  // keeps the whole text.
+  testWidgets('a plan with no file is still readable on the card', (
+    tester,
+  ) async {
+    final n = HeliosNotification(
+      id: 'n3',
+      source: 'claude',
+      sourceSession: 's1',
+      cwd: '/tmp/proj',
+      type: 'claude.permission',
+      status: 'pending',
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+      payload: {
+        'tool_name': 'ExitPlanMode',
+        'tool_input': {'plan': _plan},
+      },
+    );
+    await _pumpCard(tester, n, _serviceRecording([]));
+
+    expect(find.textContaining('## Context'), findsOneWidget);
+    expect(find.text('View plan'), findsNothing);
   });
 
   testWidgets('approving a plan waits for a mode, then sends it', (

--- a/mobile/test/preview_assets_test.dart
+++ b/mobile/test/preview_assets_test.dart
@@ -36,14 +36,26 @@ void main() {
     test('resolves a relative reference against the file that holds it', () {
       expect(resolveAsset(page, './chart.png', root), '$root/docs/chart.png');
       expect(resolveAsset(page, 'chart.png', root), '$root/docs/chart.png');
-      expect(resolveAsset(page, 'img/chart.png', root), '$root/docs/img/chart.png');
-      expect(resolveAsset(page, '../assets/logo.svg', root), '$root/assets/logo.svg');
+      expect(
+        resolveAsset(page, 'img/chart.png', root),
+        '$root/docs/img/chart.png',
+      );
+      expect(
+        resolveAsset(page, '../assets/logo.svg', root),
+        '$root/assets/logo.svg',
+      );
       expect(resolveAsset(page, './x.png?v=2#frag', root), '$root/docs/x.png');
-      expect(resolveAsset(page, 'my%20chart.png', root), '$root/docs/my chart.png');
+      expect(
+        resolveAsset(page, 'my%20chart.png', root),
+        '$root/docs/my chart.png',
+      );
     });
 
     test('reads an absolute reference against the checkout', () {
-      expect(resolveAsset(page, '/assets/logo.svg', root), '$root/assets/logo.svg');
+      expect(
+        resolveAsset(page, '/assets/logo.svg', root),
+        '$root/assets/logo.svg',
+      );
       // Which is also what stops a leading slash reaching outside it.
       expect(resolveAsset(page, '/etc/passwd', root), '$root/etc/passwd');
     });
@@ -83,12 +95,16 @@ void main() {
 
   group('planAssets', () {
     test('dedupes by path and keeps the order it found them', () {
-      final planned = planAssets(const [
-        AssetRef('img', './a.png'),
-        AssetRef('img', 'a.png'),
-        AssetRef('style', './s.css'),
-        AssetRef('img', './b.png'),
-      ], page, root);
+      final planned = planAssets(
+        const [
+          AssetRef('img', './a.png'),
+          AssetRef('img', 'a.png'),
+          AssetRef('style', './s.css'),
+          AssetRef('img', './b.png'),
+        ],
+        page,
+        root,
+      );
 
       expect(planned.map((a) => '${a.kind} ${a.path}'), [
         'img $root/docs/a.png',
@@ -98,18 +114,25 @@ void main() {
     });
 
     test('drops what it cannot resolve rather than failing', () {
-      final planned = planAssets(const [
-        AssetRef('img', 'https://example.com/x.png'),
-        AssetRef('img', './good.png'),
-        AssetRef('img', '../../../../etc/passwd'),
-      ], page, root);
+      final planned = planAssets(
+        const [
+          AssetRef('img', 'https://example.com/x.png'),
+          AssetRef('img', './good.png'),
+          AssetRef('img', '../../../../etc/passwd'),
+        ],
+        page,
+        root,
+      );
 
       expect(planned.length, 1);
       expect(planned.first.path, '$root/docs/good.png');
     });
 
     test('stops at the cap', () {
-      final refs = List.generate(maxAssets + 10, (i) => AssetRef('img', './img-$i.png'));
+      final refs = List.generate(
+        maxAssets + 10,
+        (i) => AssetRef('img', './img-$i.png'),
+      );
       expect(planAssets(refs, page, root).length, maxAssets);
     });
   });

--- a/mobile/test/provider_agnostic_test.dart
+++ b/mobile/test/provider_agnostic_test.dart
@@ -68,10 +68,13 @@ void main() {
       'a-kind-nobody-has-written-yet',
       '',
     ]) {
-      test('kind ${kind.isEmpty ? '(empty)' : kind} has a label and a body', () {
-        expect(registry.labelForKind(kind), isNotEmpty);
-        expect(registry.bodyForKind(kind), isNotEmpty);
-      });
+      test(
+        'kind ${kind.isEmpty ? '(empty)' : kind} has a label and a body',
+        () {
+          expect(registry.labelForKind(kind), isNotEmpty);
+          expect(registry.bodyForKind(kind), isNotEmpty);
+        },
+      );
     }
 
     test('the fallback names no particular agent', () {
@@ -81,7 +84,10 @@ void main() {
           isNot(contains('claude')),
           reason: 'the label for $kind names one provider',
         );
-        expect(registry.bodyForKind(kind).toLowerCase(), isNot(contains('claude')));
+        expect(
+          registry.bodyForKind(kind).toLowerCase(),
+          isNot(contains('claude')),
+        );
       }
     });
   });
@@ -91,8 +97,14 @@ void main() {
     // nobody hears. This must survive any later refactor of the settings
     // screen.
     test('an unknown provider is noisy rather than silent', () {
-      expect(NotificationService.instance.isAlertEnabled('codex.permission'), isTrue);
-      expect(NotificationService.instance.isAlertEnabled('nobody.knows'), isTrue);
+      expect(
+        NotificationService.instance.isAlertEnabled('codex.permission'),
+        isTrue,
+      );
+      expect(
+        NotificationService.instance.isAlertEnabled('nobody.knows'),
+        isTrue,
+      );
     });
   });
 
@@ -129,10 +141,16 @@ void _migrationTests() {
         'claude.permission': false,
         'claude.done': true,
       });
-      expect(migrated['permission'], isFalse,
-          reason: 'the silence the user chose must survive');
-      expect(migrated.containsKey('claude.permission'), isFalse,
-          reason: 'the stale key must not linger and override the switch');
+      expect(
+        migrated['permission'],
+        isFalse,
+        reason: 'the silence the user chose must survive',
+      );
+      expect(
+        migrated.containsKey('claude.permission'),
+        isFalse,
+        reason: 'the stale key must not linger and override the switch',
+      );
       expect(migrated['done'], isTrue);
     });
 
@@ -145,13 +163,20 @@ void _migrationTests() {
     });
 
     test('keys already stored by kind pass through', () {
-      final migrated = NotificationService.migrateLegacyAlertKeys({'permission': false});
+      final migrated = NotificationService.migrateLegacyAlertKeys({
+        'permission': false,
+      });
       expect(migrated['permission'], isFalse);
     });
 
-    test('a key naming no kind we know is kept verbatim rather than guessed', () {
-      final migrated = NotificationService.migrateLegacyAlertKeys({'weird.thing': false});
-      expect(migrated['weird.thing'], isFalse);
-    });
+    test(
+      'a key naming no kind we know is kept verbatim rather than guessed',
+      () {
+        final migrated = NotificationService.migrateLegacyAlertKeys({
+          'weird.thing': false,
+        });
+        expect(migrated['weird.thing'], isFalse);
+      },
+    );
   });
 }

--- a/mobile/test/session_test.dart
+++ b/mobile/test/session_test.dart
@@ -3,14 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:helios/models/session.dart';
 
 Session sessionWithStatus(String status, {bool queue = false}) => Session(
-      sessionId: 's1',
-      source: 'claude',
-      cwd: '/tmp/proj',
-      project: 'proj',
-      status: status,
-      supportsPromptQueue: queue,
-      createdAt: '2026-01-01T00:00:00Z',
-    );
+  sessionId: 's1',
+  source: 'claude',
+  cwd: '/tmp/proj',
+  project: 'proj',
+  status: status,
+  supportsPromptQueue: queue,
+  createdAt: '2026-01-01T00:00:00Z',
+);
 
 void main() {
   group('canSendPrompt', () {
@@ -30,11 +30,22 @@ void main() {
     });
 
     test('a busy session only accepts a prompt when it can queue', () {
-      for (final status in ['active', 'waiting_permission', 'compacting', 'starting']) {
-        expect(sessionWithStatus(status).canSendPrompt, isFalse,
-            reason: '$status without queueing');
-        expect(sessionWithStatus(status, queue: true).canSendPrompt, isTrue,
-            reason: '$status with queueing');
+      for (final status in [
+        'active',
+        'waiting_permission',
+        'compacting',
+        'starting',
+      ]) {
+        expect(
+          sessionWithStatus(status).canSendPrompt,
+          isFalse,
+          reason: '$status without queueing',
+        );
+        expect(
+          sessionWithStatus(status, queue: true).canSendPrompt,
+          isTrue,
+          reason: '$status with queueing',
+        );
       }
     });
 
@@ -61,9 +72,17 @@ void main() {
     });
 
     test('every mid-turn state asks first', () {
-      for (final status in ['active', 'waiting_permission', 'compacting', 'starting']) {
-        expect(needsTerminateConfirm([sessionWithStatus(status)]), isTrue,
-            reason: status);
+      for (final status in [
+        'active',
+        'waiting_permission',
+        'compacting',
+        'starting',
+      ]) {
+        expect(
+          needsTerminateConfirm([sessionWithStatus(status)]),
+          isTrue,
+          reason: status,
+        );
       }
     });
 
@@ -89,13 +108,13 @@ void main() {
   // user which session is worth closing.
   group('memoryLabel', () {
     Session withMemory(int? bytes) => Session.fromJson({
-          'session_id': 's1',
-          'source': 'claude',
-          'cwd': '/tmp/proj',
-          'status': 'idle',
-          'created_at': '2026-01-01T00:00:00Z',
-          'memory_bytes': ?bytes,
-        });
+      'session_id': 's1',
+      'source': 'claude',
+      'cwd': '/tmp/proj',
+      'status': 'idle',
+      'created_at': '2026-01-01T00:00:00Z',
+      'memory_bytes': ?bytes,
+    });
 
     test('megabytes below a gigabyte', () {
       expect(withMemory(412 * 1024 * 1024).memoryLabel, '412 MB');

--- a/mobile/test/terminal_frames_test.dart
+++ b/mobile/test/terminal_frames_test.dart
@@ -11,7 +11,9 @@ import 'package:helios/services/terminal/frames.dart';
 Uint8List fixture(String name) {
   final file = File('../internal/terminal/testdata/frames/$name.bin');
   if (!file.existsSync()) {
-    fail('missing ${file.path} — run: go test ./internal/terminal -run Golden -update');
+    fail(
+      'missing ${file.path} — run: go test ./internal/terminal -run Golden -update',
+    );
   }
   return file.readAsBytesSync();
 }
@@ -30,17 +32,28 @@ void main() {
     });
 
     test('resize', () {
-      expect(encodeFrame(FrameType.resize, encodeResize(120, 34)), equals(fixture('resize')));
+      expect(
+        encodeFrame(FrameType.resize, encodeResize(120, 34)),
+        equals(fixture('resize')),
+      );
     });
 
     test('snapshot', () {
-      final ansi = Uint8List.fromList(utf8.encode('\x1b[2J\x1b[H\x1b[32mready\x1b[0m'));
-      final encoded = encodeFrame(FrameType.snapshot, encodeSnapshot(1 << 40, ansi));
+      final ansi = Uint8List.fromList(
+        utf8.encode('\x1b[2J\x1b[H\x1b[32mready\x1b[0m'),
+      );
+      final encoded = encodeFrame(
+        FrameType.snapshot,
+        encodeSnapshot(1 << 40, ansi),
+      );
       expect(encoded, equals(fixture('snapshot')));
     });
 
     test('input', () {
-      final encoded = encodeFrame(FrameType.input, Uint8List.fromList([0x1b, 0x5b, 0x5a]));
+      final encoded = encodeFrame(
+        FrameType.input,
+        Uint8List.fromList([0x1b, 0x5b, 0x5a]),
+      );
       expect(encoded, equals(fixture('input')));
     });
 
@@ -78,7 +91,10 @@ void main() {
 
     test('output survives multibyte text', () {
       final frames = FrameParser().push(fixture('output'));
-      expect(utf8.decode(frames.single.payload), '\x1b[1mhello\x1b[0m 🎉 中文\r\n');
+      expect(
+        utf8.decode(frames.single.payload),
+        '\x1b[1mhello\x1b[0m 🎉 中文\r\n',
+      );
     });
 
     test('resize round-trips', () {
@@ -94,7 +110,11 @@ void main() {
     // frame per chunk would drop two of them.
     test('several frames in one chunk', () {
       final frames = FrameParser().push(fixture('stream'));
-      expect(frames.map((f) => f.type), [FrameType.output, FrameType.ping, FrameType.output]);
+      expect(frames.map((f) => f.type), [
+        FrameType.output,
+        FrameType.ping,
+        FrameType.output,
+      ]);
       expect(utf8.decode(frames[0].payload), 'first');
       expect(utf8.decode(frames[2].payload), 'second');
     });
@@ -107,14 +127,21 @@ void main() {
       for (final byte in blob) {
         collected.addAll(parser.push([byte]));
       }
-      expect(collected.map((f) => f.type), [FrameType.output, FrameType.ping, FrameType.output]);
+      expect(collected.map((f) => f.type), [
+        FrameType.output,
+        FrameType.ping,
+        FrameType.output,
+      ]);
       expect(utf8.decode(collected[2].payload), 'second');
     });
 
     test('a length prefix past the maximum is refused, not allocated', () {
       final absurd = Uint8List(headerSize);
       ByteData.view(absurd.buffer).setUint32(0, maxFrameSize + 1);
-      expect(() => FrameParser().push(absurd), throwsA(isA<FrameTooLargeException>()));
+      expect(
+        () => FrameParser().push(absurd),
+        throwsA(isA<FrameTooLargeException>()),
+      );
     });
   });
 }

--- a/mobile/test/transcript_catchup_test.dart
+++ b/mobile/test/transcript_catchup_test.dart
@@ -25,11 +25,11 @@ const _session = 's1';
 const _key = (_host, _session);
 
 Map<String, dynamic> msg(int seq) => {
-      'seq': seq,
-      'role': 'assistant',
-      'content': 'm$seq',
-      'timestamp': '2026-01-01T00:00:00Z',
-    };
+  'seq': seq,
+  'role': 'assistant',
+  'content': 'm$seq',
+  'timestamp': '2026-01-01T00:00:00Z',
+};
 
 /// The daemon's answer: `seqs`, and whether the limit cut it short.
 String body(List<int> seqs, {String epoch = 'e1', bool moreAfter = false}) =>
@@ -123,13 +123,17 @@ void main() {
 
     await notifierOf(c).pullNew();
 
-    expect(seqsOf(c), [1, 2, 3, 4, 5, 6, 7],
-        reason: 'a delta cut short must be followed to the end, not left as a hole');
     expect(
-      daemon.deltas.map((u) => u.queryParameters['after_seq']),
-      ['2', '4', '6'],
-      reason: 'each request advances the cursor to the last seq it was given',
+      seqsOf(c),
+      [1, 2, 3, 4, 5, 6, 7],
+      reason:
+          'a delta cut short must be followed to the end, not left as a hole',
     );
+    expect(daemon.deltas.map((u) => u.queryParameters['after_seq']), [
+      '2',
+      '4',
+      '6',
+    ], reason: 'each request advances the cursor to the last seq it was given');
   });
 
   test('one delta is enough when nothing was cut short', () async {
@@ -146,77 +150,93 @@ void main() {
     expect(daemon.deltas, hasLength(1));
   });
 
-  test('a trigger arriving mid-flight is run once afterwards, not dropped',
-      () async {
-    final release = Completer<void>();
-    final daemon = Daemon([
-      body([1, 2]),
-      body([3]),
-      body([4]),
-    ])
-      ..gates = [null, release.future];
+  test(
+    'a trigger arriving mid-flight is run once afterwards, not dropped',
+    () async {
+      final release = Completer<void>();
+      final daemon = Daemon([
+        body([1, 2]),
+        body([3]),
+        body([4]),
+      ])..gates = [null, release.future];
 
-    final c = containerFor(daemon);
-    await c.read(transcriptProvider(_key).future);
+      final c = containerFor(daemon);
+      await c.read(transcriptProvider(_key).future);
 
-    final first = notifierOf(c).pullNew();
-    await pumpEventQueue();
-    expect(daemon.deltas, hasLength(1), reason: 'the first read is out');
+      final first = notifierOf(c).pullNew();
+      await pumpEventQueue();
+      expect(daemon.deltas, hasLength(1), reason: 'the first read is out');
 
-    // A second event lands while that read is still waiting on the daemon.
-    notifierOf(c).pullNew();
-    await pumpEventQueue();
-    expect(daemon.deltas, hasLength(1),
-        reason: 'the second trigger must not open a second request');
+      // A second event lands while that read is still waiting on the daemon.
+      notifierOf(c).pullNew();
+      await pumpEventQueue();
+      expect(
+        daemon.deltas,
+        hasLength(1),
+        reason: 'the second trigger must not open a second request',
+      );
 
-    release.complete();
-    await first;
-    await pumpEventQueue();
+      release.complete();
+      await first;
+      await pumpEventQueue();
 
-    expect(daemon.deltas, hasLength(2),
-        reason: 'the trigger that arrived mid-flight is the one this provider '
-            'used to lose; it must produce a read that started after it');
-    expect(seqsOf(c), [1, 2, 3, 4]);
-  });
+      expect(
+        daemon.deltas,
+        hasLength(2),
+        reason:
+            'the trigger that arrived mid-flight is the one this provider '
+            'used to lose; it must produce a read that started after it',
+      );
+      expect(seqsOf(c), [1, 2, 3, 4]);
+    },
+  );
 
-  test('a failed read leaves the conversation alone and does not wedge the next',
-      () async {
-    final daemon = Daemon([body([1, 2])]);
-    final c = containerFor(daemon);
-    await c.read(transcriptProvider(_key).future);
+  test(
+    'a failed read leaves the conversation alone and does not wedge the next',
+    () async {
+      final daemon = Daemon([
+        body([1, 2]),
+      ]);
+      final c = containerFor(daemon);
+      await c.read(transcriptProvider(_key).future);
 
-    // fetchTranscript swallows the failure and answers null.
-    daemon.answers.add('not json');
-    await notifierOf(c).pullNew();
-    expect(seqsOf(c), [1, 2]);
+      // fetchTranscript swallows the failure and answers null.
+      daemon.answers.add('not json');
+      await notifierOf(c).pullNew();
+      expect(seqsOf(c), [1, 2]);
 
-    daemon.answers.add(body([3]));
-    await notifierOf(c).pullNew();
-    expect(seqsOf(c), [1, 2, 3], reason: 'the next pull must still run');
-  });
+      daemon.answers.add(body([3]));
+      await notifierOf(c).pullNew();
+      expect(seqsOf(c), [1, 2, 3], reason: 'the next pull must still run');
+    },
+  );
 
-  test('an epoch change replaces the conversation and stops the walk', () async {
-    final daemon = Daemon([
-      body([1, 2]),
-      jsonEncode({
-        'messages': [msg(9)],
-        'total': 1,
-        'returned': 1,
-        'offset': 0,
-        'has_more': false,
-        'epoch': 'e2',
-        'epoch_changed': true,
-      }),
-    ]);
-    final c = containerFor(daemon);
-    await c.read(transcriptProvider(_key).future);
+  test(
+    'an epoch change replaces the conversation and stops the walk',
+    () async {
+      final daemon = Daemon([
+        body([1, 2]),
+        jsonEncode({
+          'messages': [msg(9)],
+          'total': 1,
+          'returned': 1,
+          'offset': 0,
+          'has_more': false,
+          'epoch': 'e2',
+          'epoch_changed': true,
+        }),
+      ]);
+      final c = containerFor(daemon);
+      await c.read(transcriptProvider(_key).future);
 
-    await notifierOf(c).pullNew();
+      await notifierOf(c).pullNew();
 
-    expect(seqsOf(c), [9],
-        reason: 'the seq numbers held counted against a parse that is gone');
-    expect(daemon.deltas, hasLength(1));
-  });
+      expect(seqsOf(c), [
+        9,
+      ], reason: 'the seq numbers held counted against a parse that is gone');
+      expect(daemon.deltas, hasLength(1));
+    },
+  );
 
   test('catching up never returns the cell to a loading state', () async {
     final daemon = Daemon([
@@ -233,8 +253,12 @@ void main() {
     await notifierOf(c).pullNew();
 
     expect(seen, isNotEmpty);
-    expect(seen, everyElement(isFalse),
-        reason: 'a loading state here draws the skeleton over messages the '
-            'reader is looking at');
+    expect(
+      seen,
+      everyElement(isFalse),
+      reason:
+          'a loading state here draws the skeleton over messages the '
+          'reader is looking at',
+    );
   });
 }

--- a/mobile/test/transcript_test.dart
+++ b/mobile/test/transcript_test.dart
@@ -10,11 +10,11 @@ import 'package:helios/providers/transcript.dart';
 /// interleave two conversations.
 
 Message msg(int seq) => Message(
-      seq: seq,
-      role: 'assistant',
-      content: 'm$seq',
-      timestamp: '2026-01-01T00:00:00Z',
-    );
+  seq: seq,
+  role: 'assistant',
+  content: 'm$seq',
+  timestamp: '2026-01-01T00:00:00Z',
+);
 
 TranscriptResult result(
   List<Message> messages, {
@@ -22,28 +22,26 @@ TranscriptResult result(
   bool hasMore = false,
   String epoch = 'e1',
   bool epochChanged = false,
-}) =>
-    TranscriptResult(
-      messages: messages,
-      total: total,
-      returned: messages.length,
-      offset: 0,
-      hasMore: hasMore,
-      epoch: epoch,
-      epochChanged: epochChanged,
-    );
+}) => TranscriptResult(
+  messages: messages,
+  total: total,
+  returned: messages.length,
+  offset: 0,
+  hasMore: hasMore,
+  epoch: epoch,
+  epochChanged: epochChanged,
+);
 
 void main() {
-  const held = Transcript(
-    messages: [],
-    total: 2,
-    hasMore: true,
-    epoch: 'e1',
-  );
+  const held = Transcript(messages: [], total: 2, hasMore: true, epoch: 'e1');
 
   group('appendDelta', () {
     test('adds new messages to the end', () {
-      final base = Transcript(messages: [msg(1), msg(2)], total: 2, epoch: 'e1');
+      final base = Transcript(
+        messages: [msg(1), msg(2)],
+        total: 2,
+        epoch: 'e1',
+      );
       final next = appendDelta(base, result([msg(3)], total: 3));
       expect(next.messages.map((m) => m.seq), [1, 2, 3]);
       expect(next.total, 3);
@@ -59,7 +57,11 @@ void main() {
     // The transcript those seq numbers counted against is gone — forked, or
     // replaced. Appending across that would interleave two conversations.
     test('an epoch change replaces rather than appends', () {
-      final base = Transcript(messages: [msg(1), msg(2)], total: 2, epoch: 'e1');
+      final base = Transcript(
+        messages: [msg(1), msg(2)],
+        total: 2,
+        epoch: 'e1',
+      );
       final next = appendDelta(
         base,
         result([msg(9)], total: 1, epoch: 'e2', epochChanged: true),
@@ -93,11 +95,14 @@ void main() {
       expect(next.messages.map((m) => m.seq), [3, 4, 5, 6]);
     });
 
-    test('takes the page hasMore, which is what says whether to keep going', () {
-      final base = Transcript(messages: [msg(5)], hasMore: true, epoch: 'e1');
-      final next = prependPage(base, result([msg(4)], hasMore: false));
-      expect(next.hasMore, isFalse);
-    });
+    test(
+      'takes the page hasMore, which is what says whether to keep going',
+      () {
+        final base = Transcript(messages: [msg(5)], hasMore: true, epoch: 'e1');
+        final next = prependPage(base, result([msg(4)], hasMore: false));
+        expect(next.hasMore, isFalse);
+      },
+    );
 
     test('keeps the epoch: paging back is the same parse', () {
       final base = Transcript(messages: [msg(5)], epoch: 'e1');

--- a/mobile/test/transcript_triggers_test.dart
+++ b/mobile/test/transcript_triggers_test.dart
@@ -31,14 +31,14 @@ const _host = 'h1';
 const _session = 's1';
 
 Session session() => Session(
-      hostId: _host,
-      sessionId: _session,
-      source: 'claude',
-      cwd: '/tmp/p',
-      project: 'p',
-      status: 'idle',
-      createdAt: '2026-01-01T00:00:00Z',
-    );
+  hostId: _host,
+  sessionId: _session,
+  source: 'claude',
+  cwd: '/tmp/p',
+  project: 'p',
+  status: 'idle',
+  createdAt: '2026-01-01T00:00:00Z',
+);
 
 /// Answers every transcript read with one more message than the last.
 class Daemon {
@@ -97,7 +97,7 @@ class Daemon {
             'role': 'assistant',
             'content': 'm$_seq',
             'timestamp': '2026-01-01T00:00:00Z',
-          }
+          },
         ],
         'total': _seq,
         'returned': 1,
@@ -117,8 +117,8 @@ class Daemon {
 /// being torn down — which is the situation these triggers exist for.
 class Harness {
   Harness(this.tester, {bool empty = false, int? gateAfter})
-      : daemon = Daemon(empty: empty, gateAfter: gateAfter),
-        hosts = HostManager() {
+    : daemon = Daemon(empty: empty, gateAfter: gateAfter),
+      hosts = HostManager() {
     final service = DaemonAPIService(
       hostId: _host,
       serverUrl: 'http://localhost:1',
@@ -184,22 +184,35 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  testWidgets('coming back to a session reads what arrived while it was closed',
-      (tester) async {
-    final h = harnessFor(tester);
+  testWidgets(
+    'coming back to a session reads what arrived while it was closed',
+    (tester) async {
+      final h = harnessFor(tester);
 
-    await h.openSession();
-    expect(h.daemon.asked, hasLength(1), reason: 'the first page, from build()');
-    expect(h.daemon.deltas, isEmpty,
-        reason: 'nothing held yet, so there is no cursor to quote');
+      await h.openSession();
+      expect(
+        h.daemon.asked,
+        hasLength(1),
+        reason: 'the first page, from build()',
+      );
+      expect(
+        h.daemon.deltas,
+        isEmpty,
+        reason: 'nothing held yet, so there is no cursor to quote',
+      );
 
-    await h.leaveSession();
-    await h.openSession();
+      await h.leaveSession();
+      await h.openSession();
 
-    expect(h.daemon.deltas, hasLength(1),
-        reason: 'the provider outlives the screen, so build() does not run '
-            'again — without this trigger, re-entering reads nothing');
-  });
+      expect(
+        h.daemon.deltas,
+        hasLength(1),
+        reason:
+            'the provider outlives the screen, so build() does not run '
+            'again — without this trigger, re-entering reads nothing',
+      );
+    },
+  );
 
   testWidgets('coming back to the foreground reads the tail', (tester) async {
     final h = harnessFor(tester);
@@ -210,13 +223,18 @@ void main() {
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(h.daemon.deltas.length, before + 1,
-        reason: 'a turn can finish while the phone is locked, and the event '
-            'that announced it is gone by the time the screen is back');
+    expect(
+      h.daemon.deltas.length,
+      before + 1,
+      reason:
+          'a turn can finish while the phone is locked, and the event '
+          'that announced it is gone by the time the screen is back',
+    );
   });
 
-  testWidgets('neither read puts the skeleton back over the conversation',
-      (tester) async {
+  testWidgets('neither read puts the skeleton back over the conversation', (
+    tester,
+  ) async {
     final h = harnessFor(tester);
     await h.openSession();
     await h.leaveSession();
@@ -229,20 +247,26 @@ void main() {
     expect(find.text('m2'), findsOneWidget);
   });
 
-  testWidgets('a session with nothing written yet re-reads without a skeleton',
-      (tester) async {
-    // Nothing is held, so there is no epoch to quote and the catch-up falls
-    // back to reading the page again. That is a refresh, and a refreshing
-    // AsyncValue still reports isLoading while carrying its previous value.
-    // The catch-up read is held open, so the screen is observed while the
-    // refresh is still out rather than after it has landed.
-    final h = harnessFor(tester, empty: true, gateAfter: 1);
-    await h.openSession();
-    await h.leaveSession();
-    await h.openSession();
+  testWidgets(
+    'a session with nothing written yet re-reads without a skeleton',
+    (tester) async {
+      // Nothing is held, so there is no epoch to quote and the catch-up falls
+      // back to reading the page again. That is a refresh, and a refreshing
+      // AsyncValue still reports isLoading while carrying its previous value.
+      // The catch-up read is held open, so the screen is observed while the
+      // refresh is still out rather than after it has landed.
+      final h = harnessFor(tester, empty: true, gateAfter: 1);
+      await h.openSession();
+      await h.leaveSession();
+      await h.openSession();
 
-    expect(find.byType(MessageListSkeleton), findsNothing,
-        reason: 'the skeleton belongs to a first load; drawing it on a refresh '
-            'is what threw away the reader place this whole change protects');
-  });
+      expect(
+        find.byType(MessageListSkeleton),
+        findsNothing,
+        reason:
+            'the skeleton belongs to a first load; drawing it on a refresh '
+            'is what threw away the reader place this whole change protects',
+      );
+    },
+  );
 }

--- a/mobile/test/update_version_test.dart
+++ b/mobile/test/update_version_test.dart
@@ -53,11 +53,10 @@ void main() {
         {'tag_name': 'v2.10.0'},
         {'tag_name': 'v2.9.5'},
       ];
-      expect(service.releasesSince(shuffled, '2.8.0').map((r) => r['tag_name']), [
-        'v2.10.0',
-        'v2.9.5',
-        'v2.9.0',
-      ]);
+      expect(
+        service.releasesSince(shuffled, '2.8.0').map((r) => r['tag_name']),
+        ['v2.10.0', 'v2.9.5', 'v2.9.0'],
+      );
     });
 
     // A dev build reports "0.2.0-dev", and every published release is newer.


### PR DESCRIPTION
## The claim

A plan is not a yes-or-no question, and helios asked it as one.

When Claude finishes planning it calls `ExitPlanMode`. On the wire that is a permission like any other, so helios painted `Allow once` / `Deny` over the CLI's own dialog, with the raw tool input cut at 100 characters as the body.

Three things were lost: the mode the session continues in, the ability to disagree in words rather than with a bare no, and the plan itself.

## What it looks like now

```
┌─ Ready to code? ───────────────────────────────────────────────────────────┐
│ # Plan: give plan approval its own rows                                    │
│                                                                            │
│ ## Context                                                                 │
│ The terminal offers Allow once and Deny.                                   │
│ …14 more lines · ~/.claude/plans/rows.md                                   │
│                                                                            │
│ ❯ Yes, and use auto mode                                                   │
│     Claude edits and runs commands without asking, for the rest of this    │
│     session                                                                │
│   Yes, manually approve edits                                              │
│     Claude asks before each edit, as it does now                           │
│   Tell Claude what to change                                               │
│                                                                            │
│ ↑↓ select · enter confirm · esc cancel                                     │
└────────────────────────────────────────────────────────────────────────────┘
```

Enter on the third row opens a field. What is typed becomes the hook's deny message, prefixed with a line naming the user — a denied tool reaches the model as `Error: <message>`, and bare text there reads as a malfunction rather than as a person talking.

The phone and the desktop app get the same three rows.

## A plan is the one permission a hook cannot decide

The first cut of this replied `allow` with a `setMode` permission update. Run live, the plan never started: the CLI showed its own dialog regardless. Measured against Claude Code 2.1.259 in a single-hook environment:

| Probe | Result |
| --- | --- |
| `allow` for `ExitPlanMode` | ignored; dialog shown, plan not started |
| `allow` + `setMode` for `ExitPlanMode` | ignored; same |
| `allow` for `Bash` (control) | honoured; the command ran with no dialog |
| `deny` with a message | honoured; Claude re-planned from the words |

The control run is what makes this a statement about the tool rather than about the response shape.

So helios collects the answer on its own overlay, replies `ask` to get out of the CLI's way, and presses the matching row on the CLI's dialog. The keystroke follows the reply rather than accompanying it, because the CLI does not draw that dialog until the hook has answered. It reuses `provider.ConfirmChoice`, the screen-scraping row picker that already answers the workspace trust dialog, and polls for up to 15 seconds.

Failing to find the row is survivable and deliberately quiet: the CLI's dialog is on screen, fully usable, and answerable by hand. A renamed row degrades to that, not to a hung session.

The mode is written down twice. The CLI applies it to the running process only; helios repeats `--permission-mode` from the session record on every resume, so an approved plan also records `auto` or `manual`.

## Codex gets the same way to disagree

Checked whether Codex needs any of this. One half applies, one half does not.

**It has no plan.** Codex has no `ExitPlanMode` tool and no plan hook event. Leaving plan mode is a TUI prompt it draws itself — `Implement this plan?` — with no tool call behind it, so helios never sees it. The two mode rows and the keystroke handoff have nothing to attach to.

**It does have the bare-no gap.** Codex's own approval dialog offers eight rows, one of them `No, and tell Codex what to do differently`. Helios painted `Allow once` / `Deny` over it and answered every refusal with `Denied via helios`. The wire already carried the words — `deny` with a message is one of the two responses `PermissionRequest` honours, measured in spec 46 — so only the way to collect them was missing.

So a Codex permission gets the answer field on all three surfaces, and the typed words become the deny message under a line naming the user. Escape still denies without a word. An approval drops any words sent with it: feedback is a refusal's payload, and carried onto an approval it would send Codex a complaint about work it was just cleared to do.

Unlike Claude, the field is on every Codex permission card rather than on a plan card alone. Codex offers the row on every approval too, and there is no rule to write instead. "Don't ask again" is still absent for the old reason: `updatedPermissions` fails closed.

## Tested

- `go test ./...`, `flutter test` (186), `npm test` (271) and `tsc --noEmit` in `desktop/` — all green
- New: `internal/provider/claude/plan_test.go` (16 tests), `internal/provider/codex/permission_test.go` (8), `mobile/test/plan_card_test.dart` (4) and `mobile/test/codex_permission_card_test.dart` (3)
- End to end against a real Claude Code on an isolated daemon:
  - **auto mode** — plan ran, the file was written, `permission_mode` recorded as `auto`, no further prompts
  - **manually approve edits** — recorded `manual`, the CLI reported "manual mode on", and the Write asked again
  - **feedback** — typed words reached Claude, which re-planned with the change and asked again
- No live-CLI run for the Codex half: the behaviour it rests on — Codex honouring a deny message — is already measured in spec 46, and its hook tests drive the real HITL controller end to end.

Specs: [docs/specs/57-plan-approval.md](docs/specs/57-plan-approval.md), [docs/specs/46-codex-provider.md](docs/specs/46-codex-provider.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
