### PR TITLE
feat(codex): let a refusal say what to do differently

### DIFF
--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import type { Notification } from '../../shared/models.ts'
-import { kindOf } from '../../shared/notifications.ts'
+import { kindOf, providerOf } from '../../shared/notifications.ts'
 
 /**
  * One notification, rendered with the controls its type needs.
@@ -37,7 +37,9 @@ export function NotificationCard({
   const body = ((): JSX.Element => {
     switch (kindOf(notif.type)) {
       case 'permission':
-        return <PermissionCard payload={payload} busy={busy} act={act} />
+        return (
+          <PermissionCard payload={payload} provider={providerOf(notif.type)} busy={busy} act={act} />
+        )
       case 'question':
         return <QuestionCard payload={payload} busy={busy} act={act} />
       case 'trust':
@@ -181,10 +183,12 @@ function PlanCard({
 
 function PermissionCard({
   payload,
+  provider,
   busy,
   act,
 }: {
   payload: Record<string, unknown>
+  provider: string
   busy: boolean
   act: (body: Record<string, unknown>) => Promise<void>
 }): JSX.Element {
@@ -202,6 +206,14 @@ function PermissionCard({
   const [editing, setEditing] = useState(false)
   const [edited, setEdited] = useState(original)
   const [rule, setRule] = useState<number | null>(null)
+  const [feedback, setFeedback] = useState('')
+
+  // Codex's own approval dialog offers "No, and tell Codex what to do
+  // differently". Helios paints over that dialog, so it has to offer the row
+  // too or the only refusal it leaves is a bare no. Claude's plan card carries
+  // its own field; its other tools take a rule instead.
+  const takesFeedback = provider === 'codex'
+  const words = feedback.trim()
 
   // A plan is prose and its answer is not a yes-or-no. The state above is
   // declared first so the hook order holds whichever card is drawn.
@@ -255,10 +267,26 @@ function PermissionCard({
         </div>
       )}
 
+      {takesFeedback && (
+        <label className="field">
+          <span>Tell Codex what to do differently</span>
+          <input
+            value={feedback}
+            placeholder="Say what to do instead"
+            onChange={(event) => setFeedback(event.target.value)}
+          />
+        </label>
+      )}
+
       <Actions busy={busy}>
         <button onClick={approve}>Approve</button>
-        <button className="ghost" onClick={() => void act({ action: 'deny' })}>
-          Deny
+        {/* Words turn a refusal into another attempt, so the button says what
+            it will do with them. */}
+        <button
+          className="ghost"
+          onClick={() => void act(words === '' ? { action: 'deny' } : { action: 'deny', feedback: words })}
+        >
+          {words === '' ? 'Deny' : 'Send back'}
         </button>
         <button className="link" onClick={() => setEditing(!editing)}>
           {editing ? 'Cancel editing' : 'Edit before approving'}

--- a/docs/specs/46-codex-provider.md
+++ b/docs/specs/46-codex-provider.md
@@ -706,7 +706,36 @@ Hook map:
 means *keep going*. Helios must return `{}`. Anything else restarts the turn.
 
 Action handlers: `codex.permission` only. It maps approve/deny onto
-`{"decision": {"behavior": "allow"}}` or `deny` with a message.
+`{"decision": {"behavior": "allow"}}` or `deny` with a message. A refusal may
+carry `feedback`, which becomes that message; see "A refusal can carry words".
+
+### A refusal can carry words
+
+Codex's own approval dialog offers eight rows, and one of them is
+`No, and tell Codex what to do differently`. Helios painted `Allow once` and
+`Deny` over it, and answered every refusal with `Denied via helios` — so the
+one thing the user most often wants to say, *not like that, like this*, had
+nowhere to go.
+
+The wire already carried it. `deny` with a message is one of the two responses
+`PermissionRequest` honours, measured against 0.150.1.
+
+So the overlay gains a third row that is not a choice: `AllowText` with
+`TextLabel: "Tell Codex what to do differently"`. Enter opens the field, Enter
+sends, and the words become the deny message under a line naming who is
+speaking — a refused call comes back to the model as an error, and bare text
+there reads as a malfunction rather than as a person talking. Escape still
+denies without a word and still says `Denied via helios`.
+
+The phone and the desktop app post `feedback` on the deny action and get the
+same field. Unlike Claude, the field is on every Codex permission card rather
+than on a plan card alone: Codex has no `ExitPlanMode`, and no rule to write
+instead.
+
+Two rows are still missing, for reasons that have not changed. There is no
+"don't ask again" because `updatedPermissions` fails closed. There is no plan
+card because leaving plan mode is a TUI prompt Codex draws itself — `Implement
+this plan?` — with no tool call and no hook behind it. Helios never sees it.
 
 ### What a Codex session will not have
 

--- a/internal/provider/codex/actions.go
+++ b/internal/provider/codex/actions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/kamrul1157024/helios/internal/backend"
 	"github.com/kamrul1157024/helios/internal/notifications"
@@ -42,9 +43,15 @@ func (p *Provider) ActionRoutes() map[string]provider.ActionRoute {
 	}
 }
 
+// handlePermissionAction turns a remote surface's answer into a decision.
+//
+// A refusal may carry words, the way the terminal overlay's text field does.
+// An approval that carried them would send Codex a complaint about work it was
+// just cleared to do, so they are read on the deny path only.
 func handlePermissionAction(notif *store.Notification, body json.RawMessage) (notifications.Decision, error) {
 	var req struct {
 		Action string `json:"action"`
+		permissionAnswer
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return notifications.Decision{}, fmt.Errorf("invalid body: %w", err)
@@ -53,6 +60,9 @@ func handlePermissionAction(notif *store.Notification, body json.RawMessage) (no
 	case "approve":
 		return notifications.Decision{Status: "approved"}, nil
 	case "deny":
+		if text := strings.TrimSpace(req.Feedback); text != "" {
+			return deniedWithFeedback(text), nil
+		}
 		return notifications.Decision{Status: "denied"}, nil
 	default:
 		return notifications.Decision{}, fmt.Errorf("action must be approve/deny")

--- a/internal/provider/codex/hooks.go
+++ b/internal/provider/codex/hooks.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -372,7 +373,75 @@ func writePermResponse(w http.ResponseWriter, behavior, message string) {
 const (
 	allowOnce  = "Allow once"
 	denyChoice = "Deny"
+
+	// Codex's own approval dialog offers "No, and tell Codex what to do
+	// differently". Helios paints over that dialog, so it has to offer the row
+	// too or the only refusal it leaves the user is a bare no.
+	feedbackLabel = "Tell Codex what to do differently"
 )
+
+// What Codex reads in place of the tool's result when it is refused.
+//
+// A denied call comes back to the model as an error, so bare text there reads
+// as a malfunction rather than as a person talking. Each of these says who is
+// speaking. Codex honours a deny message; see docs/specs/46-codex-provider.md.
+const (
+	deniedReason   = "Denied via helios"
+	deniedFeedback = "The user denied this in helios and said:"
+)
+
+// permissionAnswer is what a surface sends back beyond approve or deny. Only
+// the words matter here: Codex cannot write a permission rule and cannot take
+// an edited input, so there is nothing else to carry.
+type permissionAnswer struct {
+	Feedback string `json:"feedback,omitempty"`
+}
+
+// deniedWithFeedback refuses the tool in the user's own words.
+func deniedWithFeedback(text string) notifications.Decision {
+	response, err := json.Marshal(permissionAnswer{Feedback: text})
+	if err != nil {
+		log.Printf("codex: encode denial feedback: %v", err)
+		return notifications.Decision{Status: "denied"}
+	}
+	return notifications.Decision{Status: "denied", Response: response}
+}
+
+// denyMessage is the sentence Codex reads for a refusal, whichever surface
+// refused. Unreadable feedback degrades to the bare reason rather than to a
+// tool that hangs.
+func denyMessage(sessionID string, decision *notifications.Decision) string {
+	if len(decision.Response) == 0 {
+		return deniedReason
+	}
+	var answer permissionAnswer
+	if err := json.Unmarshal(decision.Response, &answer); err != nil {
+		log.Printf("codex: read denial for %s: %v", sessionID, err)
+		return deniedReason
+	}
+	if text := strings.TrimSpace(answer.Feedback); text != "" {
+		return deniedFeedback + "\n" + text
+	}
+	return deniedReason
+}
+
+// terminalDecision reads an answer off the overlay. Anything it does not
+// recognise — escape, a row that is gone, a prompt that changed under it —
+// denies, because the safe reading of an unclear answer is no.
+func terminalDecision(choices []string, a hitl.Answer) notifications.Decision {
+	// Text first: a typed answer carries Index -1, so indexing choices with it
+	// would read off the front of the list.
+	if text := strings.TrimSpace(a.Text); text != "" {
+		return deniedWithFeedback(text)
+	}
+	if a.Cancelled() || a.Index < 0 || a.Index >= len(choices) {
+		return notifications.Decision{Status: "denied"}
+	}
+	if choices[a.Index] == allowOnce {
+		return notifications.Decision{Status: "approved"}
+	}
+	return notifications.Decision{Status: "denied"}
+}
 
 func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.Request, raw json.RawMessage) {
 	in, ok := decode(w, raw)
@@ -423,18 +492,17 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 	// matter which of them settled it.
 	//
 	// Only two choices: Codex cannot write a permission rule, so there is
-	// nothing for "don't ask again" to apply.
+	// nothing for "don't ask again" to apply. The third row is not a choice —
+	// it is the text field, and the words it takes become the deny message.
 	choices := []string{allowOnce, denyChoice}
 	defer showPrompt(ctx, key, hitl.Prompt{
-		Title:   in.ToolName,
-		Body:    []string{summarize(in.ToolInput)},
-		Choices: choices,
+		Title:     in.ToolName,
+		Body:      []string{summarize(in.ToolInput)},
+		Choices:   choices,
+		AllowText: true,
+		TextLabel: feedbackLabel,
 	}, func(a hitl.Answer) {
-		decision := notifications.Decision{Status: "denied"}
-		if !a.Cancelled() && a.Index < len(choices) && choices[a.Index] == allowOnce {
-			decision.Status = "approved"
-		}
-		if err := ctx.Mgr.Resolve(notifID, decision, "terminal"); err != nil &&
+		if err := ctx.Mgr.Resolve(notifID, terminalDecision(choices, a), "terminal"); err != nil &&
 			!errors.Is(err, store.ErrAlreadyResolved) {
 			log.Printf("codex: resolve permission %s from the terminal: %v", notifID, err)
 		}
@@ -452,7 +520,7 @@ func handlePermission(ctx *provider.HookContext, w http.ResponseWriter, r *http.
 		writePermResponse(w, "allow", "")
 		return
 	}
-	writePermResponse(w, "deny", "Denied via helios")
+	writePermResponse(w, "deny", denyMessage(key, decision))
 }
 
 // ==================== Compaction and subagents ====================

--- a/internal/provider/codex/permission_test.go
+++ b/internal/provider/codex/permission_test.go
@@ -1,0 +1,262 @@
+package codex
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kamrul1157024/helios/internal/hitl"
+	"github.com/kamrul1157024/helios/internal/notifications"
+	"github.com/kamrul1157024/helios/internal/provider"
+	"github.com/kamrul1157024/helios/internal/store"
+	"github.com/kamrul1157024/helios/internal/terminal"
+)
+
+// The bug these close: Codex's own approval dialog offers "No, and tell Codex
+// what to do differently", and helios painted a bare Deny over it. Every
+// refusal reached the model as "Denied via helios", whoever refused and
+// whatever they meant.
+
+const codexSession = "01a04dee-183a-7461-9bef-5f05c0aa510a"
+
+// codexOverlays stands in for a session's terminal, recording what helios drew
+// over it. Painting happens on the hook's goroutine while the test drives keys
+// from its own, so both directions travel by channel.
+type codexOverlays struct {
+	painted chan terminal.Overlay
+	cleared chan string
+}
+
+func (p *codexOverlays) SetOverlay(sessionID string, o terminal.Overlay) error {
+	p.painted <- o
+	return nil
+}
+
+func (p *codexOverlays) ClearOverlay(sessionID string) error {
+	p.cleared <- sessionID
+	return nil
+}
+
+// OverlayProtocol reports a host of this build, so the answer field is painted
+// rather than dropped and left to the phone.
+func (p *codexOverlays) OverlayProtocol(sessionID string) int {
+	return terminal.HostProtocol
+}
+
+func permCtx(t *testing.T) (*provider.HookContext, *codexOverlays, *hitl.Controller) {
+	t.Helper()
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	overlays := &codexOverlays{
+		painted: make(chan terminal.Overlay, 8),
+		cleared: make(chan string, 8),
+	}
+	ctl := hitl.NewController(overlays)
+	ctx := &provider.HookContext{
+		DB:             db,
+		Mgr:            notifications.NewManager(db),
+		HITL:           ctl,
+		Notify:         func(string, interface{}) {},
+		Report:         func(provider.ReportEvent) {},
+		SessionStarted: func(string) {},
+	}
+	return ctx, overlays, ctl
+}
+
+// askPerm runs the permission hook and waits for its overlay to land.
+func askPerm(t *testing.T, ctx *provider.HookContext, p *codexOverlays,
+	tool string) (<-chan *httptest.ResponseRecorder, terminal.Overlay) {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"session_id": codexSession,
+		"cwd":        "/tmp/proj",
+		"tool_name":  tool,
+		"tool_input": map[string]string{"command": "rm -rf build"},
+	})
+	if err != nil {
+		t.Fatalf("encode hook input: %v", err)
+	}
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		handlePermission(ctx, w, httptest.NewRequest("POST", "/hooks/codex/permission", nil), body)
+		done <- w
+	}()
+	return done, awaitPainted(t, p)
+}
+
+func awaitPainted(t *testing.T, p *codexOverlays) terminal.Overlay {
+	t.Helper()
+	select {
+	case o := <-p.painted:
+		return o
+	case <-time.After(5 * time.Second):
+		t.Fatal("nothing was painted on the terminal")
+		return terminal.Overlay{}
+	}
+}
+
+func awaitPermResponse(t *testing.T, done <-chan *httptest.ResponseRecorder) permResponse {
+	t.Helper()
+	select {
+	case w := <-done:
+		var resp permResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response %q: %v", w.Body.String(), err)
+		}
+		return resp
+	case <-time.After(5 * time.Second):
+		t.Fatal("the hook never answered Codex")
+		return permResponse{}
+	}
+}
+
+func TestPermission_TheOverlayOffersAWayToDisagree(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, o := askPerm(t, ctx, overlays, "shell")
+
+	if len(o.Options) != 2 {
+		t.Errorf("choices = %v, want allow and deny only", o.Options)
+	}
+	if o.Input == nil || o.Input.Label != feedbackLabel {
+		t.Errorf("input row = %v, want one labelled %q", o.Input, feedbackLabel)
+	}
+
+	ctl.HandleInput(codexSession, []byte("\x1b"))
+	awaitPermResponse(t, done)
+}
+
+// The words are the point: Codex reads them and picks a different way rather
+// than stopping.
+func TestPermission_TypedWordsReachCodex(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+
+	// Down past both choices onto the feedback row, Enter to open the field.
+	ctl.HandleInput(codexSession, []byte("\x1b[B"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\x1b[B"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\r"))
+	if o := awaitPainted(t, overlays); o.Input == nil || !o.Input.Active {
+		t.Fatalf("input = %v, want the field open after Enter on its row", o.Input)
+	}
+	ctl.HandleInput(codexSession, []byte("delete the directory, do not rm it"))
+	awaitPainted(t, overlays)
+	ctl.HandleInput(codexSession, []byte("\r"))
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny — words refuse the tool", decision.Behavior)
+	}
+	if !strings.Contains(decision.Message, "delete the directory, do not rm it") {
+		t.Errorf("message = %q, want the typed words", decision.Message)
+	}
+	// A refused call comes back as an error, so the words need someone
+	// attached to them or they read as a malfunction.
+	if !strings.Contains(decision.Message, deniedFeedback) {
+		t.Errorf("message = %q, want it to say who is speaking", decision.Message)
+	}
+}
+
+func TestPermission_EscapeStillDeniesWithoutWords(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+	ctl.HandleInput(codexSession, []byte("\x1b"))
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny", decision.Behavior)
+	}
+	if decision.Message != deniedReason {
+		t.Errorf("message = %q, want %q", decision.Message, deniedReason)
+	}
+}
+
+func TestPermission_AllowOnceStillAllows(t *testing.T) {
+	ctx, overlays, ctl := permCtx(t)
+
+	done, _ := askPerm(t, ctx, overlays, "shell")
+	ctl.HandleInput(codexSession, []byte("\r")) // "Allow once" is preselected
+
+	decision := awaitPermResponse(t, done).HookSpecificOutput.Decision
+	if decision.Behavior != "allow" {
+		t.Errorf("behavior = %q, want allow", decision.Behavior)
+	}
+	if decision.Message != "" {
+		t.Errorf("message = %q, want none on an approval", decision.Message)
+	}
+}
+
+// The phone sends the same words the overlay's field takes, and the daemon
+// cannot tell which surface answered.
+func TestPermission_ThePhoneCanSayWhatToDoDifferently(t *testing.T) {
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"deny","feedback":"use git clean instead"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if decision.Status != "denied" {
+		t.Fatalf("status = %q, want denied", decision.Status)
+	}
+	msg := denyMessage(codexSession, &decision)
+	if !strings.Contains(msg, "use git clean instead") {
+		t.Errorf("message = %q, want the phone's words", msg)
+	}
+}
+
+func TestPermission_AnApprovalDropsAnyWordsSentWithIt(t *testing.T) {
+	// Feedback is a refusal's payload. Carried onto an approval it would send
+	// Codex a complaint about work it was just cleared to do.
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"approve","feedback":"use git clean instead"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if decision.Status != "approved" {
+		t.Fatalf("status = %q, want approved", decision.Status)
+	}
+	if len(decision.Response) != 0 {
+		t.Errorf("response = %s, want nothing carried onto an approval", decision.Response)
+	}
+}
+
+func TestPermission_ABareNoKeepsItsOldWords(t *testing.T) {
+	decision, err := handlePermissionAction(&store.Notification{},
+		json.RawMessage(`{"action":"deny"}`))
+	if err != nil {
+		t.Fatalf("handlePermissionAction: %v", err)
+	}
+	if got := denyMessage(codexSession, &decision); got != deniedReason {
+		t.Errorf("message = %q, want %q", got, deniedReason)
+	}
+}
+
+// An answer helios cannot read is a no, not a crash and not a yes.
+func TestPermission_AnUnreadableAnswerDenies(t *testing.T) {
+	choices := []string{allowOnce, denyChoice}
+	for name, a := range map[string]hitl.Answer{
+		"cancelled":     {Index: -1},
+		"row that went": {Index: 7},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := terminalDecision(choices, a).Status; got != "denied" {
+				t.Errorf("status = %q, want denied", got)
+			}
+		})
+	}
+
+	broken := notifications.Decision{Status: "denied", Response: json.RawMessage(`{`)}
+	if got := denyMessage(codexSession, &broken); got != deniedReason {
+		t.Errorf("message = %q, want the bare reason for unreadable feedback", got)
+	}
+}

--- a/mobile/lib/providers/cards.dart
+++ b/mobile/lib/providers/cards.dart
@@ -231,21 +231,24 @@ class _PermissionCardState extends State<PermissionCard> {
                 ),
               ),
             ],
-            // How to say yes to a plan, and how to disagree with one
+            // How to say yes to a plan
             if (n.isPlan) ...[
               const SizedBox(height: 12),
               ..._planRows.map(_planRow),
-              const SizedBox(height: 4),
+            ],
+            // How to disagree in words rather than with a bare no
+            if (_takesFeedback) ...[
+              SizedBox(height: n.isPlan ? 4 : 12),
               TextField(
                 controller: _feedback,
                 maxLines: 3,
                 minLines: 1,
                 style: const TextStyle(fontSize: 13),
-                decoration: const InputDecoration(
+                decoration: InputDecoration(
                   isDense: true,
-                  labelText: 'Tell Claude what to change',
-                  hintText: 'Send the plan back in your own words',
-                  border: OutlineInputBorder(),
+                  labelText: _feedbackLabel,
+                  hintText: _feedbackHint,
+                  border: const OutlineInputBorder(),
                 ),
                 onChanged: (_) => setState(() {}),
               ),
@@ -290,10 +293,10 @@ class _PermissionCardState extends State<PermissionCard> {
                       backgroundColor: Theme.of(context).colorScheme.error,
                       foregroundColor: Theme.of(context).colorScheme.onError,
                     ),
-                    // Words turn a refusal into a re-plan, so the button says
-                    // what it will do with them.
+                    // Words turn a refusal into another attempt, so the button
+                    // says what it will do with them.
                     child: Text(
-                      n.isPlan && _feedback.text.trim().isNotEmpty
+                      _takesFeedback && _feedback.text.trim().isNotEmpty
                           ? 'Send back'
                           : 'Deny',
                     ),
@@ -322,6 +325,21 @@ class _PermissionCardState extends State<PermissionCard> {
       ),
     );
   }
+
+  /// Whether this card takes words as well as a yes or a no.
+  ///
+  /// A plan is not a yes-or-no question. Neither is a Codex approval: the
+  /// dialog Codex draws under helios offers "No, and tell Codex what to do
+  /// differently", so the card has to offer it too.
+  bool get _takesFeedback => n.isPlan || n.isCodex;
+
+  String get _feedbackLabel => n.isPlan
+      ? 'Tell Claude what to change'
+      : 'Tell Codex what to do differently';
+
+  String get _feedbackHint => n.isPlan
+      ? 'Send the plan back in your own words'
+      : 'Say what to do instead';
 
   /// One way of saying yes to a plan, with the mode it leaves behind spelled
   /// out under it.

--- a/mobile/lib/providers/notification_ext.dart
+++ b/mobile/lib/providers/notification_ext.dart
@@ -56,6 +56,10 @@ extension NotificationPayload on HeliosNotification {
   List<dynamic>? get permissionSuggestions =>
       payload?['permission_suggestions'] as List?;
 
+  /// Whether Codex raised this. The card is the same card whoever raised it,
+  /// but the words on it name the agent the user is talking to.
+  bool get isCodex => source == 'codex';
+
   /// A plan waiting for approval. On the wire it is a permission like any
   /// other, but it is not a yes-or-no question: the answer picks the mode the
   /// session continues in, or sends the plan back in words.

--- a/mobile/test/codex_permission_card_test.dart
+++ b/mobile/test/codex_permission_card_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:helios/models/notification.dart';
+import 'package:helios/providers/cards.dart';
+import 'package:helios/services/api_client.dart';
+import 'package:helios/services/daemon_api_service.dart';
+
+/// Codex's own approval dialog offers "No, and tell Codex what to do
+/// differently". The phone painted a bare Deny over it. These pin the words
+/// that replaced it.
+
+HeliosNotification _permission(String source) => HeliosNotification(
+      id: 'n1',
+      source: source,
+      sourceSession: 's1',
+      cwd: '/tmp/proj',
+      type: '$source.permission',
+      status: 'pending',
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+      payload: {
+        'tool_name': 'shell',
+        'tool_input': {'command': 'rm -rf build'},
+      },
+    );
+
+/// A service whose action posts land in [sent] instead of on a daemon.
+DaemonAPIService _serviceRecording(List<Map<String, dynamic>> sent) {
+  final client = MockClient((req) async {
+    if (req.url.path.contains('/auth/')) {
+      return http.Response(
+        jsonEncode({
+          'token': 't',
+          'expires_at': DateTime.now()
+              .toUtc()
+              .add(const Duration(hours: 1))
+              .toIso8601String(),
+        }),
+        200,
+      );
+    }
+    if (req.url.path.endsWith('/action')) {
+      sent.add(jsonDecode(req.body) as Map<String, dynamic>);
+      return http.Response('{}', 200);
+    }
+    return http.Response('{}', 200);
+  });
+  return DaemonAPIService(
+    hostId: 'h1',
+    serverUrl: 'http://localhost:1',
+    api: ApiClient(
+      serverUrl: 'http://localhost:1',
+      deviceId: 'd1',
+      privateKeySeed: Uint8List(32),
+      client: client,
+    ),
+  );
+}
+
+Future<void> _pumpCard(
+  WidgetTester tester,
+  HeliosNotification n,
+  DaemonAPIService sse,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: PermissionCard(
+            notification: n,
+            sse: sse,
+            selected: <String>{},
+            onSelectionChanged: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a Codex approval can be refused in words', (tester) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _permission('codex'), _serviceRecording(sent));
+
+    expect(find.text('Tell Codex what to do differently'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'use git clean instead');
+    await tester.pump();
+
+    // The refusal button says what the words will do with it.
+    expect(find.widgetWithText(FilledButton, 'Send back'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Send back'));
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first['action'], 'deny');
+    expect(sent.first['feedback'], 'use git clean instead');
+  });
+
+  testWidgets('a Codex approval is still one tap to say yes', (tester) async {
+    final sent = <Map<String, dynamic>>[];
+    await _pumpCard(tester, _permission('codex'), _serviceRecording(sent));
+
+    // Nothing to pick first: Codex has no mode rows, only the words.
+    expect(find.text('Yes, and use auto mode'), findsNothing);
+
+    final approve = find.widgetWithText(FilledButton, 'Approve');
+    expect(tester.widget<FilledButton>(approve).onPressed, isNotNull);
+    await tester.tap(approve);
+    await tester.pumpAndSettle();
+
+    expect(sent, hasLength(1));
+    expect(sent.first, {'action': 'approve'});
+  });
+
+  testWidgets('an ordinary Claude tool keeps its bare Deny', (tester) async {
+    await _pumpCard(tester, _permission('claude'), _serviceRecording([]));
+
+    // Claude writes a rule for a tool it is allowed, and the feedback row
+    // belongs to the plan card. Only Codex refuses in words on every tool.
+    expect(find.text('Tell Codex what to do differently'), findsNothing);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Deny'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Stacked on #169 — base is `feat/plan-approval-rows`, because the mobile card
this touches is the one that PR adds. Retarget to `main` once #169 lands.

## The gap

Codex's own approval dialog offers eight rows. One of them is
`No, and tell Codex what to do differently`. Helios painted `Allow once` and
`Deny` over it, and answered every refusal with `Denied via helios` — so the
thing a user most often wants to say, *not like that, like this*, had nowhere
to go.

The wire already carried it: `deny` with a message is one of the two responses
`PermissionRequest` honours, measured against 0.150.1 and recorded in spec 46.
Only the way to collect the words was missing.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| Terminal overlay | `Allow once` / `Deny` | the same two, plus an answer field |
| Phone | Approve / Deny | the same two, plus the field; Deny becomes `Send back` when words are typed |
| Desktop | Approve / Deny | same |
| The model reads | `Denied via helios` | a line naming the user, then their words |

Escape still denies without a word and still says `Denied via helios`. An
approval drops any words sent with it: feedback is a refusal's payload, and
carried onto an approval it would send Codex a complaint about work it was just
cleared to do.

One contract, three surfaces: the overlay and the action handler both build the
same `permissionAnswer`, so the daemon cannot tell which surface answered.

## What Codex still does not get

- **No plan rows.** Codex has no `ExitPlanMode` tool and no plan hook event.
  Leaving plan mode is a TUI prompt it draws itself — `Implement this plan?` —
  with no tool call behind it, so helios never sees it. Parity there would need
  the screen-scrape route that answers the trust dialog, which is separate work.
- **No "don't ask again".** `updatedPermissions` is reserved and fails closed.
  Unchanged, and already documented.

Unlike Claude, the field is on every Codex permission card rather than on a plan
card alone. Codex offers the row on every approval too, and there is no rule to
write instead.

## Tests

- `internal/provider/codex/permission_test.go` — 8 new tests driving the real
  HITL controller: the field is painted, typed words reach Codex under
  `deniedFeedback`, escape keeps the bare reason, `Allow once` still allows, the
  phone's `feedback` produces the same message, an approval drops words, and an
  unreadable answer denies rather than crashing.
- `mobile/test/codex_permission_card_test.dart` — 3 new widget tests.
- `go test ./...`, `flutter test` (186), `npm test` (271), `tsc --noEmit`,
  `flutter analyze` — all green.

No live-CLI run for this one: the behaviour it depends on — Codex honouring a
deny message — is already measured in spec 46, and the hook tests exercise the
handler end to end over a real overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)