### PR TITLE
feat: reach the file a tool touched from the row that names it

### DIFF
--- a/desktop/e2e/open-to-the-side.spec.ts
+++ b/desktop/e2e/open-to-the-side.spec.ts
@@ -1,10 +1,10 @@
 // Opening a file the transcript names, without losing the transcript.
 //
 // The rules here live in components, so there is nowhere else in this repo to
-// drive them: the chip's menu, the split it asks for, and the file tree that
-// gets out of the way while the panel is a pane on the side. That last one is
-// the point of the feature — a tree beside a file in half a window leaves the
-// file a quarter of it.
+// drive them: the chip's two buttons, the split one of them asks for, and the
+// file tree that gets out of the way while the panel is a pane on the side.
+// That last one is the point of the feature — a tree beside a file in half a
+// window leaves the file a quarter of it.
 import type { Locator, Page } from '@playwright/test'
 
 import { ALPHA, REPO, appendTranscript, pushEvent, resetTranscripts } from './daemon.ts'
@@ -35,9 +35,14 @@ function chip(window: Page, name: string): Locator {
   return shown(window).locator('.file-chip').filter({ hasText: name })
 }
 
-/** The chip's open button — the one that asks where the file should go. */
-function arrow(window: Page, name: string): Locator {
-  return chip(window, name).locator('.file-chip-act').first()
+/** The chip's ◨ — open the file beside the transcript. */
+function sideButton(window: Page, name: string): Locator {
+  return chip(window, name).locator('.file-chip-side')
+}
+
+/** The chip's ↗ — open the file in the Files tab, in front of the transcript. */
+function tabButton(window: Page, name: string): Locator {
+  return chip(window, name).locator('.file-chip-tab')
 }
 
 /**
@@ -60,10 +65,9 @@ async function openAlpha(window: Page): Promise<void> {
   await expect(shown(window).locator('.file-chip')).toHaveCount(2)
 }
 
-/** ↗ on a chip, then the menu row, leaving the file open beside the transcript. */
+/** One click on ◨, leaving the file open beside the transcript. */
 async function openToTheSide(window: Page, name: string): Promise<void> {
-  await arrow(window, name).click()
-  await window.locator('.line-menu button', { hasText: 'Open to the side' }).click()
+  await sideButton(window, name).click()
   await expect(window.locator('.panel-tabs')).toHaveCount(2)
 }
 
@@ -86,28 +90,32 @@ test('a chip opens its file beside the transcript, with the tree out of the way'
   await expect(files(window).locator('.ws-side')).toBeHidden()
 })
 
-test('with the pane already there, a second chip skips the menu', async ({ window, daemon }) => {
+test('with the pane already there, the tab button drops out', async ({ window, daemon }) => {
   // Distinct from main.go, so "the file opened" cannot pass on the file that
   // was already in the pane.
   daemon.setFile(README, '# the readme\n')
   await openAlpha(window)
+  // Both buttons while the panel is still in front of the transcript.
+  await expect(tabButton(window, 'main.go')).toBeVisible()
   await openToTheSide(window, 'main.go')
 
-  await arrow(window, 'README.md').click()
+  // Every chip loses it, not only the one that was clicked: the button is
+  // about where the panel is, and the panel is one panel.
+  await expect(tabButton(window, 'main.go')).toHaveCount(0)
+  await expect(tabButton(window, 'README.md')).toHaveCount(0)
 
-  // No menu at all: with the pane open, the other row would only undo it.
-  await expect(window.locator('.line-menu')).toHaveCount(0)
+  await sideButton(window, 'README.md').click()
+
   // The panel, not `.cm-content`: a Markdown file opens in the preview, and
   // the heading is what the reader ends up looking at.
   await expect(files(window)).toContainText('the readme')
   await expect(window.locator('.panel-tabs')).toHaveCount(2)
 })
 
-test('the other row puts the panel in front of the transcript, tree and all', async ({ window }) => {
+test('the other button puts the panel in front of the transcript, tree and all', async ({ window }) => {
   await openAlpha(window)
 
-  await arrow(window, 'main.go').click()
-  await window.locator('.line-menu button', { hasText: 'Open in the Files tab' }).click()
+  await tabButton(window, 'main.go').click()
 
   await expect(window.locator('.panel-tabs')).toHaveCount(1)
   await expect(files(window).locator('.cm-content')).toContainText('package main')
@@ -142,7 +150,7 @@ test('a tree the reader opens in the pane stays open', async ({ window, daemon }
   await files(window).locator('.ws-side-toggle').click()
   await expect(files(window).locator('.ws-side')).toBeVisible()
 
-  await arrow(window, 'README.md').click()
+  await sideButton(window, 'README.md').click()
 
   // The panel, not `.cm-content`: a Markdown file opens in the preview, and
   // the heading is what the reader ends up looking at.

--- a/desktop/e2e/open-to-the-side.spec.ts
+++ b/desktop/e2e/open-to-the-side.spec.ts
@@ -1,0 +1,151 @@
+// Opening a file the transcript names, without losing the transcript.
+//
+// The rules here live in components, so there is nowhere else in this repo to
+// drive them: the chip's menu, the split it asks for, and the file tree that
+// gets out of the way while the panel is a pane on the side. That last one is
+// the point of the feature — a tree beside a file in half a window leaves the
+// file a quarter of it.
+import type { Locator, Page } from '@playwright/test'
+
+import { ALPHA, REPO, appendTranscript, pushEvent, resetTranscripts } from './daemon.ts'
+import { expect, test } from './fixtures.ts'
+
+const ROW = 'Alpha'
+const MAIN = `${REPO}/main.go`
+const README = `${REPO}/README.md`
+
+/**
+ * The panels on screen.
+ *
+ * Everything below is scoped to these, as the other specs are: a panel behind
+ * another stays mounted and keeps its markup, so an unscoped locator finds the
+ * transcript twice and cannot tell which copy the reader is looking at.
+ */
+function shown(window: Page): Locator {
+  return window.locator('.panel-keep:not([hidden])')
+}
+
+/** The Files panel, wherever it currently is. */
+function files(window: Page): Locator {
+  return shown(window).locator('.workspace')
+}
+
+/** A chip in the transcript, by the file name it shows. */
+function chip(window: Page, name: string): Locator {
+  return shown(window).locator('.file-chip').filter({ hasText: name })
+}
+
+/** The chip's open button — the one that asks where the file should go. */
+function arrow(window: Page, name: string): Locator {
+  return chip(window, name).locator('.file-chip-act').first()
+}
+
+/**
+ * Alpha open, with a line naming two files at the end of its transcript.
+ *
+ * One line for both, which is what an agent writes when it has touched both.
+ * It arrives on the live edge — appended once the first read has landed, then
+ * announced — rather than being in the log before the app starts: a line
+ * waiting at launch is read by the initial fetch and by the refetch behind it,
+ * and every chip comes out with a twin.
+ */
+async function openAlpha(window: Page): Promise<void> {
+  await window.locator('.session-row', { hasText: ROW }).click()
+  await expect(shown(window).locator('.msg.assistant')).toHaveCount(1)
+
+  appendTranscript(ALPHA, `Edited ${MAIN} and ${README}.`)
+  pushEvent('session_status', { session_id: ALPHA, status: 'idle' })
+
+  // Both chips, so a test that clicks the second one is not racing them in.
+  await expect(shown(window).locator('.file-chip')).toHaveCount(2)
+}
+
+/** ↗ on a chip, then the menu row, leaving the file open beside the transcript. */
+async function openToTheSide(window: Page, name: string): Promise<void> {
+  await arrow(window, name).click()
+  await window.locator('.line-menu button', { hasText: 'Open to the side' }).click()
+  await expect(window.locator('.panel-tabs')).toHaveCount(2)
+}
+
+// The transcripts are module state shared by every test in the worker.
+test.afterEach(() => {
+  resetTranscripts()
+})
+
+test('a chip opens its file beside the transcript, with the tree out of the way', async ({ window }) => {
+  await openAlpha(window)
+
+  await openToTheSide(window, 'main.go')
+
+  // Two strips, two bodies: the transcript did not give up its half.
+  await expect(shown(window)).toHaveCount(2)
+  await expect(chip(window, 'main.go')).toBeVisible()
+  await expect(files(window).locator('.cm-content')).toContainText('package main')
+  // The half the pane has goes to the file, not to a tree of the directory it
+  // is in — which is the whole reason for opening it here rather than in front.
+  await expect(files(window).locator('.ws-side')).toBeHidden()
+})
+
+test('with the pane already there, a second chip skips the menu', async ({ window, daemon }) => {
+  // Distinct from main.go, so "the file opened" cannot pass on the file that
+  // was already in the pane.
+  daemon.setFile(README, '# the readme\n')
+  await openAlpha(window)
+  await openToTheSide(window, 'main.go')
+
+  await arrow(window, 'README.md').click()
+
+  // No menu at all: with the pane open, the other row would only undo it.
+  await expect(window.locator('.line-menu')).toHaveCount(0)
+  // The panel, not `.cm-content`: a Markdown file opens in the preview, and
+  // the heading is what the reader ends up looking at.
+  await expect(files(window)).toContainText('the readme')
+  await expect(window.locator('.panel-tabs')).toHaveCount(2)
+})
+
+test('the other row puts the panel in front of the transcript, tree and all', async ({ window }) => {
+  await openAlpha(window)
+
+  await arrow(window, 'main.go').click()
+  await window.locator('.line-menu button', { hasText: 'Open in the Files tab' }).click()
+
+  await expect(window.locator('.panel-tabs')).toHaveCount(1)
+  await expect(files(window).locator('.cm-content')).toContainText('package main')
+  // A panel with the whole window has room for both, and the transcript is
+  // behind it rather than beside it.
+  await expect(files(window).locator('.ws-side')).toBeVisible()
+  await expect(chip(window, 'main.go')).toBeHidden()
+})
+
+test('the tree comes back when the pane stops being a pane', async ({ window }) => {
+  await openAlpha(window)
+  await openToTheSide(window, 'main.go')
+  await expect(files(window).locator('.ws-side')).toBeHidden()
+
+  // The only way back: the tab dragged into the transcript's strip, which
+  // empties the group it came from and collapses it.
+  const strips = window.locator('.panel-tabs')
+  await strips.nth(1).locator('[data-item="panel:files"]').dragTo(strips.first())
+
+  await expect(window.locator('.panel-tabs')).toHaveCount(1)
+  await expect(files(window).locator('.ws-side')).toBeVisible()
+})
+
+// The rule is about where the panel is, not about who put it there — but the
+// reader still outranks it. A derived rule would put the tree away again on the
+// next render, which is why the effect behind this watches for the change.
+test('a tree the reader opens in the pane stays open', async ({ window, daemon }) => {
+  daemon.setFile(README, '# the readme\n')
+  await openAlpha(window)
+  await openToTheSide(window, 'main.go')
+
+  await files(window).locator('.ws-side-toggle').click()
+  await expect(files(window).locator('.ws-side')).toBeVisible()
+
+  await arrow(window, 'README.md').click()
+
+  // The panel, not `.cm-content`: a Markdown file opens in the preview, and
+  // the heading is what the reader ends up looking at.
+  await expect(files(window)).toContainText('the readme')
+  await expect(files(window).locator('.ws-side')).toBeVisible()
+})

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -473,10 +473,9 @@ function FileChip({
   const name = label ?? path.split('/').filter(Boolean).pop() ?? path
   const isDir = !name.includes('.')
   // Where the file could go, which is what decides whether there is a choice to
-  // offer: with the panel already a pane of its own, the other row would only
-  // undo the arrangement the reader has.
+  // offer: with the panel already a pane of its own, the second button would
+  // only undo the arrangement the reader has.
   const beside = useStore((state) => isBeside(currentLayout(state), panelItem('files')))
-  const [at, setAt] = useState<{ x: number; y: number } | null>(null)
 
   return (
     <span className="file-chip">
@@ -490,41 +489,25 @@ function FileChip({
         <span className="file-chip-icon">{isDir ? <Chevron dir="right" /> : '⌕'}</span>
         {name}
       </button>
+      {/* Both destinations in reach, rather than a menu asking which: the
+          answer is one of two and the reader knows it before clicking. */}
       <button
-        className="file-chip-act"
-        title={beside ? `Open ${resolved} in the pane beside this` : `Open ${resolved}`}
-        onClick={(event) => {
-          if (beside) {
-            store.openFileBeside(hostId, resolved)
-            return
-          }
-          // Below the button, as the session strip's menu does: the chip has a
-          // fixed place in the transcript, and a menu at the pointer would read
-          // as unmoored from it.
-          const box = event.currentTarget.getBoundingClientRect()
-          setAt({ x: box.left, y: box.bottom + 4 })
-        }}
+        className="file-chip-act file-chip-side"
+        title={`Open ${resolved} beside the transcript`}
+        onClick={() => store.openFileBeside(hostId, resolved)}
       >
-        ↗
+        ◨
       </button>
-      {at && (
-        <SelectionMenu
-          x={at.x}
-          y={at.y}
-          actions={[
-            {
-              label: 'Open to the side',
-              title: 'Beside the transcript, with the file tree out of the way',
-              run: () => store.openFileBeside(hostId, resolved),
-            },
-            {
-              label: 'Open in the Files tab',
-              title: 'In front of the transcript',
-              run: () => store.openFile(hostId, resolved),
-            },
-          ]}
-          onClose={() => setAt(null)}
-        />
+      {/* Gone once the pane is on the side: putting the panel back in front of
+          the transcript is undoing the arrangement, not opening a file. */}
+      {!beside && (
+        <button
+          className="file-chip-act file-chip-tab"
+          title={`Open ${resolved} in the Files tab`}
+          onClick={() => store.openFile(hostId, resolved)}
+        >
+          ↗
+        </button>
       )}
       <button
         className="file-chip-act"

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -10,6 +10,7 @@ import { AttachButton, AttachmentChips, PasteOffer, useAttachments, useDropTarge
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
 import { Chevron } from './icons.tsx'
+import { isBeside, panelItem } from './layout.ts'
 import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
 import {
   extractFilePaths,
@@ -19,7 +20,7 @@ import {
   resolveFilePath,
 } from '../markdown.ts'
 import { useMermaid } from '../mermaid.ts'
-import { store, useStore } from '../store.ts'
+import { currentLayout, store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
   canResume,
@@ -471,6 +472,12 @@ function FileChip({
   const resolved = resolveFilePath(path, cwd)
   const name = label ?? path.split('/').filter(Boolean).pop() ?? path
   const isDir = !name.includes('.')
+  // Where the file could go, which is what decides whether there is a choice to
+  // offer: with the panel already a pane of its own, the other row would only
+  // undo the arrangement the reader has.
+  const beside = useStore((state) => isBeside(currentLayout(state), panelItem('files')))
+  const [at, setAt] = useState<{ x: number; y: number } | null>(null)
+
   return (
     <span className="file-chip">
       {/* Search, not open: the transcript's path is the checkout the agent ran
@@ -483,9 +490,42 @@ function FileChip({
         <span className="file-chip-icon">{isDir ? <Chevron dir="right" /> : '⌕'}</span>
         {name}
       </button>
-      <button className="file-chip-act" title={`Open ${resolved}`} onClick={() => store.openFile(hostId, resolved)}>
+      <button
+        className="file-chip-act"
+        title={beside ? `Open ${resolved} in the pane beside this` : `Open ${resolved}`}
+        onClick={(event) => {
+          if (beside) {
+            store.openFileBeside(hostId, resolved)
+            return
+          }
+          // Below the button, as the session strip's menu does: the chip has a
+          // fixed place in the transcript, and a menu at the pointer would read
+          // as unmoored from it.
+          const box = event.currentTarget.getBoundingClientRect()
+          setAt({ x: box.left, y: box.bottom + 4 })
+        }}
+      >
         ↗
       </button>
+      {at && (
+        <SelectionMenu
+          x={at.x}
+          y={at.y}
+          actions={[
+            {
+              label: 'Open to the side',
+              title: 'Beside the transcript, with the file tree out of the way',
+              run: () => store.openFileBeside(hostId, resolved),
+            },
+            {
+              label: 'Open in the Files tab',
+              title: 'In front of the transcript',
+              run: () => store.openFile(hostId, resolved),
+            },
+          ]}
+          onClose={() => setAt(null)}
+        />
+      )}
       <button
         className="file-chip-act"
         title="Copy path"

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -554,20 +554,28 @@ function ToolUse({ message, hostId, cwd }: MessageProps): JSX.Element {
 
   return (
     <div className="msg tool-call">
-      <button className="tool-head" onClick={() => setOpen(!open)}>
-        <span className="tool-icon">{TOOL_ICONS[tool] ?? '⚙'}</span>
-        <span className="tool-name">{tool}</span>
-        <span className="tool-summary">{oneLine(message.summary)}</span>
-        <Chevron className="chevron" open={open} />
-      </button>
+      {/* The head is a row rather than one button: the file chip is three
+          buttons of its own, and a button cannot hold a button. */}
+      <div className="tool-head">
+        <button className="tool-toggle" onClick={() => setOpen(!open)}>
+          <span className="tool-icon">{TOOL_ICONS[tool] ?? '⚙'}</span>
+          <span className="tool-name">{tool}</span>
+          <span className="tool-summary">{oneLine(message.summary)}</span>
+        </button>
+        {/* On the head, not at the foot of the expansion: the file is what the
+            row is about, and reaching it should not cost an expand first. */}
+        {filePath && <FileChip hostId={hostId} cwd={cwd} path={filePath} label={filePath.split('/').pop()} />}
+        <button
+          className="tool-chevron"
+          title={open ? 'Collapse' : 'Expand'}
+          onClick={() => setOpen(!open)}
+        >
+          <Chevron className="chevron" open={open} />
+        </button>
+      </div>
       {open && (
         <div className="tool-detail">
           <ToolInput tool={tool} input={input} />
-          {filePath && (
-            <div className="file-chips">
-              <FileChip hostId={hostId} cwd={cwd} path={filePath} label={filePath.split('/').pop()} />
-            </div>
-          )}
         </div>
       )}
     </div>

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -16,6 +16,7 @@ import { sessionActions } from './session-menu.ts'
 import { SettingsPane } from './settings.tsx'
 import { StatusLine } from './status-line.tsx'
 import {
+  isBeside,
   isVisible,
   panelItem,
   panelOf,
@@ -297,6 +298,7 @@ export function Detail(): JSX.Element {
                     pending={pending}
                     visible={owner.active === item}
                     focused={owner.id === layout.focused}
+                    beside={isBeside(layout, item)}
                   />
                 </PanelBoundary>
               </div>
@@ -420,6 +422,7 @@ function ItemContent({
   pending,
   visible,
   focused,
+  beside,
 }: {
   item: ItemId
   hostId: string
@@ -428,6 +431,8 @@ function ItemContent({
   pending: number
   visible: boolean
   focused: boolean
+  /** True when this item has a pane of its own, beside another. */
+  beside: boolean
 }): JSX.Element | null {
   // Terminals are drawn by the deck in Detail, which outlives the session being
   // selected. Nothing to render here but the panel behind them.
@@ -477,7 +482,13 @@ function ItemContent({
 
   if (panel === 'files') {
     return (
-      <FilesPanel hostId={hostId} sessionId={session.session_id} cwd={session.cwd} visible={visible} />
+      <FilesPanel
+        hostId={hostId}
+        sessionId={session.session_id}
+        cwd={session.cwd}
+        visible={visible}
+        beside={beside}
+      />
     )
   }
 

--- a/desktop/src/renderer/components/files.tsx
+++ b/desktop/src/renderer/components/files.tsx
@@ -95,12 +95,15 @@ export function FilesPanel({
   sessionId,
   cwd,
   visible = true,
+  beside = false,
 }: {
   hostId: string
   sessionId: string
   cwd: string
   /** False while another tab is showing. */
   visible?: boolean
+  /** True while the panel is a pane of its own, beside another. */
+  beside?: boolean
 }): JSX.Element {
   const [rootOverride, setRootOverride] = useState<string | null>(null)
   const sessionRoot = useMemo(() => cwd.replace(/\/+$/, '') || '/', [cwd])
@@ -289,6 +292,28 @@ export function FilesPanel({
       ) as Record<string, ReadingPosition>,
     })
   }, [memory, loadedFor, rootOverride, tabs, activePath, expanded, side, viewTick])
+
+  /**
+   * The tree answers to where the panel is, not to how the file was opened.
+   *
+   * A pane beside the transcript is half a width already, and a tree in it
+   * takes that half again from the file being read. Edge-triggered rather than
+   * derived, so the toggle below still wins for the reader who wants the tree
+   * back for a moment; the panel takes the width back when the pane closes.
+   *
+   * Declared after the restore above so it has the last word on mount: a panel
+   * that opens straight into a side pane collapses, rather than putting a saved
+   * tree into half a pane. One that opens in front keeps whatever it saved,
+   * which is why an unchanged `false` does nothing here.
+   */
+  const wasBeside = useRef<boolean | null>(null)
+  useEffect(() => {
+    const was = wasBeside.current
+    wasBeside.current = beside
+    if (was === beside) return
+    if (beside) setSide(null)
+    else if (was !== null) setSide('tree')
+  }, [beside])
 
   const save = useCallback(
     async (path: string, quiet = true): Promise<void> => {

--- a/desktop/src/renderer/components/layout.ts
+++ b/desktop/src/renderer/components/layout.ts
@@ -93,6 +93,17 @@ export function isVisible(layout: Layout, item: ItemId): boolean {
   return layout.groups.some((group) => group.active === item)
 }
 
+/**
+ * Whether the item is in front of a group of its own, beside another group.
+ *
+ * What "open to the side" asks about: the file the transcript names is worth a
+ * pane next to the transcript, but only once. A second request has nowhere new
+ * to put it.
+ */
+export function isBeside(layout: Layout, item: ItemId): boolean {
+  return layout.groups.length > 1 && isVisible(layout, item)
+}
+
 /** Every item the layout holds, whether or not it is in front. */
 export function placedItems(layout: Layout): ItemId[] {
   return layout.groups.flatMap((group) => group.items)

--- a/desktop/src/renderer/markdown.ts
+++ b/desktop/src/renderer/markdown.ts
@@ -279,12 +279,17 @@ export function renderMarkdownBlocks(source: string): MarkdownBlock[] {
 }
 
 /**
- * Paths mentioned in prose: `~/a/b`, `/a/b`, or a relative path with at least
- * three segments. Same expression as the mobile app, which errs towards missing
- * a path over turning ordinary words into chips.
+ * Paths mentioned in prose: `~/a/b`, `/a/b`, a relative path with at least
+ * three segments, or a two-segment one whose last part carries a file
+ * extension — `scratch/report.md` is a file, `and/or` is two words. Same
+ * expression as the mobile app, which errs towards missing a path over turning
+ * ordinary words into chips.
+ *
+ * The three-segment branch comes first so a deep path is matched whole rather
+ * than cut down to its first two segments.
  */
 const FILE_PATH =
-  /(^|[\s:,;(`])(~\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+|\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+|[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_.-]+){2,})/gm
+  /(^|[\s:,;(`])(~\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+|\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+|[a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_.-]+){2,}|[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]*[a-zA-Z0-9_-]\.[a-zA-Z0-9]{1,8})/gm
 
 /** File paths mentioned in a message, deduped and in order of appearance. */
 export function extractFilePaths(text: string): string[] {

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -15,6 +15,8 @@ import type { GroupOrder, PathOrder } from './components/grouping.ts'
 import {
   defaultLayout,
   evenSizes,
+  groupOf,
+  isBeside,
   isVisible,
   moveItem,
   panelItem,
@@ -1236,6 +1238,35 @@ class Store {
   /** Shows a file in the Files panel, switching to it. */
   openFile(hostId: string, path: string): void {
     this.revealItem(this.state.selection, panelItem('files'))
+    this.set((s) => ({
+      fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open' },
+    }))
+  }
+
+  /**
+   * Shows a file in a Files panel beside the transcript, splitting one out if
+   * the panel is not already a pane of its own.
+   *
+   * Beside the transcript rather than in front of it, because what an agent
+   * changed and what it said about the change are read together. The panel
+   * drops its tree once it is there — see files.tsx — so the file gets the
+   * whole half.
+   */
+  openFileBeside(hostId: string, path: string): void {
+    const selection = this.state.selection
+    const files = panelItem('files')
+    if (selection) {
+      const layout = currentLayout(this.state)
+      // Already a pane of its own: splitting again would only halve it.
+      if (!isBeside(layout, files)) {
+        // Beside the transcript specifically. The focused group is the
+        // fallback for a layout with no chat in it at all, where "the side"
+        // can only mean the side of whatever is being looked at.
+        const host = groupOf(layout, panelItem('chat'))?.id ?? layout.focused
+        this.splitItem(selection, files, host, 'after')
+      }
+    }
+    this.revealItem(selection, files)
     this.set((s) => ({
       fileTarget: { hostId, path, seq: (s.fileTarget?.seq ?? 0) + 1, mode: 'open' },
     }))

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2234,17 +2234,34 @@ figure.mermaid svg {
   overflow: hidden;
 }
 
+/* A row, not a button: the file chip rides on this line and carries buttons of
+   its own. The toggle takes the space the chip and the chevron leave. */
 .tool-head {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  text-align: left;
-  border-radius: 0;
+  gap: 8px;
   padding: 9px 12px;
+}
+
+.tool-toggle {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  text-align: left;
+  border-radius: var(--r-sm);
   color: var(--on-surface);
   font-weight: 400;
+}
+
+.tool-chevron {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  color: var(--on-surface-variant);
 }
 
 .tool-icon {

--- a/desktop/test/layout.test.ts
+++ b/desktop/test/layout.test.ts
@@ -5,6 +5,7 @@ import {
   defaultLayout,
   evenSizes,
   groupOf,
+  isBeside,
   isVisible,
   moveItem,
   panelItem,
@@ -118,6 +119,25 @@ test('both groups are visible at once', () => {
   assert.deepEqual(visibleItems(layout).sort(), [CHAT, FILES].sort())
   assert.equal(isVisible(layout, CHAT), true)
   assert.equal(isVisible(layout, FILES), true)
+})
+
+// What the transcript's file chip asks before it offers to open a file to the
+// side, and what the Files panel asks before it drops its tree.
+test('a panel is beside another only once it has a group of its own', () => {
+  assert.equal(isBeside(split(), FILES), true)
+  // One group is the whole width: the transcript is in front of it, not beside.
+  assert.equal(isBeside(defaultLayout(), CHAT), false)
+  assert.equal(isBeside(defaultLayout(), FILES), false)
+})
+
+test('a panel behind another in a split group is not beside anything', () => {
+  // Two groups, but the git panel has been dragged in front of the one holding
+  // files.
+  const beside = split()
+  const layout = moveItem(beside, GIT, g(beside, 1).id, 1)
+  assert.equal(groupOf(layout, FILES)?.id, groupOf(layout, GIT)?.id)
+  assert.equal(isBeside(layout, FILES), false)
+  assert.equal(isBeside(layout, GIT), true)
 })
 
 test('moving the last item out of a group collapses it and returns its weight', () => {

--- a/desktop/test/paths.test.ts
+++ b/desktop/test/paths.test.ts
@@ -16,6 +16,21 @@ Also desktop/src/renderer/styles.css, but not src/main or plain words.`
   ])
 })
 
+test('a two-segment path counts when it names a file', () => {
+  // "Updated: `scratch/report.md`" got no chip while the rule wanted three
+  // segments, which is how most agents write a path they just wrote to.
+  const text = 'Updated: `scratch/opus5-refusal-customer-report.md` and mobile/pubspec.yaml.'
+  assert.deepEqual(extractFilePaths(text), [
+    'scratch/opus5-refusal-customer-report.md',
+    'mobile/pubspec.yaml',
+  ])
+})
+
+test('two words with a slash between them are not a path', () => {
+  const text = 'the and/or case, N/A, 24/7, km/h, and src/main stay prose'
+  assert.deepEqual(extractFilePaths(text), [])
+})
+
 test('dedupes and keeps the order of first mention', () => {
   const text = 'see a/b/c.go, then a/b/c.go again, then a/b/d.go'
   assert.deepEqual(extractFilePaths(text), ['a/b/c.go', 'a/b/d.go'])

--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -33,7 +33,11 @@ class MessageCard extends StatelessWidget {
           sessionCwd: sessionCwd,
         );
       case 'tool_use':
-        return _ToolUseCard(message: message);
+        return _ToolUseCard(
+          message: message,
+          hostId: hostId,
+          sessionCwd: sessionCwd,
+        );
       case 'tool_result':
         return _ToolResultCard(message: message);
       default:
@@ -86,6 +90,47 @@ final _filePathPattern = RegExp(
   multiLine: true,
 );
 
+/// Resolves a path the way the transcript means it: absolute paths as written,
+/// relative ones against the session's directory.
+///
+/// A relative path often repeats the last segment of the directory — cwd
+/// `.../helios/mobile` with `mobile/lib/...` — so that duplicate is dropped
+/// rather than joined into a directory that does not exist.
+String _resolveAgainstCwd(String path, String sessionCwd) {
+  if (path.startsWith('/') || path.startsWith('~')) return path;
+  final cwdLastSegment =
+      sessionCwd.split('/').where((s) => s.isNotEmpty).lastOrNull ?? '';
+  final firstSegment = path.split('/').first;
+  if (cwdLastSegment.isNotEmpty && firstSegment == cwdLastSegment) {
+    final parent = sessionCwd.substring(0, sessionCwd.lastIndexOf('/'));
+    return '$parent/$path';
+  }
+  return '$sessionCwd/$path';
+}
+
+/// Opens a file the agent touched.
+///
+/// Straight to the viewer, with no listing pushed underneath it: back from a
+/// file reached in the transcript belongs to the transcript. The folder is a
+/// button in the viewer for whoever wants it.
+void _openTranscriptFile(
+  BuildContext context, {
+  required String hostId,
+  required String sessionCwd,
+  required String path,
+}) {
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      settings: const RouteSettings(name: '/file-viewer'),
+      builder: (_) => FileViewerScreen(
+        hostId: hostId,
+        path: _resolveAgainstCwd(path, sessionCwd),
+        rootPath: sessionCwd,
+      ),
+    ),
+  );
+}
+
 List<String> _extractFilePaths(String content) {
   final seen = <String>{};
   final paths = <String>[];
@@ -119,38 +164,12 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
     }
   }
 
-  void _openFilePath(String path) {
-    String resolvedPath;
-    if (path.startsWith('/') || path.startsWith('~')) {
-      resolvedPath = path;
-    } else {
-      // Relative path — try to resolve against sessionCwd.
-      // If the first segment of the relative path matches the last segment of
-      // sessionCwd (e.g. cwd=".../helios/mobile" and path="mobile/lib/..."),
-      // strip that duplicate segment.
-      final cwdLastSegment = widget.sessionCwd.split('/').where((s) => s.isNotEmpty).lastOrNull ?? '';
-      final firstSegment = path.split('/').first;
-      if (cwdLastSegment.isNotEmpty && firstSegment == cwdLastSegment) {
-        final parent = widget.sessionCwd.substring(0, widget.sessionCwd.lastIndexOf('/'));
-        resolvedPath = '$parent/$path';
-      } else {
-        resolvedPath = '${widget.sessionCwd}/$path';
-      }
-    }
-    // Straight to the viewer, with no listing pushed underneath it: back from
-    // a file tapped in the transcript belongs to the transcript. The folder is
-    // a button in the viewer for whoever wants it.
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        settings: const RouteSettings(name: '/file-viewer'),
-        builder: (_) => FileViewerScreen(
-          hostId: widget.hostId,
-          path: resolvedPath,
-          rootPath: widget.sessionCwd,
-        ),
-      ),
-    );
-  }
+  void _openFilePath(String path) => _openTranscriptFile(
+        context,
+        hostId: widget.hostId,
+        sessionCwd: widget.sessionCwd,
+        path: path,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -288,7 +307,13 @@ class _AssistantMessageCardState extends State<_AssistantMessageCard> {
 
 class _ToolUseCard extends StatefulWidget {
   final Message message;
-  const _ToolUseCard({required this.message});
+  final String hostId;
+  final String sessionCwd;
+  const _ToolUseCard({
+    required this.message,
+    required this.hostId,
+    required this.sessionCwd,
+  });
 
   @override
   State<_ToolUseCard> createState() => _ToolUseCardState();
@@ -297,11 +322,24 @@ class _ToolUseCard extends StatefulWidget {
 class _ToolUseCardState extends State<_ToolUseCard> {
   bool _expanded = false;
 
+  /// The file this call touched, when it named one. A tool row says what was
+  /// edited and then leaves the reader to go and find it; this is the way
+  /// there.
+  String? get _filePath {
+    if (widget.hostId.isEmpty) return null;
+    final meta = widget.message.metadata;
+    if (meta == null) return null;
+    final path = meta['file_path'] ?? meta['path'] ?? meta['notebook_path'];
+    if (path is! String || path.trim().isEmpty) return null;
+    return path;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final meta = widget.message.metadata;
     final hasDetails = meta != null && meta.isNotEmpty;
+    final filePath = _filePath;
 
     return GestureDetector(
       onTap: hasDetails ? () => setState(() => _expanded = !_expanded) : null,
@@ -349,6 +387,31 @@ class _ToolUseCardState extends State<_ToolUseCard> {
                     ),
                   ),
                 ],
+                // On the row itself, not under the expansion: the file is what
+                // the row is about, and reaching it should not cost a tap on
+                // the details first.
+                if (filePath != null)
+                  InkWell(
+                    onTap: () => _openTranscriptFile(
+                      context,
+                      hostId: widget.hostId,
+                      sessionCwd: widget.sessionCwd,
+                      path: filePath,
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 2,
+                      ),
+                      child: Icon(
+                        Icons.open_in_new,
+                        size: 14,
+                        color: theme.colorScheme.tertiary,
+                        semanticLabel: 'Open ${filePath.split('/').last}',
+                      ),
+                    ),
+                  ),
                 if (hasDetails)
                   Icon(
                     _expanded ? Icons.expand_less : Icons.expand_more,

--- a/mobile/lib/widgets/message_card.dart
+++ b/mobile/lib/widgets/message_card.dart
@@ -85,10 +85,23 @@ class _UserMessageCard extends StatelessWidget {
 }
 
 /// Extracts unique file paths from message content for display as tappable chips.
+///
+/// `~/a/b`, `/a/b`, a relative path of three segments or more, or a
+/// two-segment one whose last part carries a file extension —
+/// `scratch/report.md` is a file, `and/or` is two words. The three-segment
+/// branch comes first so a deep path is matched whole rather than cut down to
+/// its first two segments.
+///
+/// Shared with the desktop app (src/renderer/markdown.ts): a change here is a
+/// change to both clients.
 final _filePathPattern = RegExp(
-  r'(^|[\s:,;(`])(~/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)+|/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)+|[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_.-]+){2,})',
+  r'(^|[\s:,;(`])(~/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)+|/[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)+|[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_.-]+){2,}|[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]*[a-zA-Z0-9_-]\.[a-zA-Z0-9]{1,8})',
   multiLine: true,
 );
+
+/// Sentence punctuation is not part of the path, and a path that ends in a
+/// stray period is one the daemon will fail to open.
+final _trailingPunctuation = RegExp(r'[.,;:)]+$');
 
 /// Resolves a path the way the transcript means it: absolute paths as written,
 /// relative ones against the session's directory.
@@ -135,7 +148,8 @@ List<String> _extractFilePaths(String content) {
   final seen = <String>{};
   final paths = <String>[];
   for (final m in _filePathPattern.allMatches(content)) {
-    final path = m.group(2)!;
+    final path = m.group(2)!.replaceFirst(_trailingPunctuation, '');
+    if (path.isEmpty) continue;
     if (seen.add(path)) paths.add(path);
   }
   return paths;

--- a/mobile/test/tool_file_button_test.dart
+++ b/mobile/test/tool_file_button_test.dart
@@ -14,7 +14,7 @@ Message _toolUse({String? filePath, String tool = 'Edit'}) => Message(
       tool: tool,
       summary: 'specs/46-codex-provider.md',
       metadata: {
-        if (filePath != null) 'file_path': filePath,
+        'file_path': ?filePath,
         'new_string': 'a line',
       },
     );
@@ -71,6 +71,38 @@ void main() {
     // there; whatever the screen says about a daemon it has no way to call is
     // its own business.
     while (tester.takeException() != null) {}
+  });
+
+  testWidgets('a path in prose becomes a chip on two segments', (
+    tester,
+  ) async {
+    // "Updated: `scratch/report.md`" got nothing while the rule wanted three
+    // segments, which is how most agents name a file they just wrote.
+    await _pumpRow(
+      tester,
+      Message(
+        role: 'assistant',
+        timestamp: '2026-09-04T10:51:49Z',
+        content: 'Updated: `scratch/opus5-refusal-customer-report.md`',
+      ),
+    );
+
+    expect(find.text('opus5-refusal-customer-report.md'), findsOneWidget);
+  });
+
+  testWidgets('two words with a slash between them stay prose', (
+    tester,
+  ) async {
+    await _pumpRow(
+      tester,
+      Message(
+        role: 'assistant',
+        timestamp: '2026-09-04T10:51:49Z',
+        content: 'The and/or case, N/A, and src/main are not files.',
+      ),
+    );
+
+    expect(find.byIcon(Icons.insert_drive_file), findsNothing);
   });
 
   testWidgets('a tool that named no file offers nothing', (tester) async {

--- a/mobile/test/tool_file_button_test.dart
+++ b/mobile/test/tool_file_button_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:helios/models/message.dart';
+import 'package:helios/widgets/message_card.dart';
+
+/// A tool row said what it wrote and left the reader to go and find it. These
+/// pin the button that opens the file instead.
+
+Message _toolUse({String? filePath, String tool = 'Edit'}) => Message(
+      role: 'tool_use',
+      timestamp: '2026-09-04T10:51:49Z',
+      tool: tool,
+      summary: 'specs/46-codex-provider.md',
+      metadata: {
+        if (filePath != null) 'file_path': filePath,
+        'new_string': 'a line',
+      },
+    );
+
+class _Pushes extends NavigatorObserver {
+  final routes = <String?>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previous) {
+    routes.add(route.settings.name);
+    super.didPush(route, previous);
+  }
+}
+
+Future<_Pushes> _pumpRow(
+  WidgetTester tester,
+  Message message, {
+  String hostId = 'h1',
+}) async {
+  final pushes = _Pushes();
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        navigatorObservers: [pushes],
+        home: Scaffold(
+          body: MessageCard(
+            message: message,
+            hostId: hostId,
+            sessionCwd: '/home/dev/helios',
+          ),
+        ),
+      ),
+    ),
+  );
+  return pushes;
+}
+
+void main() {
+  testWidgets('a tool that touched a file offers a way into it', (
+    tester,
+  ) async {
+    final pushes = await _pumpRow(tester, _toolUse(filePath: 'docs/spec.md'));
+
+    final open = find.byIcon(Icons.open_in_new);
+    expect(open, findsOneWidget);
+
+    await tester.tap(open);
+    await tester.pump();
+
+    expect(pushes.routes, contains('/file-viewer'));
+
+    // The viewer itself is not under test, and it reads its file through a
+    // provider it cannot reach here. What matters is that the button routed
+    // there; whatever the screen says about a daemon it has no way to call is
+    // its own business.
+    while (tester.takeException() != null) {}
+  });
+
+  testWidgets('a tool that named no file offers nothing', (tester) async {
+    await _pumpRow(tester, _toolUse(tool: 'Bash', filePath: null));
+
+    expect(find.byIcon(Icons.open_in_new), findsNothing);
+  });
+
+  testWidgets('without a host there is nowhere to open the file', (
+    tester,
+  ) async {
+    // The transcript renders without a host id in previews and tests; a button
+    // that cannot reach a daemon would only fail when tapped.
+    await _pumpRow(tester, _toolUse(filePath: 'docs/spec.md'), hostId: '');
+
+    expect(find.byIcon(Icons.open_in_new), findsNothing);
+  });
+}

--- a/mobile/test/tool_file_button_test.dart
+++ b/mobile/test/tool_file_button_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:helios/models/message.dart';
+import 'package:helios/screens/file_browser_screen.dart';
 import 'package:helios/widgets/message_card.dart';
 
 /// A tool row said what it wrote and left the reader to go and find it. These
@@ -20,13 +21,25 @@ Message _toolUse({String? filePath, String tool = 'Edit'}) => Message(
     );
 
 class _Pushes extends NavigatorObserver {
-  final routes = <String?>[];
+  final routes = <Route<dynamic>>[];
+
+  List<String?> get names => [for (final r in routes) r.settings.name];
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previous) {
-    routes.add(route.settings.name);
+    routes.add(route);
     super.didPush(route, previous);
   }
+}
+
+/// The viewer the last push would show, built but never mounted.
+///
+/// Mounting it would need the daemon providers it reads its file through, and
+/// what is under test is the file it was sent to open, not the reading of it.
+FileViewerScreen _viewerFrom(WidgetTester tester, _Pushes pushes) {
+  final route = pushes.routes.last as MaterialPageRoute;
+  return route.builder(tester.element(find.byType(MessageCard)))
+      as FileViewerScreen;
 }
 
 Future<_Pushes> _pumpRow(
@@ -61,16 +74,70 @@ void main() {
     final open = find.byIcon(Icons.open_in_new);
     expect(open, findsOneWidget);
 
+    // No pump after the tap: the push lands synchronously, and the viewer is
+    // read from the route rather than mounted.
     await tester.tap(open);
-    await tester.pump();
 
-    expect(pushes.routes, contains('/file-viewer'));
+    expect(pushes.names, contains('/file-viewer'));
+    final viewer = _viewerFrom(tester, pushes);
+    expect(viewer.path, '/home/dev/helios/docs/spec.md');
+    expect(viewer.hostId, 'h1');
+    expect(viewer.rootPath, '/home/dev/helios');
+  });
 
-    // The viewer itself is not under test, and it reads its file through a
-    // provider it cannot reach here. What matters is that the button routed
-    // there; whatever the screen says about a daemon it has no way to call is
-    // its own business.
-    while (tester.takeException() != null) {}
+  testWidgets('tapping a chip opens the file it names', (tester) async {
+    final pushes = await _pumpRow(
+      tester,
+      Message(
+        role: 'assistant',
+        timestamp: '2026-09-04T10:51:49Z',
+        content: 'Updated: `scratch/opus5-refusal-customer-report.md`',
+      ),
+    );
+
+    await tester.tap(find.text('opus5-refusal-customer-report.md'));
+
+    expect(pushes.names, contains('/file-viewer'));
+    expect(
+      _viewerFrom(tester, pushes).path,
+      '/home/dev/helios/scratch/opus5-refusal-customer-report.md',
+    );
+  });
+
+  testWidgets('a chip that repeats the project directory does not double it', (
+    tester,
+  ) async {
+    // The agent writes helios/mobile/lib/main.dart while sitting in .../helios.
+    final pushes = await _pumpRow(
+      tester,
+      Message(
+        role: 'assistant',
+        timestamp: '2026-09-04T10:51:49Z',
+        content: 'Wrote helios/mobile/lib/main.dart just now.',
+      ),
+    );
+
+    await tester.tap(find.text('main.dart'));
+
+    expect(
+      _viewerFrom(tester, pushes).path,
+      '/home/dev/helios/mobile/lib/main.dart',
+    );
+  });
+
+  testWidgets('an absolute chip is opened as written', (tester) async {
+    final pushes = await _pumpRow(
+      tester,
+      Message(
+        role: 'assistant',
+        timestamp: '2026-09-04T10:51:49Z',
+        content: 'See /etc/hosts/entries.conf for the rest.',
+      ),
+    );
+
+    await tester.tap(find.text('entries.conf'));
+
+    expect(_viewerFrom(tester, pushes).path, '/etc/hosts/entries.conf');
   });
 
   testWidgets('a path in prose becomes a chip on two segments', (


### PR DESCRIPTION
A transcript row says `✎ Edit specs/46-codex-provider.md` and then leaves you
to go and find the file yourself. This puts the way in on the row.

## Desktop: the chip moves up

The file chip already existed — at the foot of the expanded detail, so reading
the file cost an expand and a scroll past the diff. It now rides on the header
line, next to the summary and before the chevron.

That line had to become a row of buttons rather than one button: the chip is
three buttons of its own, and a button cannot hold a button. Clicking the name
or the chevron still toggles the detail.

## Mobile: the affordance arrives

A tool row that names a file (`file_path`, `path`, or `notebook_path`) now
shows an open icon that pushes the file viewer, with the path resolved against
the session cwd — the same resolution the assistant message already used, now
shared.

A row that names no file shows nothing. So does a transcript rendered without a
host id, as previews and tests are: a button with no daemon behind it would
only fail when tapped.

## Tests

`mobile/test/tool_file_button_test.dart` pins all three cases. Full suites are
green: 189 mobile, 271 desktop, `tsc --noEmit` and `flutter analyze` clean.

Independent of #169 — no shared files, either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)