### PR TITLE
feat(desktop): move around with vim keys, and keep the mouse out of it

### DIFF
--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { bridge } from './bridge.ts'
 import { store, terminalId, useStore } from './store.ts'
+import { startVim } from './vim/driver.ts'
 import { Detail } from './components/detail.tsx'
 import { NewSessionDialog } from './components/newsession.tsx'
 import { Rail } from './components/rail.tsx'
@@ -31,6 +32,10 @@ export function App(): JSX.Element {
 
   // The Settings item in the app menu lives in the main process.
   useEffect(() => bridge.app.onOpenSettings(() => store.openSettings()), [])
+
+  // One listener for the whole window, whether or not vim mode is on: the
+  // driver reads the flag itself, so turning it on has to bind nothing.
+  useEffect(() => startVim(), [])
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent): void => {
@@ -81,7 +86,7 @@ export function App(): JSX.Element {
             setDialog('new')
           }}
         />
-        <main className="main">
+        <main className="main" onFocusCapture={() => store.setColumn('main')}>
           <Detail />
         </main>
       </div>

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -290,7 +290,10 @@ export function ChatPanel({
   }
 
   return (
-    <div className="chat">
+    // Focusable so leaving insert mode has somewhere to put the keyboard: the
+    // transcript has no rows to step over, and blurring onto the document
+    // would leave the next motion with nothing to move.
+    <div className="chat" data-vim-zone="transcript" tabIndex={-1}>
       <div
         className="chat-scroll"
         ref={scroller}
@@ -441,6 +444,8 @@ export function ChatPanel({
             />
             <textarea
               ref={composer}
+              // Where `i` puts the cursor when the transcript has the keyboard.
+              data-vim-insert=""
               value={draft}
               rows={3}
               placeholder={

--- a/desktop/src/renderer/components/rail.tsx
+++ b/desktop/src/renderer/components/rail.tsx
@@ -17,6 +17,7 @@ export function Rail(): JSX.Element {
   const item = (id: SidebarMode, label: string, icon: JSX.Element): JSX.Element => (
     <button
       className={mode === id ? 'rail-item on' : 'rail-item'}
+      data-vim-item=""
       // Pressed rather than current: these are three states of one control,
       // and only one of them is on at a time.
       aria-pressed={mode === id}
@@ -29,7 +30,7 @@ export function Rail(): JSX.Element {
   )
 
   return (
-    <nav className="rail" aria-label="Modes">
+    <nav className="rail" aria-label="Modes" data-vim-zone="rail" onFocusCapture={() => store.setColumn('rail')}>
       {item('sessions', 'Sessions', <ListRows />)}
       {item('schedules', 'Schedules', <Clock />)}
       <span className="grow" />

--- a/desktop/src/renderer/components/settings.tsx
+++ b/desktop/src/renderer/components/settings.tsx
@@ -17,6 +17,8 @@ import {
   toggleSegment,
   type SegmentId,
 } from '../../shared/status-line.ts'
+import { DEFAULT_BINDINGS } from '../vim/keymap.ts'
+import { command } from '../vim/registry.ts'
 import { BACKDROP_STYLES, MAX_BLUR, MAX_INTENSITY, MIN_INTENSITY, backdropValue } from '../../shared/theme/backdrop.ts'
 import { parseColor, type BackdropSpec, type BackdropStyle, type Rgb } from '../../shared/theme/vscode.ts'
 import type { HeliosTheme } from '../../shared/theme/resolve.ts'
@@ -89,6 +91,7 @@ export const SECTIONS: { id: SettingsSection; label: string }[] = [
   { id: 'sessions', label: 'Sessions' },
   { id: 'terminal', label: 'Terminal' },
   { id: 'notifications', label: 'Notifications' },
+  { id: 'keys', label: 'Keys' },
   // Last, and part of this list rather than a dialog of its own: which daemons
   // the app talks to is a setting like the others.
   { id: 'hosts', label: 'Hosts' },
@@ -295,6 +298,8 @@ export function SettingsPane(): JSX.Element {
             </>
           )}
 
+          {section === 'keys' && <KeysPane />}
+
           {section === 'hosts' && <HostsPane />}
         </div>
     </div>
@@ -307,6 +312,85 @@ export function SettingsPane(): JSX.Element {
  * stacking all of them meant scrolling past three copies of the same four
  * toggles to reach the one machine you meant.
  */
+/**
+ * The vim switch, and what the keys currently do.
+ *
+ * Read-only for now: rebinding writes a `keymap.json` this pane does not have
+ * yet. Listing the bindings still earns its place — a keymap you cannot see is
+ * one you have to learn by pressing things.
+ */
+function KeysPane(): JSX.Element {
+  const enabled = useStore((s) => s.vimEnabled)
+
+  const groups = new Map<string, { keys: string; title: string; scope: string }[]>()
+  for (const binding of DEFAULT_BINDINGS) {
+    if (!binding.command) continue
+    const entry = command(binding.command)
+    const group = entry?.group ?? 'Other'
+    const zones = binding.when?.zones
+    const modes = binding.when?.modes
+    const scope = modes ? modes.join(', ') : zones ? zones.join(', ') : 'anywhere'
+    const rows = groups.get(group) ?? []
+    rows.push({ keys: spell(binding.keys), title: entry?.title ?? binding.command, scope })
+    groups.set(group, rows)
+  }
+
+  return (
+    <>
+      <section className="settings-group">
+        <h3>
+          Vim mode
+          <Info>
+            Every letter becomes a command outside a text field. Escape leaves a half-typed
+            sequence; inside a terminal nothing is taken but <code>⌃\ ⌃n</code>, so the agent keeps
+            its own Escape.
+          </Info>
+        </h3>
+
+        <label className="check">
+          <input type="checkbox" checked={enabled} onChange={(event) => store.setVimEnabled(event.target.checked)} />
+          <span>Use vim keys to move around</span>
+        </label>
+      </section>
+
+      {[...groups].map(([group, rows]) => (
+        <section key={group} className="settings-group">
+          <h3>{group}</h3>
+          <table className="keymap">
+            <tbody>
+              {rows.map((row) => (
+                <tr key={`${row.keys}:${row.title}`}>
+                  <td className="keymap-keys">
+                    <kbd>{row.keys}</kbd>
+                  </td>
+                  <td className="keymap-title">{row.title}</td>
+                  <td className="keymap-scope">{row.scope}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ))}
+    </>
+  )
+}
+
+/** `<C-w> s` reads as `⌃w s`, which is what the key caps say. */
+function spell(keys: string): string {
+  return keys
+    .split(' ')
+    .map((token) =>
+      token
+        .replace(/^<C-(.+)>$/, '⌃$1')
+        .replace(/^<M-(.+)>$/, '⌥$1')
+        .replace('<space>', '␣')
+        .replace('<leader>', '␣')
+        .replace('<CR>', '↵')
+        .replace('<Esc>', 'Esc'),
+    )
+    .join(' ')
+}
+
 function TerminalPane(): JSX.Element {
   const uploads = useStore((s) => s.terminalUploads)
 

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -379,7 +379,13 @@ export function Sidebar({
   const manual = hosts.some((host) => sortMode[host.id] === 'manual')
 
   return (
-    <aside className="sidebar" ref={aside}>
+    <aside
+      className="sidebar"
+      ref={aside}
+      // The zone this column is, which is whichever list the rail chose.
+      data-vim-zone={mode === 'sessions' ? 'sidebar' : mode}
+      onFocusCapture={() => store.setColumn('sidebar')}
+    >
       {/* Which mode this is comes from the rail, so the list starts at its own
           search rather than at a switch it is not part of. */}
       {mode === 'settings' && (
@@ -1123,6 +1129,11 @@ function SessionRow({
   return (
     <article
       className={classes.filter(Boolean).join(' ')}
+      // What the keyboard cursor steps over. Focusable but out of the tab
+      // order: Tab should still cross the app in one press, not walk a list
+      // that can be hundreds long.
+      data-vim-item=""
+      tabIndex={-1}
       // A draggable ancestor takes the pointer off the field inside it: the
       // browser starts a drag instead of placing the caret, so a title cannot
       // be clicked into while the row can be moved.

--- a/desktop/src/renderer/components/status-line.tsx
+++ b/desktop/src/renderer/components/status-line.tsx
@@ -5,7 +5,7 @@ import { PathLabel } from './path-label.tsx'
 import { SelectionMenu } from './selection-menu.tsx'
 import { modeActions } from './session-menu.ts'
 import { gitStatusQuery, providersQuery } from '../queries.ts'
-import { useStore } from '../store.ts'
+import { currentZone, useStore } from '../store.ts'
 import type { SegmentId } from '../../shared/status-line.ts'
 import { BUSY_STATUSES, statusLabel, type Session } from '../../shared/models.ts'
 
@@ -25,6 +25,10 @@ import { BUSY_STATUSES, statusLabel, type Session } from '../../shared/models.ts
 export function StatusLine({ hostId, session }: { hostId: string; session: Session }): JSX.Element | null {
   const order = useStore((s) => s.statusLine)
   const hosts = useStore((s) => s.hosts)
+  const vimEnabled = useStore((s) => s.vimEnabled)
+  const vimMode = useStore((s) => s.vimMode)
+  const vimPending = useStore((s) => s.vimPending)
+  const zone = useStore(currentZone)
   const [modeMenu, setModeMenu] = useState<{ x: number; y: number } | null>(null)
 
   const wanted = new Set(order)
@@ -43,7 +47,10 @@ export function StatusLine({ hostId, session }: { hostId: string; session: Sessi
   // bar that nobody has clicked should not pay for it.
   const { data: providers } = useQuery({ ...providersQuery(hostId), enabled: modeMenu !== null })
 
-  if (order.length === 0) return null
+  // Vim mode keeps the bar even when every session segment has been switched
+  // off: with the keymap on, what mode the keyboard is in is the one fact on
+  // this line you cannot work without.
+  if (order.length === 0 && !vimEnabled) return null
 
   const segment = (id: SegmentId): JSX.Element | null => {
     switch (id) {
@@ -121,8 +128,17 @@ export function StatusLine({ hostId, session }: { hostId: string; session: Sessi
   }
 
   return (
-    <footer className="status-line">
+    <footer className={vimEnabled ? `status-line vim ${vimMode}` : 'status-line'}>
+      {/* First, and coloured, because the mode changes what every key does —
+          the session facts beside it are true either way. */}
+      {vimEnabled && <span className="vim-mode">{vimMode.toUpperCase()}</span>}
+      {vimEnabled && <span className="vim-zone">{zone}</span>}
+
       {order.map(segment)}
+
+      {/* Last and hard right, so a half-typed sequence appears in the same
+          place whatever the segments in front of it are doing. */}
+      {vimEnabled && vimPending && <span className="vim-pending">{vimPending}</span>}
 
       {modeMenu && (
         <SelectionMenu

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -31,6 +31,7 @@ import {
   type ItemId,
   type Layout,
 } from './components/layout.ts'
+import type { Mode, Zone } from './vim/types.ts'
 import type { SegmentId } from '../shared/status-line.ts'
 import { applyDensity, applyProseSize, applyStatusSize, applyTheme } from '../shared/theme/apply.ts'
 import { hasTerminal } from '../shared/models.ts'
@@ -82,6 +83,9 @@ function shellLabel(termId: string): string {
  * never the shape for.
  */
 export type SidebarMode = 'sessions' | 'schedules' | 'settings'
+
+/** The three columns, left to right. What `Ctrl-h` and `Ctrl-l` move between. */
+export type Column = 'rail' | 'sidebar' | 'main'
 
 /** What the main panel is showing about a schedule. */
 export interface ScheduleSelection {
@@ -211,6 +215,23 @@ export interface State {
    *  coming back lands where you left. */
   settingsSection: SettingsSection
   /**
+   * Which of the three columns owns the keyboard.
+   *
+   * Only the column, not the zone: below the detail panel `Layout.focused`
+   * already knows which group has the keyboard, and a second copy of that fact
+   * would be one to keep in step. `currentZone` derives the rest.
+   */
+  column: Column
+  /**
+   * Whether keys are commands, and which mode they are commands in.
+   *
+   * The mode is authoritative and DOM focus follows it. `pending` is what has
+   * been typed and not yet resolved, which the mode line draws.
+   */
+  vimEnabled: boolean
+  vimMode: Mode
+  vimPending: string
+  /**
    * The schedules list's own search.
    *
    * Separate from `query`: the two lists hold different things, and a query
@@ -314,6 +335,32 @@ function writeGroupMode(mode: GroupMode): void {
   }
 }
 
+const VIM_KEY = 'helios.vim'
+
+/**
+ * Off until it is turned on.
+ *
+ * Vim mode makes every bare letter a command, so arriving switched on would
+ * leave someone who has never asked for it unable to type. The keymap file this
+ * grows into holds the same flag, but the flag is worth reading from here as
+ * well: the file is loaded over IPC and the first keystroke can beat it.
+ */
+function readVimEnabled(): boolean {
+  try {
+    return localStorage.getItem(VIM_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeVimEnabled(on: boolean): void {
+  try {
+    localStorage.setItem(VIM_KEY, on ? '1' : '0')
+  } catch {
+    // A full or unavailable store costs the preference, not the setting.
+  }
+}
+
 const TERMINAL_UPLOADS_KEY = 'helios.terminalUploads'
 
 /**
@@ -412,6 +459,10 @@ const initial: State = {
   renamingSession: null,
   sidebarMode: 'sessions',
   settingsSection: 'appearance',
+  column: 'sidebar',
+  vimEnabled: readVimEnabled(),
+  vimMode: 'normal',
+  vimPending: '',
   scheduleQuery: '',
   autoRunsOpen: {},
   scheduleSelection: null,
@@ -1209,6 +1260,32 @@ class Store {
     this.editLayout(target, (layout) => removeItem(layout, item))
   }
 
+  // ─── Vim mode ─────────────────────────────────────────────────────────────
+
+  setColumn(column: Column): void {
+    if (this.state.column !== column) this.set({ column })
+  }
+
+  /**
+   * Turns the keymap on or off.
+   *
+   * Always lands in normal: leaving it switched off while a mode other than
+   * normal was current would mean turning it back on into a mode nothing can
+   * leave.
+   */
+  setVimEnabled(on: boolean): void {
+    writeVimEnabled(on)
+    this.set({ vimEnabled: on, vimMode: 'normal', vimPending: '' })
+  }
+
+  setVimMode(mode: Mode): void {
+    if (this.state.vimMode !== mode) this.set({ vimMode: mode, vimPending: '' })
+  }
+
+  setVimPending(pending: string): void {
+    if (this.state.vimPending !== pending) this.set({ vimPending: pending })
+  }
+
   focusGroup(target: Selection, groupId: string): void {
     this.editLayout(target, (layout) =>
       layout.focused === groupId ? layout : { ...layout, focused: groupId },
@@ -1639,6 +1716,43 @@ export const store = new Store()
 
 export function useStore<T>(select: (state: State) => T): T {
   return useSyncExternalStore(store.subscribe, () => select(store.getSnapshot()))
+}
+
+/**
+ * Which zone owns the keyboard, derived rather than stored.
+ *
+ * The column is a fact this store keeps. Everything below it is already known:
+ * the sidebar's zone is whichever list it is showing, and the detail panel's is
+ * whatever the focused group has in front. Storing those again would give two
+ * answers that could disagree.
+ */
+export function currentZone(state: State): Zone {
+  if (state.column === 'rail') return 'rail'
+  if (state.column === 'sidebar') {
+    if (state.sidebarMode === 'schedules') return 'schedules'
+    if (state.sidebarMode === 'settings') return 'settings'
+    return 'sidebar'
+  }
+
+  const layout = currentLayout(state)
+  const group = layout.groups.find((one) => one.id === layout.focused) ?? layout.groups[0]
+  const active = group?.active ?? ''
+  // A shell is a terminal like the session's own is.
+  if (tabOf(active)) return 'terminal'
+  switch (panelOf(active)) {
+    case 'chat':
+      return 'transcript'
+    case 'terminal':
+      return 'terminal'
+    case 'approvals':
+      return 'approvals'
+    case 'git':
+      return 'git'
+    case 'files':
+      return 'files'
+    default:
+      return 'transcript'
+  }
 }
 
 /** How the selected session's panels are arranged. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -5640,3 +5640,88 @@ hr {
   flex: 1;
   min-width: 0;
 }
+
+/* ─── Vim mode ─────────────────────────────────────────────────────────────
+   The mode rides the session's own status line rather than a bar of its own.
+   Two bars at the foot of the window is one more than the window can spare,
+   and the mode belongs beside the branch: both answer "where am I". */
+.status-line .vim-mode {
+  padding: 2px 7px;
+  border-radius: var(--r-xs, 3px);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--inverse-on-surface);
+  background: var(--on-surface-variant);
+}
+
+.status-line.normal .vim-mode {
+  background: var(--primary);
+  color: var(--on-primary);
+}
+
+.status-line.insert .vim-mode {
+  background: #3f9e5c;
+  color: #fff;
+}
+
+.status-line.visual .vim-mode {
+  background: #b8860b;
+  color: #fff;
+}
+
+.status-line.terminal .vim-mode,
+.status-line.scroll .vim-mode {
+  background: #b3261e;
+  color: #fff;
+}
+
+.status-line .vim-zone {
+  opacity: 0.7;
+}
+
+/* Hard right, so a half-typed sequence is always in the same place. */
+.status-line .vim-pending {
+  margin-left: auto;
+  font-weight: 700;
+  color: var(--on-surface);
+}
+
+/* The keyboard cursor. Never drawn on a row the pointer merely passed over. */
+[data-vim-item]:focus,
+[data-vim-item]:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.keymap {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+
+.keymap td {
+  padding: 4px 8px 4px 0;
+  vertical-align: baseline;
+}
+
+.keymap-keys {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.keymap-keys kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-xs, 3px);
+  background: color-mix(in srgb, var(--on-surface) 5%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+}
+
+.keymap-scope {
+  width: 1%;
+  white-space: nowrap;
+  color: var(--on-surface-variant);
+  opacity: 0.8;
+}

--- a/desktop/src/renderer/vim/commands.ts
+++ b/desktop/src/renderer/vim/commands.ts
@@ -1,0 +1,317 @@
+import { currentLayout, currentZone, store, type Column } from '../store.ts'
+import { panelItem, type Edge, type Group, type Layout } from '../components/layout.ts'
+import { register } from './registry.ts'
+import { activate, enterZone, jump, move, textSurface } from './items.ts'
+import type { Command, Zone } from './types.ts'
+
+/**
+ * The first set of commands, and the shape every later one copies.
+ *
+ * Registered at module scope rather than from a component: `:` has to reach a
+ * command whose pane is not mounted, and half of these move the keyboard *to*
+ * a pane that is not mounted yet.
+ */
+
+const LIST_ZONES: Zone[] = ['rail', 'sidebar', 'schedules', 'files', 'approvals', 'git', 'settings']
+
+function focusedGroup(layout: Layout): Group | undefined {
+  return layout.groups.find((group) => group.id === layout.focused) ?? layout.groups[0]
+}
+
+/** The selection, the layout and the item with the keyboard, or null. */
+function panelTarget(): { selection: NonNullable<ReturnType<typeof selectionOf>>; layout: Layout; group: Group } | null {
+  const selection = selectionOf()
+  if (!selection) return null
+  const layout = currentLayout(store.getSnapshot())
+  const group = focusedGroup(layout)
+  if (!group) return null
+  return { selection, layout, group }
+}
+
+function selectionOf(): { hostId: string; sessionId: string } | null {
+  return store.getSnapshot().selection
+}
+
+function command(entry: Command): Command {
+  return entry
+}
+
+// ─── Columns ────────────────────────────────────────────────────────────────
+
+const ORDER: Column[] = ['rail', 'sidebar', 'main']
+
+/**
+ * `Ctrl-h` and `Ctrl-l` cross the three columns, and inside the detail panel
+ * they hand over to the layout's own focus.
+ *
+ * Crossing only when the panel has no further group in that direction is what
+ * makes one key work the whole width of the window, which is how LazyVim's
+ * window motions read.
+ */
+function stepColumn(by: -1 | 1): void {
+  const state = store.getSnapshot()
+  if (state.column === 'main') {
+    const target = panelTarget()
+    if (target) {
+      const at = target.layout.groups.findIndex((group) => group.id === target.group.id)
+      const next = target.layout.groups[at + by]
+      if (next) {
+        store.focusGroup(target.selection, next.id)
+        return
+      }
+    }
+  }
+  const at = ORDER.indexOf(state.column)
+  const next = ORDER[at + by]
+  if (!next) return
+  store.setColumn(next)
+  // The ring has to follow the column, or the mode line names one zone while
+  // the cursor sits in another and the next motion moves the wrong list.
+  enterZone(currentZone(store.getSnapshot()))
+}
+
+// ─── Windows ────────────────────────────────────────────────────────────────
+
+/** A fifth of the row per press, which is coarse enough to be worth a keystroke. */
+const RESIZE_STEP = 0.2
+
+function resizeFocused(by: number): void {
+  const target = panelTarget()
+  if (!target) return
+  const at = target.layout.groups.findIndex((group) => group.id === target.group.id)
+  // The last group has no sash of its own, so it borrows the one behind it and
+  // pushes the other way.
+  const last = at === target.layout.groups.length - 1
+  const sash = last ? at - 1 : at
+  if (sash < 0) return
+  store.resizeGroups(target.selection, sash, last ? -by : by)
+}
+
+function splitFocused(edge: Edge): void {
+  const target = panelTarget()
+  if (!target) return
+  store.splitItem(target.selection, target.group.active, target.group.id, edge)
+}
+
+export function registerCoreCommands(): void {
+  register(
+    command({
+      id: 'column.left',
+      title: 'Focus the pane to the left',
+      group: 'Window',
+      run: () => stepColumn(-1),
+    }),
+    command({
+      id: 'column.right',
+      title: 'Focus the pane to the right',
+      group: 'Window',
+      run: () => stepColumn(1),
+    }),
+    command({
+      id: 'window.split',
+      title: 'Split the focused panel out',
+      group: 'Window',
+      run: () => splitFocused('after'),
+    }),
+    command({
+      id: 'window.splitBefore',
+      title: 'Split the focused panel out, before',
+      group: 'Window',
+      run: () => splitFocused('before'),
+    }),
+    command({
+      id: 'window.close',
+      title: 'Close the focused panel',
+      group: 'Window',
+      run: () => {
+        const target = panelTarget()
+        if (target) store.dropItem(target.selection, target.group.active)
+      },
+    }),
+    command({
+      id: 'window.even',
+      title: 'Give every panel the same width',
+      group: 'Window',
+      run: () => {
+        const target = panelTarget()
+        if (target) store.evenGroups(target.selection)
+      },
+    }),
+    command({ id: 'window.wider', title: 'Widen the focused panel', group: 'Window', run: () => resizeFocused(RESIZE_STEP) }),
+    command({
+      id: 'window.narrower',
+      title: 'Narrow the focused panel',
+      group: 'Window',
+      run: () => resizeFocused(-RESIZE_STEP),
+    }),
+    command({
+      id: 'window.rotate',
+      title: 'Lay the panels out the other way',
+      group: 'Window',
+      run: () => {
+        const target = panelTarget()
+        if (target) store.setLayoutAxis(target.selection, target.layout.axis === 'row' ? 'column' : 'row')
+      },
+    }),
+  )
+
+  // ─── Panels ───────────────────────────────────────────────────────────────
+
+  const panels: [string, string, 'chat' | 'terminal' | 'approvals' | 'git' | 'files'][] = [
+    ['panel.chat', 'Show the transcript', 'chat'],
+    ['panel.terminal', 'Show the terminal', 'terminal'],
+    ['panel.approvals', 'Show approvals', 'approvals'],
+    ['panel.git', 'Show git', 'git'],
+    ['panel.files', 'Show files', 'files'],
+  ]
+  for (const [id, title, panel] of panels) {
+    register(
+      command({
+        id,
+        title,
+        group: 'Panel',
+        run: () => {
+          store.setPanel(panel)
+          store.setColumn('main')
+        },
+      }),
+    )
+  }
+
+  register(
+    command({
+      id: 'panel.next',
+      title: 'Next panel',
+      group: 'Panel',
+      run: () => stepPanel(1),
+    }),
+    command({
+      id: 'panel.prev',
+      title: 'Previous panel',
+      group: 'Panel',
+      run: () => stepPanel(-1),
+    }),
+  )
+
+  // ─── Modes of the sidebar ─────────────────────────────────────────────────
+
+  register(
+    command({
+      id: 'mode.sessions',
+      title: 'Show sessions',
+      group: 'Go to',
+      run: () => {
+        store.setSidebarMode('sessions')
+        store.setColumn('sidebar')
+      },
+    }),
+    command({
+      id: 'mode.schedules',
+      title: 'Show schedules',
+      group: 'Go to',
+      run: () => {
+        store.setSidebarMode('schedules')
+        store.setColumn('sidebar')
+      },
+    }),
+    command({
+      id: 'mode.settings',
+      title: 'Show settings',
+      group: 'Go to',
+      run: () => {
+        store.openSettings()
+        store.setColumn('sidebar')
+      },
+    }),
+  )
+
+  // ─── Lists ────────────────────────────────────────────────────────────────
+
+  register(
+    command({
+      id: 'list.next',
+      title: 'Next row',
+      group: 'Move',
+      when: { zones: LIST_ZONES },
+      run: (ctx, count) => move(ctx.zone, count ?? 1),
+    }),
+    command({
+      id: 'list.prev',
+      title: 'Previous row',
+      group: 'Move',
+      when: { zones: LIST_ZONES },
+      run: (ctx, count) => move(ctx.zone, -(count ?? 1)),
+    }),
+    command({
+      id: 'list.first',
+      title: 'First row',
+      group: 'Move',
+      when: { zones: LIST_ZONES },
+      run: (ctx) => jump(ctx.zone, 'first'),
+    }),
+    command({
+      id: 'list.last',
+      title: 'Last row',
+      group: 'Move',
+      when: { zones: LIST_ZONES },
+      run: (ctx) => jump(ctx.zone, 'last'),
+    }),
+    command({
+      id: 'list.activate',
+      title: 'Open the focused row',
+      group: 'Move',
+      when: { zones: LIST_ZONES },
+      run: (ctx) => activate(ctx.zone),
+    }),
+  )
+
+  // ─── Insert ───────────────────────────────────────────────────────────────
+
+  register(
+    command({
+      id: 'insert.enter',
+      title: 'Type here',
+      group: 'Mode',
+      enabled: (ctx) => textSurface(ctx.zone) !== null,
+      run: (ctx) => {
+        const surface = textSurface(ctx.zone)
+        if (!surface) return
+        // The mode goes first: focus follows it, and a listener that saw the
+        // focus before the mode would treat it as a click and race.
+        store.setVimMode('insert')
+        surface.focus()
+      },
+    }),
+    command({
+      id: 'normal.enter',
+      title: 'Back to normal mode',
+      group: 'Mode',
+      when: { modes: ['insert', 'visual', 'terminal', 'scroll'] },
+      run: (ctx) => {
+        const active = document.activeElement
+        if (active instanceof HTMLElement) active.blur()
+        store.setVimMode('normal')
+        // Blurring alone would leave the keyboard on the document, where the
+        // next motion has no list to move. Leaving insert should put the cursor
+        // back where insert was entered from.
+        enterZone(ctx.zone)
+      },
+    }),
+  )
+}
+
+function stepPanel(by: 1 | -1): void {
+  const target = panelTarget()
+  if (!target) return
+  const strip = target.group.items
+  const at = strip.indexOf(target.group.active)
+  const next = strip[(at + by + strip.length) % strip.length]
+  if (next) store.revealItem(target.selection, next)
+}
+
+/** Exported for the palette's sake: the zone a command would act on. */
+export function activeZone(): Zone {
+  return currentZone(store.getSnapshot())
+}
+
+export { panelItem }

--- a/desktop/src/renderer/vim/driver.ts
+++ b/desktop/src/renderer/vim/driver.ts
@@ -1,0 +1,177 @@
+import { currentZone, store, type Column } from '../store.ts'
+import { command } from './registry.ts'
+import { registerCoreCommands } from './commands.ts'
+import { DEFAULT_BINDINGS, LEADER, TIMEOUT_MS } from './keymap.ts'
+import { applicable, EMPTY, expandLeader, flush, keyToken, merge, resolve, type Pending } from './resolve.ts'
+import type { Binding, CommandContext, Mode } from './types.ts'
+
+/**
+ * The one keydown listener, and the timer the resolver deliberately does not
+ * own.
+ *
+ * Everything decided here is decided by `resolve`; this only supplies the
+ * keystrokes, the clock and the running. Keeping it that thin is what lets the
+ * interesting half be tested without a DOM.
+ */
+
+let pending: Pending = EMPTY
+let timer: ReturnType<typeof setTimeout> | null = null
+let keymap: Binding[] = expandLeader(DEFAULT_BINDINGS, LEADER)
+
+export function setKeymap(overrides: Binding[]): void {
+  keymap = expandLeader(merge(DEFAULT_BINDINGS, overrides), LEADER)
+}
+
+/**
+ * Whether the event is typing rather than commanding.
+ *
+ * Mode is meant to be authoritative, but the mouse can put a caret in a field
+ * without asking, and a user who has clicked into the composer must not have
+ * their next letter eaten. So focus is trusted in one direction only: it can
+ * force insert, never normal.
+ */
+function typingInto(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+/**
+ * The mode a focused element demands, if it demands one.
+ *
+ * A terminal is checked first and separately. xterm takes its keys on a hidden
+ * textarea, so the ordinary test would call it insert — and insert lets the
+ * keymap keep `Esc`, which is the one key Claude Code must receive.
+ */
+function surfaceMode(target: EventTarget | null): Mode | null {
+  if (!(target instanceof HTMLElement)) return null
+  if (target.closest('.xterm')) return 'terminal'
+  return typingInto(target) ? 'insert' : null
+}
+
+function contextOf(mode: Mode): CommandContext {
+  return { mode, zone: currentZone(store.getSnapshot()) }
+}
+
+function clear(): void {
+  pending = EMPTY
+  if (timer) clearTimeout(timer)
+  timer = null
+  store.setVimPending('')
+}
+
+function show(): void {
+  store.setVimPending([pending.count, ...pending.keys].filter(Boolean).join(' '))
+}
+
+function run(id: string, ctx: CommandContext, count: number | undefined): void {
+  const entry = command(id)
+  if (!entry) return
+  void entry.run(ctx, count)
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  const state = store.getSnapshot()
+  if (!state.vimEnabled) return
+
+  // The app's own accelerators keep working in every mode, so they are never
+  // this listener's business.
+  if (event.metaKey) return
+
+  const token = keyToken(event)
+  if (token === null) return
+
+  // An IME uses Escape to dismiss its candidate window, and Enter to accept a
+  // candidate. Taking either mid-composition strands a half-typed word.
+  if (event.isComposing) return
+
+  const demanded = surfaceMode(event.target)
+  const mode: Mode = state.vimMode === 'normal' && demanded ? demanded : state.vimMode
+  if (mode !== state.vimMode) store.setVimMode(mode)
+
+  const ctx = contextOf(mode)
+  const scoped = applicable(keymap, ctx)
+  const step = resolve(pending, token, scoped)
+  pending = step.next
+
+  if (timer) clearTimeout(timer)
+  timer = null
+
+  switch (step.action.kind) {
+    case 'run':
+      event.preventDefault()
+      clear()
+      run(step.action.command, ctx, step.action.count)
+      return
+
+    case 'pending': {
+      show()
+      // A key that has started a sequence must not also reach the page, or `g`
+      // would type a letter on its way to `g c`.
+      if (pending.keys.length > 0) event.preventDefault()
+      const exact = step.action.exact
+      if (exact?.command) {
+        const held = pending
+        timer = setTimeout(() => {
+          const timed = flush(held, applicable(keymap, contextOf(store.getSnapshot().vimMode)))
+          clear()
+          if (timed.action.kind === 'run') {
+            run(timed.action.command, contextOf(store.getSnapshot().vimMode), timed.action.count)
+          }
+        }, TIMEOUT_MS)
+      }
+      return
+    }
+
+    case 'none':
+      clear()
+  }
+}
+
+/**
+ * A click into a text field is the one place focus is allowed to set the mode.
+ * Without it the mode line would say NORMAL while the caret blinks in the
+ * composer, and the two disagreeing is the failure this design exists to avoid.
+ */
+/**
+ * Which column an element sits in.
+ *
+ * Read off the document rather than announced by each column, because the
+ * things that take focus are not always React's to know about: xterm focuses a
+ * textarea it owns, and CodeMirror focuses one of its own too.
+ */
+function columnOf(target: EventTarget | null): Column | null {
+  if (!(target instanceof HTMLElement)) return null
+  if (target.closest('.rail')) return 'rail'
+  if (target.closest('.sidebar')) return 'sidebar'
+  if (target.closest('main.main')) return 'main'
+  return null
+}
+
+function onFocusIn(event: FocusEvent): void {
+  const state = store.getSnapshot()
+  if (!state.vimEnabled) return
+
+  const column = columnOf(event.target)
+  if (column) store.setColumn(column)
+
+  const demanded = surfaceMode(event.target)
+  if (demanded) {
+    if (state.vimMode !== demanded) store.setVimMode(demanded)
+  } else if (state.vimMode === 'insert' || state.vimMode === 'terminal') {
+    store.setVimMode('normal')
+  }
+}
+
+export function startVim(): () => void {
+  registerCoreCommands()
+  // Capture, so a component's own handler cannot swallow a command key first.
+  window.addEventListener('keydown', onKeyDown, true)
+  window.addEventListener('focusin', onFocusIn, true)
+  return () => {
+    window.removeEventListener('keydown', onKeyDown, true)
+    window.removeEventListener('focusin', onFocusIn, true)
+    clear()
+  }
+}

--- a/desktop/src/renderer/vim/items.ts
+++ b/desktop/src/renderer/vim/items.ts
@@ -1,0 +1,100 @@
+import type { Zone } from './types.ts'
+
+/**
+ * Moving a keyboard cursor over whatever a zone has drawn.
+ *
+ * The rows a list shows come from React Query and live inside the component
+ * that renders them, so a command — which holds no component — cannot ask the
+ * store what is on screen. It can ask the document, and the document is the
+ * better source anyway: the order the elements are in *is* the order the eye
+ * reads, filters and folds included.
+ *
+ * A zone marks its container with `data-vim-zone` and its rows with
+ * `data-vim-item`. Nothing else is required of it.
+ */
+export function zoneRoot(zone: Zone): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-vim-zone="${zone}"]`)
+}
+
+export function items(zone: Zone): HTMLElement[] {
+  const root = zoneRoot(zone)
+  if (!root) return []
+  return [...root.querySelectorAll<HTMLElement>('[data-vim-item]')].filter(
+    // A folded group's rows are in the document and not on screen. Landing on
+    // one would move a cursor nobody can see.
+    (element) => element.offsetParent !== null,
+  )
+}
+
+export function currentIndex(list: HTMLElement[]): number {
+  const active = document.activeElement
+  if (!(active instanceof HTMLElement)) return -1
+  return list.findIndex((element) => element === active || element.contains(active))
+}
+
+/**
+ * Where the cursor was when a zone was last left.
+ *
+ * Vim keeps a cursor per window and puts you back on it. Without this, crossing
+ * to the rail and back lands on the first row every time, so the two motions
+ * that should cancel out instead lose your place.
+ */
+const lastSeen = new Map<Zone, number>()
+
+export function focusAt(list: HTMLElement[], index: number, zone?: Zone): void {
+  const at = Math.max(0, Math.min(index, list.length - 1))
+  const target = list[at]
+  if (!target) return
+  if (zone) lastSeen.set(zone, at)
+  target.focus({ preventScroll: true })
+  target.scrollIntoView({ block: 'nearest' })
+}
+
+export function move(zone: Zone, by: number): void {
+  const list = items(zone)
+  if (list.length === 0) return
+  const at = currentIndex(list)
+  focusAt(list, at === -1 ? (by > 0 ? 0 : list.length - 1) : at + by, zone)
+}
+
+export function jump(zone: Zone, to: 'first' | 'last'): void {
+  const list = items(zone)
+  if (list.length === 0) return
+  focusAt(list, to === 'first' ? 0 : list.length - 1, zone)
+}
+
+/**
+ * Runs whatever the focused row does when clicked.
+ *
+ * `click()` rather than a store call: a row's meaning belongs to the component
+ * that drew it, and half of them are already buttons.
+ */
+export function activate(zone: Zone): void {
+  const list = items(zone)
+  const at = currentIndex(list)
+  list[at === -1 ? 0 : at]?.click()
+}
+
+/** The text surface `i` puts the cursor in, if the zone has one. */
+export function textSurface(zone: Zone): HTMLElement | null {
+  const root = zoneRoot(zone)
+  return root?.querySelector<HTMLElement>('[data-vim-insert]') ?? null
+}
+
+/**
+ * Puts the keyboard cursor inside a zone that has just been moved to.
+ *
+ * Without this the mode line names the new zone while the ring is still drawn
+ * on a row in the old one, and the next `j` moves something the eye is not
+ * looking at. Already being inside counts as arrived: crossing back and forth
+ * should not lose the row you were on.
+ */
+export function enterZone(zone: Zone): void {
+  const list = items(zone)
+  if (list.length === 0) {
+    zoneRoot(zone)?.focus?.({ preventScroll: true })
+    return
+  }
+  if (currentIndex(list) !== -1) return
+  focusAt(list, lastSeen.get(zone) ?? 0, zone)
+}

--- a/desktop/src/renderer/vim/keymap.ts
+++ b/desktop/src/renderer/vim/keymap.ts
@@ -1,0 +1,55 @@
+import type { Binding, Zone } from './types.ts'
+
+/**
+ * What the keys do before anyone changes them.
+ *
+ * LazyVim rather than stock vim where the two differ: plain `Ctrl-h/l` for
+ * window motion instead of `Ctrl-w h`, and `Shift-h/l` for the next and
+ * previous panel the way LazyVim cycles buffers.
+ */
+
+export const LEADER = '<space>'
+
+/** LazyVim's `timeoutlen`. Long enough not to flash during fluent typing. */
+export const TIMEOUT_MS = 300
+
+const LISTS: Zone[] = ['rail', 'sidebar', 'schedules', 'files', 'approvals', 'git', 'settings']
+
+export const DEFAULT_BINDINGS: Binding[] = [
+  // Columns and windows.
+  { keys: '<C-h>', command: 'column.left' },
+  { keys: '<C-l>', command: 'column.right' },
+  { keys: '<C-w> s', command: 'window.split' },
+  { keys: '<C-w> S', command: 'window.splitBefore' },
+  { keys: '<C-w> q', command: 'window.close' },
+  { keys: '<C-w> =', command: 'window.even' },
+  { keys: '<C-w> >', command: 'window.wider' },
+  { keys: '<C-w> <', command: 'window.narrower' },
+  { keys: '<C-w> r', command: 'window.rotate' },
+
+  // Panels.
+  { keys: 'g c', command: 'panel.chat' },
+  { keys: 'g t', command: 'panel.terminal' },
+  { keys: 'g a', command: 'panel.approvals' },
+  { keys: 'g d', command: 'panel.git' },
+  { keys: 'g f', command: 'panel.files' },
+  { keys: 'L', command: 'panel.next' },
+  { keys: 'H', command: 'panel.prev' },
+
+  // What the sidebar is showing.
+  { keys: '<leader> 1', command: 'mode.sessions' },
+  { keys: '<leader> 2', command: 'mode.schedules' },
+  { keys: '<leader> 3', command: 'mode.settings' },
+
+  // Lists.
+  { keys: 'j', command: 'list.next', when: { zones: LISTS } },
+  { keys: 'k', command: 'list.prev', when: { zones: LISTS } },
+  { keys: 'g g', command: 'list.first', when: { zones: LISTS } },
+  { keys: 'G', command: 'list.last', when: { zones: LISTS } },
+  { keys: '<CR>', command: 'list.activate', when: { zones: LISTS } },
+
+  // Modes.
+  { keys: 'i', command: 'insert.enter' },
+  { keys: '<Esc>', command: 'normal.enter', when: { modes: ['insert', 'visual'] } },
+  { keys: '<C-\\> <C-n>', command: 'normal.enter', when: { modes: ['terminal', 'scroll'] } },
+]

--- a/desktop/src/renderer/vim/registry.ts
+++ b/desktop/src/renderer/vim/registry.ts
@@ -1,0 +1,59 @@
+import type { Command, CommandContext } from './types.ts'
+
+/**
+ * Every action the app can be asked to do, in one place.
+ *
+ * The registry is the guarantee behind the mouse-free goal: `:` lists what is
+ * in here, so an action that is registered is reachable whether or not anyone
+ * gave it a key. An action that is *not* registered is invisible in the palette
+ * and in the hint overlay, which is how the omission gets noticed.
+ *
+ * A module-scope map rather than React context: commands register beside the
+ * component that owns them, and `:` has to reach one whose pane is not mounted.
+ */
+const commands = new Map<string, Command>()
+
+export function register(...added: Command[]): void {
+  for (const command of added) {
+    const clash = commands.get(command.id)
+    // Two actions under one id would make the palette run the wrong one, and
+    // the keymap file names ids — so the collision has to be loud.
+    if (clash && clash !== command) throw new Error(`duplicate command id: ${command.id}`)
+    commands.set(command.id, command)
+  }
+}
+
+export function command(id: string): Command | undefined {
+  return commands.get(id)
+}
+
+export function all(): Command[] {
+  return [...commands.values()]
+}
+
+/**
+ * What `:` offers, in the order it offers them.
+ *
+ * Out-of-scope commands are listed and refused rather than hidden: a palette
+ * that changes shape as panes mount is one you cannot learn.
+ */
+export function palette(ctx: CommandContext): { command: Command; enabled: boolean }[] {
+  return all()
+    .map((entry) => ({ command: entry, enabled: runnable(entry, ctx) }))
+    .sort((a, b) => rank(a) - rank(b) || a.command.title.localeCompare(b.command.title))
+}
+
+export function runnable(entry: Command, ctx: CommandContext): boolean {
+  if (entry.when?.zones && !entry.when.zones.includes(ctx.zone)) return false
+  if (entry.when?.modes && !entry.when.modes.includes(ctx.mode)) return false
+  return entry.enabled?.(ctx) ?? true
+}
+
+function rank(entry: { enabled: boolean }): number {
+  return entry.enabled ? 0 : 1
+}
+
+/** Test seam. Nothing in the app clears the registry. */
+export function reset(): void {
+  commands.clear()
+}

--- a/desktop/src/renderer/vim/resolve.ts
+++ b/desktop/src/renderer/vim/resolve.ts
@@ -1,0 +1,192 @@
+import type { Binding, CommandContext, Mode, Zone } from './types.ts'
+
+/**
+ * Turning keys into commands, as a pure function.
+ *
+ * Deliberately free of the DOM and of the registry: the interesting part is
+ * which sequence wins and when, and a resolver that reached a KeyboardEvent or
+ * a store could only be tested through a stand-in for one. The timeout lives in
+ * the caller for the same reason — a timer is not a fact about a keymap.
+ */
+
+/** What has been typed so far and not yet resolved. */
+export interface Pending {
+  keys: string[]
+  /** Digits typed before a sequence. `3j` moves three rows. */
+  count: string
+}
+
+export const EMPTY: Pending = { keys: [], count: '' }
+
+export type Action =
+  | { kind: 'pending'; candidates: Binding[]; exact: Binding | null }
+  | { kind: 'run'; command: string; count?: number }
+  | { kind: 'none' }
+
+export interface Resolved {
+  next: Pending
+  action: Action
+}
+
+/** A key event reduced to what a binding can name. */
+export interface KeyStroke {
+  key: string
+  ctrlKey?: boolean
+  altKey?: boolean
+  metaKey?: boolean
+}
+
+const NAMED: Record<string, string> = {
+  ' ': '<space>',
+  Escape: '<Esc>',
+  Enter: '<CR>',
+  Tab: '<Tab>',
+  Backspace: '<BS>',
+  Delete: '<Del>',
+  ArrowUp: '<Up>',
+  ArrowDown: '<Down>',
+  ArrowLeft: '<Left>',
+  ArrowRight: '<Right>',
+}
+
+/**
+ * The token a binding would spell this stroke as, or null if vim mode should
+ * not see it at all.
+ *
+ * ⌘ returns null on purpose. Those are the app's own accelerators, they work in
+ * every mode including inside a terminal, and a keymap that could shadow ⌘Q is
+ * a keymap that can lock someone out of quitting.
+ */
+export function keyToken(stroke: KeyStroke): string | null {
+  if (stroke.metaKey) return null
+
+  const base = NAMED[stroke.key] ?? stroke.key
+  if (base.length === 0) return null
+  // A modifier pressed on its own is not a stroke.
+  if (base === 'Control' || base === 'Alt' || base === 'Shift' || base === 'Meta') return null
+
+  const inner = base.startsWith('<') && base.endsWith('>') ? base.slice(1, -1) : base
+  if (stroke.ctrlKey && stroke.altKey) return `<C-M-${inner}>`
+  if (stroke.ctrlKey) return `<C-${inner}>`
+  if (stroke.altKey) return `<M-${inner}>`
+  return base
+}
+
+export function tokens(keys: string): string[] {
+  return keys.split(' ').filter((token) => token.length > 0)
+}
+
+/**
+ * The bindings that could fire right now.
+ *
+ * Filtering here rather than inside `resolve` keeps the resolver ignorant of
+ * modes and zones, and it means the hint overlay and the resolver are looking
+ * at the same list — the overlay draws what `resolve` returned.
+ */
+export function applicable(bindings: Binding[], ctx: CommandContext): Binding[] {
+  return bindings.filter((binding) => {
+    if (binding.command === null) return false
+    return inScope(binding.when, ctx)
+  })
+}
+
+function inScope(when: { zones?: Zone[]; modes?: Mode[] } | undefined, ctx: CommandContext): boolean {
+  if (!when) return ctx.mode === 'normal'
+  if (when.modes && !when.modes.includes(ctx.mode)) return false
+  if (when.zones && !when.zones.includes(ctx.zone)) return false
+  if (!when.modes && ctx.mode !== 'normal') return false
+  return true
+}
+
+/**
+ * Folds one keystroke into the pending buffer.
+ *
+ * `bindings` must already be scoped — see `applicable`.
+ */
+export function resolve(state: Pending, token: string, bindings: Binding[]): Resolved {
+  // Esc abandons a half-typed sequence, and only that. With nothing pending it
+  // is an ordinary key, which is what lets it be bound to leaving insert mode.
+  if (token === '<Esc>' && (state.keys.length > 0 || state.count !== '')) {
+    return { next: EMPTY, action: { kind: 'none' } }
+  }
+
+  // A count only accumulates before a sequence starts. `0` is a motion in its
+  // own right, so it opens nothing — it only extends a count already running.
+  if (state.keys.length === 0 && /^[0-9]$/.test(token) && !(token === '0' && state.count === '')) {
+    return { next: { keys: [], count: state.count + token }, action: { kind: 'pending', candidates: [], exact: null } }
+  }
+
+  const keys = [...state.keys, token]
+  const candidates = bindings.filter((binding) => startsWith(tokens(binding.keys), keys))
+  if (candidates.length === 0) return { next: EMPTY, action: { kind: 'none' } }
+
+  const exact = candidates.find((binding) => tokens(binding.keys).length === keys.length) ?? null
+  const longer = candidates.some((binding) => tokens(binding.keys).length > keys.length)
+
+  // An exact match with nothing longer behind it fires now. With something
+  // longer behind it, vim waits: `d` cannot run while `dd` is still reachable.
+  if (exact && !longer) {
+    return { next: EMPTY, action: { kind: 'run', command: exact.command as string, count: countOf(state) } }
+  }
+  return { next: { keys, count: state.count }, action: { kind: 'pending', candidates, exact } }
+}
+
+/**
+ * What the pending buffer means once the caller's timer has run out.
+ *
+ * This is the other half of the ambiguity above: `d` held for `timeoutlen` with
+ * `dd` unfinished resolves to `d`, exactly as vim does.
+ */
+export function flush(state: Pending, bindings: Binding[]): Resolved {
+  const exact = bindings.find((binding) => same(tokens(binding.keys), state.keys))
+  if (!exact) return { next: EMPTY, action: { kind: 'none' } }
+  return { next: EMPTY, action: { kind: 'run', command: exact.command as string, count: countOf(state) } }
+}
+
+/** Substitutes `<leader>` so the resolver never has to know what it stands for. */
+export function expandLeader(bindings: Binding[], leader: string): Binding[] {
+  return bindings.map((binding) => ({
+    ...binding,
+    keys: tokens(binding.keys)
+      .map((token) => (token === '<leader>' ? leader : token))
+      .join(' '),
+  }))
+}
+
+/**
+ * Folds user overrides onto the defaults.
+ *
+ * Same keys and same scope replaces; a null command removes. Overrides rather
+ * than a whole keymap so a binding added in a later version arrives bound
+ * instead of missing — the reasoning `PrefsStore.load` already applies to
+ * notification alerts.
+ */
+export function merge(defaults: Binding[], overrides: Binding[]): Binding[] {
+  const out = [...defaults]
+  for (const override of overrides) {
+    const at = out.findIndex(
+      (binding) => binding.keys === override.keys && scopeKey(binding.when) === scopeKey(override.when),
+    )
+    if (at === -1) out.push(override)
+    else if (override.command === null) out.splice(at, 1)
+    else out[at] = override
+  }
+  return out
+}
+
+function scopeKey(when: { zones?: Zone[]; modes?: Mode[] } | undefined): string {
+  return `${(when?.modes ?? []).join(',')}|${(when?.zones ?? []).join(',')}`
+}
+
+function countOf(state: Pending): number | undefined {
+  return state.count === '' ? undefined : Number(state.count)
+}
+
+function startsWith(full: string[], prefix: string[]): boolean {
+  if (prefix.length > full.length) return false
+  return prefix.every((token, index) => full[index] === token)
+}
+
+function same(a: string[], b: string[]): boolean {
+  return a.length === b.length && startsWith(a, b)
+}

--- a/desktop/src/renderer/vim/types.ts
+++ b/desktop/src/renderer/vim/types.ts
@@ -1,0 +1,70 @@
+/**
+ * What vim mode is made of, as types the rest of the feature agrees on.
+ *
+ * Free of any import that reaches React or the preload bridge, so the resolver
+ * beside it stays a pure function of keys and bindings.
+ */
+
+/**
+ * The input state.
+ *
+ * The mode is authoritative and DOM focus follows it, not the other way round.
+ * Entering `insert` focuses the zone's text surface; leaving it blurs. A click
+ * into a text field is the one reverse edge, and it sets `insert` so the two
+ * can never disagree.
+ */
+export type Mode = 'normal' | 'insert' | 'visual' | 'command' | 'terminal' | 'scroll'
+
+/**
+ * Which part of the window owns the keyboard, and so what a bare letter means.
+ *
+ * Below the detail panel this is derived from `Layout.focused` rather than
+ * tracked separately: the layout already knows which group has the keyboard.
+ */
+export type Zone =
+  | 'rail'
+  | 'sidebar'
+  | 'transcript'
+  | 'terminal'
+  | 'approvals'
+  | 'git'
+  | 'files'
+  | 'editor'
+  | 'diff'
+  | 'schedules'
+  | 'settings'
+
+export interface CommandContext {
+  mode: Mode
+  zone: Zone
+}
+
+/**
+ * One thing the app can be asked to do.
+ *
+ * Every mouse action is one of these, which is what lets `:` reach what the
+ * keymap does not. `run` takes no component instance: a command must work when
+ * the pane that owns it is not mounted.
+ */
+export interface Command {
+  id: string
+  /** Imperative, and shown as typed. "Rename session". */
+  title: string
+  /** Groups the hint overlay's columns. "Session", "Window", "Git". */
+  group: string
+  when?: { zones?: Zone[]; modes?: Mode[] }
+  /** Asks before running. Destructive or agent-visible actions set it. */
+  confirm?: string
+  /** Shown but refusing, with the reason, when the target is not there. */
+  enabled?: (ctx: CommandContext) => boolean
+  run: (ctx: CommandContext, count?: number) => void | Promise<void>
+}
+
+/** A sequence of key tokens, and what it runs. */
+export interface Binding {
+  /** Space-separated tokens: `g c`, `<C-w> s`, `d d`. */
+  keys: string
+  /** A null command unbinds a default. */
+  command: string | null
+  when?: { zones?: Zone[]; modes?: Mode[] }
+}

--- a/desktop/src/shared/models.ts
+++ b/desktop/src/shared/models.ts
@@ -650,7 +650,13 @@ export type Density = 'comfortable' | 'compact'
  * the sidebar and the pane by the main panel, so the state that joins them
  * lives in the store, which cannot import a component.
  */
-export type SettingsSection = 'appearance' | 'sessions' | 'terminal' | 'notifications' | 'hosts'
+export type SettingsSection =
+  | 'appearance'
+  | 'sessions'
+  | 'terminal'
+  | 'notifications'
+  | 'keys'
+  | 'hosts'
 
 /**
  * What the backdrop picker shows, for whichever theme is active.

--- a/desktop/test/vim-resolve.test.ts
+++ b/desktop/test/vim-resolve.test.ts
@@ -1,0 +1,274 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applicable,
+  EMPTY,
+  expandLeader,
+  flush,
+  keyToken,
+  merge,
+  resolve,
+  type Action,
+  type Pending,
+} from '../src/renderer/vim/resolve.ts'
+import type { Binding, CommandContext } from '../src/renderer/vim/types.ts'
+
+const NORMAL: CommandContext = { mode: 'normal', zone: 'sidebar' }
+
+/** Feeds a whole sequence, returning what the last key did. */
+function type(bindings: Binding[], ...keys: string[]): { state: Pending; action: Action } {
+  let state = EMPTY
+  let action: Action = { kind: 'none' }
+  for (const key of keys) {
+    const step = resolve(state, key, bindings)
+    state = step.next
+    action = step.action
+  }
+  return { state, action }
+}
+
+const BINDINGS: Binding[] = [
+  { keys: 'j', command: 'sidebar.next' },
+  { keys: 'k', command: 'sidebar.prev' },
+  { keys: 'd d', command: 'session.delete' },
+  { keys: 'g g', command: 'sidebar.first' },
+  { keys: 'g c', command: 'panel.chat' },
+  { keys: 'G', command: 'sidebar.last' },
+]
+
+test('a single key runs its command', () => {
+  const { action } = type(BINDINGS, 'j')
+  assert.deepEqual(action, { kind: 'run', command: 'sidebar.next', count: undefined })
+})
+
+test('a prefix waits, then runs on completion', () => {
+  const first = resolve(EMPTY, 'g', BINDINGS)
+  assert.equal(first.action.kind, 'pending')
+  assert.deepEqual(first.next.keys, ['g'])
+
+  const second = resolve(first.next, 'c', BINDINGS)
+  assert.deepEqual(second.action, { kind: 'run', command: 'panel.chat', count: undefined })
+  assert.deepEqual(second.next, EMPTY)
+})
+
+test('the pending action carries the candidates the overlay draws', () => {
+  const { action } = type(BINDINGS, 'g')
+  assert.equal(action.kind, 'pending')
+  if (action.kind !== 'pending') return
+  assert.deepEqual(
+    action.candidates.map((binding) => binding.keys).sort(),
+    ['g c', 'g g'],
+  )
+})
+
+test('an unknown key clears rather than swallowing what follows', () => {
+  const { state, action } = type(BINDINGS, 'g', 'z')
+  assert.deepEqual(action, { kind: 'none' })
+  assert.deepEqual(state, EMPTY)
+})
+
+test('shift is part of the token, so G is not g', () => {
+  const { action } = type(BINDINGS, 'G')
+  assert.deepEqual(action, { kind: 'run', command: 'sidebar.last', count: undefined })
+})
+
+test('Esc clears a half-typed sequence', () => {
+  const half = resolve(EMPTY, 'g', BINDINGS)
+  const cleared = resolve(half.next, '<Esc>', BINDINGS)
+  assert.deepEqual(cleared.action, { kind: 'none' })
+  assert.deepEqual(cleared.next, EMPTY)
+})
+
+test('Esc clears a count with no sequence behind it', () => {
+  const counting = resolve(EMPTY, '3', BINDINGS)
+  assert.deepEqual(resolve(counting.next, '<Esc>', BINDINGS).next, EMPTY)
+})
+
+test('Esc with nothing pending is an ordinary key, so it can be bound', () => {
+  const bound: Binding[] = [{ keys: '<Esc>', command: 'normal.enter' }]
+  assert.deepEqual(resolve(EMPTY, '<Esc>', bound).action, {
+    kind: 'run',
+    command: 'normal.enter',
+    count: undefined,
+  })
+})
+
+test('an unbound Esc still resolves to nothing', () => {
+  assert.deepEqual(resolve(EMPTY, '<Esc>', BINDINGS).action, { kind: 'none' })
+})
+
+// ─── Counts ─────────────────────────────────────────────────────────────────
+
+test('digits before a sequence become a count', () => {
+  let state = EMPTY
+  for (const key of ['1', '2']) state = resolve(state, key, BINDINGS).next
+  assert.equal(state.count, '12')
+
+  const run = resolve(state, 'j', BINDINGS)
+  assert.deepEqual(run.action, { kind: 'run', command: 'sidebar.next', count: 12 })
+})
+
+test('a leading zero is a key, not a count', () => {
+  const zero = resolve(EMPTY, '0', [...BINDINGS, { keys: '0', command: 'line.start' }])
+  assert.deepEqual(zero.action, { kind: 'run', command: 'line.start', count: undefined })
+})
+
+test('zero extends a count that has already started', () => {
+  let state = EMPTY
+  for (const key of ['1', '0']) state = resolve(state, key, BINDINGS).next
+  assert.equal(state.count, '10')
+})
+
+test('a count survives a multi-key sequence', () => {
+  let state = EMPTY
+  for (const key of ['3', 'g']) state = resolve(state, key, BINDINGS).next
+  const run = resolve(state, 'c', BINDINGS)
+  assert.deepEqual(run.action, { kind: 'run', command: 'panel.chat', count: 3 })
+})
+
+// ─── Ambiguity and the timeout ──────────────────────────────────────────────
+
+const AMBIGUOUS: Binding[] = [
+  { keys: 'd', command: 'diff.open' },
+  { keys: 'd d', command: 'session.delete' },
+]
+
+test('an exact match waits while a longer one is still reachable', () => {
+  const { action } = type(AMBIGUOUS, 'd')
+  assert.equal(action.kind, 'pending')
+  if (action.kind !== 'pending') return
+  assert.equal(action.exact?.command, 'diff.open')
+})
+
+test('the timeout resolves the shorter of two matches', () => {
+  const pending = resolve(EMPTY, 'd', AMBIGUOUS)
+  const timed = flush(pending.next, AMBIGUOUS)
+  assert.deepEqual(timed.action, { kind: 'run', command: 'diff.open', count: undefined })
+})
+
+test('completing the longer sequence beats the timeout', () => {
+  const pending = resolve(EMPTY, 'd', AMBIGUOUS)
+  const second = resolve(pending.next, 'd', AMBIGUOUS)
+  assert.deepEqual(second.action, { kind: 'run', command: 'session.delete', count: undefined })
+})
+
+test('a timeout on a prefix that matches nothing exactly does nothing', () => {
+  const pending = resolve(EMPTY, 'g', BINDINGS)
+  assert.deepEqual(flush(pending.next, BINDINGS).action, { kind: 'none' })
+})
+
+// ─── Scope ──────────────────────────────────────────────────────────────────
+
+const SCOPED: Binding[] = [
+  { keys: 'j', command: 'sidebar.next', when: { zones: ['sidebar'] } },
+  { keys: 'j', command: 'diff.nextHunk', when: { zones: ['diff'] } },
+  { keys: 'i', command: 'composer.focus' },
+  { keys: '<C-\\> <C-n>', command: 'terminal.normal', when: { modes: ['terminal'] } },
+]
+
+test('the same key means different things in different zones', () => {
+  const inSidebar = applicable(SCOPED, { mode: 'normal', zone: 'sidebar' })
+  assert.deepEqual(resolve(EMPTY, 'j', inSidebar).action, {
+    kind: 'run',
+    command: 'sidebar.next',
+    count: undefined,
+  })
+
+  const inDiff = applicable(SCOPED, { mode: 'normal', zone: 'diff' })
+  assert.deepEqual(resolve(EMPTY, 'j', inDiff).action, {
+    kind: 'run',
+    command: 'diff.nextHunk',
+    count: undefined,
+  })
+})
+
+test('a binding with no modes named applies only in normal', () => {
+  const inserting = applicable(SCOPED, { mode: 'insert', zone: 'sidebar' })
+  assert.deepEqual(inserting.map((binding) => binding.command), [])
+})
+
+test('terminal mode reaches only what named it', () => {
+  const inTerminal = applicable(SCOPED, { mode: 'terminal', zone: 'terminal' })
+  assert.deepEqual(inTerminal.map((binding) => binding.command), ['terminal.normal'])
+})
+
+test('an unbound entry never becomes a candidate', () => {
+  const unbound = applicable([{ keys: 'j', command: null }], NORMAL)
+  assert.deepEqual(unbound, [])
+})
+
+// ─── The keymap file ────────────────────────────────────────────────────────
+
+test('an override replaces the default on the same keys', () => {
+  const merged = merge(BINDINGS, [{ keys: 'j', command: 'transcript.down' }])
+  assert.equal(merged.find((binding) => binding.keys === 'j')?.command, 'transcript.down')
+  assert.equal(merged.length, BINDINGS.length)
+})
+
+test('a null command removes a default', () => {
+  const merged = merge(BINDINGS, [{ keys: 'd d', command: null }])
+  assert.equal(
+    merged.some((binding) => binding.keys === 'd d'),
+    false,
+  )
+})
+
+test('an override in another scope is a second binding, not a replacement', () => {
+  const merged = merge(BINDINGS, [{ keys: 'j', command: 'files.next', when: { zones: ['files'] } }])
+  assert.equal(merged.filter((binding) => binding.keys === 'j').length, 2)
+})
+
+test('a binding the defaults do not carry is added', () => {
+  const merged = merge(BINDINGS, [{ keys: 'z z', command: 'view.centre' }])
+  assert.equal(merged.length, BINDINGS.length + 1)
+})
+
+test('leader expands before the resolver sees it', () => {
+  const expanded = expandLeader([{ keys: '<leader> f f', command: 'files.quickOpen' }], '<space>')
+  assert.equal(expanded[0]?.keys, '<space> f f')
+})
+
+// ─── Tokens ─────────────────────────────────────────────────────────────────
+
+test('a plain letter is its own token', () => {
+  assert.equal(keyToken({ key: 'j' }), 'j')
+})
+
+test('control wraps the token', () => {
+  assert.equal(keyToken({ key: 'w', ctrlKey: true }), '<C-w>')
+})
+
+test('control over a named key keeps one pair of brackets', () => {
+  assert.equal(keyToken({ key: 'Enter', ctrlKey: true }), '<C-CR>')
+})
+
+test('space and escape are named', () => {
+  assert.equal(keyToken({ key: ' ' }), '<space>')
+  assert.equal(keyToken({ key: 'Escape' }), '<Esc>')
+})
+
+test('a modifier pressed alone is not a stroke', () => {
+  assert.equal(keyToken({ key: 'Control', ctrlKey: true }), null)
+  assert.equal(keyToken({ key: 'Shift' }), null)
+})
+
+test('command belongs to the app accelerators, so vim never sees it', () => {
+  assert.equal(keyToken({ key: 'n', metaKey: true }), null)
+})
+
+test('the chord that leaves a terminal round-trips', () => {
+  const first = keyToken({ key: '\\', ctrlKey: true })
+  const second = keyToken({ key: 'n', ctrlKey: true })
+  assert.equal(first, '<C-\\>')
+  assert.equal(second, '<C-n>')
+
+  const inTerminal = applicable(SCOPED, { mode: 'terminal', zone: 'terminal' })
+  const pending = resolve(EMPTY, first as string, inTerminal)
+  assert.equal(pending.action.kind, 'pending')
+  assert.deepEqual(resolve(pending.next, second as string, inTerminal).action, {
+    kind: 'run',
+    command: 'terminal.normal',
+    count: undefined,
+  })
+})

--- a/docs/specs/57-vim-mode.md
+++ b/docs/specs/57-vim-mode.md
@@ -1,0 +1,753 @@
+# Vim Mode: Running the Desktop Without a Mouse
+
+## The goal
+
+One sentence, and every decision below answers to it:
+
+> A person who never moves their hand to the mouse can do everything the desktop
+> app can do.
+
+Not "can navigate quickly". Can do *everything*. Approve a tool call, rename a
+session, split a pane, read scrollback from four minutes ago, copy a path out of
+it, pause a schedule, pair a host. If one action needs a pointer, the hand
+leaves the keyboard, and the feature has failed at the thing it was for.
+
+Vim keybindings are the means. The mouse-free guarantee is the end. Where the
+two disagree — where being faithful to vim would leave something unreachable —
+reachability wins.
+
+## Why the obvious approach does not get there
+
+The obvious approach is to bind `j` and `k` to the session list, call it vim
+mode, and ship. The desktop has around 170 click handlers across 26 components.
+Binding the fifteen most common leaves 155 reasons to reach for the mouse, and a
+user who has to reach anyway keeps their hand there.
+
+Neovim does not solve this by binding everything. Most of Neovim has no default
+key at all. It solves it by making every action an *Ex command*, so `:` can
+reach what the keymap does not. The keymap is an accelerator over a surface that
+is already complete.
+
+That is the structure to copy, and it gives the invariant this spec is built on:
+
+**Every action registers as a command. `:` runs any command. Frequent commands
+also get a key.**
+
+Registration is the guarantee. Keys are the ergonomics. An action that someone
+forgets to register is not merely unbound — it is invisible in `:` and in the
+hint overlay, which is how the omission gets noticed.
+
+## Modality, as Neovim means it
+
+Web apps treat DOM focus as the truth and infer a "mode" from it. That inference
+is where vim modes in browsers break: focus lands somewhere unexpected, the app
+believes it is in normal mode, and `d` deletes something instead of typing a
+letter.
+
+Neovim has the dependency the other way round. The mode is the truth, and the
+cursor is a consequence. You cannot be "in a text box" while the editor thinks
+otherwise, because being in insert mode *is* what makes keys become text.
+
+So:
+
+> **The mode owns DOM focus. Entering INSERT focuses the zone's text surface.
+> Leaving INSERT blurs it. A mouse click into a text field is the single reverse
+> edge, and it sets the mode to INSERT so the two can never disagree.**
+
+Everything below follows from that rule.
+
+### The modes
+
+| Mode | When | Keys do |
+| --- | --- | --- |
+| `NORMAL` | Default | Commands |
+| `INSERT` | A text surface holds focus | Type |
+| `VISUAL` | A range is being selected | Motions extend the range |
+| `COMMAND` | `:` is open | Type into the command line |
+| `TERMINAL` | An xterm holds focus | Everything reaches the pty |
+| `SCROLL` | Reading terminal scrollback | Motions scroll the viewport |
+
+`OPERATOR-PENDING` is out of scope. There is no `d{motion}` grammar: outside a
+text buffer there are no text objects for an operator to act on.
+
+`SCROLL` is tmux's copy-mode with the copying removed. It exists because
+scrollback is the one surface a mouse currently owns outright, and because
+*reading* past output is a thing you do every few minutes. Selecting and yanking
+out of it is not — that stays a mouse job on purpose. See "The four gaps".
+
+### Entering and leaving INSERT
+
+Neovim enters insert with `i a I A o O c s`. Only three of those mean anything
+outside a text buffer:
+
+- `i` — focus the zone's text surface
+- `a` — focus it, positioned at the end (in the transcript, append to the composer)
+- `o` — open a new thing: a session in the sidebar, a shell in the terminal zone
+
+Leaving is `Esc` or `Ctrl-[`. LazyVim adds no `jk` escape by default and neither
+does this. Anyone who wants one can bind it, which is the point of the keymap
+file.
+
+### TERMINAL mode, and the one chord that leaves it
+
+This is the part most likely to trap someone, so it gets the most conservative
+answer available.
+
+In `TERMINAL` mode the app intercepts **exactly one** sequence: `Ctrl-\ Ctrl-n`,
+copied verbatim from Neovim. Everything else reaches the pty untouched.
+
+`<Esc><Esc>` — which LazyVim uses for its floating terminal — is **not**
+available, and the reason is specific. Claude Code binds single `Esc` to
+interrupt the current turn and double `Esc` to edit the previous message. Both
+must arrive intact. Stealing them would break the agent this app exists to
+drive.
+
+`Ctrl-\ Ctrl-n` is safe for the same reason Neovim chose it: no interactive
+program sends it.
+
+The ⌘ accelerators (`⌘N`, `⌘W`, `⌘,`) keep working in `TERMINAL` mode, because
+xterm never sees them.
+
+### which-key timing
+
+LazyVim sets `timeoutlen = 300`. The hint overlay appears only after a pending
+prefix has waited that long, which is what stops it flashing during fluent
+typing. Same default here, stored in `keymap.json` as `timeoutlen` so it can be
+tuned.
+
+## Zones
+
+Vim modes are global; vim *meaning* is per-window. `j` is "next line" in a
+buffer and "next entry" in the file explorer. The equivalent here is a zone.
+
+Half of this exists already, which the first draft of this spec missed.
+`Layout.focused` in `layout.ts:23` is documented as "which group a reveal lands
+in, and which one owns the keyboard", and `store.focusGroup` at `store.ts:1212`
+moves it. So focus *within* the detail panel is solved. What is missing is a
+level above it: nothing says whether the rail, the sidebar or the detail panel
+has the keyboard.
+
+```ts
+export type Zone =
+  | 'rail'
+  | 'sidebar'
+  | 'transcript'
+  | 'terminal'
+  | 'approvals'
+  | 'git'
+  | 'files'
+  | 'editor'
+  | 'diff'
+  | 'schedules'
+  | 'settings'
+```
+
+The zone is stored in the renderer store, drawn with a focus ring, and used as
+the `when` condition for every binding. Zone movement follows LazyVim rather
+than stock vim: plain `Ctrl-h/j/k/l` between zones, not `Ctrl-w h`.
+
+`Ctrl-h` and `Ctrl-l` cross the three columns — rail, sidebar, detail — and once
+inside the detail panel they hand over to `Layout.focused`, moving group to
+group. The zone of the detail panel is then whatever `panelOf(group.active)`
+names, so the zone list above is derived rather than separately tracked.
+
+Zones use real DOM focus with roving `tabindex`, not a parallel virtual
+selection. The app already carries `aria-label` and `aria-pressed` throughout;
+a virtual cursor would leave a screen reader describing a different row from the
+one the ring is on.
+
+## The layout API is already a window manager
+
+The single largest finding of the audit. `renderer/components/layout.ts` is a
+tiling window manager with groups, sashes and pure reducers, and `store.ts`
+already exposes every one of them as a method. Only drag-and-drop calls them
+today.
+
+| Key | Store method |
+| --- | --- |
+| `Ctrl-w s` | `splitItem(target, item, atGroup, edge)` |
+| `Ctrl-w q` | `dropItem(target, item)` |
+| `Ctrl-w =` | `evenGroups(target)` |
+| `Ctrl-w <` `>` | `resizeGroups(target, sash, delta)` |
+| `Ctrl-w x` | `moveItem(target, item, toGroup, index)` |
+| `Ctrl-w r` | `setLayoutAxis(target, axis)` |
+| `Ctrl-h/l` | `focusGroup(target, groupId)` |
+| `g c` … `g f` | `setPanel(panel)` |
+
+So the window commands are a keymap over methods that already exist, already
+persist, and are already covered by `test/layout.test.ts`. There is no new
+state and no new reducer.
+
+Four facts about the model change what the keys can mean, and the first draft of
+this spec got the first two wrong.
+
+**The layout is flat and single-axis.** `Layout` is `{ axis: 'row' | 'column',
+groups: Group[] }` — a row of groups, not a nested tree. So `Ctrl-w s` and
+`Ctrl-w v` cannot mean horizontal and vertical: there is only one axis, and a
+split always adds a group along it. One split key, plus `Ctrl-w r` to rotate the
+whole panel between row and column. `detail.tsx:174` already forces `column` on
+a narrow window, so rotation is a path the layout code walks today.
+
+**Directional focus needs no geometry.** A flat row means `Ctrl-h` and `Ctrl-l`
+are previous and next group in `layout.groups`, and `Ctrl-j` / `Ctrl-k` are the
+same when the axis is `column`. No DOM rectangles, no hit-testing.
+
+**`splitInto` refuses a pointless split.** `layout.ts:163` returns the layout
+unchanged when the item is alone in its group, because dissolving and rebuilding
+one group reads as nothing having happened. `Ctrl-w s` on a single-pane group is
+therefore a no-op, and the mode line should say so rather than appear broken.
+
+**`Ctrl-w q` cannot empty the panel.** `collapse` at `layout.ts:213` falls the
+last group back to the transcript. Closing the final pane returns you to chat.
+That is the right behaviour and it is already written.
+
+## The command registry
+
+```ts
+export interface Command {
+  /** Stable, dotted, never shown raw to the user. `sidebar.rename`. */
+  id: string
+  /** What `:` and the overlay display. Imperative. "Rename session". */
+  title: string
+  /** Groups the overlay's columns. "Session", "Window", "Git". */
+  group: string
+  /** Zones and modes this applies in. Absent means everywhere in NORMAL. */
+  when?: { zones?: Zone[]; modes?: Mode[] }
+  /** Asks before running. Used for anything destructive or agent-visible. */
+  confirm?: string
+  run(ctx: CommandContext, count?: number): void | Promise<void>
+}
+```
+
+`CommandContext` carries the current zone, the selection, and the store. It does
+**not** carry a React component instance: commands must be runnable from `:`
+when the relevant component is not mounted. A command whose target is not
+present is disabled rather than absent, so the palette does not change shape as
+panes come and go.
+
+Commands register at module scope beside the component that owns the action.
+Registration is not optional — see "Enforcement".
+
+## Moving a cursor over what is already drawn
+
+Lists are the exception to the rule above, and finding that out cut the largest
+risk in this spec roughly in half.
+
+A list's rows come from React Query and live inside the component that renders
+them. A command holds no component, so it cannot ask what is on screen — which
+looked like a reason to lift every list into the store.
+
+It is not. The command can ask the *document*, and the document is the better
+source: the order the elements are in **is** the order the eye reads, with
+filters, folds and sort already applied. So a zone marks itself with
+`data-vim-zone` and its rows with `data-vim-item`, and `renderer/vim/items.ts`
+moves a real DOM focus over them.
+
+```
+j / k          move focus by one         G / gg   first and last
+Enter          click the focused row     Ctrl-h/l cross columns
+```
+
+Five commands — `list.next`, `list.prev`, `list.first`, `list.last`,
+`list.activate` — then serve the sidebar, the rail, the schedules, the file
+tree, the approvals and the git panel at once. Adding a zone is two attributes,
+not a store refactor.
+
+Three things fall out of it:
+
+- **`Enter` runs the row's own `onClick`.** A row's meaning belongs to the
+  component that drew it, and half of them are already buttons.
+- **Folded rows are skipped**, by testing `offsetParent`. They are in the
+  document and not on the screen, and landing on one moves a cursor nobody can
+  see.
+- **The cursor is remembered per zone.** Vim keeps a cursor per window and puts
+  you back on it; without that, crossing to the rail and back lands on the first
+  row, so two motions that should cancel out lose your place instead.
+
+## The state that still has to move
+
+What remains is real, but it is smaller than the coverage tables suggest: the
+list state is handled above, so this is only the state a *command* must set.
+
+Most click handlers do not call the store. They call a `useState` setter that
+lives in the component. A command run from `:` has no way to reach one.
+
+The audit sorts them into two piles, and the distinction matters because the
+second pile looks like work and is not.
+
+**Must move to the store.** These are view state a keyboard user has to reach:
+
+| File | State |
+| --- | --- |
+| `files.tsx:115,116` | `tabs`, `activePath` — the Files panel keeps its own tab list |
+| `files.tsx:105,125,128` | `rootOverride`, `expanded`, `side` |
+| `files.tsx:130,132` | `quickOpen`, `rootPicker` |
+| `sidebar.tsx:204,208` | `collapsed`, `folded` |
+| `sidebar.tsx:215,220` | `showTerminated`, `menu` |
+| `sidebar.tsx:231,233,234` | `creatingIn`, `renaming`, `picker` |
+| `schedules.tsx:499` | `tab` |
+| `commits.tsx:157,328` | `all`, `picked` |
+| `git.tsx:51,52,222` | `worktree`, `worktrees`, `selected` |
+
+`files.tsx` is the awkward one. The Files panel's open tabs are component state,
+so they die on unmount and no command can address them. `files.tab` and
+`files.closeTab` in the coverage table both depend on this move.
+
+**Must not move.** Drag state and INSERT-mode drafts:
+
+`dragging`, `groupDrag`, `groupDrop`, `drag`, `over`, `edge` are pointer
+machinery. A keyboard has no drag, so these have no keyboard counterpart and
+need none. `draft`, `sending`, `comment`, `anchor`, `head` belong to a text
+surface that INSERT mode owns while it is focused.
+
+`store.ts` is already 1692 lines. This move is a refactor with no user-visible
+change, which makes it exactly the kind of thing that should land on its own,
+before the registration sweep and not tangled into it.
+
+## Two traps in the existing keyboard code
+
+Both would produce data loss rather than a missing feature, so they are called
+out here rather than left to implementation.
+
+**Blur commits, so a mode-driven blur commits too.** The inline rename fields at
+`sidebar.tsx:1066` and `detail.tsx:845` commit on `onBlur` and cancel on
+`Escape`. The rule that "leaving INSERT blurs the text surface" would therefore
+*commit* a rename the user meant to abandon. `Esc` must run the field's own
+cancel path and only then blur, so the two orderings cannot disagree.
+
+**IME composition.** `chat.tsx:467` already refuses to send while
+`event.nativeEvent.isComposing`, because Enter accepts a candidate mid-word. The
+same guard has to cover the `Esc` that leaves INSERT: an IME uses `Esc` to
+dismiss its candidate window, and stealing it would strand the composition. The
+composer has no `Escape` handler at all today, so this is new code, not a patch.
+
+## `keymap.json`
+
+Device-local, in Electron's `userData`, beside `notification-prefs.json`. It
+follows the `PrefsStore` precedent at `main/prefs.ts`: what a keyboard does is a
+property of this machine, and a user with three paired hosts should not answer
+the question three times.
+
+```jsonc
+{
+  "version": 1,
+  "enabled": true,
+  "timeoutlen": 300,
+  "leader": "<space>",
+  "bindings": [
+    { "keys": "g c",      "command": "panel.chat" },
+    { "keys": "<C-\\><C-n>", "command": "terminal.normal", "when": "terminal" },
+    { "keys": "d d",      "command": null,        "when": "sidebar" }
+  ]
+}
+```
+
+- A `bindings` entry **overrides** the default of the same `keys` and `when`.
+  The file holds overrides only, so a default added in a later version arrives
+  bound rather than missing. This is the same reasoning `PrefsStore.load`
+  already applies to `alerts`.
+- `"command": null` unbinds. Without it there is no way to remove a default you
+  dislike.
+- The file is hand-editable and hot-reloaded on write. Anyone who wants vim
+  keybindings wants to edit a file.
+- A parse failure falls back to defaults and raises a toast naming the line. It
+  never leaves the app unbound: an unusable keymap plus a mouse-free user is a
+  person who cannot recover.
+
+Settings gains a **Keys** pane listing every command with its binding, a capture
+field that records a pressed sequence, a conflict warning, and a reset. The pane
+writes the same file.
+
+## Resolution
+
+A pure module, `renderer/vim/resolve.ts`, with no DOM import — the same shape as
+`renderer/keys.ts`, and testable the same way under `node --test`.
+
+```ts
+type Resolution =
+  | { kind: 'pending'; keys: string; candidates: Command[] }
+  | { kind: 'run'; command: Command; count?: number }
+  | { kind: 'none' }
+```
+
+It holds a trie of sequences, a pending buffer, and a count prefix. A prefix
+that no longer matches resolves to `none` and clears rather than swallowing the
+key. The `timeoutlen` timer is the caller's business, not the resolver's, so the
+resolver stays a pure function of keys and keymap.
+
+`Esc` abandons a half-typed sequence **and only that**. With nothing pending it
+is an ordinary key, which is what lets it be bound to leaving insert mode. An
+earlier draft short-circuited on `Esc` unconditionally, which made the binding
+that leaves insert impossible to reach.
+
+The `candidates` list is what the overlay draws, which is why it comes out of
+the resolver rather than being computed twice.
+
+## The overlay
+
+Two parts, both at the bottom edge, both reading the registry so neither can
+drift from the real bindings.
+
+**The mode segments** ride the existing `status-line.tsx` rather than a bar of
+their own. The first draft of this spec proposed a second bar below it; that was
+wrong. Two bars at the foot of the window is one more than the window can spare,
+and the mode belongs next to the branch because both answer "where am I".
+
+```
+ NORMAL  sidebar  ~/workspace/helios  main  claude-opus-4-7  bypass        3g
+```
+
+Mode first and coloured, as lualine does. Zone second. The pending keys go hard
+right with `margin-left: auto`, so a half-typed sequence appears in the same
+place whatever the session segments in front of it are doing.
+
+One consequence worth naming: the bar renders only when a session is selected
+(`detail.tsx:372`), so with nothing selected there is no mode indicator. The
+sidebar is still navigable, and selecting anything brings the bar back.
+
+**The hint panel** slides up when a prefix has been pending for `timeoutlen`. It
+lists only the candidates the resolver returned, grouped by `Command.group`, in
+columns:
+
+```
+ <space>
+ ┌──────────────┬──────────────┬──────────────┐
+ │ f  +find     │ g  +git      │ s  +session  │
+ │ w  +window   │ h  +host     │ q  quit      │
+ └──────────────┴──────────────┴──────────────┘
+```
+
+A `+` marks a prefix, a bare label marks a leaf — which-key's own convention.
+
+## Coverage
+
+The audit below is the working list. Each row is an action reachable by mouse
+today. A row is done when a command id exists and a key or `:` reaches it.
+**Rows without a key are not gaps** — `:` covers them. Rows without a command id
+*are* gaps.
+
+### Sidebar — `sidebar.tsx`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Select session | `sidebar.select` | `Enter` |
+| Next / previous row | `sidebar.next` / `.prev` | `j` / `k` |
+| First / last row | `sidebar.first` / `.last` | `gg` / `G` |
+| Filter the list | `sidebar.search` | `/` |
+| Clear the filter | `sidebar.clearSearch` | `Esc` |
+| New session | `session.new` | `o`, `⌘N` |
+| New session in this project | `session.newHere` | `O` |
+| New group | `group.new` | `<leader>gn` |
+| New group at top level | `group.newRoot` | — |
+| Rename session | `session.rename` | `<leader>r` |
+| Regenerate title | `session.retitle` | — |
+| Resume session | `session.resume` | `<leader>R` |
+| Open terminal | `session.terminal` | `t` |
+| Pin / unpin | `session.pin` | `<leader>p` |
+| Permission mode | `session.mode` | `<leader>m` |
+| Move to group | `session.group` | `<leader>g` |
+| Terminate | `session.terminate` | `<leader>x` (confirm) |
+| Delete | `session.delete` | `dd` (confirm) |
+| Row actions menu | `sidebar.menu` | `<leader><leader>` |
+| Fold / unfold group | `sidebar.fold` | `za` |
+| Collapse host | `sidebar.foldHost` | `zc` |
+| Arrange menu | `sidebar.arrange` | `<leader>a` |
+| Toggle automated runs | `sidebar.autoRuns` | — |
+| Reorder within group | `sidebar.moveUp` / `.moveDown` | `<C-k>` / `<C-j>` |
+| Add host | `host.add` | — |
+| Quit | `app.quit` | `<leader>qq` |
+
+Reordering is drag-only today and has no keyboard route at all.
+
+### Detail and panels — `detail.tsx`, `layout.ts`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Chat / Terminal / Approvals / Git / Files | `panel.chat` … `panel.files` | `gc gt ga gd gf` |
+| Next / previous panel | `panel.next` / `.prev` | `Shift-l` / `Shift-h` |
+| New shell | `terminal.new` | `<leader>tn` |
+| Reload shell | `terminal.reload` | — |
+| Close shell | `terminal.close` | `⌘W`, `Ctrl-w q` |
+| Reconnect / disconnect | `session.reconnect` / `.disconnect` | — |
+| Select terminal tab | `terminal.tab` | `1`…`9` |
+| Dismiss the show-note | `note.dismiss` | `Esc` |
+| Split / close / equalise / resize / move | `window.*` | `Ctrl-w` family |
+
+### Transcript — `chat.tsx`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Scroll down / up | `transcript.down` / `.up` | `j` / `k` |
+| Half page | `transcript.halfDown` / `.halfUp` | `Ctrl-d` / `Ctrl-u` |
+| Top / bottom | `transcript.top` / `.bottom` | `gg` / `G` |
+| Load older | `transcript.older` | `<leader>o` |
+| Focus composer | `composer.focus` | `i` |
+| Send | `composer.send` | `Enter` in INSERT |
+| Stop the agent | `session.stop` | `<leader>s` |
+| Attach files | `composer.attach` | `<leader>A` |
+| Keep or file a paste | `paste.keep` / `paste.file` | `y` / `f` |
+| Remove an attachment | `composer.dropAttachment` | `x` |
+| Next / previous message | `transcript.nextMsg` / `.prevMsg` | `]m` / `[m` |
+| Copy message | `transcript.copy` | `yy` |
+| Expand a tool block | `transcript.toggleTool` | `za` |
+| Open / find a file chip | `chip.open` / `chip.find` | `Enter` / `gf` |
+| Copy a chip's path | `chip.copyPath` | `yp` |
+| Select lines to quote | `transcript.visual` | `v`, `V` |
+
+### Files and editor — `files.tsx`, `file-tree.tsx`, `editor.tsx`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Toggle explorer | `files.explorer` | `<leader>e`, `⌘B` |
+| Go to file | `files.quickOpen` | `<leader>ff`, `⌘P` |
+| Find in files | `files.grep` | `<leader>fg`, `⇧⌘F` |
+| Tree down / up | `tree.next` / `.prev` | `j` / `k` |
+| Collapse / expand | `tree.collapse` / `.expand` | `h` / `l` |
+| Open | `tree.open` | `Enter` |
+| Breadcrumb up | `files.up` | `-` |
+| Choose worktree or folder | `files.root` | `<leader>fw` |
+| Back to session folder | `files.rootReset` | — |
+| Select / close tab | `files.tab` / `.closeTab` | `1`…`9` / `<leader>bd` |
+| Save | `editor.save` | `⌘S`, `:w` |
+| Reload from disk | `editor.reload` | `:e!` |
+| Keep my version | `editor.keepMine` | — |
+| Preview / edit | `editor.preview` | `<leader>v` |
+| Copy contents | `editor.copyAll` | `<leader>y` |
+| Fold a section | `files.foldSection` | `za` |
+| Motions, visual, search, undo | CodeMirror vim | full vim |
+
+The editor uses `@replit/codemirror-vim`, added to the `extensions` array in
+`editor.tsx:116`. It brings its own `:` line; the app's `:` is suppressed while
+the editor holds focus, so there is one command line and it is the one whose
+buffer you are in.
+
+### Git, diff, review — `git.tsx`, `commits.tsx`, `review.tsx`, `diff-view.tsx`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Next / previous hunk | `diff.nextHunk` / `.prevHunk` | `]c` / `[c` |
+| Next / previous file | `diff.nextFile` / `.prevFile` | `]f` / `[f` |
+| Split / unified | `diff.layout` | `<leader>dl` |
+| Select a changed file | `git.selectFile` | `Enter` |
+| Scope menu | `git.scope` | `<leader>gs` |
+| Working tree / all branches | `git.allBranches` | — |
+| Pick a commit | `git.pickCommit` | `Enter` |
+| Compare two commits | `git.compare` | `Ctrl-Enter` |
+| Load more commits | `git.moreCommits` | — |
+| Worktrees | `git.worktrees` | `<leader>gw` |
+| Jump to a review file | `review.jumpFile` | `Enter` |
+| Mark reviewed | `review.mark` | `<leader>gr` |
+| Comment | `review.comment` | `c` |
+| Send comment | `review.send` | `⌘Enter` |
+
+### Approvals and notifications — `approvals.tsx`, `notification-card.tsx`
+
+Every action here changes what an agent is allowed to do, so every one carries
+`confirm`. A single letter must never approve a tool call by accident.
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Next / previous card | `approvals.next` / `.prev` | `j` / `k` |
+| Approve | `approvals.approve` | `<leader>y` (confirm) |
+| Deny | `approvals.deny` | `<leader>n` (confirm) |
+| Trust folder | `approvals.trust` | — (confirm) |
+| Edit before approving | `approvals.edit` | `i` |
+| Answer a question | `approvals.pick` | `1`…`9` |
+| Submit answers | `approvals.submit` | `⌘Enter` |
+| Skip | `approvals.skip` | — |
+| Accept / decline | `approvals.accept` / `.decline` | — (confirm) |
+| Retry | `approvals.retry` | — |
+| Dismiss | `approvals.dismiss` | `x` |
+
+### Schedules — `schedules.tsx`
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Next / previous | `schedules.next` / `.prev` | `j` / `k` |
+| Select | `schedules.select` | `Enter` |
+| New | `schedule.new` | `o` |
+| Edit | `schedule.edit` | `i` |
+| Save | `schedule.save` | `⌘S` |
+| Pause / resume | `schedule.toggle` | `<leader>p` |
+| Run now | `schedule.runNow` | `<leader>x` (confirm) |
+| Delete | `schedule.delete` | `dd` (confirm) |
+| Describe with AI | `schedule.describe` | — |
+| Test the check | `schedule.test` | — |
+| Switch tab | `schedule.tab` | `1`…`9` |
+| Open a run | `schedule.openRun` | `Enter` |
+| Link a child | `schedule.link` | — |
+| Clear selection | `schedules.clear` | `Esc` |
+
+### Rail, settings, hosts, dialogs
+
+| Action | Command | Key |
+| --- | --- | --- |
+| Sessions / Schedules / Settings | `mode.sessions` / `.schedules` / `.settings` | `<leader>1` `2` `3` |
+| Settings section | `settings.section` | `j` / `k` |
+| Open settings | `settings.open` | `⌘,` |
+| Reload themes | `settings.reloadThemes` | — |
+| Reset notification prefs | `settings.resetPrefs` | — |
+| Pair this machine | `host.pairLocal` | — |
+| Pair a remote host | `host.pairRemote` | — |
+| Every dialog: confirm / cancel | `dialog.confirm` / `.cancel` | `Enter` / `Esc` |
+| Dialog list movement | `dialog.next` / `.prev` | `Ctrl-n` / `Ctrl-p` |
+| Release notes | `updates.show` | — |
+
+`Ctrl-n` and `Ctrl-p` rather than `j`/`k` inside dialogs: a dialog with a text
+field is in INSERT, so plain letters must type.
+
+This is not a new convention. `quick-open.tsx:70` and `root-picker.tsx:107`
+already accept `ArrowDown`/`Ctrl-n`, `ArrowUp`/`Ctrl-p` and `Enter`. Those two
+are the reference implementation; the remaining dialogs — `newsession.tsx`,
+`group-picker.tsx`, `worktrees.tsx`, `updates.tsx` — should copy them rather
+than invent anything.
+
+`SECTIONS` in `settings.tsx` listed five panes. **Keys** is now the sixth,
+between Notifications and Hosts: it carries the vim switch and the whole keymap
+as a table, so what the keys do is readable without pressing them.
+
+## The four gaps
+
+Four things have no keyboard route at all today, and none is fixed by binding an
+existing handler.
+
+### 1. Terminal scrollback
+
+Reading output above the fold is a pointer operation today. `terminal.tsx` loads
+`FitAddon`, `WebLinksAddon` and `WebglAddon` — there is no search addon and no
+way to move the viewport from the keyboard.
+
+`SCROLL` mode is entered with `Ctrl-\ Ctrl-n`, the same chord that leaves
+`TERMINAL` mode. Leaving the pty and being able to read what it printed are the
+same intention, so they are the same key.
+
+- Add `@xterm/addon-search`.
+- `j k Ctrl-d Ctrl-u gg G` scroll, over `term.scrollLines()`.
+- `/` and `?` search, `n` and `N` repeat, over the search addon.
+- `Esc` returns to the live edge and to `TERMINAL`.
+
+**Selection and yank are deliberately excluded.** A copy cursor means drawing an
+overlay in cell coordinates above the WebGL canvas, and keeping it correct
+across scroll, resize and reflow. No xterm addon does it, so it is hand-built
+and it is the most expensive item in the whole feature.
+
+The trade it buys is worth naming plainly. Reading scrollback happens many times
+an hour, so it earns keys. Copying a line out of scrollback happens perhaps once
+an hour, and a mouse does it in a second. Paying the most expensive item in the
+spec for the rarest action is the wrong trade, so copying stays a mouse job.
+
+This is the one place where the mouse-free goal is knowingly not met.
+
+### 2. Row and context menus
+
+Smaller than it looks. Every popover in the app is one component,
+`selection-menu.tsx`, driven by a `MenuAction[]` — label, `run`, `danger`,
+`disabled`, and nested `children`. `session-menu.ts` builds that array. So the
+content is already data and needs no change.
+
+Two things are missing from `SelectionMenu`:
+
+- **Keyboard navigation.** It listens for `Escape` to dismiss
+  (`selection-menu.tsx:50`) and nothing else. It needs `j`/`k` to move a
+  highlight, `Enter` to run, `l`/`h` to enter and leave `children`, and it must
+  skip `disabled` rows.
+- **Anchoring to an element.** The `anchor` prop is `'point' | 'above'` and both
+  take `x`/`y`. A third value, anchored to the focused row's bounding rect, is
+  what lets a key open the menu where the pointer is not.
+
+Both land in one file, and every caller benefits at once.
+
+### 3. Drag-only reordering
+
+Manual session sort and group reparenting exist only as drags, as does pane
+rearrangement. `moveItem` in `layout.ts` already covers panes. Sessions and
+groups need `sidebar.moveUp` / `.moveDown` and a move-to-group command wired to
+the same mutation the drop handler calls.
+
+### 4. Confirmation
+
+`dd` on a session and `<leader>x` on a schedule are destructive, and a mistyped
+sequence must not be able to fire them. `Command.confirm` opens a prompt at the
+bottom edge that takes `y` or `n`, which is Neovim's `confirm` and needs no new
+concept. Approvals use the same mechanism for the opposite reason: not because
+undoing is hard, but because an agent acts on the answer immediately.
+
+## Enforcement
+
+The invariant — every action is a command — decays silently unless something
+checks it. Three mechanisms, in increasing cost:
+
+1. **`:` is the audit.** An action missing from the palette is missing from the
+   feature. This costs nothing and catches most omissions in ordinary use.
+2. **A registry test.** Assert every registered command has a unique id, a
+   non-empty title, a group the overlay knows, and — for anything with
+   `confirm` — no single-key binding. Runs under `node --test` with the
+   resolver tests.
+3. **An audit test.** A test that walks the component sources, counts `onClick`
+   handlers, and compares against a recorded number. When the count moves, the
+   author either registers the new action or updates the number deliberately.
+   Crude, but it makes the invariant visible in review, which is where it is
+   actually kept.
+
+## Testing
+
+- `resolve.ts` — pure, and where the risk is. Sequences, prefixes, counts,
+  timeouts, `Esc`, unbinding via `null`, override precedence, unknown keys.
+- The keymap loader — malformed files, unknown command ids, conflicts, and the
+  fallback that must never leave the app unbound.
+- Mode transitions — every edge in the table above, and specifically that
+  `TERMINAL` passes single and double `Esc` through untouched.
+- Playwright (`npm run e2e`) — one test that starts a session, sends a prompt,
+  opens a file, splits a pane and closes it, using **only** key events. That
+  test is the specification of the goal, and it should fail loudly rather than
+  be skipped.
+
+Both harnesses exist and need no setup. `test/layout.test.ts` already covers the
+reducers the `Ctrl-w` family binds to, so those commands need tests for the
+binding, not for the behaviour. `e2e/` runs a real daemon through
+`e2e/daemon.ts` and `e2e/fixtures.ts`, which is what makes a keyboard-only walk
+through the app possible to write at all.
+
+Two dependencies are new: `@xterm/addon-search` and `@replit/codemirror-vim`.
+Neither is in `package.json`. `@codemirror/search` is already there and is a
+different thing — it searches an editor buffer, not a terminal.
+
+## Non-goals
+
+- Registers, macros, marks and jumplists.
+- Operator-pending grammar outside the editor.
+- Vimscript or Lua configuration. `keymap.json` is data.
+- Vim mode on mobile.
+- A copy cursor over terminal scrollback. Selecting and yanking there stays a
+  mouse job — see gap 1 for the reasoning.
+- Replacing the existing ⌘ accelerators. They keep working in every mode, and
+  they are what a user who has not turned vim mode on still has.
+
+## Shape of the work
+
+The vertical slice lands as one feature but not as one commit. Reviewable order:
+
+1. `resolve.ts`, the registry types, and their tests. No UI.
+2. Zones in the store above `Layout.focused`, the focus ring, and
+   `Ctrl-h/j/k/l`.
+3. The mode machine and the mode line. Vim mode becomes switchable here.
+4. The `Ctrl-w` family over the store methods listed above. No new state.
+5. **Lift the component state named in "The state that has to move first".** No
+   user-visible change, and nothing after this point works without it.
+6. Keyboard navigation and rect anchoring in `selection-menu.tsx`.
+7. Registration sweep across the components in the coverage tables.
+8. `:` over the registry, reusing `quick-open.tsx`'s matcher.
+9. The hint overlay.
+10. `keymap.json`, the loader, and the Settings **Keys** pane.
+11. `@replit/codemirror-vim` in the editor.
+12. `SCROLL` mode and the search addon.
+
+Steps 1 to 4 are the foundation and are worth landing before anything else: they
+are self-contained, they bind to code that already exists and is already tested,
+and they are where the design is proved or found wrong.
+
+Step 5 is the one to watch. It is a pure refactor with nothing to show for it,
+which makes it the step most likely to be skipped or smuggled into step 7. It
+should not be. A registration sweep that drags a state-lifting refactor along
+with it is unreviewable, and the sweep is already the widest change in the
+feature.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -64,6 +64,7 @@ what is merged. Some are superseded and stay here for the history.
 | [54-file-change-events.md](54-file-change-events.md) | File Change Events: Watch What Someone Is Looking At |
 | [55-answering-a-question-from-the-terminal.md](55-answering-a-question-from-the-terminal.md) | Answering a Question From the Terminal |
 | [56-one-version-number.md](56-one-version-number.md) | One Version Number, and Builds That Do Not Lie About It |
+| [57-vim-mode.md](57-vim-mode.md) | Vim Mode: Running the Desktop Without a Mouse |
 | [58-files-without-a-root.md](58-files-without-a-root.md) | Files Without a Root: Folders, an Index, and a Path You Can Type |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |


### PR DESCRIPTION
## What

Vim navigation for the desktop app, off until **Settings → Keys** turns it on.

```
j k gg G Enter     walk any list, open the focused row
3j                 counts
Ctrl-h / Ctrl-l    rail ↔ sidebar ↔ panels, then group to group inside the panel
g c g t g a g d g f   chat, terminal, approvals, git, files
H / L              previous and next panel
Ctrl-w s q = < > r split, close, equalise, resize, rotate the axis
<space>1 2 3       sessions, schedules, settings
i / Esc            enter and leave the composer
Ctrl-\ Ctrl-n      leave the terminal
```

Design intent: [docs/specs/57-vim-mode.md](docs/specs/57-vim-mode.md).

## Three decisions worth reviewing

**The mode owns DOM focus, not the other way round.** Web apps infer a mode from
where focus landed, and that inference is what makes vim modes in a browser eat
the wrong keystroke. Here `i` focuses the surface and `Esc` blurs it. A click
into a text field is the single reverse edge, so the two can never disagree.

**Lists are walked through the document, not the store.** A zone marks itself
`data-vim-zone` and its rows `data-vim-item`; five generic commands then serve
the sidebar, rail, schedules, files, approvals and git at once. The rendered
order already *is* the visible order — filters, folds and sort applied — so this
is both less code and a better answer than lifting six components' state into
the store. Adding a zone is two attributes.

**The window family binds to reducers that were already there.** `splitItem`,
`dropItem`, `evenGroups`, `resizeGroups`, `setLayoutAxis` and `focusGroup` all
existed and were covered by `test/layout.test.ts`; only drag-and-drop had ever
called them. No new state, no new reducer.

## The terminal keeps its keys

`Ctrl-\ Ctrl-n` is the only sequence intercepted while a pty has focus. Claude
Code binds `Esc` to interrupt and `Esc Esc` to edit the previous message, so
neither can be borrowed. xterm reads keys through a hidden textarea, which the
ordinary test would call insert — it is checked for separately and sets
TERMINAL, which is what keeps `Esc` reaching the agent.

## One bar, not two

The mode rides the existing session status line rather than a bar of its own:

```
NORMAL  sidebar  ~/workspace/helios  main  claude-opus-4-7  bypass        3g
```

Mode first and coloured, zone second, pending keys hard right.

## Test plan

- [x] `npm test` — 304 pass, 33 of them new in `test/vim-resolve.test.ts`
- [x] `npx tsc --noEmit` clean
- [x] Driven live over CDP against a real daemon: every binding above, plus that
      `Esc` and `Esc Esc` reach the pty untouched, that a `"command": null`
      override unbinds a default, and that `⌘` never reaches the keymap
- [ ] Someone other than me turning it on for a day

## Not in this PR

`:` command palette, the which-key overlay, `keymap.json` and rebinding,
`@replit/codemirror-vim`, and terminal scroll mode. The Keys pane lists the
bindings but does not yet edit them. Scoped as steps in the spec.