### PR TITLE
fix: install without asking for a password

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,91 @@ jobs:
           path: desktop/test-results/
           retention-days: 7
 
+  install:
+    name: Install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # The installer checks out a ref from this clone, so it needs history.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Test the scripts on their own
+        run: sh scripts/install_test.sh
+
+      # And then for real. A runner is the only machine that can be given a
+      # stale /usr/local/bin/helios and have it deleted to prove the point —
+      # the case every upgrader hits, and the one the unit tests cannot cover.
+      - name: Plant an older install where installs used to go
+        run: |
+          printf '#!/bin/sh\necho helios v1.0.0-ancient\n' | sudo tee /usr/local/bin/helios > /dev/null
+          sudo chmod +x /usr/local/bin/helios
+          test "$(command -v helios)" = /usr/local/bin/helios
+
+      - name: Install over it
+        run: |
+          # Node would send the installer off to build the Electron app, which
+          # takes minutes and is what the Desktop jobs are for.
+          sudo mv "$(command -v node)" /tmp/node.hidden
+          HELIOS_SRC="$PWD" HELIOS_REF="$(git rev-parse HEAD)" SHELL=/bin/bash \
+            sh scripts/install.sh
+
+      - name: Check what it left behind
+        run: |
+          set -e
+          test ! -e /usr/local/bin/helios || { echo "the older install survived"; exit 1; }
+          test -x "$HOME/.local/bin/helios" || { echo "nothing was installed"; exit 1; }
+          grep -q 'added by helios' "$HOME/.bashrc" || { echo "PATH line not written"; exit 1; }
+          "$HOME/.local/bin/helios" version | grep -q '^helios' || {
+            echo "the installed binary is not helios"; exit 1; }
+          # An interactive shell, because that is the only kind that reads
+          # .bashrc — Ubuntu's returns early for every other kind, so sourcing
+          # it here would prove nothing about the line that was added.
+          found=$(bash -ic 'command -v helios' 2> /dev/null | tr -d '\r')
+          test "$found" = "$HOME/.local/bin/helios" || {
+            echo "a new shell resolves helios to '$found'"; exit 1; }
+
+      # The one path the install above cannot reach: there was no daemon to
+      # restart. Started here so the restart runs against a real one.
+      - name: Restart a running daemon
+        run: |
+          set -e
+          export PATH="$HOME/.local/bin:$PATH"
+
+          # The pid, or nothing. Compared rather than the whole status line,
+          # which says "is running" for the old daemon and the new one alike.
+          pid() { helios daemon status | sed -n 's/^helios daemon is running (pid \([0-9]*\)).*/\1/p'; }
+
+          # Waited for, not assumed: `daemon start -d` returns before the pid
+          # file exists, and a status read too early says "not running" — which
+          # would make restart-daemon.sh correctly do nothing, and this step
+          # pass while testing nothing at all.
+          wait_for_pid() {
+            for _ in $(seq 30); do
+              p=$(pid); [ -n "$p" ] && [ "$p" != "${1:-}" ] && { echo "$p"; return 0; }
+              sleep 1
+            done
+            return 1
+          }
+
+          helios daemon start -d
+          before=$(wait_for_pid) || { echo "the daemon never came up"; exit 1; }
+          echo "before: pid $before"
+
+          sh scripts/restart-daemon.sh "$HOME/.local/bin/helios"
+
+          after=$(wait_for_pid "$before") || {
+            echo "no daemon with a new pid after the restart"; helios daemon status; exit 1; }
+          echo "after:  pid $after"
+
+          helios daemon stop
+
   mobile:
     name: Mobile
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,12 +138,16 @@ jobs:
           set -e
           test ! -e /usr/local/bin/helios || { echo "the older install survived"; exit 1; }
           test -x "$HOME/.local/bin/helios" || { echo "nothing was installed"; exit 1; }
-          grep -q 'added by helios' "$HOME/.bashrc" || { echo "PATH line not written"; exit 1; }
           "$HOME/.local/bin/helios" version | grep -q '^helios' || {
             echo "the installed binary is not helios"; exit 1; }
-          # An interactive shell, because that is the only kind that reads
-          # .bashrc — Ubuntu's returns early for every other kind, so sourcing
-          # it here would prove nothing about the line that was added.
+          # The outcome, not the mechanism. A runner already has ~/.local/bin on
+          # its PATH, so ensure-path.sh rightly writes nothing here and there is
+          # no rc line to look for — install_test.sh covers the machines where
+          # there is. What has to be true either way is this.
+          #
+          # Asked of an interactive shell, because Ubuntu's .bashrc returns
+          # early for every other kind: a non-interactive check would pass
+          # whether the line worked or not.
           found=$(bash -ic 'command -v helios' 2> /dev/null | tr -d '\r')
           test "$found" = "$HOME/.local/bin/helios" || {
             echo "a new shell resolves helios to '$found'"; exit 1; }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Full picture: [docs/architecture.md](docs/architecture.md). Design intent lives 
 make build               # Build Go binary (includes codesign)
 make test                # Run Go tests: go test ./...
 make install             # Install the newest published release
-make install-dev         # Install this checkout to /usr/local/bin
+make install-dev         # Install this checkout to ~/.local/bin (override with PREFIX=)
 make desktop-install     # Install the newest released desktop app (macOS)
 make desktop-install-dev # Install this checkout's desktop app (macOS)
 make apk                 # Build debug APK

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ VERSION ?= $(shell git describe --tags 2>/dev/null | sed 's/^v//')
 # same way the Release workflow's dropdown does. See AGENTS.md.
 BUMP ?= patch
 REPO = kamrul1157024/helios
+# Where the binary lands. A directory you own, so no install asks for a
+# password: sudo for one file copy is a habit worth not having. Override it for
+# a machine-wide install — `make install-dev PREFIX=/usr/local/bin` — and add
+# sudo yourself if that path needs it.
+PREFIX ?= $(HOME)/.local/bin
+# This file's own directory, which is not $(CURDIR): `make install` re-enters
+# with -C on a worktree parked at the release tag, and the scripts that run
+# there have to be this checkout's, not whatever the tag shipped.
+MAKEFILE_DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 UNAME_S := $(shell uname -s)
 APK_DEBUG = mobile/build/app/outputs/flutter-apk/app-debug.apk
 APK_RELEASE = mobile/build/app/outputs/flutter-apk/app-release.apk
@@ -66,24 +75,24 @@ endif
 install:
 	$(call build_release,install)
 
-## Build this checkout and install it to /usr/local/bin
+## Build this checkout and install it to $(PREFIX)
 install-dev: build
-ifeq ($(UNAME_S),Linux)
-	# Linux returns ETXTBSY when overwriting a mapped binary; rename over it instead
-	sudo cp helios /usr/local/bin/helios.new
-	sudo mv -f /usr/local/bin/helios.new /usr/local/bin/helios
-else
-	sudo cp helios /usr/local/bin/helios
-endif
+	@mkdir -p $(PREFIX)
+# Linux returns ETXTBSY when overwriting a mapped binary; rename over it instead
+	@cp helios $(PREFIX)/helios.new
+	@mv -f $(PREFIX)/helios.new $(PREFIX)/helios
 ifeq ($(UNAME_S),Darwin)
-	sudo codesign -s - -f /usr/local/bin/helios
-	sudo xattr -d com.apple.quarantine /usr/local/bin/helios 2>/dev/null || true
+	@codesign -s - -f $(PREFIX)/helios
+	@xattr -d com.apple.quarantine $(PREFIX)/helios 2>/dev/null || true
 endif
-	@echo "helios installed to /usr/local/bin/helios"
+	@echo "helios installed to $(PREFIX)/helios"
+	@sh $(MAKEFILE_DIR)scripts/remove-old-installs.sh $(PREFIX)/helios
+	@sh $(MAKEFILE_DIR)scripts/ensure-path.sh $(PREFIX) helios
+	@sh $(MAKEFILE_DIR)scripts/restart-daemon.sh $(PREFIX)/helios
 
 uninstall:
-	sudo rm -f /usr/local/bin/helios
-	@echo "helios removed from /usr/local/bin"
+	rm -f $(PREFIX)/helios
+	@echo "helios removed from $(PREFIX)"
 
 clean:
 	rm -f helios

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Or do it by hand:
 ```bash
 git clone https://github.com/kamrul1157024/helios.git && cd helios
 
-make install           # daemon + CLI  → /usr/local/bin/helios   (needs Go 1.26+)
+make install           # daemon + CLI  → ~/.local/bin/helios      (needs Go 1.26+)
 make desktop-install   # desktop app   → /Applications/Helios.app (macOS, needs Node 22+)
 make apk-install       # Android app   → the device on adb        (needs Flutter 3.32+)
 
@@ -89,13 +89,31 @@ what you want while working on it.
 
 | Command | Builds | Installs to |
 | --- | --- | --- |
-| `make install` | the newest release, from source | `/usr/local/bin/helios` |
-| `make install-dev` | this checkout | `/usr/local/bin/helios` |
+| `make install` | the newest release, from source | `~/.local/bin/helios` |
+| `make install-dev` | this checkout | `~/.local/bin/helios` |
 | `make desktop-install` | the newest release's Electron app | `/Applications/Helios.app` |
 | `make desktop-install-dev` | this checkout's Electron app | `/Applications/Helios.app` |
 | `make desktop-app` | Electron app | `desktop/release/*.dmg` (no install) |
 | `make apk-install` | Debug APK | the connected Android device |
 | `make apk-release VERSION=x.y.z` | Release APK, named that number | `~/.helios/helios.apk` |
+
+The daemon goes to a directory you own, and the install finishes the job rather
+than leaving you a list of things to do:
+
+- **Earlier installs are deleted**, so exactly one `helios` is left on your
+  machine. Installs used to go to `/usr/local/bin`, which usually belongs to
+  root — removing that one asks for your password, once, and it is the only
+  step that ever does. A copy installed by Homebrew or apt is left alone for
+  that package manager to remove.
+- **`~/.local/bin` is put on your `PATH`** if it is not there already, by a line
+  written to `.zshrc`, `.bash_profile` or `config.fish`. Open a new terminal
+  afterwards.
+- **A running daemon is restarted**, or it would go on serving the build you
+  just replaced. Sessions and the tunnel stay up: each session is its own
+  process and outlives the daemon.
+
+Somewhere else instead: `make install PREFIX=/usr/local/bin`, with `sudo` in
+front of it if that path is the system's.
 
 Prebuilt DMGs, an AppImage, a `.deb` and an APK are attached to every
 [release](https://github.com/kamrul1157024/helios/releases/latest).

--- a/docs/setup-walkthrough.md
+++ b/docs/setup-walkthrough.md
@@ -27,7 +27,7 @@ $ make install
 ┌──────────────────────────────────────────────┐
 │  $ make install                              │
 │  go build -o helios ./cmd/helios/            │
-│  helios installed to /usr/local/bin/helios   │
+│  helios installed to ~/.local/bin/helios     │
 └──────────────────────────────────────────────┘
 ```
 

--- a/scripts/ensure-path.sh
+++ b/scripts/ensure-path.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Make the shell resolve a just-installed command to the copy that was just
+# installed, by writing the PATH line into the shell's own rc file.
+#
+#   scripts/ensure-path.sh ~/.local/bin helios
+#
+# The question is not "is this directory on PATH" but "which copy wins", so it
+# is asked that way. Older installs elsewhere on the PATH are deleted before
+# this runs (scripts/remove-old-installs.sh), leaving the honest case: either
+# our copy answers to the name, or the directory is not on the PATH at all.
+#
+# POSIX sh on purpose, and silent when the right copy already wins.
+
+set -eu
+
+DIR="${1:?usage: ensure-path.sh <directory> [command]}"
+CMD="${2:-}"
+
+if [ -t 1 ]; then
+  B=$(printf '\033[1m'); DIM=$(printf '\033[2m'); Y=$(printf '\033[33m'); N=$(printf '\033[0m')
+else
+  B=''; DIM=''; Y=''; N=''
+fi
+note() { printf '    %s%s%s\n' "$DIM" "$1" "$N"; }
+warn() { printf '%s !  %s%s\n' "$Y" "$1" "$N" >&2; }
+
+# What the shell runs today, and whether that is us. Without a command name to
+# check there is only the weaker question, so fall back to it.
+if [ -n "$CMD" ]; then
+  [ "$(command -v "$CMD" 2> /dev/null || true)" = "$DIR/$CMD" ] && exit 0
+else
+  case ":${PATH:-}:" in *":$DIR:"*) exit 0 ;; esac
+fi
+
+# Written as $HOME rather than the expanded path, so the rc file still works on
+# a machine where the home directory is somewhere else.
+case "$DIR" in
+  "$HOME"/*) REF="\$HOME${DIR#"$HOME"}"; SHOWN="~${DIR#"$HOME"}" ;;
+  *) REF="$DIR"; SHOWN="$DIR" ;;
+esac
+
+# Which file the shell actually reads. Bash on macOS reads .bash_profile for the
+# login shell Terminal opens and never .bashrc; on Linux it is the other way
+# round for the interactive shells people get.
+case "${SHELL##*/}" in
+  zsh)
+    RC="${ZDOTDIR:-$HOME}/.zshrc"
+    LINE="export PATH=\"$REF:\$PATH\""
+    RELOAD=.
+    ;;
+  bash)
+    if [ "$(uname -s)" = Darwin ]; then RC="$HOME/.bash_profile"; else RC="$HOME/.bashrc"; fi
+    LINE="export PATH=\"$REF:\$PATH\""
+    RELOAD=.
+    ;;
+  fish)
+    RC="$HOME/.config/fish/config.fish"
+    LINE="fish_add_path $REF"
+    # fish 4 dropped `.` as a name for source.
+    RELOAD=source
+    ;;
+  *)
+    warn "$SHOWN is not on your PATH, and I do not know where ${SHELL##*/} keeps its rc file."
+    note "Add this to it:  export PATH=\"$REF:\$PATH\""
+    exit 0
+    ;;
+esac
+
+RC_SHOWN="~${RC#"$HOME"}"
+
+# Already written, but this shell started before it was.
+if [ -f "$RC" ] && grep -qF "$LINE" "$RC"; then
+  note "$SHOWN is already on the PATH in $RC_SHOWN — open a new terminal to pick it up."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$RC")"
+if ! { printf '\n# added by helios\n%s\n' "$LINE" >> "$RC"; } 2> /dev/null; then
+  warn "$SHOWN is not on your PATH, and $RC_SHOWN could not be written."
+  note "Add this to it:  $LINE"
+  exit 0
+fi
+
+printf '%sAdded %s to your PATH in %s%s\n' "$B" "$SHOWN" "$RC_SHOWN" "$N"
+note "Open a new terminal, or run:  $RELOAD $RC_SHOWN"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 # POSIX sh on purpose: piped into `sh` on Debian this is dash, not bash.
 #
 # Knobs, for a test run that touches nothing real:
-#   HELIOS_PREFIX   where the binary goes         (default /usr/local/bin)
+#   HELIOS_PREFIX   where the binary goes         (default ~/.local/bin)
 #   HELIOS_APP_DIR  where the macOS app goes      (default /Applications)
 #   HELIOS_SRC      where the checkout lives      (default ~/.helios/src)
 #   HELIOS_REF      what to build                 (default the newest release)
@@ -21,7 +21,9 @@ REPO_URL="https://github.com/kamrul1157024/helios.git"
 GO_MIN_MINOR=26   # go1.26+, matching go.mod
 NODE_MIN=22       # matching .nvmrc and the Makefile
 
-PREFIX="${HELIOS_PREFIX:-/usr/local/bin}"
+# A directory the user already owns, so the install has nothing to ask for.
+# Point it at /usr/local/bin and it still works — that path wants a password.
+PREFIX="${HELIOS_PREFIX:-$HOME/.local/bin}"
 APP_DIR="${HELIOS_APP_DIR:-/Applications}"
 SRC="${HELIOS_SRC:-$HOME/.helios/src}"
 
@@ -189,39 +191,28 @@ install_daemon() {
 }
 
 step "Installing the daemon to $PREFIX"
-if [ -w "$PREFIX" ] || mkdir -p "$PREFIX" 2> /dev/null && [ -w "$PREFIX" ]; then
-  install_daemon "$PREFIX" ""
-  BIN="$PREFIX/helios"
-elif have sudo; then
-  note "$PREFIX belongs to the system, so this one step needs your password."
+# The default needs no permission. This only bites when HELIOS_PREFIX names
+# somewhere the system owns, and then it is asked for plainly rather than
+# quietly installing somewhere else and leaving two copies behind.
+SUDO=''
+if ! mkdir -p "$PREFIX" 2> /dev/null || [ ! -w "$PREFIX" ]; then
+  have sudo || fail "$PREFIX is not writable and there is no sudo here. Set HELIOS_PREFIX to a directory you own."
+  note "$PREFIX belongs to the system, so this step needs your password."
   note "It copies a single file: $PREFIX/helios. Nothing else is touched."
-  if sudo -v; then
-    install_daemon "$PREFIX" sudo
-    BIN="$PREFIX/helios"
-  else
-    BIN=''
-  fi
-else
-  warn "No sudo on this machine, and $PREFIX is not writable."
-  BIN=''
+  sudo -v || fail "Without that, $PREFIX cannot be written. Set HELIOS_PREFIX to a directory you own."
+  SUDO=sudo
 fi
-
-# Somewhere that needs no permission, when the usual place did not work out.
-if [ -z "${BIN:-}" ]; then
-  FALLBACK="$HOME/.local/bin"
-  warn "Installing to $FALLBACK instead — no administrator rights needed."
-  install_daemon "$FALLBACK" ""
-  BIN="$FALLBACK/helios"
-  case ":$PATH:" in
-    *":$FALLBACK:"*) ;;
-    *)
-      case "${SHELL##*/}" in zsh) RC="~/.zshrc" ;; bash) RC="~/.bashrc" ;; *) RC="your shell's rc file" ;; esac
-      warn "$FALLBACK is not on your PATH. Add this line to $RC:"
-      note "export PATH=\"\$HOME/.local/bin:\$PATH\""
-      ;;
-  esac
-fi
+install_daemon "$PREFIX" "$SUDO"
+BIN="$PREFIX/helios"
 note "installed $BIN"
+
+# The rest of what an install owes you: one copy on the machine, on a PATH the
+# shell reads, and a daemon running the build that was just fetched. Guarded
+# because $SRC sits on the newest release, and a release older than these
+# scripts does not carry them — this file is fetched from main.
+[ -f "$SRC/scripts/remove-old-installs.sh" ] && sh "$SRC/scripts/remove-old-installs.sh" "$BIN"
+[ -f "$SRC/scripts/ensure-path.sh" ] && sh "$SRC/scripts/ensure-path.sh" "$PREFIX" helios
+[ -f "$SRC/scripts/restart-daemon.sh" ] && sh "$SRC/scripts/restart-daemon.sh" "$BIN"
 
 # ─── The desktop app ────────────────────────────────────────────────────────
 

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Tests for the three scripts `make install` runs after the binary is copied.
+#
+#   sh scripts/install_test.sh
+#
+# They are worth testing because they are the parts that touch a machine rather
+# than a build directory: one deletes files, one edits a shell rc, one restarts
+# a service. Every case here runs against a temporary HOME and temporary
+# directories, so this is safe to run on a laptop.
+#
+# What is deliberately not covered: removing the real /usr/local/bin/helios,
+# which cannot be done to a developer's machine to prove a point. The CI job
+# runs the whole installer on a disposable runner and checks that instead.
+
+set -eu
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); printf '  ok    %s\n' "$1"; }
+fail() { FAILED=$((FAILED + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# Every test gets its own throwaway HOME, and none of them inherit the caller's.
+sandbox() {
+  BOX=$(mktemp -d)
+  HOME="$BOX/home"
+  mkdir -p "$HOME"
+  export HOME
+}
+cleanup() { [ -n "${BOX:-}" ] && rm -rf "$BOX"; }
+trap cleanup EXIT
+
+# A binary that answers `helios version` the way the real one does. The removal
+# script uses that answer to decide what it is allowed to delete.
+plant_helios() {
+  mkdir -p "$(dirname "$1")"
+  printf '#!/bin/sh\n[ "$1" = version ] && echo "helios v0.0.0-test"\nexit 0\n' > "$1"
+  chmod +x "$1"
+}
+
+printf '\nremove-old-installs.sh\n'
+
+sandbox
+plant_helios "$BOX/old/helios"
+plant_helios "$BOX/new/helios"
+PATH="$BOX/old:$BOX/new:/usr/bin:/bin" sh "$HERE/remove-old-installs.sh" "$BOX/new/helios" > /dev/null 2>&1
+[ ! -e "$BOX/old/helios" ] && pass "deletes an earlier install on the PATH" || fail "deletes an earlier install on the PATH"
+[ -e "$BOX/new/helios" ] && pass "keeps the install it was told to keep" || fail "keeps the install it was told to keep"
+cleanup
+
+# Someone's own script called helios is not ours to delete.
+sandbox
+mkdir -p "$BOX/mine"
+printf '#!/bin/sh\necho my own thing\n' > "$BOX/mine/helios"
+chmod +x "$BOX/mine/helios"
+plant_helios "$BOX/new/helios"
+PATH="$BOX/mine:$BOX/new:/usr/bin:/bin" sh "$HERE/remove-old-installs.sh" "$BOX/new/helios" > /dev/null 2>&1
+[ -e "$BOX/mine/helios" ] && pass "keeps a namesake that is not a helios binary" || fail "keeps a namesake that is not a helios binary"
+cleanup
+
+# A Homebrew-linked copy belongs to Homebrew.
+sandbox
+plant_helios "$BOX/brew/Cellar/helios/1.0/bin/helios"
+mkdir -p "$BOX/brewbin"
+ln -s "$BOX/brew/Cellar/helios/1.0/bin/helios" "$BOX/brewbin/helios"
+plant_helios "$BOX/new/helios"
+PATH="$BOX/brewbin:$BOX/new:/usr/bin:/bin" sh "$HERE/remove-old-installs.sh" "$BOX/new/helios" > /dev/null 2>&1
+[ -e "$BOX/brewbin/helios" ] && pass "keeps a copy a package manager owns" || fail "keeps a copy a package manager owns"
+cleanup
+
+printf '\nensure-path.sh\n'
+
+# The right copy already wins, so there is nothing to say and nothing to write.
+sandbox
+plant_helios "$BOX/bin/helios"
+OUT=$(PATH="$BOX/bin:/usr/bin:/bin" SHELL=/bin/zsh sh "$HERE/ensure-path.sh" "$BOX/bin" helios 2>&1)
+[ -z "$OUT" ] && pass "silent when the installed copy already answers" || fail "silent when the installed copy already answers (said: $OUT)"
+[ ! -e "$HOME/.zshrc" ] && pass "writes nothing when there is nothing to fix" || fail "writes nothing when there is nothing to fix"
+cleanup
+
+sandbox
+PATH=/usr/bin:/bin SHELL=/bin/zsh sh "$HERE/ensure-path.sh" "$HOME/.local/bin" helios > /dev/null 2>&1
+grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.zshrc" 2> /dev/null &&
+  pass "writes the PATH line to .zshrc" || fail "writes the PATH line to .zshrc"
+# Written as $HOME, not as this machine's home directory.
+grep -q "$HOME/.local" "$HOME/.zshrc" 2> /dev/null &&
+  fail "writes \$HOME rather than the expanded path" || pass "writes \$HOME rather than the expanded path"
+# Twice must not mean two lines.
+PATH=/usr/bin:/bin SHELL=/bin/zsh sh "$HERE/ensure-path.sh" "$HOME/.local/bin" helios > /dev/null 2>&1
+[ "$(grep -c 'added by helios' "$HOME/.zshrc")" = 1 ] &&
+  pass "does not write the line twice" || fail "does not write the line twice"
+cleanup
+
+sandbox
+PATH=/usr/bin:/bin SHELL=/bin/fish sh "$HERE/ensure-path.sh" "$HOME/.local/bin" helios > /dev/null 2>&1
+grep -q 'fish_add_path' "$HOME/.config/fish/config.fish" 2> /dev/null &&
+  pass "uses fish_add_path in config.fish" || fail "uses fish_add_path in config.fish"
+cleanup
+
+# Bash reads a different file depending on the platform, and getting it wrong
+# means writing a line nobody's shell ever reads.
+sandbox
+PATH=/usr/bin:/bin SHELL=/bin/bash sh "$HERE/ensure-path.sh" "$HOME/.local/bin" helios > /dev/null 2>&1
+if [ "$(uname -s)" = Darwin ]; then
+  [ -f "$HOME/.bash_profile" ] && pass "bash on macOS writes .bash_profile" || fail "bash on macOS writes .bash_profile"
+else
+  [ -f "$HOME/.bashrc" ] && pass "bash on Linux writes .bashrc" || fail "bash on Linux writes .bashrc"
+fi
+cleanup
+
+sandbox
+OUT=$(PATH=/usr/bin:/bin SHELL=/bin/nonesuch sh "$HERE/ensure-path.sh" "$HOME/.local/bin" helios 2>&1 || true)
+case "$OUT" in
+  *"export PATH"*) pass "an unknown shell is told what to add by hand" ;;
+  *) fail "an unknown shell is told what to add by hand (said: $OUT)" ;;
+esac
+cleanup
+
+printf '\nrestart-daemon.sh\n'
+
+# A stub standing in for the installed binary, which logs what it was asked to
+# do. The real one is not involved: this is about the decision, not the daemon.
+stub() {
+  cat > "$BOX/helios" <<EOF
+#!/bin/sh
+echo "\$*" >> "$BOX/calls"
+case "\$*" in
+  "daemon status") echo "$1" ;;
+  "daemon stop") exit $2 ;;
+esac
+exit 0
+EOF
+  chmod +x "$BOX/helios"
+  : > "$BOX/calls"
+}
+
+sandbox
+stub "helios daemon is running (pid 1)" 0
+sh "$HERE/restart-daemon.sh" "$BOX/helios" > /dev/null 2>&1
+grep -q 'daemon stop' "$BOX/calls" && grep -q 'daemon start -d' "$BOX/calls" &&
+  pass "restarts a daemon that is running" || fail "restarts a daemon that is running"
+cleanup
+
+sandbox
+stub "helios daemon is not running" 0
+sh "$HERE/restart-daemon.sh" "$BOX/helios" > /dev/null 2>&1
+grep -q 'daemon stop' "$BOX/calls" &&
+  fail "leaves a stopped daemon alone" || pass "leaves a stopped daemon alone"
+cleanup
+
+# Starting after a failed stop would be a second daemon, not a restart.
+sandbox
+stub "helios daemon is running (pid 1)" 1
+sh "$HERE/restart-daemon.sh" "$BOX/helios" > /dev/null 2>&1
+grep -q 'daemon start' "$BOX/calls" &&
+  fail "does not start when the stop failed" || pass "does not start when the stop failed"
+cleanup
+
+printf '\n%s passed, %s failed\n\n' "$PASSED" "$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/remove-old-installs.sh
+++ b/scripts/remove-old-installs.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Delete helios binaries left behind by earlier installs, so the one just
+# installed is the only one there is.
+#
+#   scripts/remove-old-installs.sh ~/.local/bin/helios
+#
+# Installs used to land in /usr/local/bin. Leaving that copy where it is means
+# the shell keeps running it — /usr/local/bin comes before ~/.local/bin on most
+# PATHs — and the bug reports that follow are about a version nobody is working
+# on. Prepending the new directory would only hide it, so the file goes.
+#
+# Two things it will not do. It will not delete anything it cannot confirm is a
+# helios binary, because "helios" on someone's PATH may well be their own
+# script. And it will not delete a copy under a package manager's control,
+# which is that manager's to remove.
+#
+# POSIX sh on purpose, and silent when there is nothing to remove.
+
+set -eu
+
+KEEP="${1:?usage: remove-old-installs.sh <path to the installed binary>}"
+
+if [ -t 1 ]; then
+  DIM=$(printf '\033[2m'); Y=$(printf '\033[33m'); N=$(printf '\033[0m')
+else
+  DIM=''; Y=''; N=''
+fi
+note() { printf '    %s%s%s\n' "$DIM" "$1" "$N"; }
+warn() { printf '%s !  %s%s\n' "$Y" "$1" "$N" >&2; }
+
+# Where to look: every directory on the PATH, plus the place installs used to
+# go. That last one earns its place by not needing to be on the PATH today —
+# it can be put back on tomorrow, and then the old binary is live again.
+CANDIDATES=$(
+  printf '%s\n' "${PATH:-}" | tr ':' '\n'
+  printf '%s\n' /usr/local/bin
+)
+
+# A helios binary and not a namesake. `helios version` is cheap, does not touch
+# the daemon, and nothing else answers it this way.
+is_helios() {
+  [ -f "$1" ] && [ -x "$1" ] || return 1
+  "$1" version 2> /dev/null | grep -qi '^helios'
+}
+
+# Homebrew, apt and friends keep their own records; a file removed behind their
+# back leaves them describing a package that is not there.
+managed_by_package_manager() {
+  case "$1" in
+    /opt/homebrew/* | /home/linuxbrew/* | /usr/bin/* | /bin/* | /nix/store/*) return 0 ;;
+  esac
+  # A Homebrew-linked binary is a symlink into the Cellar.
+  case "$(readlink "$1" 2> /dev/null || true)" in
+    */Cellar/* | */homebrew/*) return 0 ;;
+  esac
+  return 1
+}
+
+SEEN=''
+REMOVED=''
+for dir in $CANDIDATES; do
+  [ -n "$dir" ] || continue
+  old="$dir/helios"
+
+  # The PATH repeats itself, and /usr/local/bin is on it twice by construction.
+  case " $SEEN " in *" $old "*) continue ;; esac
+  SEEN="$SEEN $old"
+
+  [ "$old" = "$KEEP" ] && continue
+  [ -e "$old" ] || continue
+
+  if managed_by_package_manager "$old"; then
+    warn "$old belongs to a package manager — remove it with that, not by hand."
+    continue
+  fi
+
+  if ! is_helios "$old"; then
+    warn "$old is on your PATH but does not answer 'helios version' — left alone."
+    continue
+  fi
+
+  # sudo only where the directory demands it, which is the old /usr/local/bin
+  # and little else. Deleting the file of a running daemon is safe on Unix: it
+  # keeps running from the inode until it is restarted.
+  if [ -w "$dir" ]; then
+    rm -f "$old" && REMOVED="$REMOVED $old"
+  elif command -v sudo > /dev/null 2>&1; then
+    note "Removing the earlier install at $old — $dir needs your password."
+    if sudo rm -f "$old"; then
+      REMOVED="$REMOVED $old"
+    else
+      warn "Could not remove $old. It will keep shadowing the new install."
+      note "Remove it with:  sudo rm $old"
+    fi
+  else
+    warn "$old is an earlier install and $dir is not writable, with no sudo here."
+    note "Remove it with:  rm $old   (as a user who can)"
+  fi
+done
+
+for old in $REMOVED; do
+  note "removed the earlier install at $old"
+done

--- a/scripts/restart-daemon.sh
+++ b/scripts/restart-daemon.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Restart a running daemon so it runs the binary that was just installed.
+#
+#   scripts/restart-daemon.sh ~/.local/bin/helios
+#
+# A daemon started before the install keeps serving the old code from the old
+# inode, and nothing about that is visible: the CLI is new, the API answers,
+# and the fix that was just built is not in it. Restarting is the only way the
+# install means anything to a machine that was already running.
+#
+# Sessions are not affected. Each one is a `helios ptyhost` in its own session
+# (setsid, released by the parent), so it outlives the daemon that spawned it
+# and is picked up again on the next start. The tunnel outlives it too.
+#
+# POSIX sh on purpose, and silent when no daemon is running.
+
+set -eu
+
+BIN="${1:?usage: restart-daemon.sh <path to the installed binary>}"
+
+if [ -t 1 ]; then
+  B=$(printf '\033[1m'); DIM=$(printf '\033[2m'); Y=$(printf '\033[33m'); N=$(printf '\033[0m')
+else
+  B=''; DIM=''; Y=''; N=''
+fi
+note() { printf '    %s%s%s\n' "$DIM" "$1" "$N"; }
+warn() { printf '%s !  %s%s\n' "$Y" "$1" "$N" >&2; }
+
+# `helios daemon status` exits 0 either way, so the answer is in what it says.
+# "helios daemon is not running" does not contain "daemon is running".
+"$BIN" daemon status 2> /dev/null | grep -q 'daemon is running' || exit 0
+
+printf '%sRestarting the daemon so it runs the build just installed%s\n' "$B" "$N"
+note "sessions and the tunnel stay up"
+
+if ! "$BIN" daemon stop; then
+  warn "The daemon did not stop. It is still running the older build."
+  note "Restart it yourself with:  helios daemon stop && helios daemon start -d"
+  exit 0
+fi
+
+if ! "$BIN" daemon start -d; then
+  warn "The daemon stopped but did not come back."
+  note "Start it with:  helios daemon start -d"
+  exit 1
+fi


### PR DESCRIPTION
## What

`make install` and `make install-dev` no longer use `sudo`. The daemon goes to
`~/.local/bin` — a directory you already own — instead of `/usr/local/bin`,
which belongs to root and cost four `sudo` calls to copy one file.

`PREFIX` overrides it: `make install PREFIX=/usr/local/bin`, with `sudo` in
front if that path is the system's.

## Why it is more than a path change

An install that lands somewhere the shell does not look, next to an older copy
that it does, is worse than the one it replaces — the old binary keeps
answering and the bug reports come back about a version nobody is working on.
So the target finishes the job instead of printing a list of things to do.

| Script | Does |
| --- | --- |
| `remove-old-installs.sh` | Deletes earlier copies, `/usr/local/bin` included, so exactly one `helios` is left |
| `ensure-path.sh` | Puts `PREFIX` on the `PATH` via `.zshrc` / `.bash_profile` / `config.fish` |
| `restart-daemon.sh` | Restarts a running daemon, which would otherwise serve the replaced build |

## Migration

Anyone upgrading has a binary at `/usr/local/bin/helios`. The install deletes
it. That directory usually belongs to root, so it asks for a password **once** —
the only step that ever does, and only for people migrating.

Two things it will not delete: anything that fails `helios version`, since
`helios` on a PATH may be someone's own script, and anything under Homebrew,
apt or Nix, which is that manager's to remove.

## Notes

- Scripts run through `sh`, so a missing exec bit cannot break a checkout.
- They resolve against the Makefile's directory, not `$(CURDIR)` — `make install`
  re-enters with `-C` on a worktree parked at the release tag, and the tag does
  not carry these scripts.
- Sessions and the tunnel survive the daemon restart: a ptyhost is `setsid`'d
  and released, so it outlives the daemon that spawned it.

## Test plan

- [x] `go test ./...` — 19 packages, no failures
- [x] Removal: genuine old install deleted; a non-helios `helios` script left alone; a Homebrew-linked copy refused; the new binary untouched
- [x] PATH: zsh, bash-on-macOS, fish, unknown shell; idempotent on a second run; non-home prefix
- [x] Restart: daemon running, daemon not running, `daemon stop` failing
- [x] `MAKEFILE_DIR` resolves to the checkout when make runs with `-C` elsewhere
- [ ] Someone other than me runs `make install` on a machine with the old binary in place