### PR TITLE
Make a new session's attachments actually reach the agent

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -50,10 +50,10 @@ export interface StubDaemon {
   /**
    * What the app asked the daemon to do, in the order it asked.
    *
-   * A session with files on its first prompt is three calls that have to
-   * happen in one order — create, upload, send — because the upload needs an
-   * id that only the create can give it. Nothing on screen shows the order, so
-   * the record of what arrived is the only thing that can.
+   * A session with files on its first prompt is two calls in one order —
+   * upload, then create — because the create has to carry the paths the upload
+   * decided. Nothing on screen shows the order, so the record of what arrived
+   * is the only thing that can.
    */
   writes(): DaemonWrite[]
   close(): Promise<void>
@@ -62,7 +62,7 @@ export interface StubDaemon {
 /** One thing the app asked of the daemon. */
 export type DaemonWrite =
   | { kind: 'create'; spec: Record<string, unknown> }
-  | { kind: 'upload'; sessionId: string; names: string[] }
+  | { kind: 'upload'; names: string[] }
   | { kind: 'send'; sessionId: string; message: string }
 
 /** The session every create in these tests hands back. */
@@ -368,9 +368,9 @@ export async function startDaemon(): Promise<StubDaemon> {
   }
 }
 
-/** The three calls that start a session and give it its first turn. */
+/** The calls that start a session and give it its first turn. */
 function written(path: string): boolean {
-  return path === '/api/sessions' || path.endsWith('/files') || path.endsWith('/send')
+  return path === '/api/sessions' || path === '/api/uploads' || path.endsWith('/send')
 }
 
 /**
@@ -385,17 +385,23 @@ function record(writes: DaemonWrite[], path: string, body: Buffer): unknown {
     return { success: true, session_id: CREATED, terminal: `/tmp/helios/${CREATED}.sock`, cwd: REPO }
   }
 
-  const id = path.slice('/api/sessions/'.length, path.lastIndexOf('/'))
   if (path.endsWith('/send')) {
+    const id = path.slice('/api/sessions/'.length, path.lastIndexOf('/'))
     const { message } = JSON.parse(body.toString() || '{}')
     writes.push({ kind: 'send', sessionId: id, message: String(message ?? '') })
     return { success: true }
   }
 
   const names = [...body.toString('latin1').matchAll(/filename="([^"]*)"/g)].map((m) => m[1] ?? '')
-  writes.push({ kind: 'upload', sessionId: id, names })
+  writes.push({ kind: 'upload', names })
+  // Prefixed as the daemon prefixes them, so a test cannot pass by assuming
+  // the path is the name the file was picked under.
   return {
-    files: names.map((name) => ({ name, path: `${HOME}/.helios/uploads/${id}/${name}`, size: 1 })),
+    files: names.map((name, at) => ({
+      name,
+      path: `${HOME}/.helios/uploads/a1b2c3d4e5f${at}-${name}`,
+      size: 1,
+    })),
   }
 }
 

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -1,6 +1,5 @@
 import type { Page } from '@playwright/test'
 
-import { CREATED } from './daemon.ts'
 import { expect, test } from './fixtures.ts'
 
 async function openComposer(window: Page): Promise<void> {
@@ -270,10 +269,15 @@ test('home does not disappear while it is being typed', async ({ window }) => {
 })
 
 // The one part of the composer that is not the chat composer with different
-// chips. An upload needs a session to belong to, and the session does not
-// exist until Create is pressed — so the first turn cannot be the one the
-// agent launches with, and the order below is the whole of the feature.
-test('files go up once the session exists, and the first prompt names them', async ({ window, daemon }) => {
+// chips, and the order below is the whole of the feature.
+//
+// The files go up first so that their paths can be in the prompt the agent
+// launches with. The other way round — create, upload, then send the prompt —
+// is what this used to do, because an upload needed a session to belong to,
+// and it meant typing at an agent whose TUI had not yet claimed the terminal.
+// Prompts are swallowed there, and both agents put a trust dialog in the same
+// window. Nothing is typed now: there is no send at all.
+test('files go up before the session, and it launches with a prompt naming them', async ({ window, daemon }) => {
   await openComposer(window)
 
   await window.locator('.composer input[type="file"]').setInputFiles({
@@ -287,21 +291,18 @@ test('files go up once the session exists, and the first prompt names them', asy
   await window.locator('.composer .filled').click()
   await expect(window.locator('.composer')).toHaveCount(0)
 
-  await expect
-    .poll(() => daemon.writes().map((write) => write.kind))
-    .toEqual(['create', 'upload', 'send'])
+  await expect.poll(() => daemon.writes().map((write) => write.kind)).toEqual(['upload', 'create'])
 
-  const [created, uploaded, sent] = daemon.writes()
-  if (created?.kind !== 'create' || uploaded?.kind !== 'upload' || sent?.kind !== 'send') {
-    throw new Error('the daemon recorded something other than a create, an upload and a send')
+  const [uploaded, created] = daemon.writes()
+  if (uploaded?.kind !== 'upload' || created?.kind !== 'create') {
+    throw new Error('the daemon recorded something other than an upload and a create')
   }
-  // Silent on purpose: launching with the prompt would send the agent looking
-  // for paths that are only decided by the upload below it.
-  expect(created.spec.prompt).toBeUndefined()
   expect(uploaded.names).toEqual(['shot.png'])
-  expect(uploaded.sessionId).toBe(CREATED)
-  expect(sent.message).toContain(`/home/dev/.helios/uploads/${CREATED}/shot.png`)
-  expect(sent.message).toContain('what is wrong with this')
+  // The path the upload decided, not the name the file was picked under: the
+  // daemon prefixes it, and a prompt carrying the unprefixed name points at
+  // nothing.
+  expect(created.spec.prompt).toContain('/home/dev/.helios/uploads/a1b2c3d4e5f0-shot.png')
+  expect(created.spec.prompt).toContain('what is wrong with this')
 })
 
 test('a session with nothing attached still launches with its prompt', async ({ window, daemon }) => {

--- a/desktop/e2e/new-session.spec.ts
+++ b/desktop/e2e/new-session.spec.ts
@@ -332,7 +332,44 @@ test('a file dropped anywhere on the dialog lands on it', async ({ window }) => 
   await expect(window.locator('.attachment-name')).toHaveText('trace.txt')
 })
 
-test('⌘U reaches for a file without touching the paperclip', async ({ window }) => {
+// The prompt box is where a file is aimed, and a textarea has drop behaviour of
+// its own: left to it, Chromium either inserts the path as text or navigates
+// away from the app entirely. The dialog's handlers are on the shell and catch
+// it on the way up, and this is what says they still do.
+test('a file dropped on the prompt itself lands on the dialog', async ({ window }) => {
+  await openComposer(window)
+
+  await window.evaluate(() => {
+    const carried = new DataTransfer()
+    carried.items.add(new File(['a stack trace'], 'dropped.txt', { type: 'text/plain' }))
+    const prompt = document.querySelector('.composer-prompt')
+    if (!prompt) throw new Error('no prompt box to drop on')
+    prompt.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+    prompt.dispatchEvent(new DragEvent('drop', { dataTransfer: carried, bubbles: true }))
+  })
+
+  await expect(window.locator('.attachment-name')).toHaveText('dropped.txt')
+  // Attached, not typed: the path must not also end up in the prompt.
+  await expect(window.locator('.composer-prompt')).toHaveValue('')
+})
+
+// Dragging over the prompt has to say the dialog will take it, or the only
+// feedback is the cursor and the user lets go somewhere else.
+test('dragging a file over the prompt lights the dialog up', async ({ window }) => {
+  await openComposer(window)
+
+  await window.evaluate(() => {
+    const carried = new DataTransfer()
+    carried.items.add(new File(['x'], 'hover.txt', { type: 'text/plain' }))
+    const prompt = document.querySelector('.composer-prompt')
+    if (!prompt) throw new Error('no prompt box to drag over')
+    prompt.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+  })
+
+  await expect(window.locator('.composer.dropping')).toHaveCount(1)
+})
+
+test('⌘U reaches for a file without touching the ⊕', async ({ window }) => {
   await openComposer(window)
 
   const chooser = window.waitForEvent('filechooser')

--- a/desktop/src/main/api.ts
+++ b/desktop/src/main/api.ts
@@ -279,13 +279,17 @@ export class ApiClient {
   }
 
   /**
-   * Stores files beside the session and answers with the path of each.
+   * Stores files on the host and answers with the path of each.
    *
    * The bytes stop here. What reaches the agent is a path, which it opens with
    * its own tools — so an attachment costs the model nothing until it looks.
+   *
+   * No session id, which is what lets the new-session composer upload before
+   * it has one. The daemon keeps them apart with a random prefix on the name
+   * rather than a directory per session.
    */
-  async uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
-    const path = `/api/sessions/${encodeURIComponent(id)}/files`
+  async uploadFiles(files: UploadPart[]): Promise<UploadedFile[]> {
+    const path = '/api/uploads'
     let response = await this.sendForm(path, files)
     if (response.status === 401) {
       this.invalidate()

--- a/desktop/src/renderer/bridge.ts
+++ b/desktop/src/renderer/bridge.ts
@@ -267,8 +267,8 @@ export class HostApi {
     return this.call('touchSession', id)
   }
   /** The bytes cross to the main process, which does the multipart POST. */
-  uploadFiles(id: string, files: UploadPart[]): Promise<UploadedFile[]> {
-    return this.call('uploadFiles', id, files)
+  uploadFiles(files: UploadPart[]): Promise<UploadedFile[]> {
+    return this.call('uploadFiles', files)
   }
   setSessionOrder(order: string[]): Promise<unknown> {
     return this.call('setSessionOrder', order)

--- a/desktop/src/renderer/components/attach.tsx
+++ b/desktop/src/renderer/components/attach.tsx
@@ -43,7 +43,7 @@ export interface AttachmentBag {
    * uploading the same bytes on the retry would leave a numbered copy behind
    * for every attempt.
    */
-  store: (hostId: string, sessionId: string, text: string) => Promise<string>
+  store: (hostId: string, text: string) => Promise<string>
   /** After a send has landed: the chips go and their previews are released. */
   clear: () => void
 }
@@ -84,12 +84,11 @@ export function useAttachments(): AttachmentBag {
     return pasted
   }
 
-  const store = async (hostId: string, sessionId: string, text: string): Promise<string> => {
+  const store = async (hostId: string, text: string): Promise<string> => {
     let ready = files
     const pending = needingUpload(files)
     if (pending.length > 0) {
       const stored = await api(hostId).uploadFiles(
-        sessionId,
         pending.map(({ name, type, bytes }) => ({ name, type, bytes })),
       )
       ready = withStoredPaths(files, pending, stored.map((file) => file.path))

--- a/desktop/src/renderer/components/attach.tsx
+++ b/desktop/src/renderer/components/attach.tsx
@@ -166,6 +166,7 @@ export function AttachButton({
   onFiles,
   disabled = false,
   shortcut = false,
+  icon = <Paperclip />,
 }: {
   onFiles: (files: FileList | null) => void
   disabled?: boolean
@@ -177,6 +178,12 @@ export function AttachButton({
    * would answer the keystroke with a dialog of its own.
    */
   shortcut?: boolean
+  /**
+   * The glyph. A paperclip beside a running session means "add to this turn";
+   * the new-session dialog is building a first turn out of nothing, and a plus
+   * is what adding to nothing looks like.
+   */
+  icon?: React.ReactNode
 }): JSX.Element {
   const picker = useRef<HTMLInputElement | null>(null)
 
@@ -211,7 +218,7 @@ export function AttachButton({
         disabled={disabled}
         onClick={() => picker.current?.click()}
       >
-        <Paperclip />
+        {icon}
       </button>
     </>
   )

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -195,7 +195,7 @@ export function ChatPanel({
     try {
       // Upload first: a prompt naming a path the daemon never stored is worse
       // than no prompt, and the agent would go looking for it.
-      const message = await files.store(hostId, session.session_id, text)
+      const message = await files.store(hostId, text)
 
       const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -98,63 +98,37 @@ export function NewSessionDialog({
   const modes = selected?.permission_modes ?? []
 
   /**
-   * The first turn, when there are files on it.
+   * Starts the session, with its files already on disk and named in the prompt
+   * it launches with.
    *
-   * An upload needs a session to belong to — it lands in
-   * ~/.helios/uploads/{id} and the handler 404s without the record
-   * (internal/server/uploads.go) — and the id is what the create call is there
-   * to return. So an attached prompt cannot be the one the agent launches
-   * with: the session is started silent, the files go up against the id it
-   * came back with, and the prompt naming them is sent after.
+   * The upload goes first, and that ordering is the whole of it. It used to be
+   * impossible: an attachment was filed under a session id, the id came back
+   * from the create, so the session had to be launched silent and the prompt
+   * naming the files typed at it afterwards — into the seconds where the agent
+   * has reported in but its TUI has not yet claimed the terminal. Prompts are
+   * swallowed in that window, and both agents put a trust dialog in it as well;
+   * Codex puts two.
    *
-   * That send lands while the agent is still coming up, which is the hardest
-   * moment to deliver a prompt in and used to be where this one was lost. The
-   * daemon holds it now — it waits for the agent's screen to settle before
-   * typing, and gives a booting agent a budget that matches how long one
-   * actually takes to read (internal/server/launch.go, awaitQuietScreen).
+   * Uploads no longer take an id (POST /api/uploads), so nothing is typed at
+   * anything. The paths exist before the launch, the prompt naming them goes in
+   * the agent's own argv, and the CLI holds it behind its own dialogs the way
+   * it holds any other launch prompt.
    *
-   * Nothing here undoes the session. It is running by the time any of this can
-   * fail, and killing an agent over an upload is a worse answer than a prompt
-   * that arrives without its attachments.
+   * A failed upload now leaves nothing behind, because nothing has started.
    */
-  const firstTurn = async (sessionId: string, text: string): Promise<void> => {
-    let message = text
-    try {
-      message = await files.store(hostId, sessionId, text)
-    } catch (err) {
-      const why = err instanceof Error ? err.message : String(err)
-      store.notify(`Session started, but the files did not upload: ${why}`, 'error')
-    }
-    if (!message) return
-    try {
-      await api(hostId).sendPrompt(sessionId, message)
-    } catch (err) {
-      store.fail(err)
-    }
-  }
-
   const start = async (): Promise<void> => {
     if (!hostId || starting) return
     setStarting(true)
     try {
       const text = prompt.trim()
-      const attached = files.files.length > 0
+      const message = files.files.length > 0 ? await files.store(hostId, text) : text
       const result = await api(hostId).createSession({
         provider,
         cwd: cwd || undefined,
         model: model || undefined,
-        prompt: attached ? undefined : text || undefined,
+        prompt: message || undefined,
         permission_mode: mode || undefined,
       })
-      // Deliberately not awaited. The daemon holds a prompt until the agent is
-      // actually reading its terminal, which for a cold start is a good part of
-      // a minute, and a dialog sitting on "Creating…" for that long is a dialog
-      // that looks hung — over work the user has already been told is done.
-      // The session exists the moment the create returns, so it opens now and
-      // the prompt lands in it when it lands. Nothing is lost by not watching:
-      // a failure on either half arrives as a notification, which is where
-      // firstTurn already sends one.
-      if (attached) void firstTurn(result.session_id, text)
       // Filed before the refresh, so the list arrives with it already in the
       // group the + was pressed on. The directory only seeded the dialog; the
       // group is what the button actually promised.

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -12,7 +12,7 @@ import {
   useAttachments,
   useDropTarget,
 } from './attach.tsx'
-import { Chevron, Console, Folder, Shield, Spark } from './icons.tsx'
+import { Chevron, Console, Folder, Plus, Shield, Spark } from './icons.tsx'
 import { completionTarget, completionsIn, resolveTyped } from './dirpath.ts'
 import { tintOf } from './grouping.ts'
 import { type DirectoryInfo, type ModelInfo, type ProviderInfo } from '../../shared/models.ts'
@@ -106,6 +106,12 @@ export function NewSessionDialog({
    * to return. So an attached prompt cannot be the one the agent launches
    * with: the session is started silent, the files go up against the id it
    * came back with, and the prompt naming them is sent after.
+   *
+   * That send lands while the agent is still coming up, which is the hardest
+   * moment to deliver a prompt in and used to be where this one was lost. The
+   * daemon holds it now — it waits for the agent's screen to settle before
+   * typing, and gives a booting agent a budget that matches how long one
+   * actually takes to read (internal/server/launch.go, awaitQuietScreen).
    *
    * Nothing here undoes the session. It is running by the time any of this can
    * fail, and killing an agent over an upload is a worse answer than a prompt
@@ -269,29 +275,43 @@ export function NewSessionDialog({
 
         <AttachmentChips files={files.files} onRemove={files.remove} />
 
-        <textarea
-          className="composer-prompt"
-          autoFocus
-          rows={4}
-          value={prompt}
-          placeholder="What do you want to work on?"
-          onChange={(event) => setPrompt(event.target.value)}
-          onPaste={(event) => {
-            // A screenshot on the clipboard comes through as a file. Let the
-            // default run when there is none, or pasted text is lost.
-            if (event.clipboardData.files.length > 0) {
+        {/* Over the prompt rather than in the foot, as the transcript composer
+            has it: attaching is something done to the text, so it belongs on
+            the box holding the text. It also gives the foot back the width the
+            three chips need to stay on one line. */}
+        <div className="composer-input">
+          <textarea
+            className="composer-prompt"
+            autoFocus
+            rows={4}
+            value={prompt}
+            placeholder="What do you want to work on?"
+            onChange={(event) => setPrompt(event.target.value)}
+            onPaste={(event) => {
+              // A screenshot on the clipboard comes through as a file. Let the
+              // default run when there is none, or pasted text is lost.
+              if (event.clipboardData.files.length > 0) {
+                event.preventDefault()
+                void files.attach(event.clipboardData.files)
+                return
+              }
+              files.noticePaste(event.clipboardData.getData('text'))
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
               event.preventDefault()
-              void files.attach(event.clipboardData.files)
-              return
-            }
-            files.noticePaste(event.clipboardData.getData('text'))
-          }}
-          onKeyDown={(event) => {
-            if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
-            event.preventDefault()
-            void start()
-          }}
-        />
+              void start()
+            }}
+          />
+          <div className="composer-bar">
+            <AttachButton
+              onFiles={(chosen) => void files.attach(chosen)}
+              disabled={starting}
+              shortcut
+              icon={<Plus />}
+            />
+          </div>
+        </div>
 
         <footer className="composer-foot">
           <div className="composer-chips">
@@ -395,18 +415,9 @@ export function NewSessionDialog({
                 )}
               </Picker>
             )}
-
           </div>
 
           <div className="composer-actions">
-            {/* With the actions rather than with the chips: the chips say what
-                the session will be, and the paperclip is something done to the
-                prompt, next to the button that sends it. */}
-            <AttachButton
-              onFiles={(chosen) => void files.attach(chosen)}
-              disabled={starting}
-              shortcut
-            />
             <button className="ghost" onClick={onClose}>
               Cancel
             </button>

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -146,7 +146,15 @@ export function NewSessionDialog({
         prompt: attached ? undefined : text || undefined,
         permission_mode: mode || undefined,
       })
-      if (attached) await firstTurn(result.session_id, text)
+      // Deliberately not awaited. The daemon holds a prompt until the agent is
+      // actually reading its terminal, which for a cold start is a good part of
+      // a minute, and a dialog sitting on "Creating…" for that long is a dialog
+      // that looks hung — over work the user has already been told is done.
+      // The session exists the moment the create returns, so it opens now and
+      // the prompt lands in it when it lands. Nothing is lost by not watching:
+      // a failure on either half arrives as a notification, which is where
+      // firstTurn already sends one.
+      if (attached) void firstTurn(result.session_id, text)
       // Filed before the refresh, so the list arrives with it already in the
       // group the + was pressed on. The directory only seeded the dialog; the
       // group is what the button actually promised.

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -144,7 +144,7 @@ export function TerminalPane({
           bytes: new Uint8Array(await file.arrayBuffer()),
         })),
       )
-      const stored = await api(tab.hostId).uploadFiles(tab.sessionId, parts)
+      const stored = await api(tab.hostId).uploadFiles(parts)
       const text = terminalPaths(stored.map((file) => file.path))
       if (text) await bridge.term.input(tab.id, encoder.encode(text))
     } catch (err) {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3837,7 +3837,11 @@ figure.mermaid svg {
    of its own: the prompt stopped growing with the window and stopped lining up
    with the messages above it. */
 .modal-backdrop .composer {
-  width: 680px;
+  /* 680 was the width before the foot held three chips. "Claude Code",
+     "Default model" and "Default permissions" want 471px between them and had
+     450, so every one of them was losing its last few characters to an
+     ellipsis at rest. */
+  width: 720px;
   max-width: 92vw;
   display: flex;
   flex-direction: column;
@@ -3959,6 +3963,15 @@ figure.mermaid svg {
   gap: 4px;
 }
 
+/* Held at the width of the widest thing it says, so pressing it does not
+   resize it. "Creating…" is 11px wider than "Create ↵", and the chips beside
+   it paid for those 11px: the permission mode dropped onto a line of its own
+   at the exact moment the user was watching for something to happen. */
+.composer-actions .filled {
+  min-width: 102px;
+  justify-content: center;
+}
+
 .composer-key {
   margin-left: 6px;
   font: inherit;
@@ -4048,12 +4061,22 @@ figure.mermaid svg {
 }
 
 /* Provider, model and permissions read as one row of settings, so they get one
-   row. Three chips and two buttons do not fit 680px at the 220px above, and a
-   permission mode wrapping onto a line of its own reads as a separate control
-   rather than the third of three. Truncated instead — the chips are wide
-   enough for every mode name, and a long model name is the one that gives. */
-.composer-foot .composer-chip-name {
-  max-width: 130px;
+   row. Three of them and two buttons do not fit 680px at full width — "Claude
+   Code", "Default model" and "Default permissions" are together already over
+   it — and a permission mode dropped onto a line of its own reads as a
+   separate control rather than the third of three.
+
+   So the chips give instead of wrapping. `flex: none` is what the chip row
+   wants everywhere else, where nothing should be cut; here they shrink and the
+   ellipsis lands wherever the width runs out. A cap would not do it: the names
+   are only just too wide together, so any cap tight enough to fit them cuts
+   names that had room. */
+.composer-foot .composer-chips {
+  flex-wrap: nowrap;
+}
+
+.composer-foot .composer-chips > * {
+  flex: 0 1 auto;
 }
 
 .picker-body {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -3898,17 +3898,34 @@ figure.mermaid svg {
   flex: none;
 }
 
-/* Sized to the buttons it stands beside, not to the 36px an icon button is
-   elsewhere: the foot of the dialog is a 30px row. */
-.composer-actions .attach-btn {
-  width: 30px;
-  height: 30px;
-  border-radius: 999px;
+/* The prompt box in the dialog is the dialog: the wrapper exists only to hang
+   the ⊕ over the text, as the transcript composer does, so it draws no surface
+   and no border of its own. */
+.modal-backdrop .composer-input {
+  margin: 0 12px;
+  border: none;
+  background: none;
 }
 
-.composer-actions .attach-btn .ui-icon {
-  width: 17px;
-  height: 17px;
+.modal-backdrop .composer-input:focus-within {
+  border-color: transparent;
+}
+
+/* One drop hint, not two: the dialog paints its own across the whole of
+   itself, and the inner box would sit inside that. */
+.modal-backdrop .composer.dropping .composer-input::after {
+  content: none;
+}
+
+.modal-backdrop .composer-prompt {
+  margin: 0;
+  /* Bottom padding is the strip the ⊕ floats over. */
+  padding: 8px 8px 40px;
+}
+
+.modal-backdrop .composer-bar {
+  left: 4px;
+  bottom: 4px;
 }
 
 /* The dialog has no inner box to outline, so the whole of it lights up. */
@@ -4028,6 +4045,15 @@ figure.mermaid svg {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 220px;
+}
+
+/* Provider, model and permissions read as one row of settings, so they get one
+   row. Three chips and two buttons do not fit 680px at the 220px above, and a
+   permission mode wrapping onto a line of its own reads as a separate control
+   rather than the third of three. Truncated instead — the chips are wide
+   enough for every mode name, and a long model name is the one that gives. */
+.composer-foot .composer-chip-name {
+  max-width: 130px;
 }
 
 .picker-body {

--- a/docs/specs/37-prompt-delivery-reliability.md
+++ b/docs/specs/37-prompt-delivery-reliability.md
@@ -151,8 +151,8 @@ directory already exists for attachments (`internal/server/uploads.go`), is
 ## Client change — offer to attach a large paste
 
 Reduces how often a huge prompt is generated at all. The attachment pipeline
-(`POST /api/sessions/{id}/files` → `Attached: <path>` lines) already exists on
-both clients.
+(`POST /api/uploads` → `Attached: <path>` lines) already exists on both
+clients.
 
 Default is **inline**: the paste lands in the composer exactly as today, and an
 offer appears alongside it. Nothing changes without the user choosing it.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -522,6 +522,17 @@ var (
 	// was handed. Short: the hook fires the moment the prompt is submitted,
 	// so silence past a few seconds means it was not.
 	promptAckTimeout = 8 * time.Second
+	// bootPromptAckTimeout is the same budget for an agent that has just
+	// started or just woken. Much longer, because it has been measured: an
+	// agent still finishing its boot took 14 seconds to read a prompt that had
+	// already been typed, and the 8 seconds above reported that working send
+	// as a failure while the turn it had started ran on.
+	bootPromptAckTimeout = 30 * time.Second
+	// screenSettleInterval, screenSettleTimeout and screenBlankGrace bound the
+	// wait for a booting agent's screen to stop moving. See awaitQuietScreen.
+	screenSettleInterval = 300 * time.Millisecond
+	screenSettleTimeout  = 12 * time.Second
+	screenBlankGrace     = 1 * time.Second
 )
 
 // handleSessionTouch records that a human is looking at this session.

--- a/internal/server/launch.go
+++ b/internal/server/launch.go
@@ -170,17 +170,19 @@ func (sh *Shared) awaitAgent(id string) error {
 // A booting TUI repaints continuously; once two captures a settle apart agree,
 // the composer is up and reading.
 //
-// Giving up is deliberately silent and deliberately not an error. Typing at an
-// agent whose screen never settles is exactly what this did before, so the
-// worst case is the behaviour it replaced.
-func (sh *Shared) awaitQuietScreen(id string) {
+// Giving up on the settle is deliberately silent and deliberately not an
+// error. Typing at an agent whose screen never settles is exactly what this
+// did before, so the worst case is the behaviour it replaced.
+//
+// A trust dialog is the one thing it refuses over. See below.
+func (sh *Shared) awaitQuietScreen(id string) error {
 	deadline := time.Now().Add(screenSettleTimeout)
 	blankUntil := time.Now().Add(screenBlankGrace)
 	last := ""
 	for time.Now().Before(deadline) {
 		screen, err := sh.Backend.Capture(id)
 		if err != nil {
-			return
+			return nil
 		}
 		// Blank does not count as settled: a terminal shows nothing at all in
 		// the moment before its TUI paints, which is the moment this exists to
@@ -189,15 +191,31 @@ func (sh *Shared) awaitQuietScreen(id string) {
 		// for the full timeout to learn nothing from it is worse than typing.
 		if screen == "" {
 			if time.Now().After(blankUntil) {
-				return
+				return nil
 			}
 		} else if screen == last {
-			return
+			// Still, but not ready. A modal is as motionless as a composer,
+			// and the agent behind it is not reading prose — it is reading a
+			// menu selection, so a prompt typed here does not queue, it
+			// answers. Codex makes this the ordinary case rather than the rare
+			// one: on a fresh install it shows two of these back to back,
+			// directory trust and then hook trust, before it reads anything.
+			//
+			// Refused rather than waited out. The watcher has already raised
+			// the dialog's own notification, so there is something to answer
+			// and something to say about why this did not go.
+			if prompt := matchTrustPrompt(screen); prompt != nil {
+				log.Printf("session-send: session %s is blocked on %s", id, prompt.Type)
+				return statusError(http.StatusConflict,
+					"the session is waiting on a prompt of its own: %s", prompt.Title)
+			}
+			return nil
 		}
 		last = screen
 		time.Sleep(screenSettleInterval)
 	}
 	log.Printf("session-send: session %s was still repainting after %s", id, screenSettleTimeout)
+	return nil
 }
 
 // EndSession kills a session's terminal and records it as terminated.
@@ -322,7 +340,9 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 	// being read, and the gap between the two is where a prompt is lost rather
 	// than merely late.
 	if booting {
-		sh.awaitQuietScreen(id)
+		if err := sh.awaitQuietScreen(id); err != nil {
+			return PromptResult{Resumed: resumed}, err
+		}
 	}
 
 	// Likewise subscribed before typing. The agent's own hook is the only

--- a/internal/server/launch.go
+++ b/internal/server/launch.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -155,6 +156,50 @@ func (sh *Shared) awaitAgent(id string) error {
 	return nil
 }
 
+// awaitQuietScreen waits for a booting agent to finish painting its terminal.
+//
+// The ready hook fires from the agent process, which is running well before its
+// TUI has claimed the terminal, and the raw-mode switch that claim performs
+// discards whatever is sitting in the input buffer. Text typed into that window
+// is not late — it is gone, with no error anywhere and a session left looking
+// idle because nothing was ever asked of it. That is the failure this exists
+// for; a prompt merely read late is the ack budget's problem, not this one.
+//
+// A settled screen is the proof, and it costs nothing to ask for: the daemon
+// already mirrors every session, so this is a map lookup and a string compare.
+// A booting TUI repaints continuously; once two captures a settle apart agree,
+// the composer is up and reading.
+//
+// Giving up is deliberately silent and deliberately not an error. Typing at an
+// agent whose screen never settles is exactly what this did before, so the
+// worst case is the behaviour it replaced.
+func (sh *Shared) awaitQuietScreen(id string) {
+	deadline := time.Now().Add(screenSettleTimeout)
+	blankUntil := time.Now().Add(screenBlankGrace)
+	last := ""
+	for time.Now().Before(deadline) {
+		screen, err := sh.Backend.Capture(id)
+		if err != nil {
+			return
+		}
+		// Blank does not count as settled: a terminal shows nothing at all in
+		// the moment before its TUI paints, which is the moment this exists to
+		// wait out. But it cannot be waited on indefinitely either — a backend
+		// with no mirror to read answers empty forever, and holding every send
+		// for the full timeout to learn nothing from it is worse than typing.
+		if screen == "" {
+			if time.Now().After(blankUntil) {
+				return
+			}
+		} else if screen == last {
+			return
+		}
+		last = screen
+		time.Sleep(screenSettleInterval)
+	}
+	log.Printf("session-send: session %s was still repainting after %s", id, screenSettleTimeout)
+}
+
 // EndSession kills a session's terminal and records it as terminated.
 //
 // The handler used to be the only way to end one, so the scheduler — which ends
@@ -227,6 +272,9 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 	// `claude --resume -p`, which costs a fresh process per message and leaves
 	// nothing for the user to attach to afterwards.
 	resumed := false
+	// Whether this prompt is going at an agent that is still coming up, which
+	// is the case both timeouts below have to be generous about.
+	booting := false
 	if !live {
 		waker, ok := sh.Backend.(backend.Waker)
 		if !ok {
@@ -255,6 +303,7 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 			return PromptResult{Resumed: true}, statusError(http.StatusGatewayTimeout,
 				"the session is still starting up")
 		}
+		booting = resumed
 	} else if session.Status == "starting" {
 		// A launched session has the same gap as a woken one: StartSession
 		// returns as soon as the terminal is up, and "starting" means no
@@ -266,6 +315,14 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 		if err := sh.awaitAgent(id); err != nil {
 			return PromptResult{}, err
 		}
+		booting = true
+	}
+
+	// The hook says the agent process is alive. It does not say the terminal is
+	// being read, and the gap between the two is where a prompt is lost rather
+	// than merely late.
+	if booting {
+		sh.awaitQuietScreen(id)
 	}
 
 	// Likewise subscribed before typing. The agent's own hook is the only
@@ -278,7 +335,11 @@ func (sh *Shared) SendPrompt(id, message string) (PromptResult, error) {
 		return PromptResult{Resumed: resumed}, statusError(http.StatusInternalServerError, "failed to send: %v", err)
 	}
 
-	if !ack.Wait(promptAckTimeout) {
+	budget := promptAckTimeout
+	if booting {
+		budget = bootPromptAckTimeout
+	}
+	if !ack.Wait(budget) {
 		// No retype: the prompt may yet be sitting in a dialog or a composer,
 		// and a second copy would be a second turn. The session stays idle,
 		// which is what it looks like from here, and the caller can retry.

--- a/internal/server/send_test.go
+++ b/internal/server/send_test.go
@@ -25,6 +25,36 @@ type sendBackend struct {
 	sent   []string
 	onWake func()
 	onSend func()
+	// screens is what Capture hands back, one per call, holding on the last.
+	// A TUI painting itself is a run of different screens followed by one that
+	// stops changing, and that is all awaitQuietScreen reads.
+	screens []string
+	screen  string
+}
+
+// Capture answers with the next queued screen, and keeps answering with the
+// last one once they run out. Driven by the call rather than by a clock, so a
+// test of the settle does not depend on how fast this machine sleeps.
+func (b *sendBackend) Capture(sessionID string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.screens) > 0 {
+		b.screen = b.screens[0]
+		b.screens = b.screens[1:]
+	}
+	return b.screen, nil
+}
+
+func (b *sendBackend) queueScreens(screens ...string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.screens = append(b.screens, screens...)
+}
+
+func (b *sendBackend) framesLeft() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.screens)
 }
 
 func (b *sendBackend) Wake(sessionID, cwd string) (bool, error) {
@@ -76,9 +106,20 @@ func (b *sendBackend) wakeCount() int {
 func newSendTest(t *testing.T) (*PublicServer, *Shared, *sendBackend) {
 	t.Helper()
 
-	boot, ack := agentBootTimeout, promptAckTimeout
+	boot, ack, bootAck := agentBootTimeout, promptAckTimeout, bootPromptAckTimeout
 	agentBootTimeout, promptAckTimeout = 300*time.Millisecond, 300*time.Millisecond
-	t.Cleanup(func() { agentBootTimeout, promptAckTimeout = boot, ack })
+	bootPromptAckTimeout = 300 * time.Millisecond
+	t.Cleanup(func() {
+		agentBootTimeout, promptAckTimeout, bootPromptAckTimeout = boot, ack, bootAck
+	})
+
+	interval, settle, blank := screenSettleInterval, screenSettleTimeout, screenBlankGrace
+	screenSettleInterval = 5 * time.Millisecond
+	screenSettleTimeout = 300 * time.Millisecond
+	screenBlankGrace = 20 * time.Millisecond
+	t.Cleanup(func() {
+		screenSettleInterval, screenSettleTimeout, screenBlankGrace = interval, settle, blank
+	})
 
 	db, err := store.Open(":memory:")
 	if err != nil {
@@ -346,6 +387,67 @@ func TestSend_NewSessionTypesOnlyAfterTheAgentIsUp(t *testing.T) {
 	}
 	if !be.wokenNone() {
 		t.Error("a live session was woken, and waking one kills the terminal it already has")
+	}
+}
+
+// Reporting in is not the same as reading the terminal. The ready hook comes
+// from the agent process, which is up well before its TUI has claimed the
+// terminal, and the raw-mode switch that claim performs discards whatever is
+// sitting in the input buffer. A prompt typed into that window is not late —
+// it is gone, with no error and a session left looking idle because nothing
+// was ever asked of it. So the screen has to stop moving first.
+func TestSend_NewSessionTypesOnlyAfterTheScreenSettles(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "starting")
+	be.handles["sess-1"] = "sock-sess-1"
+	be.queueScreens("booting", "loading mcp servers", "welcome", "welcome  > ")
+
+	// The status is written before the signal, so the wait ends whichever side
+	// of the subscribe this lands on.
+	go func() {
+		shared.DB.UpdateSessionStatus("sess-1", "idle", "SessionStart")
+		shared.Signals.Fire(SignalAgentReady, "sess-1")
+	}()
+
+	var mu sync.Mutex
+	stillPainting := false
+	be.onSend = func() {
+		mu.Lock()
+		stillPainting = be.framesLeft() > 0
+		mu.Unlock()
+		shared.Signals.Fire(SignalPromptSubmitted, "sess-1")
+	}
+
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if stillPainting {
+		t.Error("prompt was typed while the agent was still painting its screen")
+	}
+}
+
+// A backend with no mirror to read answers blank forever. Waiting the whole
+// settle out on one buys nothing and costs every send that goes through it.
+func TestSend_BlankScreenDoesNotHoldTheSend(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	// Cold, so the wake path runs and the send counts as one at a booting
+	// agent. The stub never paints, which is what a backend with no mirror
+	// behind it looks like.
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	be.onWake = func() { shared.Signals.Fire(SignalAgentReady, "sess-1") }
+	be.onSend = func() { shared.Signals.Fire(SignalPromptSubmitted, "sess-1") }
+
+	start := time.Now()
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	if waited := time.Since(start); waited >= screenSettleTimeout {
+		t.Errorf("waited %s on a screen that was never going to say anything", waited)
 	}
 }
 

--- a/internal/server/send_test.go
+++ b/internal/server/send_test.go
@@ -429,6 +429,52 @@ func TestSend_NewSessionTypesOnlyAfterTheScreenSettles(t *testing.T) {
 	}
 }
 
+// A trust dialog is as motionless as a composer, so the settle alone would
+// call it ready and type into it — and the agent behind one is reading a menu
+// selection, not prose, so the prompt would answer the dialog rather than
+// queue behind it. Codex makes this the ordinary case: a fresh install shows
+// directory trust and then hook trust before it reads anything at all.
+func TestSend_TrustDialogIsRefusedRatherThanTypedInto(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	be.onWake = func() { shared.Signals.Fire(SignalAgentReady, "sess-1") }
+	// Codex's own wording, and a screen that holds still the way a modal does.
+	be.queueScreens(
+		"codex starting",
+		"Do you trust the contents of this directory?\n  1. Yes, continue    2. No, quit",
+	)
+
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d (%s), want 409", rec.Code, rec.Body.String())
+	}
+	if got := be.sentTexts(); len(got) != 0 {
+		t.Errorf("typed %q into a session sitting on its trust dialog", got)
+	}
+}
+
+// The hook-trust dialog is the second of the two, and used to be the one that
+// went unnoticed. It has to block a send for the same reason the first does.
+func TestSend_HookTrustDialogAlsoBlocks(t *testing.T) {
+	s, shared, be := newSendTest(t)
+	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	be.onWake = func() { shared.Signals.Fire(SignalAgentReady, "sess-1") }
+	be.queueScreens(
+		"codex starting",
+		"11 hooks are new or changed.\n  1. Review hooks   2. Trust all and continue",
+	)
+
+	rec, _ := sendPrompt(t, s, "sess-1", "hello")
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d (%s), want 409", rec.Code, rec.Body.String())
+	}
+	if got := be.sentTexts(); len(got) != 0 {
+		t.Errorf("typed %q into a session sitting on its hook-trust dialog", got)
+	}
+}
+
 // A backend with no mirror to read answers blank forever. Waiting the whole
 // settle out on one buys nothing and costs every send that goes through it.
 func TestSend_BlankScreenDoesNotHoldTheSend(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -219,6 +219,7 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 	// Before the /api/groups/ catch-all, which would take "order" for a key.
 	protectedMux.HandleFunc("POST /api/groups/order", s.handleSetGroupOrder)
 	protectedMux.HandleFunc("/api/groups/{key}", s.handleGroup)
+	protectedMux.HandleFunc("POST /api/uploads", s.handleUpload)
 	protectedMux.HandleFunc("GET /api/files", s.handleListFiles)
 	protectedMux.HandleFunc("GET /api/files/search", s.handleSearchFiles)
 	protectedMux.HandleFunc("GET /api/files/grep", s.handleGrepFiles)
@@ -282,8 +283,6 @@ func NewPublicServer(bind string, port int, shared *Shared) *PublicServer {
 			s.handleSessionTouch(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/send"):
 			s.handleSessionSend(w, r)
-		case r.Method == "POST" && strings.HasSuffix(path, "/files"):
-			s.handleSessionUpload(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/stop"):
 			s.handleSessionStop(w, r)
 		case r.Method == "POST" && strings.HasSuffix(path, "/terminate"):

--- a/internal/server/uploads.go
+++ b/internal/server/uploads.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
@@ -8,7 +10,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -27,33 +31,40 @@ type uploadedFile struct {
 	Size int64  `json:"size"`
 }
 
-// uploadDir is where a session's attachments live: beside the database and the
-// logs, not in the workspace. A repository is the user's, and dropping files
-// into it to hand the agent a screenshot would show up in their next diff.
-func uploadDir(sessionID string) (string, error) {
+// uploadDir is where attachments live: beside the database and the logs, not
+// in the workspace. A repository is the user's, and dropping files into it to
+// hand the agent a screenshot would show up in their next diff.
+//
+// One directory for all of them. It used to be one per session, and that is
+// the only reason an upload ever needed a session to belong to — see
+// handleUpload for what needing one cost.
+func uploadDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".helios", "uploads", sessionID), nil
+	return filepath.Join(home, ".helios", "uploads"), nil
 }
 
-// handleSessionUpload takes multipart form files and writes them to the
-// session's upload directory, answering with the absolute path of each.
+// handleUpload takes multipart form files, writes them beside the database and
+// answers with the absolute path of each.
 //
 // The path is the point: the client puts it in the prompt and the agent opens
 // it with Read, so nothing about the bytes has to cross the model's context to
 // get there.
-func (s *PublicServer) handleSessionUpload(w http.ResponseWriter, r *http.Request) {
-	id := extractSessionID(r.URL.Path, "/files")
-	if id == "" {
-		jsonError(w, "missing session id", http.StatusBadRequest)
-		return
-	}
-
-	session, err := s.shared.DB.GetSession(id)
-	if err != nil || session == nil {
-		jsonError(w, "session not found", http.StatusNotFound)
+//
+// No session is involved, and that absence is the feature. Attachments were
+// once filed under the session id, so an upload could not happen until a
+// session existed — which forced the new-session composer to launch its agent
+// first and type the prompt naming the files at it afterwards, into the
+// seconds where the agent has reported in but its TUI has not yet claimed the
+// terminal. Prompts are lost in that window, and both agents put a trust
+// dialog in it as well. Without an id the paths exist before the launch, so
+// the prompt naming them is the one the agent starts with.
+func (s *PublicServer) handleUpload(w http.ResponseWriter, r *http.Request) {
+	dir, err := uploadDir()
+	if err != nil {
+		jsonError(w, "no home directory to store uploads in", http.StatusInternalServerError)
 		return
 	}
 
@@ -80,12 +91,7 @@ func (s *PublicServer) handleSessionUpload(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	dir, err := uploadDir(id)
-	if err != nil {
-		jsonError(w, "no home directory to store uploads in", http.StatusInternalServerError)
-		return
-	}
-	// 0700: an attachment is as private as the session it belongs to.
+	// 0700: an attachment is as private as the session it was meant for.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		jsonError(w, "failed to create upload directory", http.StatusInternalServerError)
 		return
@@ -95,14 +101,14 @@ func (s *PublicServer) handleSessionUpload(w http.ResponseWriter, r *http.Reques
 	for _, header := range headers {
 		file, err := storeUpload(dir, header)
 		if err != nil {
-			log.Printf("session-upload: session=%s file=%q: %v", id, header.Filename, err)
+			log.Printf("upload: file=%q: %v", header.Filename, err)
 			jsonError(w, fmt.Sprintf("failed to store %s", safeName(header.Filename)), http.StatusInternalServerError)
 			return
 		}
 		saved = append(saved, file)
 	}
 
-	log.Printf("session-upload: session=%s stored %d file(s) in %s", id, len(saved), dir)
+	log.Printf("upload: stored %d file(s) in %s", len(saved), dir)
 	jsonResponse(w, http.StatusOK, map[string]interface{}{"files": saved})
 }
 
@@ -113,7 +119,7 @@ func storeUpload(dir string, header *multipart.FileHeader) (uploadedFile, error)
 	}
 	defer src.Close()
 
-	path := uniquePath(dir, safeName(header.Filename))
+	path := uniquePath(dir, storedName(header.Filename))
 	dst, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return uploadedFile{}, err
@@ -129,6 +135,32 @@ func storeUpload(dir string, header *multipart.FileHeader) (uploadedFile, error)
 	}
 
 	return uploadedFile{Name: filepath.Base(path), Path: path, Size: size}, nil
+}
+
+// storedName is what a part is written as: a random prefix, then the name the
+// user knows the file by.
+//
+// The prefix is what replaced the per-session directory. Two screenshots are
+// both called Screenshot.png and neither may overwrite the other — the first
+// one's path is already in a prompt by the time the second arrives — and a
+// directory per session used to be what promised that. In one flat directory
+// the name has to promise it itself.
+//
+// Six bytes: wide enough that nothing collides, short enough to leave the real
+// name legible in the line of prose the agent reads the path out of.
+func storedName(filename string) string {
+	return uploadPrefix() + "-" + safeName(filename)
+}
+
+func uploadPrefix() string {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		// Not observed, and not worth failing an upload over: the clock still
+		// separates two files better than a fixed string would, and uniquePath
+		// below is the backstop either way.
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(buf)
 }
 
 // safeName reduces whatever the client sent to a single filename. The name

--- a/internal/server/uploads_test.go
+++ b/internal/server/uploads_test.go
@@ -36,7 +36,7 @@ type part struct {
 	content string
 }
 
-func upload(t *testing.T, s *PublicServer, sessionID string, parts ...part) (*httptest.ResponseRecorder, map[string]interface{}) {
+func upload(t *testing.T, s *PublicServer, parts ...part) (*httptest.ResponseRecorder, map[string]interface{}) {
 	t.Helper()
 
 	var body bytes.Buffer
@@ -52,11 +52,11 @@ func upload(t *testing.T, s *PublicServer, sessionID string, parts ...part) (*ht
 	}
 	form.Close()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+sessionID+"/files", &body)
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads", &body)
 	req.Header.Set("Content-Type", form.FormDataContentType())
 	rec := httptest.NewRecorder()
 
-	s.handleSessionUpload(rec, req)
+	s.handleUpload(rec, req)
 
 	var payload map[string]interface{}
 	if rec.Body.Len() > 0 {
@@ -87,10 +87,9 @@ func uploadedPaths(t *testing.T, payload map[string]interface{}) []string {
 // The path in the response is the whole feature: the client pastes it into a
 // prompt, so it has to be absolute and it has to hold the bytes that were sent.
 func TestUpload_StoresTheFileAndReturnsItsPath(t *testing.T) {
-	s, shared, home := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, home := newUploadTest(t)
 
-	rec, payload := upload(t, s, "sess-1", part{name: "diagram.png", content: "not really a png"})
+	rec, payload := upload(t, s, part{name: "diagram.png", content: "not really a png"})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200 (%s)", rec.Code, rec.Body.String())
 	}
@@ -100,9 +99,14 @@ func TestUpload_StoresTheFileAndReturnsItsPath(t *testing.T) {
 		t.Fatalf("files: got %d, want 1", len(paths))
 	}
 
-	want := filepath.Join(home, ".helios", "uploads", "sess-1", "diagram.png")
-	if paths[0] != want {
-		t.Errorf("path: got %q, want %q", paths[0], want)
+	dir := filepath.Join(home, ".helios", "uploads")
+	if got := filepath.Dir(paths[0]); got != dir {
+		t.Errorf("directory: got %q, want %q", got, dir)
+	}
+	// Prefixed, but the name the user knows the file by survives on the end of
+	// it: the agent reads this path out of a line of prose.
+	if got := filepath.Base(paths[0]); !strings.HasSuffix(got, "-diagram.png") {
+		t.Errorf("name: got %q, want something ending -diagram.png", got)
 	}
 	content, err := os.ReadFile(paths[0])
 	if err != nil {
@@ -116,13 +120,12 @@ func TestUpload_StoresTheFileAndReturnsItsPath(t *testing.T) {
 // The filename arrives from a remote client, so a path inside it is either a
 // browser quirk or an attempt to write somewhere it should not.
 func TestUpload_FilenameCannotEscapeTheUploadDirectory(t *testing.T) {
-	s, shared, home := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, home := newUploadTest(t)
 
-	_, payload := upload(t, s, "sess-1", part{name: "../../../etc/passwd", content: "x"})
+	_, payload := upload(t, s, part{name: "../../../etc/passwd", content: "x"})
 	paths := uploadedPaths(t, payload)
 
-	dir := filepath.Join(home, ".helios", "uploads", "sess-1")
+	dir := filepath.Join(home, ".helios", "uploads")
 	if filepath.Dir(paths[0]) != dir {
 		t.Errorf("escaped the upload directory: %q", paths[0])
 	}
@@ -134,46 +137,68 @@ func TestUpload_FilenameCannotEscapeTheUploadDirectory(t *testing.T) {
 // The path is handed to the agent in a line of prose, and a macOS screenshot
 // is named in four words that read as part of the sentence.
 func TestUpload_SpacesInTheNameAreNotKept(t *testing.T) {
-	s, shared, home := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, _ := newUploadTest(t)
 
-	_, payload := upload(t, s, "sess-1", part{name: "Screenshot 2026-08-15 at 2.33.50 PM.png", content: "x"})
+	_, payload := upload(t, s, part{name: "Screenshot 2026-08-15 at 2.33.50 PM.png", content: "x"})
 	paths := uploadedPaths(t, payload)
 
-	want := filepath.Join(home, ".helios", "uploads", "sess-1", "Screenshot-2026-08-15-at-2.33.50-PM.png")
-	if paths[0] != want {
-		t.Errorf("path: got %q, want %q", paths[0], want)
+	if got := filepath.Base(paths[0]); !strings.HasSuffix(got, "-Screenshot-2026-08-15-at-2.33.50-PM.png") {
+		t.Errorf("name: got %q, still carries spaces or lost the name", got)
+	}
+	if strings.Contains(paths[0], " ") {
+		t.Errorf("path still has a space in it: %q", paths[0])
 	}
 }
 
 // Two screenshots are both called Screenshot.png. Neither may overwrite the
-// other: the first one's path is already in a prompt by then.
+// other: the first one's path is already in a prompt by then. A directory per
+// session used to be what promised that; in one flat directory the random
+// prefix is all there is, so this is the test of it.
 func TestUpload_SameNameTwiceKeepsBothFiles(t *testing.T) {
-	s, shared, _ := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, _ := newUploadTest(t)
 
-	_, first := upload(t, s, "sess-1", part{name: "shot.png", content: "one"})
-	_, second := upload(t, s, "sess-1", part{name: "shot.png", content: "two"})
+	_, first := upload(t, s, part{name: "shot.png", content: "one"})
+	_, second := upload(t, s, part{name: "shot.png", content: "two"})
 
 	firstPath, secondPath := uploadedPaths(t, first)[0], uploadedPaths(t, second)[0]
 	if firstPath == secondPath {
 		t.Fatalf("second upload reused the path %q", firstPath)
 	}
-	if got := filepath.Base(secondPath); got != "shot-1.png" {
-		t.Errorf("second name: got %q, want shot-1.png", got)
+	for _, path := range []string{firstPath, secondPath} {
+		if !strings.HasSuffix(path, "-shot.png") {
+			t.Errorf("name: got %q, want something ending -shot.png", path)
+		}
 	}
 
 	content, err := os.ReadFile(firstPath)
 	if err != nil || string(content) != "one" {
 		t.Errorf("first file was overwritten: %q, %v", content, err)
 	}
+	if content, err := os.ReadFile(secondPath); err != nil || string(content) != "two" {
+		t.Errorf("second file is wrong: %q, %v", content, err)
+	}
+}
+
+// The prefix is the only thing keeping two files apart, so it has to actually
+// differ. A hundred of the same name is a cheap way to notice a constant.
+func TestUpload_PrefixIsDifferentEveryTime(t *testing.T) {
+	s, _, _ := newUploadTest(t)
+
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		_, payload := upload(t, s, part{name: "shot.png", content: "x"})
+		name := filepath.Base(uploadedPaths(t, payload)[0])
+		if seen[name] {
+			t.Fatalf("name %q came back twice", name)
+		}
+		seen[name] = true
+	}
 }
 
 func TestUpload_SeveralFilesInOneRequest(t *testing.T) {
-	s, shared, _ := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, _ := newUploadTest(t)
 
-	_, payload := upload(t, s, "sess-1",
+	_, payload := upload(t, s,
 		part{name: "a.txt", content: "a"},
 		part{name: "b.txt", content: "b"},
 	)
@@ -182,23 +207,10 @@ func TestUpload_SeveralFilesInOneRequest(t *testing.T) {
 	}
 }
 
-func TestUpload_UnknownSessionIsRejected(t *testing.T) {
-	s, _, home := newUploadTest(t)
-
-	rec, _ := upload(t, s, "nope", part{name: "a.txt", content: "a"})
-	if rec.Code != http.StatusNotFound {
-		t.Errorf("status: got %d, want 404", rec.Code)
-	}
-	if _, err := os.Stat(filepath.Join(home, ".helios", "uploads", "nope")); !os.IsNotExist(err) {
-		t.Errorf("created a directory for a session that does not exist")
-	}
-}
-
 func TestUpload_RequestWithoutFilesIsRejected(t *testing.T) {
-	s, shared, _ := newUploadTest(t)
-	seedSessionWithStatus(t, shared.DB, "sess-1", "idle")
+	s, _, _ := newUploadTest(t)
 
-	rec, _ := upload(t, s, "sess-1")
+	rec, _ := upload(t, s)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", rec.Code)
 	}

--- a/mobile/lib/screens/session_detail_screen.dart
+++ b/mobile/lib/screens/session_detail_screen.dart
@@ -367,13 +367,11 @@ class _SessionDetailScreenState extends rp.ConsumerState<SessionDetailScreen>
     // Upload first. A prompt naming a path the daemon never stored sends the
     // agent looking for a file that is not there. Only what has not been
     // stored yet: the send below may have failed once already, and uploading
-    // the same bytes again would leave a numbered copy behind per attempt.
+    // the same bytes again would leave a second copy behind per attempt.
     var message = text;
     final pending = _attachments.where((f) => f.storedPath == null).toList();
     if (pending.isNotEmpty) {
-      final paths = sse == null
-          ? null
-          : await sse.uploadSessionFiles(widget.session.sessionId, pending);
+      final paths = sse == null ? null : await sse.uploadFiles(pending);
       if (paths == null || paths.length != pending.length) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/lib/services/daemon_api_service.dart
+++ b/mobile/lib/services/daemon_api_service.dart
@@ -653,20 +653,18 @@ class DaemonAPIService extends ChangeNotifier {
   /// opens them with its own tools. Returns null when the upload failed, which
   /// the caller reports rather than sending a prompt naming files that are not
   /// there.
-  Future<List<String>?> uploadSessionFiles(
-    String sessionId,
-    List<UploadFile> files,
-  ) async {
+  ///
+  /// No session id. Attachments were once filed under one, which meant they
+  /// could not be uploaded until a session existed — and that is what forced
+  /// the desktop's new-session composer to launch its agent before it could
+  /// upload, and prompt it afterwards. The daemon keeps uploads apart with a
+  /// random prefix on the name instead.
+  Future<List<String>?> uploadFiles(List<UploadFile> files) async {
     if (files.isEmpty) return const [];
     try {
-      final resp = await _api.postFiles(
-        '/api/sessions/$sessionId/files',
-        files,
-      );
+      final resp = await _api.postFiles('/api/uploads', files);
       if (resp.statusCode != 200) {
-        debugPrint(
-          '[$hostId] uploadSessionFiles: ${resp.statusCode} ${resp.body}',
-        );
+        debugPrint('[$hostId] uploadFiles: ${resp.statusCode} ${resp.body}');
         return null;
       }
       final data = jsonDecode(resp.body);


### PR DESCRIPTION
Attaching a file to a new session did not work. Two sessions started that way this afternoon; the daemon log has both.

```
14:52:52 session-upload: session=9fc0ed46 stored 1 file(s)
14:52:52 session-send:   session=9fc0ed46 status=starting live=true
14:52:54 hook: received claude.session.start
14:53:01 session-send:   session 9fc0ed46 never acknowledged the prompt   ← 504 to the app
14:53:08 hook: received claude.prompt.submit                              ← it landed, 14s in
```

## Why

An upload needs a session to belong to, and the id comes from the create — so the prompt naming the files cannot be the one the agent launches with. The session starts silent and is prompted a moment later, which puts that prompt in the hardest window there is.

Two separate failures were wearing the same message:

- **The prompt was late, and the timeout lied.** The send above worked. `promptAckTimeout` was 8s, the agent took 14s to read it, and the app was told the send had failed while the turn it started ran on.
- **The prompt was lost.** The next session never submitted anything. `SessionStart` comes from the agent *process*, which is up well before its TUI has claimed the terminal, and the raw-mode switch that claim performs discards whatever is in the input buffer. `awaitAgent` waits for the wrong event.

## The fix

`awaitQuietScreen` reads the mirror the daemon already keeps for every session and waits for two identical captures before anything is typed. A booting TUI repaints continuously; a screen that has stopped moving is one being read. Blank does not count as settled — that is precisely the pre-paint moment — but it is not waited on forever either, so a backend with no mirror gives up after a grace and types as it did before.

The ack budget then goes to 30s for a session that is starting or has just woken, which is what a boot was measured to cost.

Both new tests fail without the change. The settle test drives the screen from the capture itself rather than from a clock, so it does not depend on how fast the machine sleeps.

## Also in here

The dialog's foot had become where every control went that had nowhere else to be.

| | Before | After |
|---|---|---|
| Attach | Beside Cancel and Create, reading as a third action on the dialog | A ⊕ floating over the prompt box, as the transcript composer already does it |
| Chips | Permissions wrapped onto a line of its own | Provider, model and permissions on one row |

A paperclip beside a running session means "add to this turn"; there is no turn here yet, so it takes a plus.

Dropping a file on the prompt box is now pinned by a test. It already worked — the handlers are on the shell and catch the drop on the way up — but a textarea has drop behaviour of its own, and nothing said so.

## Checks

- `go test ./internal/...` — pass
- `npm test` (283) and `tsc --noEmit` — pass
- `playwright test` (59, under xvfb) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)