### PR TITLE
fix(desktop): highlight selected notification options

### DIFF
--- a/desktop/src/renderer/components/notification-card.tsx
+++ b/desktop/src/renderer/components/notification-card.tsx
@@ -367,11 +367,17 @@ function QuestionCard({
             <button
               key={optionIndex}
               className={`option ${(chosen[questionIndex] ?? []).includes(optionIndex) ? 'chosen' : ''}`}
+              aria-pressed={(chosen[questionIndex] ?? []).includes(optionIndex)}
               onClick={() => pick(question, questionIndex, optionIndex)}
             >
               <span className="option-label">
-                {question.multiSelect &&
-                  ((chosen[questionIndex] ?? []).includes(optionIndex) ? '☑ ' : '☐ ')}
+                {question.multiSelect
+                  ? (chosen[questionIndex] ?? []).includes(optionIndex)
+                    ? '☑ '
+                    : '☐ '
+                  : (chosen[questionIndex] ?? []).includes(optionIndex)
+                    ? '◉ '
+                    : '○ '}
                 {option.label}
               </span>
               {option.description && <span className="option-desc">{option.description}</span>}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2716,6 +2716,7 @@ figure.mermaid svg {
   padding: 10px 14px;
   border-radius: var(--r-sm);
   background: var(--surface-high);
+  border: 1px solid transparent;
   color: var(--on-surface);
   font-weight: 500;
 }
@@ -2726,7 +2727,12 @@ figure.mermaid svg {
 
 .option.chosen {
   background: var(--primary-container);
+  border-color: var(--primary);
   color: var(--on-primary-container);
+}
+
+.option.chosen:hover {
+  background: var(--primary-container);
 }
 
 .option-desc {


### PR DESCRIPTION
## Summary

- show radio markers for single-select notification answers
- keep selected rows visibly highlighted across hover and custom themes
- expose selection through `aria-pressed`

## Verification

- `npm run typecheck`
- `npm test` (283 tests)