### PR TITLE
fix: stop a Codex web search failing its PostToolUse hook

### DIFF
--- a/internal/provider/codex/codex_test.go
+++ b/internal/provider/codex/codex_test.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -706,6 +707,46 @@ func TestToolPostPokesTheFileWatcher(t *testing.T) {
 
 			if pokes != 1 {
 				t.Errorf("poked %d times, want 1", pokes)
+			}
+		})
+	}
+}
+
+// A tool_response is shaped by the tool, not by Codex. Decoding it as a string
+// turned every search into a failed PostToolUse hook.
+func TestToolPostAcceptsAnyToolResponseShape(t *testing.T) {
+	db, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	responses := map[string]interface{}{
+		"string": "ok",
+		"object": map[string]interface{}{"results": []string{"a", "b"}},
+		"array":  []interface{}{map[string]string{"url": "a"}},
+		"null":   nil,
+	}
+	for name, response := range responses {
+		t.Run(name, func(t *testing.T) {
+			ctx := &provider.HookContext{
+				DB:             db,
+				Mgr:            notifications.NewManager(db),
+				Notify:         func(string, interface{}) {},
+				Report:         func(provider.ReportEvent) {},
+				SessionStarted: func(string) {},
+			}
+			body, _ := json.Marshal(map[string]interface{}{
+				"session_id":    "01a04dee-183a-7461-9bef-5f05c0aa510a",
+				"cwd":           "/tmp",
+				"tool_name":     "web_search",
+				"tool_response": response,
+			})
+			w := httptest.NewRecorder()
+			handleToolPost(ctx, w, httptest.NewRequest("POST", "/hooks/codex/tool/post", nil), body)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status %d, want 200 (body %q)", w.Code, w.Body.String())
 			}
 		})
 	}

--- a/internal/provider/codex/hooks.go
+++ b/internal/provider/codex/hooks.go
@@ -36,10 +36,14 @@ type hookInput struct {
 	ToolName       string          `json:"tool_name,omitempty"`
 	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
 	ToolUseID      string          `json:"tool_use_id,omitempty"`
-	ToolResponse   string          `json:"tool_response,omitempty"`
-	Trigger        string          `json:"trigger,omitempty"` // PreCompact/PostCompact
-	AgentID        string          `json:"agent_id,omitempty"`
-	AgentType      string          `json:"agent_type,omitempty"`
+	// ToolResponse is raw because its shape is the tool's, not Codex's: shell
+	// returns a string, web_search an object. Decoding it as a string made
+	// every PostToolUse after a search a failed hook — curl -f saw the 400 and
+	// exited 22 — for a field nothing reads.
+	ToolResponse json.RawMessage `json:"tool_response,omitempty"`
+	Trigger      string          `json:"trigger,omitempty"` // PreCompact/PostCompact
+	AgentID      string          `json:"agent_id,omitempty"`
+	AgentType    string          `json:"agent_type,omitempty"`
 	// Stop
 	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
 	StopHookActive       bool   `json:"stop_hook_active,omitempty"`


### PR DESCRIPTION
## What was happening

A Codex session that ran a web search showed this after every single search:

```
PostToolUse hook (failed)
error: hook exited with code 22
```

Helios installs its Codex hooks as curl commands in `~/.codex/hooks.json`:

```
cat | curl -sS -f -X POST ... http://localhost:7654/hooks/codex/tool/post
```

`curl -f` exits **22** on any HTTP >= 400, so the failing hook was the daemon
turning its own request away.

## Why

`tool_response` is shaped by the tool, not by Codex. `shell` and `read` return a
string; `web_search` returns an object. `hookInput` declared the field as a
`string`, so `json.Unmarshal` failed, `decode` wrote `400 invalid request body`,
and curl exited 22 — which is exactly why the failures landed after searches and
nowhere else.

The field is never read anywhere in the codebase. The whole failure was decoding
a value nothing uses.

Reproduced against a running daemon before the fix:

```
tool_response: {"results":[...]}  -> curl: (22) HTTP 400
tool_response: "ok"               -> {} exit=0
```

## The fix

Decode it as `json.RawMessage`, which accepts whatever the tool sends.

Nothing was lost while this was broken — PostToolUse fires after the tool has
already run, so the damage was the noise plus the status ticks Codex missed.

## Test

`TestToolPostAcceptsAnyToolResponseShape` covers string, object, array and null.
It fails on `main` for the object and array cases and passes here.