### PR TITLE
fix(desktop): give an unhovered session row its title back

### DIFF
--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1203,15 +1203,11 @@ function SessionRow({
           </span>
         )}
         {/* Two shapes for two situations. A live or cold session offers an icon
-            that is already in the row before the pointer arrives and only fades
-            in — a button that appears into the layout re-measures the title
-            under the cursor, and a list that reflows as the pointer crosses it
-            is what makes hovering feel jarring. A terminated one gets the word,
+            that opens out of nothing under the pointer, so an unhovered row
+            spends its whole width on the title. A terminated one gets the word,
             because resuming is the only move it has left and it should not have
             to be hovered to say so. */}
-        {/* Held in the row like the action beside it, so the title does not
-            shift when the pointer arrives. Hidden while the field is up: it
-            opens what is already open. */}
+        {/* Hidden while the field is up: it opens what is already open. */}
         {!editing && (
           <button
             className="row-act"

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1334,27 +1334,35 @@ small {
   font-size: 12px;
 }
 
-/* Held in the layout whether or not it is showing, and faded rather than
-   switched. A button that appears into the row pushes the title it is next to,
-   so the words move under the pointer that came to read them — which is what
-   made hovering feel jarring. Nothing in a row moves now; only the ink
-   changes. It also sets the row's height, and so the list's rhythm. */
+/* Collapsed to nothing until the pointer arrives, so the title reads across
+   the room three buttons were holding for a hover that had not happened. The
+   negative margin swallows .row-main's gap while the button is zero-wide;
+   width and opacity move together so the words slide rather than jump. Height
+   is kept at every width, since it sets the row's height and so the list's
+   rhythm. */
 .row-act {
   flex: none;
-  width: 22px;
+  width: 0;
   height: 22px;
+  margin-left: -8px;
   padding: 0;
   display: grid;
   place-items: center;
+  overflow: hidden;
   border-radius: 6px;
   color: var(--on-surface-variant);
   opacity: 0;
-  transition: opacity 120ms ease;
+  transition:
+    opacity 120ms ease,
+    width 120ms ease,
+    margin-left 120ms ease;
 }
 
 .session-row:hover .row-act,
 .session-row.selected .row-act,
 .row-act:focus-visible {
+  width: 22px;
+  margin-left: 0;
   opacity: 1;
 }
 
@@ -1433,8 +1441,13 @@ small {
 
 
 [data-density='compact'] .row-act {
-  width: 18px;
   height: 18px;
+}
+
+[data-density='compact'] .session-row:hover .row-act,
+[data-density='compact'] .session-row.selected .row-act,
+[data-density='compact'] .row-act:focus-visible {
+  width: 18px;
 }
 
 [data-density='compact'] .project {


### PR DESCRIPTION
## Summary
- Session row actions (rename, terminal, more) were held in the layout at full width and only faded on hover, so every row lost ~90px of title width to buttons that were not showing.
- They now collapse to zero width and expand on row hover, selection, or keyboard focus. A negative margin swallows `.row-main`'s 8px gap while collapsed; height is kept at every width so the row height and list rhythm never move.
- Compact density had `width: 18px` unconditionally, so it needed the same split between base and revealed state.

## Test plan
- [x] `npm run typecheck`
- [x] `npx playwright test session-state.spec.ts` — 3 passed
- [x] Measured in the real Electron app: title 292px unhovered → 202px hovered, row height 51.7px in both states