### PR TITLE
fix(desktop): tidy the session row's context menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,12 @@ DESKTOP_DMG = desktop/release/helios-desktop-$(DESKTOP_VERSION)-$(DESKTOP_ARCH).
 # electron-builder suffixes the staging directory with the arch, except on the
 # x64 build, where it is bare `mac`.
 DESKTOP_APP = desktop/release/$(if $(filter arm64,$(DESKTOP_ARCH)),mac-arm64,mac)/Helios.app
+# Where the app lands, matching HELIOS_APP_DIR in scripts/install.sh. The
+# default asks for no password: /Applications is group-writable by admin, which
+# is what an install without one relies on. A standard account is not in that
+# group, so point this at $(HOME)/Applications rather than reaching for sudo —
+# a bundle owned by root is one the next install cannot replace.
+APP_DIR ?= /Applications
 
 # make runs recipes under /bin/sh, which never sources a profile, so an nvm
 # install is invisible unless the parent shell already exported it.
@@ -266,19 +272,20 @@ endif
 desktop-install:
 	$(call build_release,desktop-install)
 
-## Package this checkout's desktop app and install it into /Applications (macOS)
+## Package this checkout's desktop app and install it into $(APP_DIR) (macOS)
 desktop-install-dev: desktop-app
 ifneq ($(UNAME_S),Darwin)
 	@echo "make desktop-install is macOS-only; on Linux install the AppImage or .deb from desktop/release" >&2
 	@exit 1
 else
 	@test -d "$(DESKTOP_APP)" || (echo "$(DESKTOP_APP) not found — see desktop/release" >&2 && exit 1)
+	@mkdir -p "$(APP_DIR)"
 	# Replaced rather than copied over: a copy leaves the previous build's files
 	# behind inside the bundle.
-	rm -rf /Applications/Helios.app
-	cp -R "$(DESKTOP_APP)" /Applications/Helios.app
-	xattr -dr com.apple.quarantine /Applications/Helios.app 2>/dev/null || true
-	@echo "Helios.app installed to /Applications"
+	rm -rf "$(APP_DIR)/Helios.app"
+	cp -R "$(DESKTOP_APP)" "$(APP_DIR)/Helios.app"
+	xattr -dr com.apple.quarantine "$(APP_DIR)/Helios.app" 2>/dev/null || true
+	@echo "Helios.app installed to $(APP_DIR)"
 endif
 
 desktop-clean:

--- a/desktop/src/renderer/components/session-menu.ts
+++ b/desktop/src/renderer/components/session-menu.ts
@@ -76,7 +76,7 @@ export function sessionActions(
 
   // One entry per group, ticked on the one this session is filed under.
   // Choosing another moves it; choosing the current one takes it out.
-  const actions: MenuAction[] = groups.map((group) => {
+  const filing: MenuAction[] = groups.map((group) => {
     const inside = held === group.key
     return {
       label: `${inside ? '✓ ' : '\u2003'}${group.name}`,
@@ -84,7 +84,7 @@ export function sessionActions(
     }
   })
 
-  actions.push({
+  filing.push({
     label: 'New group…',
     run: () => {
       const name = window.prompt('Name the group')?.trim()
@@ -94,6 +94,11 @@ export function sessionActions(
       })
     },
   })
+
+  // A child menu rather than the top of this one: a host with a dozen groups
+  // pushed the actions below it off the bottom, and every one of those entries
+  // is a place to file the session rather than a thing to do to it.
+  const actions: MenuAction[] = [{ label: 'Move to group', children: filing }]
 
   actions.push(
     {

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1203,15 +1203,11 @@ function SessionRow({
           </span>
         )}
         {/* Two shapes for two situations. A live or cold session offers an icon
-            that is already in the row before the pointer arrives and only fades
-            in — a button that appears into the layout re-measures the title
-            under the cursor, and a list that reflows as the pointer crosses it
-            is what makes hovering feel jarring. A terminated one gets the word,
+            that opens out of nothing under the pointer, so an unhovered row
+            spends its whole width on the title. A terminated one gets the word,
             because resuming is the only move it has left and it should not have
             to be hovered to say so. */}
-        {/* Held in the row like the action beside it, so the title does not
-            shift when the pointer arrives. Hidden while the field is up: it
-            opens what is already open. */}
+        {/* Hidden while the field is up: it opens what is already open. */}
         {!editing && (
           <button
             className="row-act"

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1334,27 +1334,35 @@ small {
   font-size: 12px;
 }
 
-/* Held in the layout whether or not it is showing, and faded rather than
-   switched. A button that appears into the row pushes the title it is next to,
-   so the words move under the pointer that came to read them — which is what
-   made hovering feel jarring. Nothing in a row moves now; only the ink
-   changes. It also sets the row's height, and so the list's rhythm. */
+/* Collapsed to nothing until the pointer arrives, so the title reads across
+   the room three buttons were holding for a hover that had not happened. The
+   negative margin swallows .row-main's gap while the button is zero-wide;
+   width and opacity move together so the words slide rather than jump. Height
+   is kept at every width, since it sets the row's height and so the list's
+   rhythm. */
 .row-act {
   flex: none;
-  width: 22px;
+  width: 0;
   height: 22px;
+  margin-left: -8px;
   padding: 0;
   display: grid;
   place-items: center;
+  overflow: hidden;
   border-radius: 6px;
   color: var(--on-surface-variant);
   opacity: 0;
-  transition: opacity 120ms ease;
+  transition:
+    opacity 120ms ease,
+    width 120ms ease,
+    margin-left 120ms ease;
 }
 
 .session-row:hover .row-act,
 .session-row.selected .row-act,
 .row-act:focus-visible {
+  width: 22px;
+  margin-left: 0;
   opacity: 1;
 }
 
@@ -1433,8 +1441,13 @@ small {
 
 
 [data-density='compact'] .row-act {
-  width: 18px;
   height: 18px;
+}
+
+[data-density='compact'] .session-row:hover .row-act,
+[data-density='compact'] .session-row.selected .row-act,
+[data-density='compact'] .row-act:focus-visible {
+  width: 18px;
 }
 
 [data-density='compact'] .project {


### PR DESCRIPTION
## Summary

- A session row's context menu listed every group on the host at the top, pushing Rename, Pin, Terminate and Delete off the bottom of the screen on a host with a dozen of them. Those entries all answer one question — where to file the session — so they move under a `Move to group ›` submenu together with `New group…`.
- An unhovered session row gets its title back (`54b1259`, already on this branch).
- `make desktop-install-dev` takes `APP_DIR`, defaulting to `/Applications`. The binary already honours `PREFIX` and `scripts/install.sh` already honours `HELIOS_APP_DIR`; make was the one installer with the path baked in, which makes `sudo` look like the only way out on an account outside the `admin` group. A bundle left owned by root is one the next install cannot replace.

## Test plan

- [x] `npm test` — 283 pass
- [x] `npm run e2e` — 54 pass, including `the tab strip menu offers exactly what the row does` and the two permission-mode submenu tests
- [x] `npx tsc --noEmit` clean
- [x] Menu read over CDP from a running build: top level is `Move to group ›`, `Rename`, `Regenerate title`, `Pin`, `Permission mode ›`, `Terminate`, `Delete`; the submenu opens on hover and on click, and stays on screen
- [x] `make -n desktop-install-dev APP_DIR=~/Applications` retargets; the default expansion is unchanged