### PR TITLE
feat(desktop): show the session workspace path on sidebar rows

### DIFF
--- a/desktop/e2e/sidebar.spec.ts
+++ b/desktop/e2e/sidebar.spec.ts
@@ -1,0 +1,61 @@
+// The session row in the sidebar, and the one control that ends the app.
+//
+// The row grew a line for the directory it runs in — mobile has always carried
+// it — and the parity that matters is the order: title, then path, then status,
+// the same three lines the phone shows. These rules live in a component, and
+// there is no component test framework here, so they are checked from the
+// running app.
+import type { Page } from '@playwright/test'
+
+import { REPO } from './daemon.ts'
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+function row(window: Page) {
+  return window.locator('.session-row', { hasText: ALPHA })
+}
+
+test.beforeEach(async ({ window }) => {
+  await expect(row(window)).toBeVisible()
+})
+
+test('a session row shows the directory it runs in, full path in the title', async ({ window }) => {
+  const path = row(window).locator('.row-cwd')
+  await expect(path).toBeVisible()
+  await expect(path).toHaveText(REPO)
+  // The visible text is shortened elsewhere; the title is always the whole path,
+  // which is what a hover is for.
+  await expect(path).toHaveAttribute('title', REPO)
+})
+
+test('the row reads title, then path, then status — the mobile order', async ({ window }) => {
+  const alpha = row(window)
+  const title = await alpha.locator('.row-title').boundingBox()
+  const path = await alpha.locator('.row-cwd').boundingBox()
+  const status = await alpha.locator('.row-status').boundingBox()
+
+  // By vertical position rather than DOM order, because the order the user reads
+  // is the one worth pinning: a later flex tweak could reorder them on screen
+  // without touching the markup.
+  expect(title && path && status).toBeTruthy()
+  expect(title!.y).toBeLessThan(path!.y)
+  expect(path!.y).toBeLessThan(status!.y)
+})
+
+test('Quit Helios asks before it quits, and Cancel backs out', async ({ window }) => {
+  // The footer's button, not the modal's — the modal has one of the same name,
+  // and it does not exist yet.
+  await window.locator('.sidebar-foot').getByRole('button', { name: 'Quit Helios' }).click()
+
+  const modal = window.locator('.modal')
+  await expect(modal).toBeVisible()
+  await expect(modal.locator('.modal-head h2')).toHaveText('Quit Helios?')
+
+  // Cancel, not confirm: confirming would call app.quit() and end the run.
+  await modal.getByRole('button', { name: 'Cancel' }).click()
+  await expect(modal).toHaveCount(0)
+
+  // The window is still here — nothing quit behind the dialog.
+  await expect(row(window)).toBeVisible()
+})

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -1292,6 +1292,19 @@ function SessionRow({
         <span className="row-time">{timeAgo(session.last_event_at ?? session.created_at)}</span>
       </div>
 
+      {/* Where the session lives, on a line of its own between the title and the
+          status the way the mobile cards order it. Shortened to its last two
+          segments — the leaf is the part that tells sessions apart, so the
+          leading directories give way to a "…/" and the full path waits in the
+          title. The sidebar groups by directory, but only when grouping is on;
+          the flat list and the manual tree both leave the row itself saying
+          nothing about where it runs. */}
+      {session.cwd && (
+        <div className="row-cwd" title={session.cwd}>
+          {shortCwd(session.cwd)}
+        </div>
+      )}
+
       {/* What the session is, under what it is called. Kept off the title's
           line so the title gets the whole width — a long one is the common
           case, and it was losing half its room to a trail of small print. */}
@@ -1320,18 +1333,6 @@ function SessionRow({
           </span>
         )}
       </div>
-
-      {/* Where the session lives, on a line of its own the way the mobile cards
-          carry it. Shortened to its last two segments — the leaf is the part
-          that tells sessions apart, so the leading directories give way to a
-          "…/" and the full path waits in the title. The sidebar groups by
-          directory, but only when grouping is on; the flat list and the manual
-          tree both leave the row itself saying nothing about where it runs. */}
-      {session.cwd && (
-        <div className="row-cwd" title={session.cwd}>
-          {shortCwd(session.cwd)}
-        </div>
-      )}
     </article>
   )
 }

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -37,6 +37,7 @@ import {
   type GroupNode,
 } from './grouping.ts'
 import { GroupPicker } from './group-picker.tsx'
+import { Modal } from './newsession.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 import { sessionActions } from './session-menu.ts'
@@ -233,6 +234,9 @@ export function Sidebar({
   // Which group header is being renamed in place, keyed the same way.
   const [renaming, setRenaming] = useState<string | null>(null)
   const [picker, setPicker] = useState(false)
+  // Quitting is the one control that ends the app rather than dropping it to
+  // the tray, so it asks first. Held here, not fired straight from the button.
+  const [confirmQuit, setConfirmQuit] = useState(false)
   const aside = useRef<HTMLElement | null>(null)
 
   // The width is a CSS variable rather than state: the value is read by the
@@ -938,11 +942,31 @@ export function Sidebar({
           </button>
         )}
         {/* Closing the window leaves the app on the tray so approvals keep
-            arriving; this is the one control that actually ends it. */}
-        <button className="link danger" onClick={() => void bridge.app.quit()}>
+            arriving; this is the one control that actually ends it, so it asks
+            before it does. */}
+        <button className="link danger" onClick={() => setConfirmQuit(true)}>
           Quit Helios
         </button>
       </footer>
+
+      {confirmQuit && (
+        <Modal title="Quit Helios?" onClose={() => setConfirmQuit(false)}>
+          <p className="pane-note">
+            Closing the window leaves Helios in the tray, where it keeps
+            delivering approvals. Quitting stops that — your sessions keep
+            running on their daemons, but this app will not surface anything
+            from them until you open it again.
+          </p>
+          <div className="pane-actions">
+            <button className="ghost" onClick={() => setConfirmQuit(false)}>
+              Cancel
+            </button>
+            <button className="danger" onClick={() => void bridge.app.quit()}>
+              Quit Helios
+            </button>
+          </div>
+        </Modal>
+      )}
 
       {menu && (
         <SelectionMenu

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -36,6 +36,7 @@ import {
   type GroupNode,
 } from './grouping.ts'
 import { GroupPicker } from './group-picker.tsx'
+import { PathLabel } from './path-label.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 import { sessionActions } from './session-menu.ts'
@@ -1288,7 +1289,18 @@ function SessionRow({
             {shortMode(session.permission_mode)}
           </span>
         )}
-        <span className="grow" />
+        {/* Where the session lives, filling the gap the memory reading is
+            pushed off the right of. The sidebar groups by directory, but only
+            when grouping is on and only down to the leaf — the flat list and
+            the manual tree both leave the row itself saying nothing about where
+            it runs. The mobile cards have always shown this; the pane's status
+            line shows it once a session is open. This is the same fact on the
+            row, so it need not be opened to be placed. */}
+        {session.cwd ? (
+          <PathLabel path={session.cwd} className="row-cwd" />
+        ) : (
+          <span className="grow" />
+        )}
         {session.memory_bytes !== undefined && (
           <span className="row-ram" title="Memory this terminal holds">
             {formatBytes(session.memory_bytes)}

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   isTerminated,
   needsRecovery,
   sessionLabel,
+  shortCwd,
   shortMode,
   shortModel,
   statusLabel,
@@ -36,7 +37,6 @@ import {
   type GroupNode,
 } from './grouping.ts'
 import { GroupPicker } from './group-picker.tsx'
-import { PathLabel } from './path-label.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 import { sessionActions } from './session-menu.ts'
@@ -1289,24 +1289,25 @@ function SessionRow({
             {shortMode(session.permission_mode)}
           </span>
         )}
-        {/* Where the session lives, filling the gap the memory reading is
-            pushed off the right of. The sidebar groups by directory, but only
-            when grouping is on and only down to the leaf — the flat list and
-            the manual tree both leave the row itself saying nothing about where
-            it runs. The mobile cards have always shown this; the pane's status
-            line shows it once a session is open. This is the same fact on the
-            row, so it need not be opened to be placed. */}
-        {session.cwd ? (
-          <PathLabel path={session.cwd} className="row-cwd" />
-        ) : (
-          <span className="grow" />
-        )}
+        <span className="grow" />
         {session.memory_bytes !== undefined && (
           <span className="row-ram" title="Memory this terminal holds">
             {formatBytes(session.memory_bytes)}
           </span>
         )}
       </div>
+
+      {/* Where the session lives, on a line of its own the way the mobile cards
+          carry it. Shortened to its last two segments — the leaf is the part
+          that tells sessions apart, so the leading directories give way to a
+          "…/" and the full path waits in the title. The sidebar groups by
+          directory, but only when grouping is on; the flat list and the manual
+          tree both leave the row itself saying nothing about where it runs. */}
+      {session.cwd && (
+        <div className="row-cwd" title={session.cwd}>
+          {shortCwd(session.cwd)}
+        </div>
+      )}
     </article>
   )
 }

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1306,18 +1306,20 @@ small {
   background: color-mix(in srgb, var(--on-surface) 9%, transparent);
 }
 
-/* Where the session runs, taking the free width the memory reading is pushed
-   off the right of. PathLabel is flex:1 already, so it fills the gap the old
-   spacer held and gives its leading directories up before the leaf — the same
-   split the status line spends. Monospace, like the model and mode beside it. */
+/* Where the session runs, on its own line under the status the way the mobile
+   cards carry it. Already shortened to "…/parent/leaf" by shortCwd, so it
+   rarely needs the ellipsis — but a long leaf still gives way rather than
+   widening the row. Monospace, like the model and mode above it and the mobile
+   cards it mirrors. */
 .row-cwd {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--on-surface-variant);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-/* The path a directory at a time, dimmer than the folder it leads to, so the
-   leaf reads first when the row is narrow enough to eat the rest. */
-.row-cwd .split-dir {
-  color: color-mix(in srgb, var(--on-surface-variant) 70%, transparent);
 }
 
 .row-ram {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1306,6 +1306,20 @@ small {
   background: color-mix(in srgb, var(--on-surface) 9%, transparent);
 }
 
+/* Where the session runs, taking the free width the memory reading is pushed
+   off the right of. PathLabel is flex:1 already, so it fills the gap the old
+   spacer held and gives its leading directories up before the leaf — the same
+   split the status line spends. Monospace, like the model and mode beside it. */
+.row-cwd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* The path a directory at a time, dimmer than the folder it leads to, so the
+   leaf reads first when the row is narrow enough to eat the rest. */
+.row-cwd .split-dir {
+  color: color-mix(in srgb, var(--on-surface-variant) 70%, transparent);
+}
+
 .row-ram {
   font-variant-numeric: tabular-nums;
 }

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -5311,6 +5311,9 @@ hr {
 
 .pane-actions {
   display: flex;
+  /* Centred, because the row mixes a bare text link with padded buttons: left
+     to stretch, the link's text rides higher than the labels beside it. */
+  align-items: center;
   justify-content: flex-end;
   gap: 8px;
   margin-top: 20px;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1312,6 +1312,11 @@ small {
    widening the row. Monospace, like the model and mode above it and the mobile
    cards it mirrors. */
 .row-cwd {
+  /* Shrunk to the text rather than stretched across the row, so the pointer
+     below sits on the path name and not the empty space beside it. Bounded to
+     the row's width so a long path still truncates instead of widening it. */
+  align-self: flex-start;
+  max-width: 100%;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1320,6 +1325,9 @@ small {
   line-height: 1.4;
   color: var(--on-surface-variant);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* A pointer over the path alone: it is the one part of the row worth resting
+     on, since that is what brings its full self up in the title. */
+  cursor: pointer;
 }
 
 .row-ram {

--- a/desktop/test/session-state.test.ts
+++ b/desktop/test/session-state.test.ts
@@ -9,6 +9,7 @@ import {
   canResume,
   hasTerminal,
   needsRecovery,
+  shortCwd,
   shortMode,
   shortModel,
   type Session,
@@ -99,4 +100,32 @@ test('permission modes are said the short way, and unknown ones verbatim', () =>
   assert.equal(shortMode('acceptEdits'), 'accept')
   assert.equal(shortMode('plan'), 'plan')
   assert.equal(shortMode('auto'), 'auto')
+})
+
+// The directory a session runs in, shortened for a narrow sidebar row: the last
+// two segments behind a "…/", the leaf kept whole because it is what tells two
+// sessions apart. Mirrors shortCwd in mobile/lib/models/session.dart, so both
+// clients read a path the same way; the full path stays in the row's tooltip.
+test('a deep path keeps its last two segments behind an ellipsis', () => {
+  assert.equal(shortCwd('/Users/dev/workspace/helios'), '…/workspace/helios')
+  assert.equal(shortCwd('/a/b/c/d/e'), '…/d/e')
+})
+
+test('two segments or fewer are left whole', () => {
+  assert.equal(shortCwd('/tmp/repo'), '/tmp/repo')
+  assert.equal(shortCwd('/repo'), '/repo')
+  assert.equal(shortCwd('repo'), 'repo')
+})
+
+test('a trailing slash is not counted as a segment', () => {
+  assert.equal(shortCwd('/Users/dev/workspace/helios/'), '…/workspace/helios')
+})
+
+test('the root and an empty path are left as they are', () => {
+  assert.equal(shortCwd('/'), '/')
+  assert.equal(shortCwd(''), '')
+})
+
+test('a relative path is shortened the same way', () => {
+  assert.equal(shortCwd('workspace/helios/desktop'), '…/helios/desktop')
 })


### PR DESCRIPTION
Closes #181

## What

Shows each session's **workspace path** on its sidebar row, on the secondary (config) line next to status / model / mode / memory. Previously the sidebar only used `cwd` for search and grouping — you had to open a session to see where it runs (via the pane's status line). Mobile has always shown the workspace on its cards; this brings the desktop sidebar to parity.

## How

- `desktop/src/renderer/components/sidebar.tsx` — render `session.cwd` through the existing `PathLabel` in `SessionRow`'s `row-sub` line, in place of the empty `grow` spacer. `PathLabel` is `flex: 1`, so it fills the free width and pushes the memory reading to the right, exactly where the spacer had it. When a session has no `cwd`, the spacer is kept so the layout is unchanged.
- `desktop/src/renderer/styles.css` — `.row-cwd` styling: monospace to match the model/mode beside it, and a dimmed `.split-dir` so the leading directories give way before the leaf folder when the row is narrow. This reuses `PathLabel`'s existing truncation (spend the directories, keep the filename) — the same treatment the status line's `cwd` segment uses.

## Notes

- The path shows on every row, including under directory grouping. That's intentional: the group header only shows the leaf, and the flat list / manual tree show nothing — so the full path on the row is complementary, not redundant. It also matches the mobile cards.

## How Has This Been Tested

- `npm run typecheck` — no errors in the changed files. (The repo's checkout has a pre-existing, unrelated failure: `mermaid` and `@playwright/test` are not installed in this environment, so `tsc`/`npm run build` fail on those modules on a clean tree as well.)
- Change is presentation-only: one reused component and two CSS rules, no logic or data-flow changes.

## Review Checklist

- [x] Reuses the existing `PathLabel` component and its truncation
- [x] No layout change when `cwd` is empty
- [x] Comments explain the intent in the house style
