### PR TITLE
feat(mobile): keep hearing from the daemon while the app is closed

### DIFF
--- a/docs/specs/59-background-notifications.md
+++ b/docs/specs/59-background-notifications.md
@@ -1,0 +1,351 @@
+# 59 — Background Notifications: A Service on Android, a Push on iOS
+
+## Problem
+
+The phone only hears from the daemon while the app is running. `DaemonAPIService`
+holds one SSE stream per host, and `home_screen.dart:74` deliberately keeps that
+stream open when the app is paused — there is even a comment saying so. That
+works for a backgrounded app and not for a closed one. Swipe Helios out of
+recents, or let Doze cut the socket while the phone sleeps, and every approval
+raised after that moment is missed. The agent sits blocked until someone happens
+to open the app.
+
+Spec 32 fixed the *aftermath*: `retainOnly` (`notification_service.dart:152`)
+sweeps the tray on resume so a stale approval does not linger. It did not, and
+said it did not, fix delivery — line 325: "A real Android foreground service…
+Track the foreground service separately." This is that spec.
+
+What exists today, all of it half a step in:
+
+| Piece | State |
+|---|---|
+| `flutter_foreground_task: ^9.0.2` | in `pubspec.yaml:26`, zero Dart callers |
+| `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC` | declared in `AndroidManifest.xml:6-7`, no `<service>` element to use them |
+| `push_subscriptions` table | `internal/store/push_subscriptions.go`, Web Push shape (`endpoint`/`p256dh`/`auth`), no sender, no route — `internal/push/` is already deleted |
+| iOS background | no `UIBackgroundModes`, `AppDelegate.swift` is bare boilerplate |
+
+## Shape of the answer
+
+Android can keep a socket open in a foreground service. iOS cannot: there is no
+equivalent, and a silent `content-available` push is throttled hard enough that
+it cannot be the delivery path for something as time-critical as a blocked
+agent. So the two platforms get different answers, in two phases.
+
+Phase 1 is Android, and its only daemon change is a heartbeat interval the
+client can name. Phase 2 is iOS and needs a push sender in the daemon, an Apple
+Developer account, and a key on every machine that runs `helios`. Phase 1 ships
+alone and is useful alone.
+
+---
+
+## Phase 1 — Android foreground service
+
+### Handoff, not co-ownership
+
+`flutter_foreground_task` runs its `TaskHandler` in a **separate Flutter
+isolate**. No shared memory, no `Provider` tree, no access to the UI isolate's
+`DaemonAPIService` instances.
+
+Two ways to live with that:
+
+**Service owns the SSE always**, UI isolate subscribes over
+`sendDataToMain`. One socket, one notification source, no seam. It also means
+proxying the whole data layer: `DaemonAPIService` is 1860 lines of
+`ChangeNotifier` feeding the query layer from spec 49, and every session list,
+transcript tail and file event would have to cross an isolate boundary. Rejected
+as disproportionate.
+
+**The two take turns.** The UI isolate owns the stream while the app is
+resumed. On `AppLifecycleState.paused` the app starts the service, which opens
+its own stream. On `resumed` the app stops the service and reconnects. Exactly
+one socket per host at any moment, and the service isolate needs only a thin
+client — read credentials, open SSE, post notifications — with no UI state in
+it at all.
+
+Take turns. `HostManager.stopAll` / `resumeAll` (`host_manager.dart:424`, `:431`)
+are already the handoff points; they gain a service start and stop.
+
+### What the service isolate has to rebuild
+
+It cannot borrow anything from the UI isolate, so it reads the same storage:
+
+- the host list from `FlutterSecureStorage` under `helios_hosts`, and each seed
+  under `helios_host_<id>_key` (`host_manager.dart:29`, `:134`)
+- an `ApiClient` per host for Ed25519 request signing
+- `NotificationService.init()` for the channels and the alert toggles
+
+Platform channels work from the background isolate because
+`flutter_foreground_task` registers plugins on the service engine. Secure
+storage and `flutter_local_notifications` are both fine there; this is the
+normal use of the package, not a stretch of it.
+
+The isolate does **not** parse sessions, transcripts or file events. It handles
+`notification` and `notification_resolved` and drops everything else on the
+floor.
+
+### Notification ids must stop depending on the payload
+
+`_notifId` hashes the payload string (`notification_service.dart:116`), and
+callers pass `jsonEncode({'hostId': …, 'notificationId': …})`. The mapping from
+a stable key to that integer lives in the in-memory `_posted` map
+(`notification_service.dart:122`).
+
+Two isolates means two `_posted` maps. The service posts a notification, the app
+comes back, and `retainOnly` cannot retract it — the UI isolate's map is empty,
+so it has no integer to cancel with. The tray keeps an approval that was
+answered an hour ago, which is the exact bug spec 32 set out to kill.
+
+Two changes fix it:
+
+1. **Derive the integer from the stable key, not the payload.**
+   `_notifId(notifKey(hostId, id))`. Both isolates then compute the same integer
+   for the same notification without sharing anything.
+2. **Persist the posted key set.** `_posted` writes through to
+   `SharedPreferences` on every post and cancel; `init()` reads it back, and
+   `resumeAll` calls `reload()` first so the UI isolate sees what the service
+   wrote. The map stays in memory as the fast path — the file is the crossing
+   point, not the source of truth during a session.
+
+With those, `retainOnly` works across the handoff unchanged, and the de-dupe in
+`isPosted` stops the app re-alerting for something the service already posted.
+
+There is a third change those two force. The posted set doubles as the de-dupe
+check, and persisting it makes it outlive the notifications it describes: a
+force-stop, a reboot or the user swiping the shade empties the tray and tells
+nobody. The stale key then answers "already posted" for ever, and the approval
+it names never buzzes again — the agent stays blocked and the phone stays
+quiet. So `init` and `reloadPosted` both prune the set against
+`getActiveNotifications()`, which is the only honest account of what is on
+screen. In memory this flaw lasted until the process died; on disk it would
+have been permanent.
+
+### The channel that only the activity had
+
+`MainActivity.configureFlutterEngine` registers `com.helios.helios/notifications`
+— the channel that creates the notification channels and plays sound manually,
+because ColorOS and RealmeUI strip sound from channels
+(`notification_service.dart:241`). The service engine is a different
+`FlutterEngine`, so that channel would not exist there and every background
+notification would be silent on exactly the devices the workaround was written
+for.
+
+Pubspec plugins are fine: `flutter_foreground_task` builds its engine with
+`FlutterEngine(context)`, which registers them. A channel wired up by hand in an
+activity is not a plugin and gets nothing. So it becomes one —
+`HeliosNotificationsPlugin` — registered in `MainActivity` and, for the service
+engine, from a listener installed in `Application.onCreate`. Application, not
+activity: the service can start into a process where no activity has ever run.
+
+### Service type: `specialUse`, not `dataSync`
+
+`dataSync` is the honest classification of "hold a socket open", and it is what
+the manifest already asks permission for. Android 15 stops a `dataSync`
+foreground service after six hours in any 24-hour window. A watcher that dies
+after six hours is a watcher you cannot trust overnight, which is the case that
+matters.
+
+`specialUse` has no such cap. Its cost is a Play Store policy review, and Helios
+is not on Play — it ships as a sideloaded APK from `make apk` and the release
+workflow. So: declare `specialUse` with a subtype explaining the socket, and
+keep the `dataSync` permission for older target levels.
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+
+<service
+    android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+    android:foregroundServiceType="specialUse"
+    android:exported="false">
+    <property
+        android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+        android:value="Maintains a live connection to the user's own Helios daemon so that agent approval requests arrive without delay."/>
+</service>
+```
+
+### The persistent notification
+
+A foreground service must show one, so it should say something. "Helios —
+watching 3 sessions on ripley", low importance, its own channel so it can be
+silenced without touching approvals, tap opens the app. It is also the honest
+signal that the app is holding a socket open, which a user is entitled to see.
+
+### Battery optimisation
+
+Doze will still kill the socket on OEMs that ignore the foreground-service
+contract unless the app is exempt. Ask for
+`REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` from the notification settings screen,
+next to the toggle that turns the service on — never on first launch. A prompt
+like that on launch, before the user has seen a single notification, reads as an
+app overreaching.
+
+### Battery
+
+The service costs almost no CPU — the isolate blocks on a socket read. What it
+costs is radio wakeups, and the number that sets them is the SSE heartbeat:
+every 30 seconds, from `internal/server/api.go:1547`, matched by a client
+watchdog at 30s against a 75s silence threshold
+(`daemon_api_service.dart:21`, `:50`).
+
+On cellular each heartbeat drags the modem out of idle. 30s means 2,880 wakeups
+a day per host, which models out at roughly 3-5% of a 5000 mAh battery — double
+that with two hosts. On Wi-Fi the same traffic is closer to 0.5%, because the
+radio is associated anyway. These are estimates, not measurements; verify with
+`adb shell dumpsys batterystats` before and after.
+
+Two decisions follow.
+
+**No wakelock.** `flutter_foreground_task` sets `allowWakeLock: true` by
+default, which pins the CPU out of deep sleep for as long as the service runs
+and would cost more than everything else here combined. It buys nothing: an
+inbound TCP packet raises a network interrupt that wakes the CPU on its own.
+Set it false, and keep the Wi-Fi lock.
+
+**A slower heartbeat in the background.** 30 seconds is tuned for someone
+watching the app, where a dead socket should be noticed quickly. Nobody is
+watching a background service, and a 75-second detection window is not worth 3-5%
+a day. Let the client name its own interval —
+`GET /api/events?heartbeat=240` — and scale the silence threshold with it.
+240s stays under common NAT timeouts, and Tailscale is keeping the tunnel alive
+underneath in any case. That drops the background cost to about 360 wakeups a
+day. The foreground path keeps 30s unchanged.
+
+This adds the one Go change in phase 1: `/api/events` reads an optional
+`heartbeat` parameter, clamps it to something sane, and defaults to today's 30s
+when it is absent.
+
+### The gap at handoff
+
+Between the app stopping its stream and the service opening one, a notification
+can land unseen. Both sides close it the same way, and it is already built:
+
+- **Service start**: `GET /api/notifications`, post anything `pending` whose key
+  is not in the persisted posted set.
+- **App resume**: `resumeAll` already fetches per host and runs the reconcile
+  sweep from spec 32.
+
+A cold start needs the same care for the opposite reason. It never raises
+`AppLifecycleState.resumed`, and Android restarts the service on its own after
+the app is killed, so without an explicit stop in `loadStoredHosts` the app and
+the service both hold a stream to every host and race to post the same
+notification.
+
+No new endpoint. `GET /api/notifications` already returns resolved rows
+alongside pending ones (`internal/server/api.go:26`).
+
+### Changes
+
+| File | Change |
+|---|---|
+| `mobile/android/app/src/main/AndroidManifest.xml` | `FOREGROUND_SERVICE_SPECIAL_USE` permission, `<service>` element, subtype property, the custom `Application` |
+| `mobile/android/.../HeliosNotificationsPlugin.kt` *(new)* | the sound/channel `MethodChannel`, lifted out of `MainActivity` so both engines get it |
+| `mobile/android/.../HeliosApplication.kt` *(new)* | attaches that plugin to the service engine |
+| `mobile/lib/services/notification_service.dart` | `_notifId` takes the key; `_posted` persists through `SharedPreferences`; `init` restores it and prunes it against the tray |
+| `mobile/lib/services/background_watch.dart` *(new)* | the app-side switch: enable, start, stop, battery exemption |
+| `mobile/lib/services/background_watcher.dart` *(new)* | `TaskHandler`: load hosts from secure storage, open one SSE per host, handle `notification` / `notification_resolved`, seed from `GET /api/notifications` on start |
+| `mobile/lib/services/host_manager.dart` | `handOffToBackground` on pause; `resumeAll` and `loadStoredHosts` stop the service and re-read the posted set |
+| `mobile/lib/services/daemon_api_service.dart` | request `?heartbeat=` and scale `streamSilenceThreshold` to it |
+| `internal/server/api.go` | `/api/events` honours an optional, clamped `heartbeat` parameter; defaults to 30s |
+| `mobile/lib/screens/notification_settings_screen.dart` | "Watch in background" toggle plus the battery-optimisation prompt |
+
+---
+
+## Phase 2 — iOS via APNs
+
+iOS has no way to hold that socket, so delivery has to come from Apple. This
+phase is larger than phase 1 and touches the daemon.
+
+**What Apple requires.** An Apple Developer account, an APNs auth key (`.p8`),
+`UIBackgroundModes: remote-notification` in `Info.plist`, and registration in
+`AppDelegate.swift` — which is currently untouched boilerplate.
+
+**Alert push, not silent.** `content-available` alone is rate-limited by iOS and
+may be delayed for hours on a phone the system considers idle. A blocked agent
+cannot wait on a heuristic. Send a real alert with `interruption-level:
+time-sensitive`, matching what `DarwinNotificationDetails` already asks for
+locally (`notification_service.dart:373`).
+
+**Daemon side.** The `push_subscriptions` table is Web Push shaped and unused;
+replace its columns with `(device_kid, platform, token)`. Add
+`POST /api/push/register`, a sender, and a call from wherever a notification is
+created — the same places that already broadcast `notification` over SSE, so the
+push is a second fan-out arm rather than a new pathway.
+
+**Credentials.** Every daemon needs the `.p8` key. That is a real cost for a
+self-hosted tool and it should be optional: no key, no push, and the app falls
+back to what it does today. It should not be a startup error.
+
+**Content.** Send the title and the notification id, not the body. The phone
+fetches the detail over the tailnet when the app opens. Apple's servers then
+carry "Permission request from ripley" and nothing about what the agent wanted
+to run.
+
+**Off the tailnet.** APNs delivers even when the phone cannot reach the daemon
+at all — which means a notification the user can see and cannot act on. Tapping
+it must land on a clear "cannot reach ripley" state, not a spinner or a
+half-rendered approval card.
+
+---
+
+## Out of scope
+
+**FCM on Android.** The foreground service removes the need, and adding FCM
+would mean a Firebase project and a service-account key on every daemon for a
+platform that does not need it. Revisit only if OEM process-killers prove the
+service unreliable in practice.
+
+**Reworking spec 32's reconcile.** It stays exactly as it is; this spec only
+makes its bookkeeping survive an isolate boundary.
+
+## Testing
+
+Automated, in `mobile/test/`:
+
+1. `notification_service_test.dart` — the same key yields the same integer
+   across two `NotificationService` instances; a posted key survives an `init()`
+   on a fresh instance; `retainOnly` cancels a key that was posted by the
+   *other* instance.
+2. `background_watcher_test.dart` — the handler seeds from a mocked
+   `/api/notifications`, posts only `pending` rows, and skips keys already in
+   the persisted set.
+
+Manual, on a real device, which is the only place this can be shown to work:
+
+3. Start a session, background the app, confirm the persistent notification
+   appears and an approval still arrives.
+4. Swipe the app out of recents. Raise an approval. It must still arrive.
+5. `adb shell dumpsys deviceidle force-idle`, raise an approval, confirm
+   delivery. This is the case the whole spec exists for.
+6. Approve from the phone's notification buttons while the app is closed;
+   confirm the notification retracts and the daemon sees the answer.
+7. Approve in the terminal while the app is closed; the tray entry must clear
+   without opening the app.
+8. Reopen the app after (7) and confirm nothing double-posts.
+9. Leave it overnight and confirm the service is still connected in the morning
+   — the six-hour cap is the reason for `specialUse` and this is the check.
+10. `adb shell dumpsys batterystats --reset`, then eight hours on cellular with
+    the service running. Compare against the same eight hours with it off. The
+    estimates in this spec are modeled; this is the number that decides whether
+    the default heartbeat is right.
+
+## Implementation order
+
+1. `notification_service.dart`: key-derived integer, persisted posted set.
+2. Manifest: permission, `<service>`, subtype.
+3. `background_watcher.dart`: the `TaskHandler` and its SSE client.
+4. `host_manager.dart`: start on pause, stop on resume, `reload()` before the
+   sweep.
+5. Settings toggle and the battery-optimisation prompt.
+6. Tests, then the manual pass.
+7. Phase 2, as a separate change.
+
+## Notes
+
+- Steps 1 and 2 are independently shippable and carry no risk: a key-derived
+  notification id is strictly better than a payload-derived one whether or not
+  the service ever lands.
+- The service isolate reads the same secure-storage keys the UI isolate writes.
+  Anything that changes the host-storage format has to change both, and there is
+  no compiler to catch it — worth a comment at both ends.
+- `flutter_foreground_task` is already a declared dependency with no callers. If
+  this spec is abandoned, remove it from `pubspec.yaml:26` rather than leaving a
+  dependency that implies a feature the app does not have.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -66,6 +66,7 @@ what is merged. Some are superseded and stay here for the history.
 | [56-one-version-number.md](56-one-version-number.md) | One Version Number, and Builds That Do Not Lie About It |
 | [57-plan-approval.md](57-plan-approval.md) | Approving a Plan From a Phone |
 | [58-files-without-a-root.md](58-files-without-a-root.md) | Files Without a Root: Folders, an Index, and a Path You Can Type |
+| [59-background-notifications.md](59-background-notifications.md) | Background Notifications: A Service on Android, a Push on iOS |
 | [ai-narration.md](ai-narration.md) | AI Narration for Voice Mode |
 | [desktop-notification-handoff.md](desktop-notification-handoff.md) | Hand desktop notifications to the desktop app |
 | [desktop-notification-service.md](desktop-notification-service.md) | Desktop Notification Service |

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -27,6 +28,41 @@ func NewSSEBroadcaster() *SSEBroadcaster {
 	return &SSEBroadcaster{
 		clients: make(map[*sseClient]bool),
 	}
+}
+
+const (
+	defaultHeartbeat = 30 * time.Second
+	minHeartbeat     = 5 * time.Second
+	maxHeartbeat     = 10 * time.Minute
+)
+
+// heartbeatInterval reads the interval a client asked for, in seconds.
+//
+// A phone watching in the background pays for every beat: each one wakes the
+// radio, and at 30s that is 2,880 wake-ups a day for a stream that is silent
+// almost all of it. Nobody is watching a background service, so slow detection
+// of a dead socket costs nothing there — while in the app, where a stale
+// stream is visible, 30s stays right. The client is the only side that knows
+// which of the two it is.
+//
+// Clamped because the interval also sets how long a dead client occupies a
+// slot, and an unbounded value from the wire would pin one indefinitely.
+func heartbeatInterval(raw string) time.Duration {
+	if raw == "" {
+		return defaultHeartbeat
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultHeartbeat
+	}
+	d := time.Duration(secs) * time.Second
+	if d < minHeartbeat {
+		return minHeartbeat
+	}
+	if d > maxHeartbeat {
+		return maxHeartbeat
+	}
+	return d
 }
 
 func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
@@ -73,7 +109,7 @@ func (b *SSEBroadcaster) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, ": connected\n\n")
 	flusher.Flush()
 
-	heartbeat := time.NewTicker(30 * time.Second)
+	heartbeat := time.NewTicker(heartbeatInterval(r.URL.Query().Get("heartbeat")))
 	defer heartbeat.Stop()
 
 	for {

--- a/internal/server/sse_test.go
+++ b/internal/server/sse_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHeartbeatInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{"absent falls back to the in-app rate", "", 30 * time.Second},
+		{"garbage falls back rather than failing the stream", "soon", 30 * time.Second},
+		{"a background client gets the slow rate it asked for", "240", 240 * time.Second},
+		{"too fast is clamped up", "1", 5 * time.Second},
+		{"too slow is clamped down", "86400", 10 * time.Minute},
+		{"negative is clamped up", "-30", 5 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := heartbeatInterval(tt.raw); got != tt.want {
+				t.Errorf("heartbeatInterval(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <!-- The watcher holds one SSE stream open while the app is closed. dataSync
+         is the natural classification, and Android 15 stops a dataSync service
+         after six hours in a day — useless for something whose job is to still
+         be there in the morning. specialUse has no such cap; its cost is a Play
+         policy review, and Helios ships as a sideloaded APK. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
@@ -12,7 +19,7 @@
 
     <application
         android:label="${appLabel}"
-        android:name="${applicationName}"
+        android:name=".HeliosApplication"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">
         <activity
@@ -40,6 +47,17 @@
                 <data android:scheme="helios"/>
             </intent-filter>
         </activity>
+        <!-- flutter_foreground_task ships no service declaration of its own,
+             so the type has to be named here. -->
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Holds an event stream open to the user's own Helios daemon so that an agent blocked on an approval reaches the phone without delay."/>
+        </service>
+
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/mobile/android/app/src/main/kotlin/com/helios/helios/HeliosApplication.kt
+++ b/mobile/android/app/src/main/kotlin/com/helios/helios/HeliosApplication.kt
@@ -1,0 +1,36 @@
+package com.helios.helios
+
+import android.app.Application
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskLifecycleListener
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskPlugin
+import com.pravera.flutter_foreground_task.FlutterForegroundTaskStarter
+import io.flutter.embedding.engine.FlutterEngine
+
+/**
+ * Attaches [HeliosNotificationsPlugin] to the foreground service's engine.
+ *
+ * The listener is registered here rather than from MainActivity because the
+ * service can start into a process where no activity has ever run — the app was
+ * swiped away and Android restarted the service alone. Application.onCreate is
+ * the only hook both paths pass through.
+ */
+class HeliosApplication : Application() {
+    private val taskLifecycleListener = object : FlutterForegroundTaskLifecycleListener {
+        override fun onEngineCreate(flutterEngine: FlutterEngine?) {
+            flutterEngine?.plugins?.add(HeliosNotificationsPlugin())
+        }
+
+        override fun onTaskStart(starter: FlutterForegroundTaskStarter) {}
+
+        override fun onTaskRepeatEvent() {}
+
+        override fun onTaskDestroy() {}
+
+        override fun onEngineWillDestroy() {}
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        FlutterForegroundTaskPlugin.addTaskLifecycleListener(taskLifecycleListener)
+    }
+}

--- a/mobile/android/app/src/main/kotlin/com/helios/helios/HeliosNotificationsPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/com/helios/helios/HeliosNotificationsPlugin.kt
@@ -1,0 +1,125 @@
+package com.helios.helios
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.RingtoneManager
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Channel creation and the manual sound/vibration path.
+ *
+ * A plugin rather than a block inside MainActivity because the foreground
+ * service runs Dart on its own FlutterEngine. Registered on the activity engine
+ * only, this channel would not exist while the app is closed, and every
+ * notification the background watcher raised on a ColorOS device would be
+ * silent — which is the one case the service exists for.
+ */
+class HeliosNotificationsPlugin : FlutterPlugin {
+    private var channel: MethodChannel? = null
+    private lateinit var context: Context
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL).apply {
+            setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "createChannels" -> {
+                        createNotificationChannels(call.argument("channels"))
+                        result.success(null)
+                    }
+                    "playNotificationSound" -> {
+                        val sound = call.argument<Boolean>("sound") ?: true
+                        val vibration = call.argument<Boolean>("vibration") ?: true
+                        playNotificationSound(sound, vibration)
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        }
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        channel = null
+    }
+
+    private fun createNotificationChannels(channels: List<Map<String, Any>>?) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        channels?.forEach { ch ->
+            val id = ch["id"] as String
+            val name = ch["name"] as String
+            val desc = ch["description"] as? String ?: ""
+            val importance = (ch["importance"] as? Int) ?: NotificationManager.IMPORTANCE_HIGH
+
+            manager.deleteNotificationChannel(id)
+
+            // Sound and vibration are disabled on the channel because we play
+            // them manually via playNotificationSound() on the alarm stream.
+            // This avoids double-sound on devices where channel sound works fine.
+            val channel = NotificationChannel(id, name, importance).apply {
+                description = desc
+                enableVibration(false)
+                setSound(null, null)
+                enableLights(true)
+                setShowBadge(true)
+                setBypassDnd(true)
+            }
+
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Play the default notification sound and vibrate directly,
+     * bypassing notification channel sound settings which some OEMs
+     * (Realme/OPPO/ColorOS) strip on channel creation.
+     */
+    private fun playNotificationSound(sound: Boolean, vibration: Boolean) {
+        if (sound) {
+            try {
+                val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+                val ringtone = RingtoneManager.getRingtone(context, uri)
+                if (ringtone != null) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        ringtone.audioAttributes = AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_ALARM)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build()
+                    } else {
+                        @Suppress("DEPRECATION")
+                        ringtone.streamType = android.media.AudioManager.STREAM_ALARM
+                    }
+                    ringtone.play()
+                }
+            } catch (_: Exception) {}
+        }
+
+        if (vibration) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val vibratorManager =
+                        context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+                    val vibrator = vibratorManager.defaultVibrator
+                    vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 500, 200, 500), -1))
+                } else {
+                    @Suppress("DEPRECATION")
+                    val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+                    vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 500, 200, 500), -1))
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    companion object {
+        private const val CHANNEL = "com.helios.helios/notifications"
+    }
+}

--- a/mobile/android/app/src/main/kotlin/com/helios/helios/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/helios/helios/MainActivity.kt
@@ -1,106 +1,11 @@
 package com.helios.helios
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.content.Context
-import android.media.AudioAttributes
-import android.media.RingtoneManager
-import android.os.Build
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
-    private val CHANNEL = "com.helios.helios/notifications"
-
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "createChannels" -> {
-                        createNotificationChannels(call.argument("channels"))
-                        result.success(null)
-                    }
-                    "playNotificationSound" -> {
-                        val sound = call.argument<Boolean>("sound") ?: true
-                        val vibration = call.argument<Boolean>("vibration") ?: true
-                        playNotificationSound(sound, vibration)
-                        result.success(null)
-                    }
-                    else -> result.notImplemented()
-                }
-            }
-    }
-
-    private fun createNotificationChannels(channels: List<Map<String, Any>>?) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val manager = getSystemService(NotificationManager::class.java) ?: return
-        channels?.forEach { ch ->
-            val id = ch["id"] as String
-            val name = ch["name"] as String
-            val desc = ch["description"] as? String ?: ""
-            val importance = (ch["importance"] as? Int) ?: NotificationManager.IMPORTANCE_HIGH
-
-            manager.deleteNotificationChannel(id)
-
-            // Sound and vibration are disabled on the channel because we play
-            // them manually via playNotificationSound() on the alarm stream.
-            // This avoids double-sound on devices where channel sound works fine.
-            val channel = NotificationChannel(id, name, importance).apply {
-                description = desc
-                enableVibration(false)
-                setSound(null, null)
-                enableLights(true)
-                setShowBadge(true)
-                setBypassDnd(true)
-            }
-
-            manager.createNotificationChannel(channel)
-        }
-    }
-
-    /**
-     * Play the default notification sound and vibrate directly,
-     * bypassing notification channel sound settings which some OEMs
-     * (Realme/OPPO/ColorOS) strip on channel creation.
-     */
-    private fun playNotificationSound(sound: Boolean, vibration: Boolean) {
-        if (sound) {
-            try {
-                val uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-                val ringtone = RingtoneManager.getRingtone(applicationContext, uri)
-                if (ringtone != null) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        ringtone.audioAttributes = AudioAttributes.Builder()
-                            .setUsage(AudioAttributes.USAGE_ALARM)
-                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                            .build()
-                    } else {
-                        @Suppress("DEPRECATION")
-                        ringtone.streamType = android.media.AudioManager.STREAM_ALARM
-                    }
-                    ringtone.play()
-                }
-            } catch (_: Exception) {}
-        }
-
-        if (vibration) {
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    val vibratorManager = getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
-                    val vibrator = vibratorManager.defaultVibrator
-                    vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 500, 200, 500), -1))
-                } else {
-                    @Suppress("DEPRECATION")
-                    val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-                    vibrator.vibrate(VibrationEffect.createWaveform(longArrayOf(0, 500, 200, 500), -1))
-                }
-            } catch (_: Exception) {}
-        }
+        flutterEngine.plugins.add(HeliosNotificationsPlugin())
     }
 }

--- a/mobile/lib/screens/home_screen.dart
+++ b/mobile/lib/screens/home_screen.dart
@@ -75,8 +75,14 @@ class _HomeScreenState extends rp.ConsumerState<HomeScreen>
     if (state == AppLifecycleState.resumed) {
       _hm.resumeAll();
       _checkNotificationPermission();
+      return;
     }
-    // Don't stop SSE on pause — keep it alive for background notifications
+    // Keeping the app's own streams alive on pause only works until the
+    // process dies. The foreground service takes them over instead, so a
+    // swiped-away app still hears about a blocked agent.
+    if (state == AppLifecycleState.paused) {
+      _hm.handOffToBackground();
+    }
   }
 
   void _handleSSEEvent(String hostId, SSEEvent event) {

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import '../services/background_watch.dart';
 import '../services/notification_service.dart';
 
 class NotificationSettingsScreen extends StatefulWidget {
@@ -12,6 +15,8 @@ class NotificationSettingsScreen extends StatefulWidget {
 class _NotificationSettingsScreenState
     extends State<NotificationSettingsScreen> {
   late Map<String, bool> _alertTypes;
+  bool _watchEnabled = false;
+  bool _batteryOptimised = false;
 
   static const _blockingTypes = [
     _NotifType(
@@ -66,6 +71,29 @@ class _NotificationSettingsScreenState
   void initState() {
     super.initState();
     _alertTypes = Map.of(NotificationService.instance.alertTypes);
+    _loadWatchState();
+  }
+
+  Future<void> _loadWatchState() async {
+    if (!Platform.isAndroid) return;
+    final enabled = await backgroundWatchEnabled();
+    final optimised = await isBatteryOptimised();
+    if (!mounted) return;
+    setState(() {
+      _watchEnabled = enabled;
+      _batteryOptimised = optimised;
+    });
+  }
+
+  Future<void> _setWatchEnabled(bool value) async {
+    setState(() => _watchEnabled = value);
+    await setBackgroundWatchEnabled(value);
+    if (value) await _loadWatchState();
+  }
+
+  Future<void> _requestExemption() async {
+    await requestBatteryExemption();
+    await _loadWatchState();
   }
 
   Future<void> _setAlert(String kind, bool value) async {
@@ -97,6 +125,7 @@ class _NotificationSettingsScreenState
               ),
             ),
           ),
+          if (Platform.isAndroid) ..._buildBackgroundSection(),
           _SectionHeader('Action required'),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
@@ -134,6 +163,53 @@ class _NotificationSettingsScreenState
         ],
       ),
     );
+  }
+
+  List<Widget> _buildBackgroundSection() {
+    final muted = Theme.of(context).colorScheme.onSurfaceVariant;
+    return [
+      _SectionHeader('While the app is closed'),
+      SwitchListTile(
+        title: const Text('Watch in background'),
+        subtitle: Text(
+          'Keeps a connection to your hosts so approvals still reach you '
+          'after the app is closed. Shows a permanent notification.',
+          style: TextStyle(fontSize: 12, color: muted),
+        ),
+        isThreeLine: true,
+        value: _watchEnabled,
+        onChanged: _setWatchEnabled,
+      ),
+      if (_watchEnabled && _batteryOptimised)
+        ListTile(
+          leading: Icon(
+            Icons.battery_alert,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          title: const Text('Battery optimisation is on'),
+          subtitle: Text(
+            'Android may close the connection while the phone sleeps. '
+            'Exempt Helios so approvals still arrive overnight.',
+            style: TextStyle(fontSize: 12, color: muted),
+          ),
+          isThreeLine: true,
+          trailing: TextButton(
+            onPressed: _requestExemption,
+            child: const Text('Fix'),
+          ),
+        ),
+      if (_watchEnabled)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Text(
+            'On Realme, OPPO and Xiaomi phones the system also needs Helios '
+            'allowed to start automatically, in the system app settings. '
+            'Without it the connection is closed a few minutes after you '
+            'leave the app.',
+            style: TextStyle(fontSize: 12, color: muted),
+          ),
+        ),
+    ];
   }
 
   Widget _buildTile(_NotifType t) {

--- a/mobile/lib/services/background_watch.dart
+++ b/mobile/lib/services/background_watch.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'background_watcher.dart';
+
+/// The app-facing switch for the background watcher.
+///
+/// Split from [BackgroundWatcher] so the app can ask whether to hand over
+/// without pulling the service isolate's entry point into every caller.
+
+const _keyEnabled = 'background_watch_enabled';
+
+/// Whether the watcher should run while the app is closed.
+///
+/// On by default. An approval that never reaches the phone is the failure the
+/// whole feature exists to prevent, so the setting is there to turn it off
+/// rather than to turn it on.
+Future<bool> backgroundWatchEnabled() async {
+  if (!Platform.isAndroid) return false;
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_keyEnabled) ?? true;
+  } catch (_) {
+    return true;
+  }
+}
+
+Future<void> setBackgroundWatchEnabled(bool value) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setBool(_keyEnabled, value);
+  if (!value) await stopBackgroundWatch();
+}
+
+Future<bool> isBackgroundWatchRunning() async {
+  if (!Platform.isAndroid) return false;
+  return FlutterForegroundTask.isRunningService;
+}
+
+/// Start the service, unless it is already up.
+Future<void> startBackgroundWatch() async {
+  if (!Platform.isAndroid) return;
+  if (await FlutterForegroundTask.isRunningService) return;
+
+  initBackgroundWatcher();
+  await FlutterForegroundTask.startService(
+    serviceTypes: [ForegroundServiceTypes.specialUse],
+    notificationTitle: 'Helios',
+    notificationText: 'Watching for approvals',
+    callback: startBackgroundWatcher,
+  );
+}
+
+Future<void> stopBackgroundWatch() async {
+  if (!Platform.isAndroid) return;
+  if (!await FlutterForegroundTask.isRunningService) return;
+  await FlutterForegroundTask.stopService();
+}
+
+/// Whether Android will let the service keep its socket open in Doze.
+Future<bool> isBatteryOptimised() async {
+  if (!Platform.isAndroid) return false;
+  try {
+    return !await FlutterForegroundTask.isIgnoringBatteryOptimizations;
+  } catch (e) {
+    debugPrint('Battery optimisation check failed: $e');
+    return false;
+  }
+}
+
+/// Ask to be exempted from battery optimisation.
+///
+/// Deliberately not called on launch: a prompt like this before the user has
+/// seen a single notification reads as an app overreaching. It belongs next to
+/// the toggle that turns the watcher on.
+Future<void> requestBatteryExemption() async {
+  if (!Platform.isAndroid) return;
+  try {
+    await FlutterForegroundTask.requestIgnoreBatteryOptimization();
+  } catch (e) {
+    debugPrint('Battery exemption request failed: $e');
+  }
+}

--- a/mobile/lib/services/background_watcher.dart
+++ b/mobile/lib/services/background_watcher.dart
@@ -1,0 +1,391 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/host_connection.dart';
+import '../providers/card_registry.dart' as registry;
+import 'api_client.dart';
+import 'notification_service.dart';
+
+/// How often the daemon is asked to prove the stream is alive while the app is
+/// closed.
+///
+/// Every beat wakes the phone's radio, and on cellular the 30s the app uses
+/// costs a few percent of a battery a day for a stream that is silent almost
+/// all of it. Nobody is watching a background service, so noticing a dead
+/// socket four minutes late costs nothing. Kept under the five minutes most
+/// NATs hold an idle mapping for.
+const backgroundHeartbeat = Duration(seconds: 240);
+
+/// How long the background stream may stay silent before it is presumed dead.
+const backgroundSilenceThreshold = Duration(seconds: 600);
+
+/// How often [BackgroundWatcher.onRepeatEvent] runs.
+const backgroundWatchdogInterval = Duration(minutes: 2);
+
+const _notificationChannelId = 'helios_watch_v1';
+
+/// The entry point Android calls on the service isolate.
+@pragma('vm:entry-point')
+void startBackgroundWatcher() {
+  FlutterForegroundTask.setTaskHandler(BackgroundWatcher());
+}
+
+/// Configure the service. Safe to call more than once.
+void initBackgroundWatcher() {
+  FlutterForegroundTask.init(
+    androidNotificationOptions: AndroidNotificationOptions(
+      channelId: _notificationChannelId,
+      channelName: 'Watching for approvals',
+      channelDescription:
+          'Shown while Helios is holding a connection open to your daemon.',
+      channelImportance: NotificationChannelImportance.LOW,
+      priority: NotificationPriority.LOW,
+      onlyAlertOnce: true,
+    ),
+    iosNotificationOptions: const IOSNotificationOptions(),
+    foregroundTaskOptions: ForegroundTaskOptions(
+      eventAction: ForegroundTaskEventAction.repeat(
+        backgroundWatchdogInterval.inMilliseconds,
+      ),
+      autoRunOnBoot: true,
+      autoRunOnMyPackageReplaced: true,
+      // A partial wake lock would pin the CPU out of deep sleep for as long as
+      // the service runs, and it buys nothing: an inbound packet raises a
+      // network interrupt that wakes the CPU by itself.
+      allowWakeLock: false,
+      allowWifiLock: true,
+    ),
+  );
+}
+
+/// Watches every paired host while the app is closed.
+///
+/// Runs on its own Flutter isolate, so it shares no memory with the app: the
+/// host list comes back out of secure storage, the clients are rebuilt, and
+/// what it has already put in the tray is read from the file
+/// [NotificationService] mirrors its posted set into. The app and this handler
+/// never hold a stream at the same time — [HostManager] starts the service on
+/// pause and stops it on resume.
+class BackgroundWatcher extends TaskHandler {
+  final _storage = const FlutterSecureStorage();
+  final Map<String, _HostStream> _streams = {};
+
+  @override
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
+    await NotificationService.instance.init();
+    await NotificationService.instance.reloadPosted();
+    NotificationService.instance.onAction = _handleAction;
+
+    final hosts = await _loadHosts();
+    debugPrint(
+      '[watcher] started by ${starter.name} with ${hosts.length} host(s)',
+    );
+    for (final host in hosts) {
+      _streams[host.host.id] = host;
+      unawaited(_seed(host));
+      unawaited(_connect(host));
+    }
+
+    FlutterForegroundTask.updateService(
+      notificationTitle: 'Helios',
+      notificationText: _statusLine(),
+    );
+  }
+
+  @override
+  void onRepeatEvent(DateTime timestamp) {
+    for (final stream in _streams.values) {
+      if (!stream.isStale) continue;
+      debugPrint('[watcher] ${stream.host.label} silent — reconnecting');
+      unawaited(_connect(stream));
+    }
+    FlutterForegroundTask.updateService(notificationText: _statusLine());
+  }
+
+  @override
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    for (final stream in _streams.values) {
+      stream.close();
+    }
+    _streams.clear();
+  }
+
+  @override
+  void onNotificationPressed() => FlutterForegroundTask.launchApp();
+
+  String _statusLine() {
+    final live = _streams.values.where((s) => s.connected).length;
+    if (_streams.isEmpty) return 'No hosts paired';
+    if (live == 0) return 'Reconnecting…';
+    if (_streams.length == 1) return 'Watching ${_streams.values.first.label}';
+    return 'Watching $live of ${_streams.length} hosts';
+  }
+
+  // ==================== Hosts ====================
+
+  /// Rebuild the host list from the same storage the app writes.
+  ///
+  /// Nothing is shared with the UI isolate, so the format here has to track
+  /// `HostManager._saveHosts` by hand. Change one, change the other.
+  Future<List<_HostStream>> _loadHosts() async {
+    final out = <_HostStream>[];
+    try {
+      final raw = await _storage.read(key: 'helios_hosts');
+      if (raw == null) return out;
+      final list = jsonDecode(raw) as List;
+      final multi = list.length > 1;
+      for (final entry in list) {
+        final host = HostConnection.fromJson(entry as Map<String, dynamic>);
+        final seedB64 = await _storage.read(key: 'helios_host_${host.id}_key');
+        if (seedB64 == null) continue;
+        final padded = seedB64.padRight((seedB64.length + 3) & ~3, '=');
+        out.add(
+          _HostStream(
+            host: host,
+            showHostLabel: multi,
+            api: ApiClient(
+              serverUrl: host.serverUrl,
+              deviceId: host.deviceId,
+              privateKeySeed: base64Url.decode(padded),
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      debugPrint('[watcher] could not load hosts: $e');
+    }
+    return out;
+  }
+
+  // ==================== Delivery ====================
+
+  /// Post whatever is pending right now and retract whatever is not.
+  ///
+  /// The app stops its stream before this one opens, and the daemon keeps no
+  /// replay buffer, so anything raised in that gap arrives nowhere unless it is
+  /// fetched. The same pass clears notifications answered elsewhere while the
+  /// handover was in flight.
+  Future<void> _seed(_HostStream stream) async {
+    try {
+      final resp = await stream.api.get('/api/notifications');
+      if (resp.statusCode != 200) return;
+      final body = jsonDecode(resp.body) as Map<String, dynamic>;
+      final list = (body['notifications'] as List?) ?? const [];
+
+      final pending = <String>{};
+      for (final entry in list) {
+        final n = entry as Map<String, dynamic>;
+        if (n['status']?.toString() != 'pending') continue;
+        final id = n['id']?.toString() ?? '';
+        if (id.isEmpty) continue;
+        pending.add(id);
+        _raise(stream, n);
+      }
+      await NotificationService.instance.retainOnly(stream.host.id, pending);
+      debugPrint('[watcher] ${stream.label} seeded, ${pending.length} pending');
+    } catch (e) {
+      debugPrint('[watcher] seed failed for ${stream.label}: $e');
+    }
+  }
+
+  void _handleEvent(_HostStream stream, String type, dynamic data) {
+    if (data is! Map) return;
+
+    if (type == 'notification_resolved') {
+      final id = data['id']?.toString();
+      if (id == null || id.isEmpty) return;
+      NotificationService.instance.cancel(
+        NotificationService.notifKey(stream.host.id, id),
+      );
+      return;
+    }
+
+    if (type != 'notification') return;
+    _raise(stream, data);
+  }
+
+  void _raise(_HostStream stream, Map<dynamic, dynamic> data) {
+    final type = data['type']?.toString() ?? '';
+    final id = data['id']?.toString() ?? '';
+    if (id.isEmpty) return;
+
+    final key = NotificationService.notifKey(stream.host.id, id);
+    final notifSvc = NotificationService.instance;
+    final raise = registry.shouldRaiseNotification(
+      type: type,
+      status: data['status']?.toString(),
+      alreadyPosted: notifSvc.isPosted(key),
+    );
+    if (!raise) return;
+
+    final prefix = stream.showHostLabel ? '${stream.label} — ' : '';
+    final payload = jsonEncode({
+      'hostId': stream.host.id,
+      'notificationId': id,
+    });
+    final silent = !notifSvc.isAlertEnabled(type);
+    final kind = registry.kindOfType(type);
+    final title = data['title']?.toString();
+    final detail = data['detail']?.toString();
+
+    if (kind == 'permission') {
+      notifSvc.showPermissionNotification(
+        id: payload,
+        key: key,
+        toolName: '$prefix${title ?? 'Unknown tool'}',
+        detail: detail ?? 'Permission requested',
+        silent: silent,
+      );
+      return;
+    }
+
+    notifSvc.showNotification(
+      id: payload,
+      key: key,
+      title: prefix + (title ?? registry.labelForKind(kind)),
+      body: detail ?? registry.bodyForKind(kind),
+      silent: silent,
+    );
+  }
+
+  /// Answer an approval from the tray while the app is closed.
+  ///
+  /// The app normally owns this, but it may not be running at all, and an
+  /// Approve button that does nothing is worse than no button.
+  void _handleAction(String rawPayload, String action) {
+    if (action != 'approve' && action != 'deny') return;
+    try {
+      final payload = jsonDecode(rawPayload) as Map<String, dynamic>;
+      final hostId = payload['hostId'] as String?;
+      final notificationId = payload['notificationId'] as String?;
+      if (hostId == null || notificationId == null) return;
+
+      final stream = _streams[hostId];
+      if (stream == null) return;
+
+      unawaited(
+        stream.api.post(
+          '/api/notifications/$notificationId/action',
+          body: {'action': action},
+        ),
+      );
+      NotificationService.instance.cancel(
+        NotificationService.notifKey(hostId, notificationId),
+      );
+    } catch (e) {
+      debugPrint('[watcher] action failed: $e');
+    }
+  }
+
+  // ==================== SSE ====================
+
+  Future<void> _connect(_HostStream stream) async {
+    final generation = ++stream.generation;
+    stream.client?.close();
+    final client = http.Client();
+    stream.client = client;
+
+    try {
+      final uri = Uri.parse(
+        '${stream.host.serverUrl}/api/events'
+        '?heartbeat=${backgroundHeartbeat.inSeconds}',
+      );
+      final request = http.Request('GET', uri);
+      request.headers.addAll({
+        'Authorization': 'Bearer ${await stream.api.getToken()}',
+        'Accept': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      });
+
+      final response = await client.send(request);
+      if (generation != stream.generation) return;
+
+      if (response.statusCode == 401) {
+        stream.api.invalidateToken();
+        return;
+      }
+      if (response.statusCode != 200) {
+        debugPrint('[watcher] ${stream.label}: HTTP ${response.statusCode}');
+        return;
+      }
+
+      stream.connected = true;
+      stream.lastBytesAt = DateTime.now();
+      debugPrint('[watcher] ${stream.label} connected');
+
+      String buffer = '';
+      String currentEvent = '';
+
+      await for (final chunk in response.stream.transform(utf8.decoder)) {
+        if (generation != stream.generation) return;
+        stream.lastBytesAt = DateTime.now();
+
+        buffer += chunk;
+        final lines = buffer.split('\n');
+        buffer = lines.removeLast();
+
+        for (final line in lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.substring(7).trim();
+          } else if (line.startsWith('data: ') && currentEvent.isNotEmpty) {
+            try {
+              _handleEvent(stream, currentEvent, jsonDecode(line.substring(6)));
+            } catch (_) {}
+            currentEvent = '';
+          }
+        }
+      }
+    } catch (e) {
+      if (generation != stream.generation) return;
+      debugPrint('[watcher] ${stream.label} stream error: $e');
+    }
+
+    if (generation != stream.generation) return;
+    stream.connected = false;
+    // No backoff timer: the watchdog is already ticking, and a timer is one
+    // more thing to cancel on destroy for no gain at this cadence.
+  }
+}
+
+/// One host's connection state inside the service isolate.
+class _HostStream {
+  _HostStream({
+    required this.host,
+    required this.api,
+    required this.showHostLabel,
+  });
+
+  final HostConnection host;
+  final ApiClient api;
+
+  /// Whether the notification text should name the host. Off for a single
+  /// host, where the name adds nothing.
+  final bool showHostLabel;
+
+  http.Client? client;
+  bool connected = false;
+  DateTime? lastBytesAt;
+  int generation = 0;
+
+  String get label => host.label;
+
+  bool get isStale {
+    if (!connected) return true;
+    final at = lastBytesAt;
+    if (at == null) return false;
+    return DateTime.now().difference(at) > backgroundSilenceThreshold;
+  }
+
+  void close() {
+    generation++;
+    connected = false;
+    client?.close();
+    client = null;
+    api.close();
+  }
+}

--- a/mobile/lib/services/host_manager.dart
+++ b/mobile/lib/services/host_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:cryptography/cryptography.dart';
@@ -8,7 +9,9 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/host_connection.dart';
 import 'api_client.dart';
+import 'background_watch.dart';
 import 'daemon_api_service.dart';
+import 'notification_service.dart';
 
 /// Narrows the offline hosts to the ones the current filter is showing.
 ///
@@ -97,6 +100,15 @@ class HostManager extends ChangeNotifier {
 
   /// Load stored hosts on app start.
   Future<void> loadStoredHosts() async {
+    // A cold start never raises AppLifecycleState.resumed, so nothing else
+    // retires the watcher — and Android restarts it on its own after the app is
+    // killed. Without this the app and the service both hold a stream to every
+    // host, racing to post the same notification.
+    if (Platform.isAndroid) {
+      await stopBackgroundWatch();
+      await NotificationService.instance.reloadPosted();
+    }
+
     try {
       final raw = await _secureStorage.read(key: _hostsKey);
       if (raw != null) {
@@ -420,6 +432,27 @@ class HostManager extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Hand the streams to the foreground service as the app goes away.
+  ///
+  /// The app's own streams die with its process, so something has to hold them
+  /// while it is gone. Exactly one side is connected at a time: the app's
+  /// streams are stopped first, and the service seeds itself from
+  /// `/api/notifications` to cover the gap between the two.
+  Future<void> handOffToBackground() async {
+    if (!Platform.isAndroid) return;
+    if (!await backgroundWatchEnabled()) return;
+    if (_hosts.isEmpty) return;
+
+    stopAll();
+    try {
+      await startBackgroundWatch();
+    } catch (e) {
+      // Losing the handover must not cost the foreground streams as well.
+      debugPrint('Failed to start background watch: $e');
+      await resumeAll();
+    }
+  }
+
   /// Stop all services (app background).
   void stopAll() {
     for (final service in _services.values) {
@@ -429,6 +462,18 @@ class HostManager extends ChangeNotifier {
 
   /// Restart all services (app resume).
   Future<void> resumeAll() async {
+    if (Platform.isAndroid) {
+      await stopBackgroundWatch();
+      // The service posted and retracted notifications from its own isolate,
+      // with its own heap. Its record of what is in the tray lives in shared
+      // storage, and reading it back is what lets the sweep below retract
+      // something this isolate never posted.
+      await NotificationService.instance.reloadPosted();
+    }
+    await _resumeHosts();
+  }
+
+  Future<void> _resumeHosts() async {
     for (final host in _hosts) {
       final service = _services[host.id];
       if (service == null) continue;

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -112,14 +112,25 @@ class NotificationService {
     await prefs.setString(_keyAlertTypes, jsonEncode(_alertTypes));
   }
 
-  /// Convert a string ID to a positive notification ID.
-  static int _notifId(String id) => id.hashCode & 0x7FFFFFFF;
+  /// The integer the plugin is given for a notification, derived from its
+  /// [notifKey].
+  ///
+  /// Keyed rather than payload-derived because two isolates post these. The
+  /// foreground service watches the stream while the app is closed, and the app
+  /// has to be able to retract what the service posted — which it can only do
+  /// by arriving at the same integer from the same key, with nothing shared in
+  /// memory between them.
+  static int _notifId(String key) => key.hashCode & 0x7FFFFFFF;
 
-  /// Posted OS notifications, keyed by [notifKey] → the integer id handed to
-  /// the plugin. The integer is derived from the JSON payload string, so
-  /// rebuilding it at cancel time would depend on map key order; a retraction
-  /// that silently misses is worse than none.
-  final Map<String, int> _posted = {};
+  static const _keyPostedNotifications = 'notif_posted_keys';
+
+  /// Keys currently posted to the tray.
+  ///
+  /// Mirrored into SharedPreferences on every change: the app and the
+  /// background service run in separate isolates with separate heaps, and this
+  /// file is the only thing they both see. Held in memory as well so the common
+  /// path does not wait on disk.
+  final Set<String> _posted = {};
 
   /// Stable key for a notification, independent of payload encoding.
   static String notifKey(String hostId, String notificationId) =>
@@ -127,16 +138,76 @@ class NotificationService {
 
   /// Whether a notification is currently posted for this key. Doubles as the
   /// de-dupe check, so a replayed event does not re-alert.
-  bool isPosted(String key) => _posted.containsKey(key);
+  bool isPosted(String key) => _posted.contains(key);
+
+  /// Re-read the posted set written by the other isolate.
+  ///
+  /// Called on resume, before the reconcile sweep: the service may have posted
+  /// or retracted notifications while the app was away, and this instance's
+  /// in-memory copy predates all of it.
+  Future<void> reloadPosted() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.reload();
+      _posted
+        ..clear()
+        ..addAll(prefs.getStringList(_keyPostedNotifications) ?? const []);
+    } catch (e) {
+      debugPrint('[NotificationService] reloadPosted failed: $e');
+    }
+    await _pruneToTray();
+  }
+
+  /// Drop keys the tray no longer holds.
+  ///
+  /// The posted set doubles as the de-dupe check, and it outlives the
+  /// notifications it describes: a force-stop, a reboot, or the user swiping
+  /// the shade clears the tray without telling anyone. Left alone, the stale
+  /// key says "already posted" for ever and the approval it names never buzzes
+  /// again — the agent stays blocked and the phone stays quiet. The tray itself
+  /// is the only honest answer about what is on screen.
+  Future<void> _pruneToTray() async {
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    if (android == null) return;
+
+    try {
+      final active = await android.getActiveNotifications();
+      final live = active.map((n) => n.id).toSet();
+      final gone = _posted.where((key) => !live.contains(_notifId(key)));
+      if (gone.isEmpty) return;
+      debugPrint('[NotificationService] pruning ${gone.length} stale key(s)');
+      _posted.removeAll(gone.toList());
+      await _savePosted();
+    } catch (e) {
+      debugPrint('[NotificationService] prune failed: $e');
+    }
+  }
+
+  /// Drop the in-memory copy without touching shared storage, standing in for
+  /// an isolate that has not read the file yet.
+  @visibleForTesting
+  void forgetPostedForTest() => _posted.clear();
+
+  Future<void> _savePosted() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(_keyPostedNotifications, _posted.toList());
+    } catch (e) {
+      debugPrint('[NotificationService] savePosted failed: $e');
+    }
+  }
 
   /// Retract a posted notification. A no-op when nothing is posted for this
   /// key, which is the common case for types that never raise one.
   Future<void> cancel(String key) async {
-    final nid = _posted.remove(key);
-    if (nid == null) return;
+    if (!_posted.remove(key)) return;
+    await _savePosted();
     try {
-      await _plugin.cancel(nid);
-      debugPrint('[NotificationService] cancel key=$key nid=$nid');
+      await _plugin.cancel(_notifId(key));
+      debugPrint('[NotificationService] cancel key=$key');
     } catch (e) {
       debugPrint('[NotificationService] cancel failed for $key: $e');
     }
@@ -151,7 +222,7 @@ class NotificationService {
   /// would leave it in the tray forever.
   Future<void> retainOnly(String hostId, Set<String> pendingIds) async {
     final prefix = '$hostId:';
-    final stale = _posted.keys
+    final stale = _posted
         .where(
           (key) =>
               key.startsWith(prefix) &&
@@ -165,19 +236,21 @@ class NotificationService {
 
   /// Retract every notification this service has posted.
   Future<void> cancelAll() async {
-    final ids = _posted.values.toList();
+    final keys = _posted.toList();
     _posted.clear();
-    for (final nid in ids) {
+    await _savePosted();
+    for (final key in keys) {
       try {
-        await _plugin.cancel(nid);
+        await _plugin.cancel(_notifId(key));
       } catch (e) {
-        debugPrint('[NotificationService] cancelAll failed for $nid: $e');
+        debugPrint('[NotificationService] cancelAll failed for $key: $e');
       }
     }
   }
 
   Future<void> init() async {
     final prefs = await SharedPreferences.getInstance();
+    _posted.addAll(prefs.getStringList(_keyPostedNotifications) ?? const []);
     _soundEnabled = prefs.getBool(_keySoundEnabled) ?? true;
     _vibrationEnabled = prefs.getBool(_keyVibrationEnabled) ?? true;
     final alertJson = prefs.getString(_keyAlertTypes);
@@ -288,6 +361,8 @@ class NotificationService {
         );
       }
     }
+
+    await _pruneToTray();
   }
 
   Future<bool> requestPermission() async {
@@ -337,9 +412,9 @@ class NotificationService {
     required String detail,
     bool silent = false,
   }) async {
-    final nid = _notifId(id);
+    final nid = _notifId(key);
     debugPrint(
-      '[NotificationService] showPermission id=$id nid=$nid tool=$toolName',
+      '[NotificationService] showPermission key=$key nid=$nid tool=$toolName',
     );
 
     final androidDetails = AndroidNotificationDetails(
@@ -381,7 +456,8 @@ class NotificationService {
         NotificationDetails(android: androidDetails, iOS: iosDetails),
         payload: id,
       );
-      _posted[key] = nid;
+      _posted.add(key);
+      await _savePosted();
       if (!silent) await _playSound();
       debugPrint('[NotificationService] showPermission SUCCESS');
     } catch (e) {
@@ -397,9 +473,9 @@ class NotificationService {
     required String body,
     bool silent = false,
   }) async {
-    final nid = _notifId(id);
+    final nid = _notifId(key);
     debugPrint(
-      '[NotificationService] showNotification id=$id nid=$nid title=$title',
+      '[NotificationService] showNotification key=$key nid=$nid title=$title',
     );
 
     final androidDetails = AndroidNotificationDetails(
@@ -429,7 +505,8 @@ class NotificationService {
         NotificationDetails(android: androidDetails, iOS: iosDetails),
         payload: id,
       );
-      _posted[key] = nid;
+      _posted.add(key);
+      await _savePosted();
       if (!silent) await _playSound();
       debugPrint('[NotificationService] showNotification SUCCESS');
     } catch (e) {

--- a/mobile/test/notification_service_test.dart
+++ b/mobile/test/notification_service_test.dart
@@ -18,8 +18,12 @@ void main() {
 
   late List<MethodCall> calls;
 
+  /// What the platform reports is currently in the tray.
+  late List<Map<String, Object?>> activeNotifications;
+
   setUp(() async {
     calls = [];
+    activeNotifications = [];
     SharedPreferences.setMockInitialValues({});
 
     // Unit tests get no plugin registration, so the platform instance the
@@ -32,6 +36,7 @@ void main() {
       calls.add(call);
       // initialize() returns a bool; everything else here returns void.
       if (call.method == 'initialize') return true;
+      if (call.method == 'getActiveNotifications') return activeNotifications;
       return null;
     });
     messenger.setMockMethodCallHandler(_nativeChannel, (call) async => null);
@@ -91,8 +96,8 @@ void main() {
     expect(NotificationService.instance.isPosted(key), isFalse);
   });
 
-  // The plugin id is derived from the payload string, so a cancel that rebuilt
-  // it from the parts would depend on JSON key order and silently miss.
+  // The plugin id is derived from the key, so any isolate holding the same key
+  // arrives at the same integer without sharing memory.
   test('cancel uses the same integer id that show used', () async {
     const key = 'host-a:n1';
     await NotificationService.instance.showPermissionNotification(
@@ -217,6 +222,98 @@ void main() {
     test('a host with nothing posted is a no-op', () async {
       await NotificationService.instance.retainOnly('host-z', {'n1'});
       expect(calls.where((c) => c.method == 'cancel'), isEmpty);
+    });
+  });
+
+  // The foreground service posts from its own isolate, with its own heap. The
+  // app can only retract what the service posted by reaching the same integer
+  // from the same key, and by learning the key from the one thing they share.
+  group('across the isolate boundary', () {
+    test('a key posted by the other isolate is retractable here', () async {
+      const key = 'host-a:n1';
+
+      // What the service isolate would have posted.
+      await NotificationService.instance.showPermissionNotification(
+        id: '{"hostId":"host-a","notificationId":"n1"}',
+        key: key,
+        toolName: 'Bash',
+        detail: 'rm -rf /tmp/x',
+        silent: true,
+      );
+      final postedId = shownId();
+      expect(postedId, isNotNull);
+      activeNotifications = [
+        {'id': postedId},
+      ];
+
+      // This isolate knows nothing about it until it reads the shared file.
+      NotificationService.instance.forgetPostedForTest();
+      expect(NotificationService.instance.isPosted(key), isFalse);
+
+      await NotificationService.instance.reloadPosted();
+      expect(NotificationService.instance.isPosted(key), isTrue);
+
+      calls.clear();
+      await NotificationService.instance.cancel(key);
+      expect(cancelledId(), postedId);
+    });
+
+    // A force-stop, a reboot or a swipe of the shade empties the tray without
+    // telling anyone. The key would otherwise keep answering "already posted"
+    // and that approval would never buzz again.
+    test('a key whose notification is gone from the tray is dropped', () async {
+      const key = 'host-a:n1';
+      await NotificationService.instance.showNotification(
+        id: 'p1',
+        key: key,
+        title: 'a',
+        body: 'a',
+        silent: true,
+      );
+      expect(NotificationService.instance.isPosted(key), isTrue);
+
+      // The tray now reports nothing, as it would after a force-stop.
+      activeNotifications = [];
+      await NotificationService.instance.reloadPosted();
+
+      expect(NotificationService.instance.isPosted(key), isFalse);
+    });
+
+    test('a key still in the tray survives the prune', () async {
+      const key = 'host-a:n1';
+      await NotificationService.instance.showNotification(
+        id: 'p1',
+        key: key,
+        title: 'a',
+        body: 'a',
+        silent: true,
+      );
+      activeNotifications = [
+        {'id': shownId()},
+      ];
+
+      await NotificationService.instance.reloadPosted();
+
+      expect(NotificationService.instance.isPosted(key), isTrue);
+    });
+
+    test('showing writes the key through to shared storage', () async {
+      await NotificationService.instance.showNotification(
+        id: 'p1',
+        key: 'host-a:n1',
+        title: 'a',
+        body: 'a',
+        silent: true,
+      );
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList('notif_posted_keys'), contains('host-a:n1'));
+
+      await NotificationService.instance.cancel('host-a:n1');
+      expect(
+        prefs.getStringList('notif_posted_keys'),
+        isNot(contains('host-a:n1')),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

The phone only heard about a blocked agent while its process was alive. Swipe Helios out of recents, or let Doze cut the socket, and every approval after that moment was missed. Spec 32 fixed the aftermath — the tray self-heals on resume — and explicitly deferred the foreground service that fixes delivery. This is that service.

Design and reasoning: [docs/specs/59-background-notifications.md](docs/specs/59-background-notifications.md).

- **The app and the service take turns.** The app hands its streams over on pause and takes them back on resume, so exactly one side holds a socket per host. The alternative — service owns the stream always — means proxying all of `DaemonAPIService` across an isolate boundary.
- **Notification ids are derived from the stable key**, not the payload string, so either isolate can retract what the other posted. The posted set is mirrored into `SharedPreferences` and pruned on load against the notifications actually in the tray; persisting it without that would make a force-stop or a user swipe silence that approval permanently.
- **The sound channel becomes a plugin** registered on both engines. Left in `MainActivity`, every background notification would be silent on exactly the OEMs the manual sound path was written for.
- **`specialUse`, not `dataSync`** — Android 15 stops a `dataSync` service after six hours a day, and Helios sideloads, so the Play review `specialUse` would otherwise cost does not apply.
- **Battery**: no wake lock (an inbound packet wakes the CPU by itself) and a 240s heartbeat in the background instead of 30s — roughly 360 radio wake-ups a day instead of 2,880. `/api/events` now takes an optional clamped `heartbeat` parameter; the in-app default is unchanged.

iOS is not covered. It has no foreground-service equivalent, so it needs APNs and a push sender in the daemon — phase 2 in the spec.

## Test plan

- [x] `go test ./internal/server/` — new `TestHeartbeatInterval` covers the clamp
- [x] `flutter test` — 193 pass, including new cross-isolate and tray-prune cases
- [x] `flutter analyze` — no new issues
- [x] Backgrounded: service starts, connects, seeds
- [x] Swiped out of recents: activity gone, service alive as `types=0x40000000`, stream connected
- [x] Deep Doze (`dumpsys deviceidle force-idle`): a Bash permission request arrived, and was retracted when answered elsewhere
- [x] Cold start and foreground: service stopped, so the two never race
- [x] Sound channel resolves in the service isolate — no `MissingPluginException`
- [ ] Overnight run to confirm no six-hour cap applies

Note: `TestSend_NewSessionTypesOnlyAfterTheScreenSettles` fails on clean `main` too — pre-existing, unrelated to this branch.