### PR TITLE
fix(desktop): keep an approval on the screen it appeared on

### DIFF
--- a/desktop/src/main/anchor.ts
+++ b/desktop/src/main/anchor.ts
@@ -1,0 +1,39 @@
+/** A rectangle in screen coordinates. */
+export interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+const WIDTH = 400
+const INSET = 12
+
+/**
+ * Where the HUD sits, decided once per showing.
+ *
+ * The card stack reports its own height whenever a card is added or removed,
+ * and the window is resized to match. Choosing the corner on each of those
+ * reads the pointer again — so a second approval arriving after the user had
+ * moved to another display carried the first one across with it, mid-read. The
+ * corner is picked when the HUD appears and held until it goes away.
+ */
+export class HudAnchor {
+  private origin: { x: number; y: number } | null = null
+
+  /** Top-right of [workArea] the first time, then the corner already held. */
+  place(workArea: Rect, height: number): Rect {
+    if (!this.origin) {
+      this.origin = {
+        x: workArea.x + workArea.width - WIDTH - INSET,
+        y: workArea.y + INSET,
+      }
+    }
+    return { ...this.origin, width: WIDTH, height }
+  }
+
+  /** Forgets the corner, so the next showing can land where the user now is. */
+  release(): void {
+    this.origin = null
+  }
+}

--- a/desktop/src/main/hud.ts
+++ b/desktop/src/main/hud.ts
@@ -1,11 +1,10 @@
 import { BrowserWindow, app, ipcMain, screen } from 'electron'
 import path from 'node:path'
 
+import { HudAnchor, type Rect } from './anchor.ts'
 import type { Notification } from '../shared/models.ts'
 import type { NotifyTarget } from './notify.ts'
 
-const WIDTH = 400
-const INSET = 12
 /** Past this the stack scrolls rather than the window growing off the screen. */
 const MAX_HEIGHT = 720
 
@@ -30,6 +29,7 @@ export interface HudCard {
 export class Hud {
   private window: BrowserWindow | null = null
   private readonly cards = new Map<string, HudCard>()
+  private readonly corner = new HudAnchor()
 
   constructor(
     private readonly rendererDir: string,
@@ -83,11 +83,13 @@ export class Hud {
 
   hide(): void {
     this.window?.hide()
+    this.corner.release()
   }
 
   destroy(): void {
     this.window?.destroy()
     this.window = null
+    this.corner.release()
   }
 
   private ensureWindow(): BrowserWindow {
@@ -145,16 +147,12 @@ export class Hud {
 
   /**
    * Top-right of the work area of the display the cursor is on, which is the
-   * screen the user is looking at and already clears the menu bar.
+   * screen the user is looking at and already clears the menu bar. Only the
+   * first call after a showing begins chooses it; see HudAnchor.
    */
-  private anchor(height: number): { x: number; y: number; width: number; height: number } {
+  private anchor(height: number): Rect {
     const { workArea } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
-    return {
-      x: workArea.x + workArea.width - WIDTH - INSET,
-      y: workArea.y + INSET,
-      width: WIDTH,
-      height,
-    }
+    return this.corner.place(workArea, height)
   }
 }
 

--- a/desktop/test/hud-anchor.test.ts
+++ b/desktop/test/hud-anchor.test.ts
@@ -1,0 +1,52 @@
+// The HUD is resized every time a card is added or removed, and the corner used
+// to be recomputed on each of those from wherever the pointer had got to. A
+// second approval then carried the first one onto another display while it was
+// being read. The corner belongs to the showing, not to the resize.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { HudAnchor } from '../src/main/anchor.ts'
+
+const laptop = { x: 0, y: 25, width: 1512, height: 945 }
+const external = { x: 1512, y: 0, width: 2560, height: 1415 }
+
+test('the corner is the top right of the work area it is given', () => {
+  const bounds = new HudAnchor().place(laptop, 200)
+  assert.deepEqual(bounds, { x: 1512 - 400 - 12, y: 25 + 12, width: 400, height: 200 })
+})
+
+test('a resize changes the height and nothing else', () => {
+  const anchor = new HudAnchor()
+  const first = anchor.place(laptop, 200)
+  const grown = anchor.place(laptop, 520)
+
+  assert.equal(grown.x, first.x)
+  assert.equal(grown.y, first.y)
+  assert.equal(grown.height, 520)
+})
+
+// The regression itself: the pointer has moved to the other screen by the time
+// the second card arrives, so place() is handed a different work area.
+test('a card arriving after the pointer moved does not follow it', () => {
+  const anchor = new HudAnchor()
+  const first = anchor.place(laptop, 200)
+  const second = anchor.place(external, 520)
+
+  assert.equal(second.x, first.x)
+  assert.equal(second.y, first.y)
+})
+
+test('the next showing lands where the user now is', () => {
+  const anchor = new HudAnchor()
+  anchor.place(laptop, 200)
+  anchor.release()
+  const reopened = anchor.place(external, 200)
+
+  assert.deepEqual(reopened, { x: 1512 + 2560 - 400 - 12, y: 12, width: 400, height: 200 })
+})
+
+test('releasing an anchor that was never placed is harmless', () => {
+  const anchor = new HudAnchor()
+  anchor.release()
+  assert.equal(anchor.place(external, 200).x, 1512 + 2560 - 400 - 12)
+})


### PR DESCRIPTION
## Summary

The HUD is resized every time a card is added or removed. The stack measures itself and reports one number — its height — and the window is set to match. The bounds carrying that height carried a position too, and `anchor()` recomputed the position from the pointer on every report.

So a second approval arriving after you had moved to the other monitor took the first one across with it, mid-read. The renderer said "taller". The main process heard "taller, and move to wherever the pointer is".

`HudAnchor` now picks the corner from the work area the first time it is asked and holds it until the HUD hides. A later resize changes only the height. Which display the HUD opens on is unchanged — still the one the pointer is on when the approval lands — and `hide()` releases the corner so the next one can land somewhere else.

Found while debugging a report of desktop notifications disrupting focus. Two other causes turned up and are **not** in this PR: a stale dev instance doubling every notification (environmental), and AeroSpace switching workspace when Helios is activated, which needs a decision about `app.focus({ steal: true })` in `Hud.focus()` rather than a bug fix.

Measured and cleared of blame: the HUD is a non-activating panel, and showing or clicking it raises neither `did-become-active` nor `browser-window-focus`. The panel fix from #111 works. The window moving was the whole of it.

## Test plan

- [x] `npm test` — 297 pass, 0 fail (5 new in `hud-anchor.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `node build.mjs` — clean
- [x] Mutation-checked: forcing the corner to be recomputed on every call fails exactly the regression case (`not ok 3 - a card arriving after the pointer moved does not follow it`) and nothing else
- [ ] **Not verified on two displays.** Only the built-in display was attached, and there the old and new code produce identical coordinates. Someone docked should confirm a second approval no longer drags the stack across.