### PR TITLE
fix(desktop): keep host seeds in the clear, and keep the ones we cannot read

### DIFF
--- a/desktop/e2e/hosts-store.spec.ts
+++ b/desktop/e2e/hosts-store.spec.ts
@@ -1,0 +1,97 @@
+// What a write to hosts.json is allowed to do to the entries it did not write.
+//
+// Seeds were once put through the OS key store. The Keychain binds an item to
+// the code signature that wrote it and these builds are ad-hoc signed, so an
+// upgrade left the app unable to read its own seeds — and load() dropped what
+// it could not read, which the next persist() then erased from the file. The
+// hosts looked like they had vanished on install. Nothing is encrypted any
+// more, and an entry that still is has to survive being written around.
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { _electron as electron, expect, test, type ElectronApplication } from '@playwright/test'
+
+import { startDaemon, type StubDaemon } from './daemon.ts'
+
+const READABLE = 'readable-host'
+const LEGACY = 'legacy-host'
+
+interface Stored {
+  id: string
+  name: string
+  secret: string
+  encrypted?: boolean
+}
+
+test('a seed left over from the encrypting builds is not deleted by the next write', async () => {
+  test.setTimeout(120000)
+  let daemon: StubDaemon | null = null
+  let app: ElectronApplication | null = null
+  const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'helios-hosts-'))
+
+  try {
+    daemon = await startDaemon()
+    const file = path.join(userData, 'hosts.json')
+    await fs.writeFile(
+      file,
+      JSON.stringify([
+        {
+          id: READABLE,
+          name: 'readable',
+          url: daemon.url,
+          device_id: READABLE,
+          local: false,
+          secret: crypto.randomBytes(32).toString('base64url'),
+        },
+        // Ciphertext this build has no key for, exactly as an upgraded machine
+        // finds it.
+        {
+          id: LEGACY,
+          name: 'legacy',
+          url: 'http://127.0.0.1:7655',
+          device_id: LEGACY,
+          local: true,
+          secret: crypto.randomBytes(64).toString('base64'),
+          encrypted: true,
+        },
+      ]),
+    )
+
+    app = await electron.launch({
+      args: ['.', `--user-data-dir=${userData}`],
+      env: { ...process.env, HELIOS_RELEASES_URL: 'data:application/json,[]' },
+    })
+    const window = await app.firstWindow()
+    await window.waitForLoadState('domcontentloaded')
+
+    // A rename is the cheapest thing that makes the app rewrite the file.
+    await window.locator('.sidebar-foot').getByRole('button', { name: 'Add host' }).click()
+    const name = window.locator('.host-name-input').first()
+    await expect(name).toBeVisible()
+    await name.fill('renamed')
+    await name.blur()
+
+    await expect
+      .poll(async () => {
+        const stored = JSON.parse(await fs.readFile(file, 'utf8')) as Stored[]
+        return stored.find((h) => h.id === READABLE)?.name
+      })
+      .toBe('renamed')
+
+    const stored = JSON.parse(await fs.readFile(file, 'utf8')) as Stored[]
+    const legacy = stored.find((h) => h.id === LEGACY)
+    expect(legacy).toBeTruthy()
+    expect(legacy!.encrypted).toBe(true)
+
+    // The one it can read is written back in the clear, with no flag claiming
+    // a key store holds it.
+    const readable = stored.find((h) => h.id === READABLE)
+    expect(readable!.encrypted).toBeUndefined()
+  } finally {
+    await app?.close()
+    await daemon?.close()
+    await fs.rm(userData, { recursive: true, force: true })
+  }
+})

--- a/desktop/src/main/hosts.ts
+++ b/desktop/src/main/hosts.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { app, safeStorage } from 'electron'
+import { app } from 'electron'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -14,9 +14,10 @@ const INTERNAL_URL = 'http://127.0.0.1:7654'
 const DEFAULT_LOCAL_URL = 'http://127.0.0.1:7655'
 
 interface StoredHost extends HostRecord {
-  /** Encrypted device seed, base64. Plaintext only if safeStorage is unavailable. */
+  /** The device seed, base64. Written in the clear; the file is 0600. */
   secret: string
-  encrypted: boolean
+  /** Set by builds that put the seed through the OS key store. Never written. */
+  encrypted?: boolean
 }
 
 export interface HostHandle {
@@ -42,6 +43,16 @@ export interface HostHandle {
  */
 export class HostRegistry extends EventEmitter {
   private hosts = new Map<string, HostHandle>()
+  /**
+   * Entries from an older file whose seed is ciphertext, kept verbatim.
+   *
+   * Nothing here can read them — the key store bound them to a code signature
+   * these ad-hoc builds no longer have, which is what made every upgrade look
+   * like the hosts had vanished. They are carried through a write rather than
+   * dropped, because persist() rebuilds the file from memory and anything left
+   * out of it is deleted from disk.
+   */
+  private locked: StoredHost[] = []
   private readonly file: string
 
   constructor(userDataDir = app.getPath('userData')) {
@@ -50,10 +61,13 @@ export class HostRegistry extends EventEmitter {
   }
 
   load(): void {
+    this.locked = []
     for (const stored of this.readFile()) {
-      const seed = this.decrypt(stored)
-      if (!seed) continue
-      this.instantiate({ ...stripSecret(stored) }, { kid: stored.device_id, seed })
+      if (stored.encrypted) {
+        this.locked.push(stored)
+        continue
+      }
+      this.instantiate({ ...stripSecret(stored) }, { kid: stored.device_id, seed: stored.secret })
     }
     this.emit('hosts', this.list())
   }
@@ -212,35 +226,15 @@ export class HostRegistry extends EventEmitter {
   }
 
   private persist(): void {
-    const stored: StoredHost[] = [...this.hosts.values()].map((h) => ({
-      ...h.record,
-      ...this.encrypt(h.key.seed),
-    }))
+    const stored: StoredHost[] = [
+      ...[...this.hosts.values()].map((h) => ({ ...h.record, secret: h.key.seed })),
+      ...this.locked,
+    ]
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
-    // 0600 regardless of encryption: on a box with no Secret Service the seed
-    // is in here in the clear, and file permissions are then the only guard.
+    // The seed is in here in the clear, so the mode is the only guard on it.
     fs.writeFileSync(this.file, JSON.stringify(stored, null, 2), { mode: 0o600 })
   }
 
-  private encrypt(seed: string): { secret: string; encrypted: boolean } {
-    if (safeStorage.isEncryptionAvailable()) {
-      return { secret: safeStorage.encryptString(seed).toString('base64'), encrypted: true }
-    }
-    // Linux with no keyring daemon. Degrading to a 0600 file is worse than the
-    // Keychain and better than refusing to run, which is the actual choice.
-    return { secret: seed, encrypted: false }
-  }
-
-  private decrypt(stored: StoredHost): string | null {
-    if (!stored.encrypted) return stored.secret
-    try {
-      return safeStorage.decryptString(Buffer.from(stored.secret, 'base64'))
-    } catch {
-      // A key encrypted under a different login, or a corrupt keychain entry.
-      // The host is unusable until it is paired again.
-      return null
-    }
-  }
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What broke

Installing a new desktop build looked like the app had forgotten every host it was paired with.

Each host's device seed went through Electron's `safeStorage`. On macOS that is the Keychain, and the Keychain binds an item to the code signature that wrote it. `electron-builder.yml` sets `identity: null`, so every build is ad-hoc signed with a fresh identity — the new build could not read what the old one wrote.

From there the loss was automatic:

1. `load()` skipped any host whose seed would not decrypt (`if (!seed) continue`).
2. `persist()` rebuilds the file from what is in memory.
3. So the first pair or rename after the upgrade erased the skipped hosts from `hosts.json` for good.

## What changed

- Nothing is encrypted. The seed authenticates to a daemon on loopback or a tailnet, sits beside a plaintext `helios.db`, and `hosts.json` is already `0600` — the Keychain was buying very little and cost real data. `safeStorage` is gone from the file.
- An entry left over from the encrypting builds is kept verbatim through a write rather than dropped. It is unreadable, but unreadable is not a reason to delete someone's host.

Anyone upgrading past this keeps their old entries in the file; a host that was encrypted still has to be paired again, because no key for it exists on the machine any more.

## Test plan

- [x] `desktop/e2e/hosts-store.spec.ts` — seeds a readable host beside a legacy `encrypted: true` one, renames through the Hosts pane to force a write, asserts the legacy entry survived and the readable one is written back with no `encrypted` flag. Fails on `main`, passes here.
- [x] `npm test` — 292 pass
- [x] `npx playwright test` — 58 pass
- [x] `npm run typecheck`