### PR TITLE
fix(desktop): keep the HUD from demoting the app to accessory

### DIFF
--- a/desktop/src/main/hud.ts
+++ b/desktop/src/main/hud.ts
@@ -129,7 +129,16 @@ export class Hud {
     })
 
     window.setAlwaysOnTop(true, 'screen-saver')
-    window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+    // skipTransformProcessType keeps Electron from flipping the whole app
+    // between regular and accessory (UIElement) when the panel joins all
+    // spaces. That flip drops the Dock indicator, makes the Dock icon
+    // unclickable, and — because it changes the app's activation — drags the
+    // frontmost app out of its fullscreen space. The HUD only needs to be
+    // visible everywhere, not to restyle the process.
+    window.setVisibleOnAllWorkspaces(true, {
+      visibleOnFullScreen: true,
+      skipTransformProcessType: true,
+    })
     window.on('closed', () => {
       this.window = null
     })


### PR DESCRIPTION
## Summary

Follow-up to #184. On macOS, showing the approval HUD while another app was in fullscreen kicked you out of fullscreen, and the Helios Dock icon lost its running indicator and became unclickable.

The cause is `setVisibleOnAllWorkspaces(true, …)` in `hud.ts`. By default Electron reacts to that call by transforming the app's process type between *regular* and *accessory* (UIElement). An accessory app has no Dock indicator and an unresponsive Dock icon — and the activation change is what drags the frontmost app out of its fullscreen space.

Passing `skipTransformProcessType: true` keeps the HUD visible on every space (including over fullscreen apps) without restyling the process.

This is independent of, and pre-dates, the anchor-pin work in #184 — that PR only touched positioning; this touches the panel's space/activation behavior.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 297 pass, 0 fail
- [x] Verified live in the dev build: with an app in macOS fullscreen, the HUD now overlays without exiting fullscreen, and the Dock icon keeps its indicator and stays clickable.