### PR TITLE
feat(desktop): fold a tool row the way the terminal does

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react'
 
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -9,6 +9,7 @@ import { removeFirst } from '../attachments.ts'
 import { AttachButton, AttachmentChips, PasteOffer, useAttachments, useDropTarget } from './attach.tsx'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
+import { followsItsCall, resultOf } from './tool-calls.ts'
 import { Chevron } from './icons.tsx'
 import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
 import {
@@ -259,14 +260,19 @@ export function ChatPanel({
               </button>
             )}
             {messages.length === 0 && <p className="empty-note">No transcript yet.</p>}
-            {messages.map((message, index) => (
-              <Message
-                key={`${message.timestamp}-${index}`}
-                message={message}
-                hostId={hostId}
-                cwd={session.cwd}
-              />
-            ))}
+            {messages.map((message, index) =>
+              // A result that followed its own call is drawn on that call's
+              // row, so it does not get a line of its own here.
+              followsItsCall(messages, index) ? null : (
+                <Message
+                  key={`${message.timestamp}-${index}`}
+                  message={message}
+                  result={resultOf(messages, index)}
+                  hostId={hostId}
+                  cwd={session.cwd}
+                />
+              ),
+            )}
             {busy && <div className="typing">agent is working…</div>}
           </>
         )}
@@ -389,16 +395,18 @@ interface MessageProps {
   message: TranscriptMessage
   hostId: string
   cwd: string
+  /** How the call went, for a tool_use whose result came next. */
+  result?: boolean
 }
 
 /**
  * One transcript entry. The roles are the daemon's
  * (internal/transcript/reader.go): user, assistant, tool_use, tool_result.
  */
-function Message({ message, hostId, cwd }: MessageProps): JSX.Element | null {
+function Message({ message, hostId, cwd, result }: MessageProps): JSX.Element | null {
   switch (message.role) {
     case 'tool_use':
-      return <ToolUse message={message} hostId={hostId} cwd={cwd} />
+      return <ToolUse message={message} hostId={hostId} cwd={cwd} result={result} />
     case 'tool_result':
       return <ToolResult message={message} />
     case 'assistant':
@@ -528,38 +536,97 @@ const CODE_FIELDS: { key: string; label?: string }[] = [
 /** Tools whose call changes a file, and whose diff is the point of the row. */
 const WRITING_TOOLS = new Set(['Edit', 'MultiEdit', 'Write'])
 
-/**
- * A summary is one line by definition, but the thing it summarises often is
- * not — a heredoc, a multi-line command. Collapsing the whitespace here rather
- * than leaving it to `white-space: nowrap` keeps the ellipsis honest: the
- * browser would otherwise measure the untouched string and decide the row
- * needs a width no sidebar has.
- */
 function oneLine(text: string | undefined): string {
   return (text ?? '').replace(/\s+/g, ' ').trim()
 }
 
 /**
- * A tool call: one line collapsed, the input expanded. The expansion is
- * tool-aware because a Bash command and an Edit's replacement text want
- * different treatment, and a raw JSON dump serves neither.
+ * What the row says the call was.
+ *
+ * The daemon's summary cuts a command at 80 characters (internal/transcript/
+ * reader.go), which is where `git commit -m "…"` loses the message and two
+ * pipelines become the same string. The command itself is in the input, so the
+ * row shows that and lets it wrap.
  */
-function ToolUse({ message, hostId, cwd }: MessageProps): JSX.Element {
+function headline(tool: string, input: Record<string, unknown>, summary?: string): string {
+  if (tool === 'Bash' || tool === 'BashOutput') {
+    const command = str(input.command) || str(input.cmd)
+    if (command) return command.trim()
+  }
+  return oneLine(summary)
+}
+
+/**
+ * How many lines the clamp is hiding, or 0 when it is hiding none.
+ *
+ * Measured rather than counted: what a line is depends on the width of the
+ * panel and the font in it, neither of which this knows. Re-measured on resize
+ * for the same reason.
+ */
+function useHiddenLines(text: string, open: boolean): [RefObject<HTMLSpanElement>, number] {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [hidden, setHidden] = useState(0)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el || open) {
+      setHidden(0)
+      return
+    }
+    const measure = (): void => {
+      const line = parseFloat(getComputedStyle(el).lineHeight) || 1
+      setHidden(Math.max(0, Math.round((el.scrollHeight - el.clientHeight) / line)))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [text, open])
+
+  return [ref, hidden]
+}
+
+/**
+ * A tool call: what it ran, and what it ran on.
+ *
+ * The command is shown in full and wrapped rather than cut at the width of the
+ * panel — reading which of two similar commands this was is the whole use of
+ * the row. Only the overflow past a few lines folds, and it says how much it is
+ * holding back, as the terminal does.
+ */
+function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
   const tool = message.tool ?? 'tool'
   const input = (message.metadata ?? {}) as Record<string, unknown>
   const filePath = typeof input.file_path === 'string' ? input.file_path : null
   // A write is the part of a session worth reading, and a collapsed row names
   // the tool without saying what it did to the file.
   const [open, setOpen] = useState(WRITING_TOOLS.has(tool))
+  const text = headline(tool, input, message.summary)
+  const [summaryRef, hidden] = useHiddenLines(text, open)
 
   return (
     <div className="msg tool-call">
-      <button className="tool-head" onClick={() => setOpen(!open)}>
+      <button className={open ? 'tool-head open' : 'tool-head'} onClick={() => setOpen(!open)}>
         <span className="tool-icon">{TOOL_ICONS[tool] ?? '⚙'}</span>
         <span className="tool-name">{tool}</span>
-        <span className="tool-summary">{oneLine(message.summary)}</span>
+        <span className="tool-summary" ref={summaryRef}>
+          {text}
+        </span>
+        {result !== undefined && (
+          <span
+            className={result ? 'tool-verdict' : 'tool-verdict failed'}
+            title={result ? 'The call succeeded' : 'The call failed'}
+          >
+            {result ? '✓' : '✕'}
+          </span>
+        )}
         <Chevron className="chevron" open={open} />
       </button>
+      {hidden > 0 && (
+        <button className="tool-more" onClick={() => setOpen(true)}>
+          … +{hidden} {hidden === 1 ? 'line' : 'lines'}
+        </button>
+      )}
       {open && (
         <div className="tool-detail">
           <ToolInput tool={tool} input={input} />
@@ -578,14 +645,11 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
   const entries = Object.entries(input)
   if (entries.length === 0) return <p className="tool-empty">No input recorded.</p>
 
+  // No code block for the command: the row above is showing it, in full.
   if (tool === 'Bash' || tool === 'BashOutput') {
-    const command = str(input.command) || str(input.cmd)
-    return (
-      <>
-        {command && <CodeBlock code={command} language="bash" />}
-        <KeyValues entries={entries.filter(([key]) => key !== 'command' && key !== 'cmd')} />
-      </>
-    )
+    const rest = entries.filter(([key]) => key !== 'command' && key !== 'cmd')
+    if (rest.length === 0) return <p className="tool-empty">Nothing else was passed.</p>
+    return <KeyValues entries={rest} />
   }
 
   // What changed, as a patch. Two code blocks — the text searched for and the

--- a/desktop/src/renderer/components/tool-calls.ts
+++ b/desktop/src/renderer/components/tool-calls.ts
@@ -1,0 +1,28 @@
+import type { TranscriptMessage } from '../../shared/models.ts'
+
+/**
+ * Pairing a call with the result that followed it.
+ *
+ * A tool_result carries no output — the daemon records the tool's name and
+ * whether it worked (internal/transcript/reader.go) — so drawing it as a
+ * message of its own spends a line of the transcript on the word "done". Paired
+ * up, it is a tick at the end of the row that earned it.
+ */
+
+/** Whether the message at this index is a result belonging to the call above it. */
+export function followsItsCall(messages: TranscriptMessage[], index: number): boolean {
+  return messages[index]?.role === 'tool_result' && messages[index - 1]?.role === 'tool_use'
+}
+
+/**
+ * How the call at this index went, or undefined when nothing says.
+ *
+ * Undefined is not the same as false: a call whose result has not arrived yet —
+ * the agent is still running it — must not be drawn as one that failed.
+ */
+export function resultOf(messages: TranscriptMessage[], index: number): boolean | undefined {
+  if (messages[index]?.role !== 'tool_use') return undefined
+  const next = messages[index + 1]
+  if (next?.role !== 'tool_result') return undefined
+  return next.success !== false
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1999,7 +1999,7 @@ small {
 }
 
 .msg {
-  margin: 0 0 14px;
+  margin: 0 0 8px;
   width: 100%;
 }
 
@@ -2298,15 +2298,26 @@ figure.mermaid svg {
   z-index: 1;
   display: flex;
   min-width: 0;
-  align-items: center;
+  /* Top, not centre: the command wraps, and a centred icon beside three lines
+     of it floats in the middle of the row with nothing to line up with. */
+  align-items: flex-start;
   gap: 10px;
   width: 100%;
   text-align: left;
   border-radius: var(--r-md) var(--r-md) 0 0;
-  padding: 9px 12px;
+  padding: 6px 10px;
   background: var(--surface-container);
   color: var(--on-surface);
   font-weight: 400;
+}
+
+.tool-icon,
+.tool-name,
+.tool-head .chevron {
+  /* The wrapping summary sets the row's height; these keep to the first line
+     of it rather than stretching down the side. */
+  flex: none;
+  line-height: 1.45;
 }
 
 .tool-icon {
@@ -2322,25 +2333,61 @@ figure.mermaid svg {
   font-weight: 600;
 }
 
+/* Wrapped, not cut.
+ *
+ * A command truncated at the width of the panel hides the half that says which
+ * command it was — the flag, the path, the message. So it wraps, and only what
+ * runs past three lines is folded away, with a row underneath saying how much.
+ */
 .tool-summary {
   flex: 1;
-  /* Without this the ellipsis never fires: a flex child defaults to
-     min-width:auto, so a long summary keeps its full intrinsic width, the head
-     overflows the card, and what shows is an arbitrary window into the middle
-     of the text rather than its start. */
+  /* A flex child defaults to min-width:auto, which refuses to shrink below the
+     intrinsic width of the text — the head would overflow the card instead of
+     wrapping inside it. */
   min-width: 0;
   color: var(--on-surface-variant);
   font-family: var(--mono);
+  /* A command is quoted, not typeset: `--repo` has to stay two hyphens. */
+  font-variant-ligatures: none;
   font-size: 11.5px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.tool-head.open .tool-summary {
+  display: block;
+  overflow: visible;
+}
+
+/* What the clamp is holding back, said out loud. */
+.tool-more {
+  display: block;
+  width: 100%;
+  padding: 0 10px 6px 34px;
+  border-radius: 0;
+  background: none;
+  color: var(--on-surface-variant);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  text-align: left;
+  opacity: 0.75;
+}
+
+.tool-more:hover {
+  opacity: 1;
+  background: none;
+  text-decoration: underline;
 }
 
 /* No height of its own: a patch reads as part of the transcript, scrolled with
    the messages around it rather than through a window cut into the card. */
 .tool-detail {
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-top: 1px solid var(--outline-variant);
 }
 
@@ -2351,7 +2398,7 @@ figure.mermaid svg {
 /* Full-bleed: the gutter and the tinted rows run to the edges of the card, as
    they do in a file view. */
 .tool-diff {
-  margin: 0 -12px -10px;
+  margin: 0 -10px -8px;
 }
 
 .tool-code-label {
@@ -2396,12 +2443,25 @@ figure.mermaid svg {
   color: var(--on-surface-variant);
 }
 
-/* A result is one line: the interesting half of the exchange is the call. */
+/* A tick at the end of the call, rather than a line under it saying "Bash
+   done". It is the whole of what a tool_result carries. */
+.tool-verdict {
+  flex: none;
+  line-height: 1.45;
+  color: var(--s-active);
+}
+
+.tool-verdict.failed {
+  color: var(--error);
+}
+
+/* Only for a result whose call is not above it — otherwise it is drawn as the
+   tick, and this row does not exist. */
 .msg.tool-result {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin: -8px 0 14px 4px;
+  margin: -4px 0 8px 4px;
   font-size: 11.5px;
   color: var(--on-surface-variant);
 }

--- a/desktop/test/tool-calls.test.ts
+++ b/desktop/test/tool-calls.test.ts
@@ -1,0 +1,45 @@
+// A result drawn twice, or a running call drawn as a failure, are both worse
+// than the line this saves — so the pairing is checked rather than eyeballed.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { followsItsCall, resultOf } from '../src/renderer/components/tool-calls.ts'
+import type { TranscriptMessage } from '../src/shared/models.ts'
+
+function call(tool = 'Bash'): TranscriptMessage {
+  return { seq: 0, role: 'tool_use', tool, timestamp: '2026-01-01T00:00:00Z' }
+}
+
+function result(success: boolean): TranscriptMessage {
+  return { seq: 0, role: 'tool_result', tool: 'Bash', success, timestamp: '2026-01-01T00:00:00Z' }
+}
+
+test('a result after its call is folded into it', () => {
+  const messages = [call(), result(true)]
+  assert.equal(followsItsCall(messages, 1), true)
+  assert.equal(resultOf(messages, 0), true)
+})
+
+test('a failure reads as one', () => {
+  const messages = [call(), result(false)]
+  assert.equal(resultOf(messages, 0), false)
+})
+
+test('a call still running has no verdict, which is not a failure', () => {
+  const messages = [call()]
+  assert.equal(resultOf(messages, 0), undefined)
+})
+
+test('a result with no call above it keeps its own row', () => {
+  const messages = [
+    { seq: 0, role: 'assistant', content: 'thinking', timestamp: '2026-01-01T00:00:00Z' },
+    result(true),
+  ] as TranscriptMessage[]
+  assert.equal(followsItsCall(messages, 1), false)
+})
+
+test('the verdict belongs to the call it followed, not the one before that', () => {
+  const messages = [call('Read'), call('Bash'), result(false)]
+  assert.equal(resultOf(messages, 0), undefined)
+  assert.equal(resultOf(messages, 1), false)
+})


### PR DESCRIPTION
## Summary

- **The command is shown in full and wrapped.** It is taken from the tool's own input rather than the daemon's summary, which cuts at 80 characters (`internal/transcript/reader.go`) — that is where a commit message or a second pipeline used to disappear.
- **Only the overflow folds.** Three lines, then a `… +N lines` row saying how much is held back. The count is measured from the rendered box and re-measured on resize, since what counts as a line depends on the panel's width and font.
- **The result is a tick on the row that earned it**, not a `Bash done` line beneath it — a `tool_result` carries nothing else. An orphan result keeps its own row; a call still running shows no verdict, which is deliberately distinct from failing.
- **Compacter:** 14px between rows → 8px, head padding 9/12 → 6/10, and expanding a Bash call no longer repeats the command already displayed above it.
- Ligatures off in the command text, so `--repo` stays two hyphens instead of drawing an em dash.

Desktop only. The output preview half of the terminal's folding (`… +3 lines` of *result* text) is not here: the daemon parses `content` on a `tool_result` block but does not forward it, so there is nothing to preview yet.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 307 pass, including 5 new in `test/tool-calls.test.ts` covering the pairing rules: verdict folds onto its call, failure reads as failure, a running call has no verdict, an orphan result keeps its row, and a verdict never attaches to the wrong call
- [x] `npm run e2e` — 64 pass
- [x] Rendered the rows in Electron and compared against the terminal's own folding
- [ ] Read a real session in the running app