### PR TITLE
feat(desktop): give the window back to the conversation

### DIFF
--- a/desktop/e2e/composer.spec.ts
+++ b/desktop/e2e/composer.spec.ts
@@ -1,0 +1,56 @@
+// The prompt box: one line until there is more to show.
+//
+// The height is set from JavaScript against a measurement the stylesheet caps,
+// which is exactly the arrangement that breaks quietly — a box that never grows
+// hides what is being typed, and one that never stops eats the transcript.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+async function open(window: Page): Promise<void> {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+}
+
+function box(window: Page) {
+  return window.locator('.composer textarea')
+}
+
+async function height(window: Page): Promise<number> {
+  const measured = await box(window).boundingBox()
+  return measured?.height ?? 0
+}
+
+test('an empty composer is one line tall', async ({ window }) => {
+  await open(window)
+
+  // One line of text plus its padding. The old box reserved 84px whether
+  // anything had been typed or not.
+  expect(await height(window)).toBeLessThan(50)
+})
+
+test('the box grows with what is typed, and shrinks back when it is sent', async ({ window }) => {
+  await open(window)
+  const empty = await height(window)
+
+  await box(window).fill('one\ntwo\nthree\nfour')
+  const filled = await height(window)
+  expect(filled).toBeGreaterThan(empty)
+
+  await box(window).fill('')
+  await expect.poll(() => height(window)).toBe(empty)
+})
+
+test('a very long prompt stops growing and scrolls instead', async ({ window }) => {
+  await open(window)
+
+  await box(window).fill(Array.from({ length: 200 }, (_, i) => `line ${i}`).join('\n'))
+
+  const panel = await window.locator('.chat').boundingBox()
+  const grown = await height(window)
+  // Capped at a third of the window, so the conversation is still readable.
+  expect(grown).toBeLessThan((panel?.height ?? 0) / 2)
+  expect(await box(window).evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true)
+})

--- a/desktop/e2e/panel-drop.spec.ts
+++ b/desktop/e2e/panel-drop.spec.ts
@@ -1,0 +1,68 @@
+// A file dragged at a conversation is meant for the conversation.
+//
+// The drop target used to be the composer alone — a 40px strip at the foot of
+// the panel. These check the whole panel takes it, which is a thing that breaks
+// silently: a missed drop looks like a file that simply did not attach.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+async function open(window: Page): Promise<void> {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+}
+
+/** Drags a file onto whatever the selector names, and lets go of it. */
+async function dropOn(window: Page, selector: string, name: string): Promise<void> {
+  await window.evaluate(
+    ([target, filename]) => {
+      const carried = new DataTransfer()
+      carried.items.add(new File(['a stack trace'], filename as string, { type: 'text/plain' }))
+      const el = document.querySelector(target as string)
+      if (!el) throw new Error(`nothing at ${target} to drop on`)
+      el.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+      el.dispatchEvent(new DragEvent('drop', { dataTransfer: carried, bubbles: true }))
+    },
+    [selector, name],
+  )
+}
+
+test('a file dropped on the transcript attaches to the prompt', async ({ window }) => {
+  await open(window)
+
+  // The scroller, which is the part of the panel a reader is looking at — and
+  // nowhere near the composer that used to be the only target.
+  await dropOn(window, '.chat-scroll', 'trace.txt')
+
+  await expect(window.locator('.attachment-name')).toHaveText('trace.txt')
+})
+
+test('dragging over the transcript says it will take the file', async ({ window }) => {
+  await open(window)
+
+  await window.evaluate(() => {
+    const carried = new DataTransfer()
+    carried.items.add(new File(['x'], 'x.txt', { type: 'text/plain' }))
+    document
+      .querySelector('.chat-scroll')
+      ?.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+  })
+
+  await expect(window.locator('.chat.dropping')).toHaveCount(1)
+})
+
+test('a session dragged from the sidebar is not a file, and is left alone', async ({ window }) => {
+  await open(window)
+
+  await window.evaluate(() => {
+    const carried = new DataTransfer()
+    carried.setData('text/plain', 'not a file')
+    document
+      .querySelector('.chat-scroll')
+      ?.dispatchEvent(new DragEvent('dragover', { dataTransfer: carried, bubbles: true }))
+  })
+
+  await expect(window.locator('.chat.dropping')).toHaveCount(0)
+})

--- a/desktop/e2e/sidebar-fold.spec.ts
+++ b/desktop/e2e/sidebar-fold.spec.ts
@@ -1,0 +1,67 @@
+// Folding the list column away.
+//
+// The trap this guards is a rail button that looks broken: asking for a mode
+// while the column is folded has to bring the column back, or the click does
+// nothing visible and the app looks dead.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+function sidebar(window: Page) {
+  return window.locator('.sidebar')
+}
+
+function fold(window: Page) {
+  return window.locator('.rail-fold')
+}
+
+test('the fold button hides the list and brings it back', async ({ window }) => {
+  await expect(sidebar(window)).toBeVisible()
+
+  await fold(window).click()
+  await expect(sidebar(window)).toHaveCount(0)
+  // The rail stays: what is open is still reachable, and so is the way back.
+  await expect(window.locator('.rail')).toBeVisible()
+
+  await fold(window).click()
+  await expect(sidebar(window)).toBeVisible()
+})
+
+test('⌘B folds it too', async ({ window }) => {
+  await expect(sidebar(window)).toBeVisible()
+
+  await window.keyboard.press('ControlOrMeta+b')
+  await expect(sidebar(window)).toHaveCount(0)
+
+  await window.keyboard.press('ControlOrMeta+b')
+  await expect(sidebar(window)).toBeVisible()
+})
+
+test('⌘B in the prompt is left to the prompt', async ({ window }) => {
+  await window.locator('.session-row').first().click()
+  await window.locator('.composer textarea').click()
+
+  await window.keyboard.press('ControlOrMeta+b')
+
+  // Bold belongs to the field that has the keyboard, not to the window.
+  await expect(sidebar(window)).toBeVisible()
+})
+
+test('asking for a mode while folded brings the list back showing it', async ({ window }) => {
+  await fold(window).click()
+  await expect(sidebar(window)).toHaveCount(0)
+
+  await window.locator('.rail-item[aria-label="Schedules"]').click()
+
+  await expect(sidebar(window)).toBeVisible()
+  await expect(window.locator('.rail-item[aria-label="Schedules"]')).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('picking the mode already showing folds it', async ({ window }) => {
+  await expect(sidebar(window)).toBeVisible()
+
+  await window.locator('.rail-item[aria-label="Sessions"]').click()
+
+  await expect(sidebar(window)).toHaveCount(0)
+  await expect(window.locator('.rail-item[aria-label="Sessions"]')).toHaveAttribute('aria-pressed', 'false')
+})

--- a/desktop/src/renderer/app.tsx
+++ b/desktop/src/renderer/app.tsx
@@ -8,6 +8,12 @@ import { Rail } from './components/rail.tsx'
 import { Sidebar } from './components/sidebar.tsx'
 import { ReleaseNotes } from './components/updates.tsx'
 
+/** Whether the keyboard belongs to a field rather than to the window. */
+function typingInto(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  return target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+}
+
 export function App(): JSX.Element {
   const loading = useStore((s) => s.loading)
   const toast = useStore((s) => s.toast)
@@ -38,6 +44,13 @@ export function App(): JSX.Element {
         event.preventDefault()
         setSeed(null)
         setDialog('new')
+      }
+      // ⌘B folds the list away, as it does in an editor. Not while a field has
+      // the keyboard: ⌘B is bold in a composer, and stealing it there would
+      // fold the window on someone reaching for it.
+      if ((event.metaKey || event.ctrlKey) && event.key === 'b' && !typingInto(event.target)) {
+        event.preventDefault()
+        store.toggleSidebar()
       }
       // ⌘W closes the selected session's terminal, not the window: the
       // terminal is the only thing in this layout that can be closed.

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -247,7 +247,10 @@ export function ChatPanel({
   }
 
   return (
-    <div className="chat">
+    // The whole panel takes a drop, not just the box at the foot of it: a file
+    // dragged at a conversation is meant for the conversation, and aiming for
+    // a 40px strip is a hit test the reader should not have to pass.
+    <div className={dropping ? 'chat dropping' : 'chat'} {...dropHandlers}>
       <div
         className="chat-scroll"
         ref={scroller}
@@ -326,7 +329,7 @@ export function ChatPanel({
           </button>
         </div>
       ) : (
-        <div className={dropping ? 'composer dropping' : 'composer'} {...dropHandlers}>
+        <div className="composer">
           {files.pasted !== null && draft.includes(files.pasted) && (
             <PasteOffer text={files.pasted} onFile={fileThePaste} onKeep={files.keepThePaste} />
           )}
@@ -602,7 +605,18 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
 
   return (
     <div className="msg tool-call">
-      <button className={open ? 'tool-head open' : 'tool-head'} onClick={() => setOpen(!open)}>
+      <div
+        className={open ? 'tool-head open' : 'tool-head'}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return
+          event.preventDefault()
+          setOpen(!open)
+        }}
+      >
         <span className="tool-icon">{TOOL_ICONS[tool] ?? '⚙'}</span>
         <span className="tool-name">{tool}</span>
         <span className="tool-summary" ref={summaryRef}>
@@ -621,17 +635,28 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
             {result ? '✓' : '✕'}
           </span>
         )}
+        {/* On the row, not in the fold: opening the file a call touched is the
+            common thing to want from it, and it was three clicks down. */}
+        {filePath && (
+          <button
+            className="tool-open"
+            title={`Open ${resolveFilePath(filePath, cwd)}`}
+            aria-label={`Open ${filePath.split('/').pop() ?? filePath}`}
+            onClick={(event) => {
+              // The row behind this expands; opening the file is not that.
+              event.stopPropagation()
+              store.openFile(hostId, resolveFilePath(filePath, cwd))
+            }}
+          >
+            ↗
+          </button>
+        )}
         <Chevron className="chevron" open={open} />
-      </button>
+      </div>
 
       {open && (
         <div className="tool-detail">
           <ToolInput tool={tool} input={input} />
-          {filePath && (
-            <div className="file-chips">
-              <FileChip hostId={hostId} cwd={cwd} path={filePath} label={filePath.split('/').pop()} />
-            </div>
-          )}
         </div>
       )}
     </div>
@@ -639,7 +664,9 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
 }
 
 function ToolInput({ tool, input }: { tool: string; input: Record<string, unknown> }): JSX.Element {
-  const entries = Object.entries(input)
+  // file_path is the row's own text for these, and a field repeating it is the
+  // same string twice with a label on one of them.
+  const entries = Object.entries(input).filter(([key]) => key !== 'file_path')
   if (entries.length === 0) return <p className="tool-empty">No input recorded.</p>
 
   // The command, but only when the row above is showing a description instead

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -166,6 +166,17 @@ export function ChatPanel({
 
   useEffect(() => () => retries.current.forEach(clearTimeout), [])
 
+  // One line until there is more than one line to show. Measured rather than
+  // counted: the box's width decides where the text wraps, and a newline is
+  // not the only thing that starts a row. The cap is in the stylesheet, so
+  // past it the textarea scrolls instead of eating the transcript.
+  useEffect(() => {
+    const el = composer.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${el.scrollHeight}px`
+  }, [draft])
+
   const loadOlder = async (): Promise<void> => {
     if (loadingOlder.current || !transcript.hasNextPage) return
     loadingOlder.current = true
@@ -326,7 +337,7 @@ export function ChatPanel({
             <textarea
               ref={composer}
               value={draft}
-              rows={3}
+              rows={1}
               placeholder={
                 cold
                   ? 'Send a prompt — the session wakes first'
@@ -612,6 +623,11 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
         <span className="tool-summary" ref={summaryRef}>
           {text}
         </span>
+        {hidden > 0 && !open && (
+          <span className="tool-more">
+            +{hidden} {hidden === 1 ? 'line' : 'lines'}
+          </span>
+        )}
         {result !== undefined && (
           <span
             className={result ? 'tool-verdict' : 'tool-verdict failed'}
@@ -622,11 +638,7 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
         )}
         <Chevron className="chevron" open={open} />
       </button>
-      {hidden > 0 && (
-        <button className="tool-more" onClick={() => setOpen(true)}>
-          … +{hidden} {hidden === 1 ? 'line' : 'lines'}
-        </button>
-      )}
+
       {open && (
         <div className="tool-detail">
           <ToolInput tool={tool} input={input} />

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -9,7 +9,7 @@ import { removeFirst } from '../attachments.ts'
 import { AttachButton, AttachmentChips, PasteOffer, useAttachments, useDropTarget } from './attach.tsx'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
 import { DiffView } from './diff-view.tsx'
-import { followsItsCall, resultOf } from './tool-calls.ts'
+import { foldedCommand, followsItsCall, headline, oneLine, resultOf } from './tool-calls.ts'
 import { Chevron } from './icons.tsx'
 import { SelectionMenu, useTextSelection } from './selection-menu.tsx'
 import {
@@ -547,26 +547,6 @@ const CODE_FIELDS: { key: string; label?: string }[] = [
 /** Tools whose call changes a file, and whose diff is the point of the row. */
 const WRITING_TOOLS = new Set(['Edit', 'MultiEdit', 'Write'])
 
-function oneLine(text: string | undefined): string {
-  return (text ?? '').replace(/\s+/g, ' ').trim()
-}
-
-/**
- * What the row says the call was.
- *
- * The daemon's summary cuts a command at 80 characters (internal/transcript/
- * reader.go), which is where `git commit -m "…"` loses the message and two
- * pipelines become the same string. The command itself is in the input, so the
- * row shows that and lets it wrap.
- */
-function headline(tool: string, input: Record<string, unknown>, summary?: string): string {
-  if (tool === 'Bash' || tool === 'BashOutput') {
-    const command = str(input.command) || str(input.cmd)
-    if (command) return command.trim()
-  }
-  return oneLine(summary)
-}
-
 /**
  * How many lines the clamp is hiding, or 0 when it is hiding none.
  *
@@ -613,7 +593,12 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
   // the tool without saying what it did to the file.
   const [open, setOpen] = useState(WRITING_TOOLS.has(tool))
   const text = headline(tool, input, message.summary)
-  const [summaryRef, hidden] = useHiddenLines(text, open)
+  const [summaryRef, clamped] = useHiddenLines(text, open)
+  // A described row hides the command itself, not the rest of a line of it, so
+  // the count is the command's length rather than what the clamp cut.
+  const command = foldedCommand(tool, input)
+  const commandLines = command ? command.trim().split('\n').length : 0
+  const hidden = open ? 0 : commandLines > 1 ? commandLines : clamped
 
   return (
     <div className="msg tool-call">
@@ -657,11 +642,21 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
   const entries = Object.entries(input)
   if (entries.length === 0) return <p className="tool-empty">No input recorded.</p>
 
-  // No code block for the command: the row above is showing it, in full.
+  // The command, but only when the row above is showing a description instead
+  // of it. Without one the row is already the command, and opening it unclamps
+  // what was cut rather than printing it twice.
   if (tool === 'Bash' || tool === 'BashOutput') {
-    const rest = entries.filter(([key]) => key !== 'command' && key !== 'cmd')
-    if (rest.length === 0) return <p className="tool-empty">Nothing else was passed.</p>
-    return <KeyValues entries={rest} />
+    const command = foldedCommand(tool, input)
+    const rest = entries.filter(
+      ([key]) => key !== 'command' && key !== 'cmd' && !(command && key === 'description'),
+    )
+    if (!command && rest.length === 0) return <p className="tool-empty">Nothing else was passed.</p>
+    return (
+      <>
+        {command && <CodeBlock code={command} language="bash" />}
+        <KeyValues entries={rest} />
+      </>
+    )
   }
 
   // What changed, as a patch. Two code blocks — the text searched for and the

--- a/desktop/src/renderer/components/rail.tsx
+++ b/desktop/src/renderer/components/rail.tsx
@@ -1,5 +1,5 @@
 import { store, useStore, type SidebarMode } from '../store.ts'
-import { Clock, Gear, ListRows } from './icons.tsx'
+import { Chevron, Clock, Gear, ListRows } from './icons.tsx'
 
 /**
  * What the window is showing, chosen from the left edge.
@@ -13,16 +13,31 @@ import { Clock, Gear, ListRows } from './icons.tsx'
  */
 export function Rail(): JSX.Element {
   const mode = useStore((s) => s.sidebarMode)
+  const open = useStore((s) => s.sidebarOpen)
 
+  /**
+   * Picking a mode brings the list back.
+   *
+   * Asking for the schedules while the list is folded away and being shown
+   * nothing is the obvious trap here: the button would look broken. Picking the
+   * mode that is already showing folds it instead, which is the toggle every
+   * editor puts on the same button.
+   */
   const item = (id: SidebarMode, label: string, icon: JSX.Element): JSX.Element => (
     <button
-      className={mode === id ? 'rail-item on' : 'rail-item'}
+      className={mode === id && open ? 'rail-item on' : 'rail-item'}
       // Pressed rather than current: these are three states of one control,
       // and only one of them is on at a time.
-      aria-pressed={mode === id}
+      aria-pressed={mode === id && open}
       aria-label={label}
       title={label}
-      onClick={() => store.setSidebarMode(id)}
+      onClick={() => {
+        if (mode === id) store.toggleSidebar()
+        else {
+          store.setSidebarMode(id)
+          store.toggleSidebar(true)
+        }
+      }}
     >
       {icon}
     </button>
@@ -30,6 +45,15 @@ export function Rail(): JSX.Element {
 
   return (
     <nav className="rail" aria-label="Modes">
+      <button
+        className="rail-item rail-fold"
+        aria-label={open ? 'Hide the list' : 'Show the list'}
+        aria-expanded={open}
+        title={`${open ? 'Hide' : 'Show'} the list (⌘B)`}
+        onClick={() => store.toggleSidebar()}
+      >
+        <Chevron dir={open ? 'left' : 'right'} />
+      </button>
       {item('sessions', 'Sessions', <ListRows />)}
       {item('schedules', 'Schedules', <Clock />)}
       <span className="grow" />

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -175,7 +175,7 @@ export function Sidebar({
   onNewSession,
 }: {
   onNewSession: (seed?: { hostId: string; cwd: string; group?: string }) => void
-}): JSX.Element {
+}): JSX.Element | null {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
   const { sessions, stats, pending: awaiting } = useHostSessions()
@@ -185,6 +185,7 @@ export function Sidebar({
   const selection = useStore((s) => s.selection)
   const renamingSession = useStore((s) => s.renamingSession)
   const mode = useStore((s) => s.sidebarMode)
+  const open = useStore((s) => s.sidebarOpen)
   const settingsSection = useStore((s) => s.settingsSection)
   // Its own search, because the two lists hold different things and a query
   // typed against one is meaningless against the other.
@@ -382,6 +383,10 @@ export function Sidebar({
   // One host answering "manual" is enough to show the switch as on: the click
   // writes the other way to every host, which settles any disagreement.
   const manual = hosts.some((host) => sortMode[host.id] === 'manual')
+
+  // Unmounted rather than hidden: the list holds a query per host, and a
+  // folded column has no business polling for rows nobody is looking at.
+  if (!open) return null
 
   return (
     <aside className="sidebar" ref={aside}>

--- a/desktop/src/renderer/components/terminal.tsx
+++ b/desktop/src/renderer/components/terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 
+import { useDropTarget } from './attach.tsx'
 import { silenceDeviceReports } from './deviceReports.ts'
 import { linkHandler, webLinkActivate } from './links.ts'
 import { isLargePaste, pastedName, pastedTextAttachment, terminalPaths } from '../attachments.ts'
@@ -123,6 +124,9 @@ export function TerminalPane({
   const uploads = useStore((s) => s.terminalUploads)
   /** A pasted block big enough to ask about, held until the reader chooses. */
   const [pasted, setPasted] = useState<string | null>(null)
+  const { dropping, handlers: dropHandlers } = useDropTarget((files) => {
+    if (uploads) void insertUploads([...files])
+  })
 
   /**
    * Puts dropped or pasted files where the agent can reach them, and types the
@@ -380,19 +384,13 @@ export function TerminalPane({
   // Whether it is on screen is the group's business, not the pane's: the item
   // wrapper carries `hidden`, and a pane that is up fills the cell it is in.
   return (
-    <div className="pane">
-      <div
-        className="pane-term"
-        ref={hostRef}
-        // Always swallowed, uploads on or off: a file dropped on a window
-        // Electron has not claimed navigates it to that file, replacing the app.
-        onDragOver={(event) => event.preventDefault()}
-        onDrop={(event) => {
-          event.preventDefault()
-          if (!uploads) return
-          void insertUploads([...event.dataTransfer.files])
-        }}
-      />
+    // The pane takes the drop, not the grid inside it: the padding around the
+    // terminal is part of the terminal as far as a reader aiming at it is
+    // concerned. Always swallowed, uploads on or off — a file dropped on a
+    // window Electron has not claimed navigates it to that file, replacing the
+    // app.
+    <div className={dropping ? 'pane dropping' : 'pane'} {...dropHandlers}>
+      <div className="pane-term" ref={hostRef} />
       {pasted !== null && (
         <div
           className="paste-offer paste-offer-term"

--- a/desktop/src/renderer/components/tool-calls.ts
+++ b/desktop/src/renderer/components/tool-calls.ts
@@ -9,6 +9,47 @@ import type { TranscriptMessage } from '../../shared/models.ts'
  * up, it is a tick at the end of the row that earned it.
  */
 
+/** A string field of a tool's input, or '' when it is anything else. */
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * A summary is one line by definition, but the thing it summarises often is
+ * not — a heredoc, a multi-line command.
+ */
+export function oneLine(text: string | undefined): string {
+  return (text ?? '').replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * What the row says the call was.
+ *
+ * The agent's own description first, where it wrote one: "Push and open the
+ * second PR" is what the reader wants from a row, and the twelve-line heredoc
+ * that did it is what they want from opening the row.
+ *
+ * Failing that, the command — not the daemon's summary, which cuts at 80
+ * characters (internal/transcript/reader.go), the point where `git commit -m
+ * "…"` loses its message and two pipelines become the same string.
+ */
+export function headline(tool: string, input: Record<string, unknown>, summary?: string): string {
+  if (tool === 'Bash' || tool === 'BashOutput') {
+    const described = oneLine(str(input.description))
+    if (described) return described
+    const command = str(input.command) || str(input.cmd)
+    if (command) return command.trim()
+  }
+  return oneLine(summary)
+}
+
+/** The command a row is holding behind a description, if it is holding one. */
+export function foldedCommand(tool: string, input: Record<string, unknown>): string {
+  if (tool !== 'Bash' && tool !== 'BashOutput') return ''
+  if (!oneLine(str(input.description))) return ''
+  return str(input.command) || str(input.cmd)
+}
+
 /** Whether the message at this index is a result belonging to the call above it. */
 export function followsItsCall(messages: TranscriptMessage[], index: number): boolean {
   return messages[index]?.role === 'tool_result' && messages[index - 1]?.role === 'tool_use'

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -269,6 +269,14 @@ export interface State {
   /** Whether a file dropped or pasted on a terminal is uploaded to its daemon. */
   terminalUploads: boolean
   /**
+   * Whether the list column is showing.
+   *
+   * Folded, the rail stays: what is open is still reachable, and the switch
+   * back is where the switch away was. The session under the pointer keeps the
+   * whole window, which is the point of folding it.
+   */
+  sidebarOpen: boolean
+  /**
    * How much of a session the sidebar shows. Kept here as well as on <html>
    * because the control that changes it lives in the sidebar and has to show
    * which way it is set.
@@ -327,6 +335,24 @@ function writeGroupMode(mode: GroupMode): void {
 }
 
 const TERMINAL_UPLOADS_KEY = 'helios.terminalUploads'
+const SIDEBAR_OPEN_KEY = 'helios.sidebarOpen'
+
+/** Open unless it has been folded away, and it stays folded across restarts. */
+function readSidebarOpen(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_OPEN_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
+function writeSidebarOpen(open: boolean): void {
+  try {
+    localStorage.setItem(SIDEBAR_OPEN_KEY, open ? '1' : '0')
+  } catch {
+    // A full or unavailable store costs the preference, not the fold.
+  }
+}
 
 /**
  * On unless it has been turned off. A file dropped on the terminal is on this
@@ -439,6 +465,7 @@ const initial: State = {
   termFont: fontStack('terminal', bridge.theme.boot().fonts.terminal),
   termSize: bridge.theme.boot().sizes.terminal,
   terminalUploads: readTerminalUploads(),
+  sidebarOpen: readSidebarOpen(),
   density: bridge.theme.boot().density,
   statusLine: bridge.theme.boot().statusLine,
   toast: null,
@@ -733,6 +760,13 @@ class Store {
   }
 
   /** Turns uploading a file dropped or pasted on a terminal on or off. */
+  /** Folds the list column away, or brings it back. */
+  toggleSidebar(open?: boolean): void {
+    const next = open ?? !this.getSnapshot().sidebarOpen
+    this.set({ sidebarOpen: next })
+    writeSidebarOpen(next)
+  }
+
   setTerminalUploads(on: boolean): void {
     this.set({ terminalUploads: on })
     writeTerminalUploads(on)

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1994,6 +1994,7 @@ small {
 }
 
 .chat {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -2305,6 +2306,7 @@ figure.mermaid svg {
    has scrolled into the middle of it. It can only stick while nothing between
    here and the transcript's scroller clips: hence no `overflow` on the card. */
 .tool-head {
+  cursor: pointer;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -2375,6 +2377,34 @@ figure.mermaid svg {
 .tool-head.open .tool-summary {
   display: block;
   overflow: visible;
+}
+
+/* The one action a file row is usually wanted for. Quiet until the row is
+   under the pointer, so a list of them is not a column of arrows. */
+.tool-open {
+  flex: none;
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+  background: none;
+  color: var(--on-surface-variant);
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.msg.tool-call:hover .tool-open,
+.tool-open:focus-visible {
+  opacity: 1;
+}
+
+.tool-open:hover {
+  background: var(--surface-highest);
+  color: var(--primary);
 }
 
 /* What the clamp is holding back, said on the same line — a row that costs a
@@ -2616,6 +2646,9 @@ figure.mermaid svg {
 
 /* A file dropped anywhere over the composer counts, so the whole of it lights
    up rather than some target the pointer has to find. */
+/* Over the panel it was dropped on, which is the whole of what accepts it. */
+.pane.dropping::after,
+.chat.dropping::after,
 .composer.dropping .composer-input::after {
   content: 'Drop to attach';
   position: absolute;
@@ -4042,6 +4075,14 @@ figure.mermaid svg {
    itself, and the inner box would sit inside that. */
 .modal-backdrop .composer.dropping .composer-input::after {
   content: none;
+}
+
+/* The transcript's own hint is drawn over the panel, and inside the dialog
+   there is no panel — the dialog draws its own. */
+.chat.dropping::after,
+.pane.dropping::after {
+  z-index: 3;
+  font-size: 13px;
 }
 
 .modal-backdrop .composer-prompt {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -5552,9 +5552,16 @@ hr {
    file view shows one. The whole block scrolls sideways as a unit so the
    columns stay lined up, and the gutters stick to the left edge while it does. */
 .diff-unified {
-  /* The tint of an added line is mixed into this, and the sticky numbers are
-     painted with it, so a pane on a different surface sets it once. */
-  --diff-bg: var(--surface-container);
+  /* The tint of a changed line is mixed into this, and the sticky numbers are
+     painted with it, so a pane on a different surface sets it once.
+     The page surface rather than the card it sits on: mixing a pale accent
+     into an already-pale card gave a milky wall of colour that the syntax
+     colours then had to compete with. Against the darker surface the patch
+     reads as recessed, which is what a terminal's diff looks like. */
+  --diff-bg: var(--surface);
+  /* Enough to say which side a line is on, not enough to fight the text. A
+     file of nothing but additions is a whole card of this. */
+  --diff-tint: 10%;
   overflow-x: auto;
   font-family: var(--mono);
   /* A patch has to read as the bytes it is. With ligatures on, `--- a/file`
@@ -5580,11 +5587,11 @@ hr {
 }
 
 .diff-line.d-add {
-  background: color-mix(in srgb, var(--s-active) 16%, var(--diff-bg));
+  background: color-mix(in srgb, var(--s-active) var(--diff-tint), var(--diff-bg));
 }
 
 .diff-line.d-del {
-  background: color-mix(in srgb, var(--error) 16%, var(--diff-bg));
+  background: color-mix(in srgb, var(--error) var(--diff-tint), var(--diff-bg));
 }
 
 /* With the syntax colours on, a green line and a red line would be two colours

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -630,6 +630,18 @@ small {
   overflow: hidden;
 }
 
+/* The fold sits above the modes and apart from them: it is not a fourth thing
+   the window can show, it is whether the third column is there at all. */
+.rail-fold {
+  color: var(--on-surface-variant);
+  margin-bottom: 4px;
+}
+
+.rail-fold .chevron-icon {
+  width: 16px;
+  height: 16px;
+}
+
 /* Wider than it looks: a 4px edge is a target that has to be hunted, so the
    grip reaches inside the panel where nothing else is clickable. It paints
    nothing until the pointer is on it. */
@@ -2333,11 +2345,12 @@ figure.mermaid svg {
   font-weight: 600;
 }
 
-/* Wrapped, not cut.
+/* One line per call, and the count of what that hides.
  *
- * A command truncated at the width of the panel hides the half that says which
- * command it was — the flag, the path, the message. So it wraps, and only what
- * runs past three lines is folded away, with a row underneath saying how much.
+ * A transcript is mostly these rows, so each one costs a line and no more. The
+ * text still wraps rather than being cut with `nowrap` — the clamp is what
+ * holds it to one line, and lifting the clamp on expand is then the whole of
+ * showing the rest.
  */
 .tool-summary {
   flex: 1;
@@ -2356,7 +2369,7 @@ figure.mermaid svg {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 1;
 }
 
 .tool-head.open .tool-summary {
@@ -2364,24 +2377,15 @@ figure.mermaid svg {
   overflow: visible;
 }
 
-/* What the clamp is holding back, said out loud. */
+/* What the clamp is holding back, said on the same line — a row that costs a
+   second line to report that it saved one has saved nothing. */
 .tool-more {
-  display: block;
-  width: 100%;
-  padding: 0 10px 6px 34px;
-  border-radius: 0;
-  background: none;
+  flex: none;
   color: var(--on-surface-variant);
   font-family: var(--mono);
-  font-size: 11.5px;
-  text-align: left;
-  opacity: 0.75;
-}
-
-.tool-more:hover {
-  opacity: 1;
-  background: none;
-  text-decoration: underline;
+  font-size: 11px;
+  line-height: 1.45;
+  opacity: 0.7;
 }
 
 /* No height of its own: a patch reads as part of the transcript, scrolled with
@@ -2512,10 +2516,13 @@ figure.mermaid svg {
 }
 
 /* The box the prompt is typed into: the textarea gives up its own frame so
-   the buttons can sit inside one, on a row of their own rather than floating
-   over the text they belong to. */
+   the buttons can sit inside one, beside the text rather than under it. */
 .composer-input {
   position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 4px 6px;
   border: 1px solid transparent;
   border-radius: var(--r-md);
   background: var(--surface-high);
@@ -2526,28 +2533,13 @@ figure.mermaid svg {
   border-color: var(--primary);
 }
 
-/* Over the text rather than under it: a row of its own would push the box
-   taller for buttons that are only ever at its edges. The bar itself lets
-   clicks through, so the gap between the buttons still focuses the composer. */
+/* Beside the text, on the last line of it. A strip of its own under the text
+   cost 44px of the window whether one line had been typed or ten. */
 .composer-bar {
-  position: absolute;
-  left: 8px;
-  right: 8px;
-  bottom: 8px;
   display: flex;
+  flex: none;
   align-items: center;
   gap: 4px;
-  pointer-events: none;
-}
-
-.composer-bar button {
-  pointer-events: auto;
-}
-
-/* Attach holds the left edge; everything that acts on the turn — Stop, then
-   Send — gathers at the right. */
-.composer-bar .attach-btn {
-  margin-right: auto;
 }
 
 .send-btn {
@@ -2571,16 +2563,20 @@ figure.mermaid svg {
   border-width: 2px;
 }
 
+/* One line to start with, growing with what is typed (see the effect in
+   ChatPanel) and stopping at a third of the window — past that the composer
+   would be eating the conversation it is answering. */
 .composer textarea {
-  /* Inline-block by default, and auto margins do not centre one. */
   display: block;
-  width: 100%;
-  /* Bottom padding is the strip the buttons float over. */
-  padding: 10px 12px 44px;
+  flex: 1;
+  min-width: 0;
+  padding: 7px 6px;
   background: transparent;
   border: none;
-  resize: vertical;
-  min-height: 84px;
+  /* The height is set from the content, so a drag handle would only fight it. */
+  resize: none;
+  overflow-y: auto;
+  max-height: 33vh;
   line-height: 1.5;
 }
 

--- a/desktop/test/tool-calls.test.ts
+++ b/desktop/test/tool-calls.test.ts
@@ -3,7 +3,12 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { followsItsCall, resultOf } from '../src/renderer/components/tool-calls.ts'
+import {
+  foldedCommand,
+  followsItsCall,
+  headline,
+  resultOf,
+} from '../src/renderer/components/tool-calls.ts'
 import type { TranscriptMessage } from '../src/shared/models.ts'
 
 function call(tool = 'Bash'): TranscriptMessage {
@@ -42,4 +47,33 @@ test('the verdict belongs to the call it followed, not the one before that', () 
   const messages = [call('Read'), call('Bash'), result(false)]
   assert.equal(resultOf(messages, 0), undefined)
   assert.equal(resultOf(messages, 1), false)
+})
+
+test('a described Bash row says what the agent meant, not how it did it', () => {
+  const input = { command: 'gh pr create --body "$(cat <<\'EOF\'\nlong\nEOF\n)"', description: 'Open the PR' }
+  assert.equal(headline('Bash', input), 'Open the PR')
+  assert.equal(foldedCommand('Bash', input), input.command)
+})
+
+test('without a description the row is the command itself, and folds nothing', () => {
+  const input = { command: 'npm run typecheck' }
+  assert.equal(headline('Bash', input), 'npm run typecheck')
+  // Nothing to hold back: the row already shows it, and opening unclamps it.
+  assert.equal(foldedCommand('Bash', input), '')
+})
+
+test('a blank description does not count as one', () => {
+  const input = { command: 'ls', description: '   ' }
+  assert.equal(headline('Bash', input), 'ls')
+  assert.equal(foldedCommand('Bash', input), '')
+})
+
+test('a description on another tool is left to that tool', () => {
+  const input = { file_path: '/tmp/x.go', description: 'not a bash row' }
+  assert.equal(headline('Edit', input, 'x.go'), 'x.go')
+  assert.equal(foldedCommand('Edit', input), '')
+})
+
+test('a multi-line summary is flattened, so the row stays a row', () => {
+  assert.equal(headline('Grep', {}, 'first\n  second'), 'first second')
 })


### PR DESCRIPTION
## Summary

Five things that were spending the window on themselves, or hiding what the reader wanted.

- **The prompt box** reserved 84px whether anything had been typed or not — 44 of them a strip beneath the text holding two buttons that only sit at its edges. Buttons move up beside the text, the box starts at one line and grows with what is typed, measured (the box's width decides where text wraps). Capped at a third of the window, scrolling past that.
- **A tool row is one line**, with the `+N lines` count on the same line rather than beneath it.
- **A Bash row says what the command was for.** Where the agent wrote a description, that takes the row and the command moves into the fold with its line count beside it — a twelve-line heredoc that opens a PR used to read as twelve lines of quoting with the point buried inside. Without a description nothing changes: the row is the command.
- **The file a Read or Write touched opens from its row.** The arrow was three clicks down, on a chip below the fields. The head gives up being a `<button>` so the arrow can be one, and the fold stops repeating the path the row already shows.
- **The whole panel takes a dropped file** — the transcript anywhere, and a terminal pane including the padding around the grid — instead of a 40px strip at the foot. A drag carrying anything but files is still left alone.
- **The list column folds**, from a new rail button or ⌘B, and stays folded across restarts. Picking the mode already showing folds it; picking another brings the column back showing that mode. ⌘B inside a field is left to the field, where it means bold. Folded, the column is unmounted rather than hidden, so it stops polling for rows nobody is looking at.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 312 pass, 5 new for the row text: a described row shows the description and folds the command, an undescribed one shows the command and folds nothing, a blank description does not count, a description on another tool is left alone, a multi-line summary is flattened
- [x] `npx playwright test e2e/composer.spec.ts` — 3 pass
- [x] `npx playwright test e2e/sidebar-fold.spec.ts` — 5 pass
- [x] `npx playwright test e2e/panel-drop.spec.ts` — 3 pass
- [x] `npx playwright test e2e/new-session.spec.ts` — 24 pass, the dialog's own drop behaviour unchanged
- [ ] Full e2e suite — left to CI