### PR TITLE
feat(desktop): fold a schedule chain, and number the patches

### DIFF
--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -623,21 +623,9 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
         <span className="tool-summary" ref={summaryRef}>
           {text}
         </span>
-        {hidden > 0 && !open && (
-          <span className="tool-more">
-            +{hidden} {hidden === 1 ? 'line' : 'lines'}
-          </span>
-        )}
-        {result !== undefined && (
-          <span
-            className={result ? 'tool-verdict' : 'tool-verdict failed'}
-            title={result ? 'The call succeeded' : 'The call failed'}
-          >
-            {result ? '✓' : '✕'}
-          </span>
-        )}
-        {/* On the row, not in the fold: opening the file a call touched is the
-            common thing to want from it, and it was three clicks down. */}
+        {/* Beside the name, not at the end of the row: it opens that file, and
+            an arrow an inch away from what it acts on reads as belonging to
+            the row's own controls. */}
         {filePath && (
           <button
             className="tool-open"
@@ -651,6 +639,20 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
           >
             ↗
           </button>
+        )}
+        <span className="grow" />
+        {hidden > 0 && !open && (
+          <span className="tool-more">
+            +{hidden} {hidden === 1 ? 'line' : 'lines'}
+          </span>
+        )}
+        {result !== undefined && (
+          <span
+            className={result ? 'tool-verdict' : 'tool-verdict failed'}
+            title={result ? 'The call succeeded' : 'The call failed'}
+          >
+            {result ? '✓' : '✕'}
+          </span>
         )}
         <Chevron className="chevron" open={open} />
       </div>

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react'
 
-import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api, statusOf } from '../bridge.ts'
 import { keys } from '../keys.ts'
-import { appendDelta, transcriptMessages, transcriptQuery } from '../queries.ts'
+import { appendDelta, fileContentQuery, transcriptMessages, transcriptQuery } from '../queries.ts'
 import { removeFirst } from '../attachments.ts'
 import { AttachButton, AttachmentChips, PasteOffer, useAttachments, useDropTarget } from './attach.tsx'
 import { multiEditDiff, unifiedDiff } from '../diff.ts'
+import { hunkHeader, lineOf } from './edit-offsets.ts'
 import { DiffView } from './diff-view.tsx'
 import { foldedCommand, followsItsCall, headline, oneLine, resultOf } from './tool-calls.ts'
 import { Chevron } from './icons.tsx'
@@ -656,16 +657,26 @@ function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
 
       {open && (
         <div className="tool-detail">
-          <ToolInput tool={tool} input={input} />
+          <ToolInput tool={tool} input={input} hostId={hostId} cwd={cwd} />
         </div>
       )}
     </div>
   )
 }
 
-function ToolInput({ tool, input }: { tool: string; input: Record<string, unknown> }): JSX.Element {
-  // file_path is the row's own text for these, and a field repeating it is the
-  // same string twice with a label on one of them.
+function ToolInput({
+  tool,
+  input,
+  hostId,
+  cwd,
+}: {
+  tool: string
+  input: Record<string, unknown>
+  hostId: string
+  cwd: string
+}): JSX.Element {
+  // file_path is the row's own text, and the arrow on the row opens it, so a
+  // field repeating the path is the same string twice with a label on one.
   const entries = Object.entries(input).filter(([key]) => key !== 'file_path')
   if (entries.length === 0) return <p className="tool-empty">No input recorded.</p>
 
@@ -694,11 +705,7 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
     return (
       <>
         <KeyValues entries={entries.filter(([key]) => !coded.has(key))} />
-        <div className="tool-diff">
-          {/* Unified, not the default split: a tool call's diff sits inline in
-              the transcript, which is far too narrow for two columns. */}
-          <DiffView diff={diff} language={languageForPath(str(input.file_path))} layout="unified" />
-        </div>
+        <ToolDiff diff={diff} input={input} hostId={hostId} cwd={cwd} />
       </>
     )
   }
@@ -720,6 +727,55 @@ function ToolInput({ tool, input }: { tool: string; input: Record<string, unknow
   }
 
   return <KeyValues entries={entries} />
+}
+
+/**
+ * The patch, numbered against the file it was written to where that can be
+ * settled.
+ *
+ * The call carries no offsets, so the numbers come from finding the written
+ * text in the file itself — one cached read per path, shared with the Files
+ * panel. When the file has moved on, or the text sits in it twice, the patch is
+ * drawn unnumbered rather than numbered from a guess.
+ */
+function ToolDiff({
+  diff,
+  input,
+  hostId,
+  cwd,
+}: {
+  diff: string
+  input: Record<string, unknown>
+  hostId: string
+  cwd: string
+}): JSX.Element {
+  const path = resolveFilePath(str(input.file_path), cwd)
+  const written = str(input.new_string)
+  // A Write is the whole file, so it starts where files start. Only an Edit
+  // has to be found. A MultiEdit's edits sit at several places at once, and one
+  // header cannot describe them.
+  const whole = Boolean(str(input.content) || str(input.new_content))
+  const file = useQuery({
+    ...fileContentQuery(hostId, path),
+    enabled: path !== '' && written !== '' && !whole,
+  })
+
+  const numbered = useMemo(() => {
+    if (whole) return `${hunkHeader(diff, 1)}
+${diff}`
+    const content = file.data && file.data.encoding !== 'base64' ? file.data.content : ''
+    const header = hunkHeader(diff, content ? lineOf(content, written) : null)
+    return header ? `${header}
+${diff}` : diff
+  }, [diff, file.data, written, whole])
+
+  return (
+    <div className="tool-diff">
+      {/* Unified, not the default split: a tool call's diff sits inline in the
+          transcript, which is far too narrow for two columns. */}
+      <DiffView diff={numbered} language={languageForPath(str(input.file_path))} layout="unified" />
+    </div>
+  )
 }
 
 /** The patch a tool call implies, or "" for calls that changed no file. */

--- a/desktop/src/renderer/components/edit-offsets.ts
+++ b/desktop/src/renderer/components/edit-offsets.ts
@@ -1,0 +1,58 @@
+/**
+ * Where in the file an edit landed.
+ *
+ * An Edit tool call records the text it looked for and the text it wrote, and
+ * nothing about where either sat — so a patch built from it has no line numbers
+ * to show. The file does have them: finding the written text in the file it was
+ * written to gives the offset the gutter needs.
+ *
+ * It can fail, and quietly returning nothing is the right answer when it does.
+ * The file moves on — later edits shift the lines, and a session read back a
+ * day later may not contain the text at all. A number that is merely plausible
+ * is worse than none, because a gutter looks authoritative.
+ */
+
+/**
+ * The 1-based line the text starts on, or null when the file does not settle
+ * the question.
+ *
+ * Null for absent, and null for more than one match: two candidates mean the
+ * edit could have been either, and picking the first would be a guess.
+ */
+export function lineOf(content: string, needle: string): number | null {
+  if (needle === '' || content === '') return null
+
+  const first = content.indexOf(needle)
+  if (first === -1) return null
+  if (content.indexOf(needle, first + 1) !== -1) return null
+
+  let line = 1
+  for (let at = content.indexOf('\n'); at !== -1 && at < first; at = content.indexOf('\n', at + 1)) {
+    line++
+  }
+  return line
+}
+
+/**
+ * The `@@` header a patch needs to carry numbers, or '' when there is none to
+ * give it.
+ *
+ * Written as a header rather than passed as a start line because that is what
+ * every other patch in the app already carries: the diff view reads numbers
+ * from `@@` and nothing else, so a resolved offset joins the same path as a
+ * patch that came from git.
+ */
+export function hunkHeader(diff: string, start: number | null): string {
+  if (start === null || diff === '') return ''
+  let before = 0
+  let after = 0
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('-')) before++
+    else if (line.startsWith('+')) after++
+    else {
+      before++
+      after++
+    }
+  }
+  return `@@ -${start},${before} +${start},${after} @@`
+}

--- a/desktop/src/renderer/components/schedule-tree.ts
+++ b/desktop/src/renderer/components/schedule-tree.ts
@@ -1,0 +1,82 @@
+import type { Schedule } from '../../shared/models.ts'
+
+/**
+ * The after-chain as a tree, and which of it is showing.
+ *
+ * A job that follows another is drawn under it, indented. A long chain — a
+ * rebrand run split into thirty steps, each waiting on the last — then walks
+ * off the right edge of the sidebar and buries every other schedule on the
+ * host. Folding a root hides what follows it; the count on the row says how
+ * much.
+ */
+
+/** How deep in the chain each schedule sits, so a grandchild indents twice. */
+export function depthOf(schedules: Schedule[]): Record<string, number> {
+  const parent: Record<string, string> = {}
+  for (const sc of schedules) parent[sc.id] = sc.after_id ?? ''
+  const depth: Record<string, number> = {}
+  for (const sc of schedules) {
+    let n = 0
+    // Bounded: after_id is editable, so a cycle in it must not become a hang.
+    for (let at = sc.after_id ?? ''; at && n < 16; at = parent[at] ?? '') n++
+    depth[sc.id] = n
+  }
+  return depth
+}
+
+/** How many jobs hang off each one, at any depth below it. */
+export function followerCounts(schedules: Schedule[]): Record<string, number> {
+  const children: Record<string, string[]> = {}
+  for (const sc of schedules) {
+    const parent = sc.after_id ?? ''
+    if (!parent) continue
+    ;(children[parent] ??= []).push(sc.id)
+  }
+
+  const counts: Record<string, number> = {}
+  const count = (id: string, seen: Set<string>): number => {
+    if (counts[id] !== undefined) return counts[id]
+    if (seen.has(id)) return 0
+    seen.add(id)
+    let total = 0
+    for (const child of children[id] ?? []) total += 1 + count(child, seen)
+    counts[id] = total
+    return total
+  }
+  for (const sc of schedules) count(sc.id, new Set())
+  return counts
+}
+
+/**
+ * The rows to draw, given which roots are folded.
+ *
+ * A schedule is hidden when anything above it in the chain is folded — folding
+ * a root has to take its grandchildren with it, or the chain reappears one
+ * level down with nothing above it to explain the indent.
+ */
+export function visibleSchedules(schedules: Schedule[], folded: ReadonlySet<string>): Schedule[] {
+  const byId = new Map(schedules.map((sc) => [sc.id, sc]))
+  const shown = (sc: Schedule): boolean => {
+    const seen = new Set<string>([sc.id])
+    for (let at = sc.after_id ?? ''; at && !seen.has(at); ) {
+      if (folded.has(at)) return false
+      seen.add(at)
+      at = byId.get(at)?.after_id ?? ''
+    }
+    return true
+  }
+  return schedules.filter(shown)
+}
+
+/**
+ * Past this depth the indent stops growing.
+ *
+ * The nesting is worth showing; the pixels are not. A thirty-deep chain
+ * indented all the way leaves no width for the name, which is the one thing
+ * the row exists to say.
+ */
+export const MAX_INDENT_DEPTH = 4
+
+export function indentFor(depth: number): number {
+  return 10 + Math.min(depth, MAX_INDENT_DEPTH) * 12
+}

--- a/desktop/src/renderer/components/schedules.tsx
+++ b/desktop/src/renderer/components/schedules.tsx
@@ -23,6 +23,8 @@ import {
 import { store, useStore } from '../store.ts'
 import { sessionLabel, type CheckResult, type Schedule } from '../../shared/models.ts'
 import { schedulePrompt } from '../schedule-prompt.ts'
+import { Chevron } from './icons.tsx'
+import { depthOf, followerCounts, indentFor, visibleSchedules } from './schedule-tree.ts'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
 
 /** The drag payload: one schedule's id, carried on the event. */
@@ -98,6 +100,16 @@ export function ScheduleList({
   }, [all, query])
 
   const depths = useMemo(() => depthOf(schedules), [schedules])
+  const followers = useMemo(() => followerCounts(schedules), [schedules])
+  // Folded by default: a chain is one job in several steps, and the steps are
+  // the root's business until asked for. The count on the row is what says
+  // they are there.
+  const [unfolded, setUnfolded] = useState<ReadonlySet<string>>(new Set())
+  const folded = useMemo(
+    () => new Set(Object.keys(followers).filter((id) => followers[id] && !unfolded.has(id))),
+    [followers, unfolded],
+  )
+  const rows = useMemo(() => visibleSchedules(schedules, folded), [schedules, folded])
 
   if (error) {
     return (
@@ -121,7 +133,7 @@ export function ScheduleList({
 
   return (
     <div className="sched-rows">
-      {schedules.map((sc) => (
+      {rows.map((sc) => (
         <div
           key={sc.id}
           className={[
@@ -132,7 +144,7 @@ export function ScheduleList({
           ]
             .filter(Boolean)
             .join(' ')}
-          style={{ paddingLeft: 10 + (depths[sc.id] ?? 0) * 14 }}
+          style={{ paddingLeft: indentFor(depths[sc.id] ?? 0) }}
           draggable
           onDragStart={(event) => {
             // The id rides on the event rather than in state: state is a render
@@ -160,10 +172,36 @@ export function ScheduleList({
           }}
         >
           <span className="sched-row-top">
+            {followers[sc.id] ? (
+              <button
+                className="sched-fold"
+                aria-expanded={!folded.has(sc.id)}
+                aria-label={`${folded.has(sc.id) ? 'Show' : 'Hide'} the ${followers[sc.id]} chained after ${sc.name}`}
+                title={`${followers[sc.id]} chained after this`}
+                onClick={(event) => {
+                  // The row behind this opens the schedule; folding is not
+                  // opening it.
+                  event.stopPropagation()
+                  setUnfolded((open) => {
+                    const next = new Set(open)
+                    if (next.has(sc.id)) next.delete(sc.id)
+                    else next.add(sc.id)
+                    return next
+                  })
+                }}
+              >
+                <Chevron open={!folded.has(sc.id)} />
+              </button>
+            ) : (
+              <span className="sched-fold empty" />
+            )}
             <span className="sched-kind" title={kindTitle(sc)}>
               {kindGlyph(sc)}
             </span>
             <span className="sched-row-name">{sc.name}</span>
+            {followers[sc.id] && folded.has(sc.id) ? (
+              <span className="sched-followers">+{followers[sc.id]}</span>
+            ) : null}
             <span className={`sched-row-state ${statusClass(sc)}`}>{stateWord(sc)}</span>
           </span>
           <span className="sched-row-sub">{subtitle(sc)}</span>
@@ -223,19 +261,6 @@ function confirmDelete(schedules: Schedule[], id: string): boolean {
       'A job that follows another has no clock of its own, so it cannot be kept without it. ' +
       'Their runs stay, as ordinary sessions.',
   )
-}
-
-/** How deep in the after-chain each schedule sits, so a grandchild indents twice. */
-function depthOf(schedules: Schedule[]): Record<string, number> {
-  const parent: Record<string, string> = {}
-  for (const sc of schedules) parent[sc.id] = sc.after_id ?? ''
-  const depth: Record<string, number> = {}
-  for (const sc of schedules) {
-    let n = 0
-    for (let at = sc.after_id ?? ''; at && n < 16; at = parent[at] ?? '') n++
-    depth[sc.id] = n
-  }
-  return depth
 }
 
 /**

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -5559,9 +5559,11 @@ hr {
      colours then had to compete with. Against the darker surface the patch
      reads as recessed, which is what a terminal's diff looks like. */
   --diff-bg: var(--surface);
-  /* Enough to say which side a line is on, not enough to fight the text. A
-     file of nothing but additions is a whole card of this. */
-  --diff-tint: 10%;
+  /* Strong enough that a changed row is unmistakable against the context
+     around it — measured at 1.9:1 against the untinted rows, with the text on
+     it still at 7.4:1. The accents are pale, so the number reads higher than
+     it looks. */
+  --diff-tint: 30%;
   overflow-x: auto;
   font-family: var(--mono);
   /* A patch has to read as the bytes it is. With ligatures on, `--- a/file`
@@ -5594,14 +5596,25 @@ hr {
   background: color-mix(in srgb, var(--error) var(--diff-tint), var(--diff-bg));
 }
 
-/* With the syntax colours on, a green line and a red line would be two colours
-   fighting for the same letters. The tint and the sign carry what changed; the
-   text keeps the colours that say what it means. */
+/* The words stay the brightest thing on the row, whether or not a grammar is
+   colouring them. Green text on a green row measures 6:1 where the plain text
+   measures 9:1, and it is the text that has to be read — the tint, the sign
+   and the bar down the edge are what say which side the line is on. */
 .diff-line.d-add,
 .diff-line.d-del,
 .diff-cell.d-add,
 .diff-cell.d-del {
   color: var(--on-surface);
+}
+
+/* Scannable without reading: the eye finds the edge of the block before it
+   finds the signs. */
+.diff-line.d-add {
+  box-shadow: inset 2px 0 0 var(--s-active);
+}
+
+.diff-line.d-del {
+  box-shadow: inset 2px 0 0 var(--error);
 }
 
 .diff-line.d-add .diff-sign {
@@ -5644,6 +5657,7 @@ hr {
 
 .diff-sign {
   width: 1ch;
+  font-weight: 700;
   user-select: none;
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -6056,6 +6056,41 @@ hr {
   color: var(--on-surface-variant);
 }
 
+/* The disclosure for a chain. A row with nothing under it keeps the space, so
+   the names down a list still start at the same column. */
+.sched-fold {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border-radius: 3px;
+  background: none;
+  color: var(--on-surface-variant);
+}
+
+.sched-fold.empty {
+  visibility: hidden;
+}
+
+.sched-fold .chevron-icon {
+  width: 12px;
+  height: 12px;
+}
+
+/* How many steps the fold is holding, so a folded chain is not a job that
+   silently lost its followers. */
+.sched-followers {
+  flex: none;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--surface-highest);
+  color: var(--on-surface-variant);
+  font-size: 10px;
+  line-height: 15px;
+}
+
 .sched-drop-hint {
   font-size: 11px;
   color: var(--primary);

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2297,8 +2297,10 @@ figure.mermaid svg {
    bare `.tool` here inherited its width, its fixed 36px height and its
    `place-items: center` — which clipped the expanded row to the height of a
    button and centred the overflow so the left of every line was cut off. */
+/* No card. A transcript is mostly tool rows, and a filled box around each of
+   them turned the column into a stack of grey slabs with the conversation
+   squeezed between. What is left is the row itself. */
 .msg.tool-call {
-  background: var(--surface-container);
   border-radius: var(--r-md);
 }
 
@@ -2319,8 +2321,10 @@ figure.mermaid svg {
   width: 100%;
   text-align: left;
   border-radius: var(--r-md) var(--r-md) 0 0;
-  padding: 6px 10px;
-  background: var(--surface-container);
+  padding: 4px 8px;
+  /* Opaque, but the panel's own colour: it is sticky, so a patch scrolling
+     under it must not show through. */
+  background: var(--surface);
   color: var(--on-surface);
   font-weight: 400;
 }
@@ -2355,7 +2359,9 @@ figure.mermaid svg {
  * showing the rest.
  */
 .tool-summary {
-  flex: 1;
+  /* Shrinks, but does not grow: the arrow after it has to stay beside the name
+     rather than being pushed to the far edge by an empty span. */
+  flex: 0 1 auto;
   /* A flex child defaults to min-width:auto, which refuses to shrink below the
      intrinsic width of the text — the head would overflow the card instead of
      wrapping inside it. */
@@ -2379,27 +2385,27 @@ figure.mermaid svg {
   overflow: visible;
 }
 
-/* The one action a file row is usually wanted for. Quiet until the row is
-   under the pointer, so a list of them is not a column of arrows. */
+/* Without a card behind it the row still has to read as something that opens,
+   so it answers the pointer. */
+.tool-head:hover {
+  background: var(--surface-container);
+}
+
+/* The one action a file row is usually wanted for, so it is always there:
+   hiding it until hover means knowing it exists before it can be used. */
 .tool-open {
   flex: none;
-  width: 20px;
-  height: 18px;
+  width: 18px;
+  height: 16px;
+  margin-left: 2px;
   padding: 0;
   display: grid;
   place-items: center;
   border-radius: 4px;
   background: none;
   color: var(--on-surface-variant);
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1;
-  opacity: 0;
-  transition: opacity 120ms ease;
-}
-
-.msg.tool-call:hover .tool-open,
-.tool-open:focus-visible {
-  opacity: 1;
 }
 
 .tool-open:hover {

--- a/desktop/test/edit-offsets.test.ts
+++ b/desktop/test/edit-offsets.test.ts
@@ -1,0 +1,37 @@
+// A gutter looks authoritative, so the rule these enforce is that a number is
+// only shown when the file settles the question — never when it is a guess.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { hunkHeader, lineOf } from '../src/renderer/components/edit-offsets.ts'
+
+const file = ['package main', '', 'func main() {', '\tprintln("hi")', '}', ''].join('\n')
+
+test('a unique match reports the line it starts on, counting from 1', () => {
+  assert.equal(lineOf(file, 'package main'), 1)
+  assert.equal(lineOf(file, 'func main() {'), 3)
+  assert.equal(lineOf(file, '\tprintln("hi")\n}'), 4)
+})
+
+test('text the file does not hold has no line', () => {
+  assert.equal(lineOf(file, 'func other() {'), null)
+})
+
+test('text the file holds twice has no line either', () => {
+  const twice = 'a\nsame\nb\nsame\n'
+  assert.equal(lineOf(twice, 'same'), null)
+})
+
+test('an empty needle or an empty file answers nothing', () => {
+  assert.equal(lineOf(file, ''), null)
+  assert.equal(lineOf('', 'anything'), null)
+})
+
+test('the header counts the lines each side of the patch', () => {
+  const diff = [' kept', '-gone', '+added', '+also added'].join('\n')
+  assert.equal(hunkHeader(diff, 10), '@@ -10,2 +10,3 @@')
+})
+
+test('no start line means no header, so the patch stays unnumbered', () => {
+  assert.equal(hunkHeader(' kept\n+added', null), '')
+})

--- a/desktop/test/schedule-tree.test.ts
+++ b/desktop/test/schedule-tree.test.ts
@@ -1,0 +1,77 @@
+// after_id is editable, so the shape it describes is whatever somebody typed —
+// including a chain pointing at itself. None of that may hang the sidebar or
+// lose a row.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  depthOf,
+  followerCounts,
+  indentFor,
+  MAX_INDENT_DEPTH,
+  visibleSchedules,
+} from '../src/renderer/components/schedule-tree.ts'
+import type { Schedule } from '../src/shared/models.ts'
+
+function job(id: string, after?: string): Schedule {
+  return {
+    id,
+    name: id,
+    kind: after ? 'after' : 'timer',
+    enabled: true,
+    after_id: after,
+    mode: 'new',
+    prompt: '',
+    fail_streak: 0,
+    fires_today: 0,
+    created_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+/** root → a → b → c, and a second root with nothing after it. */
+const chain = [job('root'), job('a', 'root'), job('b', 'a'), job('c', 'b'), job('lone')]
+
+test('depth counts the links above a job', () => {
+  const depth = depthOf(chain)
+  assert.equal(depth.root, 0)
+  assert.equal(depth.a, 1)
+  assert.equal(depth.c, 3)
+  assert.equal(depth.lone, 0)
+})
+
+test('a follower count is everything below, not just the next link', () => {
+  const counts = followerCounts(chain)
+  assert.equal(counts.root, 3)
+  assert.equal(counts.a, 2)
+  assert.equal(counts.c, 0)
+  assert.equal(counts.lone, 0)
+})
+
+test('folding a root takes its grandchildren with it', () => {
+  const shown = visibleSchedules(chain, new Set(['root'])).map((sc) => sc.id)
+  assert.deepEqual(shown, ['root', 'lone'])
+})
+
+test('folding a link hides only what follows that link', () => {
+  const shown = visibleSchedules(chain, new Set(['a'])).map((sc) => sc.id)
+  assert.deepEqual(shown, ['root', 'a', 'lone'])
+})
+
+test('nothing folded shows everything', () => {
+  assert.equal(visibleSchedules(chain, new Set()).length, chain.length)
+})
+
+test('a cycle in after_id neither hangs nor eats the list', () => {
+  const cycle = [job('x', 'y'), job('y', 'x'), job('free')]
+  assert.equal(depthOf(cycle).x, 16)
+  assert.deepEqual(
+    visibleSchedules(cycle, new Set()).map((sc) => sc.id),
+    ['x', 'y', 'free'],
+  )
+  assert.equal(followerCounts(cycle).free, 0)
+})
+
+test('the indent stops growing so the name keeps its width', () => {
+  assert.ok(indentFor(1) < indentFor(2))
+  assert.equal(indentFor(MAX_INDENT_DEPTH), indentFor(30))
+})


### PR DESCRIPTION
## Summary

**Schedules.** A rebrand split into thirty steps, each waiting on the last, drew thirty rows each indented one further than the row above — the names walked off the right edge and buried every other schedule on the host.

- A chain folds under the job that starts it, with the number of steps on the row so a fold is not a job that silently lost its followers.
- Folded by default: a chain is one job in several steps, and the steps are the root's business until asked for.
- The indent stops growing after four levels. The nesting is worth showing; the pixels are not.
- `after_id` is editable, so both the depth walk and the visibility walk are bounded — a cycle in it must not hang the sidebar.

**Line numbers in transcript patches** (the open question from #188). An `Edit` records the text it wrote and nothing about where it sat, so the offset is resolved by finding that text in the file — one cached read per path, shared with the Files panel, and skipped entirely for a `Write`, which starts where files start. Text the file no longer holds, or holds twice, leaves the patch unnumbered: a gutter looks authoritative, and a plausible wrong number is worse than none.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 320 pass, 13 new
  - `test/schedule-tree.test.ts`: depth, follower counts at any depth, folding a root takes its grandchildren, folding a link hides only what follows it, a cycle in `after_id` neither hangs nor eats rows, the indent stops growing
  - `test/edit-offsets.test.ts`: a unique match reports its line, absent text and text appearing twice both report nothing, the header counts each side of the patch
- [x] `npx playwright test e2e/schedules-sync.spec.ts` — 12 pass
- [ ] Full e2e suite — left to CI