### PR TITLE
feat(desktop): act on several sessions at once

### DIFF
--- a/desktop/e2e/bulk-sessions.spec.ts
+++ b/desktop/e2e/bulk-sessions.spec.ts
@@ -1,0 +1,92 @@
+// Acting on several sessions at once.
+//
+// The risk here is not that a button does nothing — it is that it does the
+// right thing to the wrong rows, or half of them. So these assert what reached
+// the daemon, not what the bar said.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+function bar(window: Page) {
+  return window.locator('.bulk-bar')
+}
+
+function ticks(window: Page) {
+  return window.locator('.session-row .row-tick')
+}
+
+async function startPicking(window: Page): Promise<void> {
+  await expect(window.locator('.session-row').first()).toBeVisible()
+  await window.locator('.select-toggle').click()
+  await expect(bar(window)).toBeVisible()
+}
+
+test('Select shows the ticks, and Done takes them away', async ({ window }) => {
+  await expect(ticks(window)).toHaveCount(0)
+
+  await startPicking(window)
+  expect(await ticks(window).count()).toBeGreaterThan(0)
+
+  await bar(window).getByText('Done').click()
+  await expect(ticks(window)).toHaveCount(0)
+  await expect(bar(window)).toHaveCount(0)
+})
+
+test('the bar counts what is held', async ({ window }) => {
+  await startPicking(window)
+
+  await ticks(window).nth(0).check()
+  await expect(bar(window)).toContainText('1 selected')
+
+  await ticks(window).nth(1).check()
+  await expect(bar(window)).toContainText('2 selected')
+})
+
+test('⌘-click picks a row without opening it', async ({ window }) => {
+  await expect(window.locator('.session-row').first()).toBeVisible()
+
+  await window.locator('.session-row').first().click({ modifiers: ['ControlOrMeta'] })
+
+  await expect(bar(window)).toContainText('1 selected')
+  // Picking is not opening: the panel stays where it was.
+  await expect(window.locator('.panel-tabs')).toHaveCount(0)
+})
+
+test('deleting the selection asks once, then deletes every one of them', async ({ window, daemon }) => {
+  await startPicking(window)
+  await ticks(window).nth(0).check()
+  await ticks(window).nth(1).check()
+
+  window.on('dialog', (dialog) => void dialog.accept())
+  await bar(window).getByText('Delete').click()
+
+  await expect
+    .poll(() => daemon.writes().filter((write) => write.kind === 'delete').length)
+    .toBe(2)
+  // The selection is spent, so a second click cannot delete the same rows.
+  await expect(bar(window)).not.toContainText('2 selected')
+})
+
+test('a refused confirmation deletes nothing', async ({ window, daemon }) => {
+  await startPicking(window)
+  await ticks(window).nth(0).check()
+
+  window.on('dialog', (dialog) => void dialog.dismiss())
+  await bar(window).getByText('Delete').click()
+
+  await expect(bar(window)).toContainText('1 selected')
+  expect(daemon.writes().filter((write) => write.kind === 'delete')).toHaveLength(0)
+})
+
+test('Pin pins everything held, in one call each', async ({ window, daemon }) => {
+  await startPicking(window)
+  await ticks(window).nth(0).check()
+  await ticks(window).nth(1).check()
+
+  await bar(window).getByText('Pin', { exact: true }).click()
+
+  await expect.poll(() => daemon.writes().filter((write) => write.kind === 'patch').length).toBe(2)
+  for (const write of daemon.writes()) {
+    if (write.kind === 'patch') expect(write.patch).toEqual({ pinned: true })
+  }
+})

--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -64,6 +64,10 @@ export type DaemonWrite =
   | { kind: 'create'; spec: Record<string, unknown> }
   | { kind: 'upload'; names: string[] }
   | { kind: 'send'; sessionId: string; message: string }
+  // What a bulk action issues: one call per session held, so a test can check
+  // that all of them went out and none went twice.
+  | { kind: 'delete'; sessionId: string }
+  | { kind: 'patch'; sessionId: string; patch: Record<string, unknown> }
 
 /** The session every create in these tests hands back. */
 export const CREATED = 's-created'
@@ -325,6 +329,28 @@ export async function startDaemon(): Promise<StubDaemon> {
       res.write(': open\n\n')
       streams.add(res)
       req.on('close', () => streams.delete(res))
+      return
+    }
+
+    if (req.method === 'DELETE' && path.startsWith('/api/sessions/')) {
+      writes.push({ kind: 'delete', sessionId: path.slice('/api/sessions/'.length) })
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ success: true }))
+      return
+    }
+
+    if (req.method === 'PATCH' && path.startsWith('/api/sessions/')) {
+      const chunks: Buffer[] = []
+      req.on('data', (chunk: Buffer) => chunks.push(chunk))
+      req.on('end', () => {
+        writes.push({
+          kind: 'patch',
+          sessionId: path.slice('/api/sessions/'.length),
+          patch: JSON.parse(Buffer.concat(chunks).toString() || '{}') as Record<string, unknown>,
+        })
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ success: true }))
+      })
       return
     }
 

--- a/desktop/src/renderer/components/bulk-bar.tsx
+++ b/desktop/src/renderer/components/bulk-bar.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from '../bridge.ts'
+import { providersQuery } from '../queries.ts'
+import { store } from '../store.ts'
+import { actionsFor } from './session-selection.ts'
+import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
+import type { Session, SessionGroup } from '../../shared/models.ts'
+
+/**
+ * What can be done to everything picked, and how many that is.
+ *
+ * The bar is where a bulk action lives rather than the row's own menu: a menu
+ * opened on one row and applied to nine reads as acting on the row it was
+ * opened from. Here the count is the first thing said, so what is about to
+ * happen and how much of it are in the same sentence.
+ */
+export function BulkBar({
+  held,
+  rows,
+  groups,
+}: {
+  held: string[]
+  rows: { hostId: string; session: Session }[]
+  groups: Record<string, SessionGroup[]>
+}): JSX.Element {
+  const [menu, setMenu] = useState<{ kind: 'file' | 'mode'; x: number; y: number } | null>(null)
+  const summary = actionsFor(held, rows)
+  const hostId = held.length > 0 ? (rows.find((row) => held.includes(`${row.hostId}:${row.session.session_id}`))?.hostId ?? '') : ''
+  const { data: providers } = useQuery({ ...providersQuery(hostId), enabled: hostId !== '' })
+
+  if (summary.count === 0) {
+    return (
+      <div className="bulk-bar">
+        <span className="bulk-count">Pick sessions to act on several at once</span>
+        <button className="ghost" onClick={() => store.setSelectMode(false)}>
+          Done
+        </button>
+      </div>
+    )
+  }
+
+  const filing: MenuAction[] = [
+    {
+      label: 'No group',
+      run: () => void store.bulk('Filed', (host, id) => api(host).patchSession(id, { group_key: '' })),
+    },
+    ...(groups[hostId] ?? []).map((group) => ({
+      label: group.name,
+      run: () =>
+        void store.bulk('Filed', (host, id) => api(host).patchSession(id, { group_key: group.key })),
+    })),
+  ]
+
+  // The modes the provider offers, taken from the first session held: a
+  // selection spanning two providers has no one list, and the daemon refuses
+  // what does not apply anyway.
+  const modes: MenuAction[] = (providers ?? [])
+    .flatMap((provider) => provider.permission_modes ?? [])
+    .filter((mode, at, all) => all.indexOf(mode) === at)
+    .map((mode) => ({
+      label: mode,
+      run: () => void store.bulk(`Set ${mode} on`, (host, id) => api(host).setPermissionMode(id, mode)),
+    }))
+
+  return (
+    <div className="bulk-bar">
+      <span className="bulk-count">{summary.count} selected</span>
+
+      <button
+        className="ghost"
+        onClick={() =>
+          void store.bulk(summary.pin === 'pin' ? 'Pinned' : 'Unpinned', (host, id) =>
+            api(host).patchSession(id, { pinned: summary.pin === 'pin' }),
+          )
+        }
+      >
+        {summary.pin === 'pin' ? 'Pin' : 'Unpin'}
+      </button>
+
+      {/* Groups belong to a host, so there is no group that means the same
+          thing across two daemons. */}
+      <button
+        className="ghost"
+        disabled={!summary.canFile}
+        title={summary.canFile ? 'File all of them under one group' : 'The selection is on more than one host'}
+        onClick={(event) => setMenu({ kind: 'file', x: event.clientX, y: event.clientY })}
+      >
+        Move to group
+      </button>
+
+      <button
+        className="ghost"
+        disabled={modes.length === 0}
+        onClick={(event) => setMenu({ kind: 'mode', x: event.clientX, y: event.clientY })}
+      >
+        Permission mode
+      </button>
+
+      <button
+        className="ghost danger"
+        disabled={!summary.canTerminate}
+        title={summary.canTerminate ? 'Stop the agents' : 'Nothing selected is still running'}
+        onClick={() => {
+          if (!confirm(`Terminate ${summary.count} sessions? Each agent stops, and only Resume brings it back.`)) {
+            return
+          }
+          void store.bulk('Terminated', (host, id) => api(host).terminate(id))
+        }}
+      >
+        Terminate
+      </button>
+
+      <button
+        className="ghost danger"
+        onClick={() => {
+          if (!confirm(`Remove ${summary.count} sessions from Helios? Their transcript files stay on disk.`)) {
+            return
+          }
+          for (const key of held) store.closeTab(key)
+          void store.bulk('Removed', (host, id) => api(host).deleteSession(id))
+        }}
+      >
+        Delete
+      </button>
+
+      <span className="grow" />
+      <button className="ghost" onClick={() => store.setSelectMode(false)}>
+        Done
+      </button>
+
+      {menu && (
+        <SelectionMenu
+          x={menu.x}
+          y={menu.y}
+          actions={menu.kind === 'file' ? filing : modes}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/icons.tsx
+++ b/desktop/src/renderer/components/icons.tsx
@@ -117,6 +117,16 @@ export function Plus({ className = '' }: { className?: string }): JSX.Element {
   )
 }
 
+/** Picking several rows at once: a box with a tick in it. */
+export function Ticks({ className = '' }: { className?: string }): JSX.Element {
+  return (
+    <svg className={`ui-icon ${className}`.trim()} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4.5 5.5h9M4.5 12h9M4.5 18.5h6" />
+      <path d="M15 15.5l2.5 2.5 5-5" />
+    </svg>
+  )
+}
+
 /**
  * A list of sessions, for the rail. Bulleted, so it is not the sort icon.
  *

--- a/desktop/src/renderer/components/session-selection.ts
+++ b/desktop/src/renderer/components/session-selection.ts
@@ -1,0 +1,149 @@
+import { canResume, type Session } from '../../shared/models.ts'
+
+/**
+ * Which sessions a bulk action applies to.
+ *
+ * A selection spans hosts — the list interleaves them — so a member is a host
+ * and a session together, and every action has to be issued per host. What is
+ * pure here is the arithmetic: what a click adds, what a group header covers,
+ * and which actions the selection can carry. The calls themselves are the
+ * store's.
+ */
+
+export interface SessionRef {
+  hostId: string
+  sessionId: string
+}
+
+/** One member, as a string, so a Set can hold it. */
+export function refKey(hostId: string, sessionId: string): string {
+  return hostId + ':' + sessionId
+}
+
+/**
+ * Split at the first colon only.
+ *
+ * A host id never holds one; a session id can — a shell terminal is
+ * `sess-1:sh2` — so splitting on every colon would hand the daemon half an id.
+ */
+export function parseRef(key: string): SessionRef {
+  const at = key.indexOf(':')
+  if (at === -1) return { hostId: key, sessionId: '' }
+  return { hostId: key.slice(0, at), sessionId: key.slice(at + 1) }
+}
+
+/** In or out. The click that does this is ⌘-click, or a tick in the box. */
+export function toggle(selection: readonly string[], key: string): string[] {
+  return selection.includes(key) ? selection.filter((held) => held !== key) : [...selection, key]
+}
+
+/**
+ * Everything between the last click and this one, added to what is held.
+ *
+ * The order is the order the list is drawn in, which is the order a reader
+ * means by "these". Shift-clicking backwards selects the same rows as
+ * shift-clicking forwards, so the two ends are sorted rather than assumed.
+ */
+export function extend(
+  selection: readonly string[],
+  ordered: readonly string[],
+  anchor: string | null,
+  target: string,
+): string[] {
+  const to = ordered.indexOf(target)
+  const from = anchor === null ? -1 : ordered.indexOf(anchor)
+  if (to === -1) return [...selection]
+  if (from === -1) return toggle(selection, target)
+
+  const [start, end] = from <= to ? [from, to] : [to, from]
+  const range = ordered.slice(start, end + 1)
+  return [...selection, ...range.filter((key) => !selection.includes(key))]
+}
+
+/**
+ * A group header's tick covers the rows under it.
+ *
+ * Ticking a group whose rows are already all held clears them instead, so the
+ * header is a toggle rather than a one-way gate — otherwise the only way to
+ * undo it is to untick each row.
+ */
+export function toggleAll(selection: readonly string[], keys: readonly string[]): string[] {
+  const all = keys.length > 0 && keys.every((key) => selection.includes(key))
+  if (all) return selection.filter((held) => !keys.includes(held))
+  return [...selection, ...keys.filter((key) => !selection.includes(key))]
+}
+
+/** Whether a header should draw as ticked, half-ticked, or empty. */
+export function coverage(
+  selection: readonly string[],
+  keys: readonly string[],
+): 'none' | 'some' | 'all' {
+  if (keys.length === 0) return 'none'
+  const held = keys.filter((key) => selection.includes(key)).length
+  if (held === 0) return 'none'
+  return held === keys.length ? 'all' : 'some'
+}
+
+/**
+ * Every session a group header covers, at any depth under it.
+ *
+ * Structural rather than importing GroupNode: the tree is built by the
+ * grouping module, which has no business knowing about selection, and this has
+ * no business knowing about trees beyond the two fields it walks.
+ */
+interface TreeNode {
+  sessions: { session_id: string }[]
+  children: TreeNode[]
+}
+
+export function keysInNode(hostId: string, node: TreeNode): string[] {
+  const keys = node.sessions.map((session) => refKey(hostId, session.session_id))
+  for (const child of node.children) keys.push(...keysInNode(hostId, child))
+  return keys
+}
+
+/** The members, grouped by the host that has to be asked. */
+export function byHost(selection: readonly string[]): Map<string, string[]> {
+  const hosts = new Map<string, string[]>()
+  for (const key of selection) {
+    const { hostId, sessionId } = parseRef(key)
+    const held = hosts.get(hostId)
+    if (held) held.push(sessionId)
+    else hosts.set(hostId, [sessionId])
+  }
+  return hosts
+}
+
+/**
+ * What the bar can offer for what is held.
+ *
+ * Pin reads as one thing or the other rather than both: a mixed selection
+ * pins, because the reader who picked ten rows and pressed Pin meant all ten
+ * to end up pinned.
+ *
+ * Groups belong to a host, so filing is only offered when everything held is
+ * on one host — there is no group that means the same thing on two daemons.
+ */
+export function actionsFor(
+  selection: readonly string[],
+  sessions: readonly { hostId: string; session: Session }[],
+): {
+  count: number
+  hosts: number
+  pin: 'pin' | 'unpin'
+  canFile: boolean
+  canTerminate: boolean
+} {
+  const held = sessions.filter(({ hostId, session }) =>
+    selection.includes(refKey(hostId, session.session_id)),
+  )
+  const hosts = new Set(held.map(({ hostId }) => hostId))
+  return {
+    count: held.length,
+    hosts: hosts.size,
+    pin: held.length > 0 && held.every(({ session }) => session.pinned) ? 'unpin' : 'pin',
+    canFile: hosts.size === 1,
+    // Nothing to end that has already ended.
+    canTerminate: held.some(({ session }) => !canResume(session)),
+  }
+}

--- a/desktop/src/renderer/components/sidebar.tsx
+++ b/desktop/src/renderer/components/sidebar.tsx
@@ -27,7 +27,7 @@ import {
   type Session,
   type HostStats,
 } from '../../shared/models.ts'
-import { Chevron, Console, Cpu, Memory, Pencil, Plus, Search, Sort } from './icons.tsx'
+import { Chevron, Ticks, Console, Cpu, Memory, Pencil, Plus, Search, Sort } from './icons.tsx'
 import {
   buildCwdTree,
   buildTree,
@@ -40,7 +40,9 @@ import { GroupPicker } from './group-picker.tsx'
 import { Modal } from './newsession.tsx'
 import { ScheduleHost } from './schedules.tsx'
 import { SelectionMenu, type MenuAction } from './selection-menu.tsx'
+import { BulkBar } from './bulk-bar.tsx'
 import { sessionActions } from './session-menu.ts'
+import { coverage, extend, keysInNode, refKey, toggle, toggleAll } from './session-selection.ts'
 import { SECTIONS } from './settings.tsx'
 
 /** What the sidebar may be dragged to. Narrower hides titles; wider is a
@@ -384,6 +386,32 @@ export function Sidebar({
   // writes the other way to every host, which settles any disagreement.
   const manual = hosts.some((host) => sortMode[host.id] === 'manual')
 
+  // ─── Selection ─────────────────────────────────────────────────────────
+  //
+  // The order a Shift-click means is the order on screen, which is the order
+  // the rows were sorted into above — not the daemon's, and not the order the
+  // hosts were paired in.
+  const held = useStore((s) => s.sessionSelection)
+  const picking = useStore((s) => s.selectMode)
+  const anchor = useStore((s) => s.selectionAnchor)
+  const rowOrder = useMemo(
+    () => grouped.flatMap((group) => group.rows.map((row) => refKey(group.host.id, row.session.session_id))),
+    [grouped],
+  )
+  const rowsHeld = useMemo(
+    () => grouped.flatMap((group) => group.rows.map((row) => ({ hostId: group.host.id, session: row.session }))),
+    [grouped],
+  )
+
+  const pick = (hostId: string, sessionId: string, how: 'toggle' | 'range'): void => {
+    const key = refKey(hostId, sessionId)
+    if (how === 'range') {
+      store.setSessionSelection(extend(held, rowOrder, anchor, key), key)
+      return
+    }
+    store.setSessionSelection(toggle(held, key), key)
+  }
+
   // Unmounted rather than hidden: the list holds a query per host, and a
   // folded column has no business polling for rows nobody is looking at.
   if (!open) return null
@@ -501,6 +529,15 @@ export function Sidebar({
           )}
         </div>
         <button
+          className={picking ? 'tool select-toggle on' : 'tool select-toggle'}
+          aria-label="Select sessions"
+          aria-pressed={picking}
+          title="Select several — ⌘-click a row, or Shift-click for a run"
+          onClick={() => store.setSelectMode(!picking)}
+        >
+          <Ticks />
+        </button>
+        <button
           className="tool primary"
           aria-label="New session"
           title="New session (⌘N)"
@@ -509,6 +546,10 @@ export function Sidebar({
           <Plus />
         </button>
       </header>
+      )}
+
+      {mode === 'sessions' && picking && (
+        <BulkBar held={held} rows={rowsHeld} groups={groupsByHost} />
       )}
 
       <div className="sidebar-list" hidden={mode !== 'sessions'}>
@@ -568,9 +609,13 @@ export function Sidebar({
                 ids.splice(to, 0, ids.splice(from, 1)[0] as string)
                 void store.reorderSessions(host.id, ids)
               }}
+              picking={picking}
+              picked={held.includes(refKey(host.id, session.session_id))}
+              onPick={(how) => pick(host.id, session.session_id, how)}
             />
           )
 
+          const keysUnder = (node: GroupNode): string[] => keysInNode(host.id, node)
           const renderNode = (node: GroupNode): JSX.Element => {
             const path = node.path.join('/')
             const foldKey = `${host.id}:${path}`
@@ -613,6 +658,22 @@ export function Sidebar({
                     })
                   }}
                 >
+                  {/* One tick for the whole group. What it covers is the rows
+                      the group is drawing, at any depth under it — folding a
+                      group does not take its sessions out of the selection the
+                      header offers. */}
+                  {picking && !editing && (
+                    <input
+                      className="row-tick"
+                      type="checkbox"
+                      checked={coverage(held, keysUnder(node)) === 'all'}
+                      ref={(box) => {
+                        if (box) box.indeterminate = coverage(held, keysUnder(node)) === 'some'
+                      }}
+                      aria-label={`Select everything in ${node.name || 'Ungrouped'}`}
+                      onChange={() => store.setSessionSelection(toggleAll(held, keysUnder(node)))}
+                    />
+                  )}
                   {editing ? (
                     <InlineNameField
                       initial={node.name}
@@ -890,6 +951,9 @@ export function Sidebar({
                           setMenu({ kind: 'session', hostId: host.id, session, x, y })
                         }
                         onDropBefore={() => {}}
+                        picking={picking}
+                        picked={held.includes(refKey(host.id, session.session_id))}
+                        onPick={(how) => pick(host.id, session.session_id, how)}
                       />
                     ))}
                 </div>
@@ -1120,6 +1184,9 @@ function SessionRow({
   onDragEnd,
   onContextMenu,
   onDropBefore,
+  picking,
+  picked,
+  onPick,
 }: {
   hostId: string
   session: Session
@@ -1137,6 +1204,10 @@ function SessionRow({
   onDragEnd: () => void
   onContextMenu: (x: number, y: number) => void
   onDropBefore: (draggedId: string) => void
+  /** Selection: the ticks are showing, this row is held, and how a click lands. */
+  picking: boolean
+  picked: boolean
+  onPick: (how: 'toggle' | 'range') => void
 }): JSX.Element {
   const live = hasTerminal(session)
   const busy = BUSY_STATUSES.has(session.status)
@@ -1147,6 +1218,8 @@ function SessionRow({
     'session-row',
     session.status,
     selected ? 'selected' : '',
+    picking ? 'picking' : '',
+    picked ? 'picked' : '',
     dragging ? 'dragging' : '',
     draggable ? 'movable' : '',
   ]
@@ -1179,7 +1252,26 @@ function SessionRow({
         event.preventDefault()
         onDropBefore(event.dataTransfer.getData('text/plain'))
       }}
-      onClick={() => store.select(hostId, session.session_id)}
+      onClick={(event) => {
+        // A modifier is what turns a click into a selection; without one the
+        // row opens, as it always has. Shift takes the run between here and
+        // the last one picked.
+        if (event.shiftKey) {
+          onPick('range')
+          return
+        }
+        if (event.metaKey || event.ctrlKey) {
+          onPick('toggle')
+          return
+        }
+        // While the ticks are showing, a plain click ticks: the reader is
+        // building a selection, not browsing.
+        if (picking) {
+          onPick('toggle')
+          return
+        }
+        store.select(hostId, session.session_id)
+      }}
       // Pointed at, not opened. A right-click is a question about a session,
       // and answering it by loading that session into the panel throws away
       // whatever the user was reading — the one thing they did not ask for.
@@ -1198,6 +1290,18 @@ function SessionRow({
           : store.openTerminal(hostId, session, !live))
       }}
     >
+      {/* The tick, only while a selection is being built. It is not a second
+          way to open the row: clicking it picks, and stops there. */}
+      {picking && (
+        <input
+          className="row-tick"
+          type="checkbox"
+          checked={picked}
+          aria-label={`Select ${label}`}
+          onClick={(event) => event.stopPropagation()}
+          onChange={() => onPick('toggle')}
+        />
+      )}
       <div className="row-main">
         {editing ? (
           <InlineNameField

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -31,6 +31,7 @@ import {
   type ItemId,
   type Layout,
 } from './components/layout.ts'
+import { parseRef } from './components/session-selection.ts'
 import { fontStack } from '../shared/fonts.ts'
 import type { SegmentId } from '../shared/status-line.ts'
 import {
@@ -269,6 +270,20 @@ export interface State {
   /** Whether a file dropped or pasted on a terminal is uploaded to its daemon. */
   terminalUploads: boolean
   /**
+   * Sessions picked out for one action to be done to all of them, as
+   * `hostId:sessionId`. Empty is the ordinary state of the list: a click still
+   * opens a session, and only a modifier or a tick starts a selection.
+   */
+  sessionSelection: string[]
+  /**
+   * Whether the ticks are showing. On while a selection is held, and held on
+   * by the Select button so an empty selection can be started with the mouse
+   * alone.
+   */
+  selectMode: boolean
+  /** The row a Shift-click measures its range from. */
+  selectionAnchor: string | null
+  /**
    * Whether the list column is showing.
    *
    * Folded, the rail stays: what is open is still reachable, and the switch
@@ -465,6 +480,9 @@ const initial: State = {
   termFont: fontStack('terminal', bridge.theme.boot().fonts.terminal),
   termSize: bridge.theme.boot().sizes.terminal,
   terminalUploads: readTerminalUploads(),
+  sessionSelection: [],
+  selectMode: false,
+  selectionAnchor: null,
   sidebarOpen: readSidebarOpen(),
   density: bridge.theme.boot().density,
   statusLine: bridge.theme.boot().statusLine,
@@ -765,6 +783,56 @@ class Store {
     const next = open ?? !this.getSnapshot().sidebarOpen
     this.set({ sidebarOpen: next })
     writeSidebarOpen(next)
+  }
+
+  /** Shows or hides the ticks. Leaving takes the selection with it. */
+  setSelectMode(on: boolean): void {
+    if (on) this.set({ selectMode: true })
+    else this.set({ selectMode: false, sessionSelection: [], selectionAnchor: null })
+  }
+
+  /** Replaces what is held, and remembers where a range would measure from. */
+  setSessionSelection(selection: string[], anchor?: string | null): void {
+    this.set({
+      sessionSelection: selection,
+      selectionAnchor: anchor === undefined ? this.getSnapshot().selectionAnchor : anchor,
+      // A selection with nothing in it still shows its ticks: the reader is
+      // mid-thought, and taking the boxes away under the pointer is worse than
+      // an empty bar.
+      selectMode: selection.length > 0 ? true : this.getSnapshot().selectMode,
+    })
+  }
+
+  clearSessionSelection(): void {
+    this.set({ sessionSelection: [], selectionAnchor: null })
+  }
+
+  /**
+   * One action, applied to every session held, host by host.
+   *
+   * allSettled rather than all: the point of a bulk action is that it finishes.
+   * One host being unreachable must not leave the other half undone, and what
+   * failed is said afterwards rather than thrown.
+   */
+  async bulk(
+    label: string,
+    apply: (hostId: string, sessionId: string) => Promise<unknown>,
+  ): Promise<void> {
+    const held = this.getSnapshot().sessionSelection
+    if (held.length === 0) return
+    const results = await Promise.allSettled(
+      held.map((key) => {
+        const { hostId, sessionId } = parseRef(key)
+        return apply(hostId, sessionId)
+      }),
+    )
+    const failed = results.filter((result) => result.status === 'rejected').length
+    for (const hostId of new Set(held.map((key) => parseRef(key).hostId))) {
+      void this.invalidateSessionsFor(hostId)
+    }
+    this.set({ sessionSelection: [], selectionAnchor: null })
+    if (failed === 0) this.notify(`${label} ${held.length}`)
+    else this.notify(`${label} ${held.length - failed} of ${held.length} — ${failed} failed`, 'error')
   }
 
   setTerminalUploads(on: boolean): void {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -2304,14 +2304,12 @@ figure.mermaid svg {
   border-radius: var(--r-md);
 }
 
-/* Sticky, so the file a long patch belongs to is still named once the reader
-   has scrolled into the middle of it. It can only stick while nothing between
-   here and the transcript's scroller clips: hence no `overflow` on the card. */
+/* Not sticky. It was, back when the row was a filled card with a rounded top —
+   flat, a header pinned over the transcript is a line of text with the
+   conversation sliding under it and being cut off at its edge, which reads as
+   a rendering fault rather than as a header. */
 .tool-head {
   cursor: pointer;
-  position: sticky;
-  top: 0;
-  z-index: 1;
   display: flex;
   min-width: 0;
   /* Top, not centre: the command wraps, and a centred icon beside three lines
@@ -2322,9 +2320,6 @@ figure.mermaid svg {
   text-align: left;
   border-radius: var(--r-md) var(--r-md) 0 0;
   padding: 4px 8px;
-  /* Opaque, but the panel's own colour: it is sticky, so a patch scrolling
-     under it must not show through. */
-  background: var(--surface);
   color: var(--on-surface);
   font-weight: 400;
 }
@@ -5555,8 +5550,10 @@ hr {
 /* ─── Diffs: unified, then side by side ─────────────────────────────────── */
 
 /* One column, one row per line, gutters at the left: a patch read the way a
-   file view shows one. The whole block scrolls sideways as a unit so the
-   columns stay lined up, and the gutters stick to the left edge while it does. */
+   file view shows one.
+   Long lines wrap rather than scrolling sideways. A patch in a transcript is
+   read, not navigated — text held behind a horizontal scrollbar is text
+   nobody sees, and prose in a Markdown file is one long line per paragraph. */
 .diff-unified {
   /* The tint of a changed line is mixed into this, and the sticky numbers are
      painted with it, so a pane on a different surface sets it once.
@@ -5565,12 +5562,14 @@ hr {
      colours then had to compete with. Against the darker surface the patch
      reads as recessed, which is what a terminal's diff looks like. */
   --diff-bg: var(--surface);
+  /* The width of both gutters and the sign, so a wrapped line can be indented
+     to start under the text above it rather than under the numbers. */
+  --diff-gutter: 11ch;
   /* Strong enough that a changed row is unmistakable against the context
      around it — measured at 1.9:1 against the untinted rows, with the text on
      it still at 7.4:1. The accents are pale, so the number reads higher than
      it looks. */
   --diff-tint: 30%;
-  overflow-x: auto;
   font-family: var(--mono);
   /* A patch has to read as the bytes it is. With ligatures on, `--- a/file`
      draws an em dash and `@@` draws a glyph, so a header stops looking like
@@ -5583,13 +5582,13 @@ hr {
 
 .diff-line {
   display: flex;
+  /* The numbers keep to the first line of a wrapped row rather than centring
+     themselves against the height of it. */
+  align-items: flex-start;
   gap: 8px;
-  /* Wider than the block when a line is long, but never narrower: a short
-     patch would otherwise tint only as far as its longest line. */
-  width: max-content;
-  min-width: 100%;
   padding-right: 12px;
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   /* Opaque, because the numbers slide over the code on a sideways scroll. */
   background: var(--diff-bg);
 }
@@ -5648,17 +5647,15 @@ hr {
   border-block: 1px solid var(--outline-variant);
 }
 
-/* The numbers and the sign travel together: one sticky column, or the second
-   number would come to rest on top of the first. */
+/* The numbers and the sign travel together, and hold a fixed width so the
+   text starts at the same column on every row. */
 .diff-nums {
-  position: sticky;
-  left: 0;
-  z-index: 1;
   display: flex;
   flex: none;
   gap: 8px;
+  width: var(--diff-gutter);
   padding: 0 4px 0 12px;
-  background: inherit;
+  box-sizing: content-box;
 }
 
 .diff-sign {
@@ -5735,6 +5732,7 @@ hr {
 }
 
 .diff-text {
+  flex: 1;
   min-width: 0;
 }
 

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -642,6 +642,79 @@ small {
   height: 16px;
 }
 
+/* ─── Bulk selection ────────────────────────────────────────────────────── */
+
+/* The tick takes a column of its own down the left, so it sits beside the
+   whole card rather than above its first line. */
+.session-row.picking {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: 8px;
+}
+
+.session-row.picking > :not(.row-tick) {
+  grid-column: 2;
+}
+
+.session-row.picking .row-tick {
+  grid-row: 1 / -1;
+}
+
+/* The tick on a row, and on a group header. Shown only while a selection is
+   being built, so an ordinary list is not a column of empty boxes. */
+.row-tick {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  margin: 0 2px 0 0;
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+/* What is held, and what can be done to it. Under the search rather than over
+   the list: it appears and disappears, and a bar that pushes the rows down
+   from above is easier to follow than one that covers the top of them. */
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--surface-container);
+  box-shadow: inset 0 -1px 0 var(--outline-variant);
+  font-size: 12px;
+}
+
+.bulk-count {
+  margin-right: 4px;
+  color: var(--on-surface-variant);
+  font-weight: 600;
+}
+
+.bulk-bar button {
+  padding: 3px 8px;
+  font-size: 11.5px;
+}
+
+.bulk-bar button.danger {
+  color: var(--error);
+}
+
+.bulk-bar button:disabled {
+  opacity: 0.4;
+}
+
+/* A picked row, which is not the same as the open one: one is what the panel
+   is showing, the other is what the bar would act on. */
+.session-row.picked {
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+}
+
+.session-row.picked.selected {
+  background: color-mix(in srgb, var(--primary) 24%, transparent);
+}
+
 /* Wider than it looks: a 4px edge is a target that has to be hunted, so the
    grip reaches inside the panel where nothing else is clickable. It paints
    nothing until the pointer is on it. */

--- a/desktop/test/session-selection.test.ts
+++ b/desktop/test/session-selection.test.ts
@@ -1,0 +1,134 @@
+// Selection arithmetic. A bulk action is only as safe as the set it is handed:
+// a range that misses a row means work left undone, and one that catches a row
+// the reader did not mean is a session deleted by accident.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  actionsFor,
+  byHost,
+  coverage,
+  extend,
+  keysInNode,
+  parseRef,
+  refKey,
+  toggle,
+  toggleAll,
+} from '../src/renderer/components/session-selection.ts'
+import type { Session } from '../src/shared/models.ts'
+
+function session(id: string, extra: Partial<Session> = {}): Session {
+  return {
+    session_id: id,
+    source: 'claude',
+    cwd: '/repo',
+    project: 'repo',
+    status: 'idle',
+    pinned: false,
+    created_at: '2026-01-01T00:00:00Z',
+    supports_prompt_queue: true,
+    ...extra,
+  }
+}
+
+const ordered = ['h1:a', 'h1:b', 'h1:c', 'h2:d']
+
+test('a key survives the round trip', () => {
+  assert.deepEqual(parseRef(refKey('h1', 'a')), { hostId: 'h1', sessionId: 'a' })
+})
+
+test('a session id holding a colon of its own comes back whole', () => {
+  assert.deepEqual(parseRef(refKey('h1', 'sess-1:sh2')), { hostId: 'h1', sessionId: 'sess-1:sh2' })
+})
+
+test('toggling adds then removes', () => {
+  assert.deepEqual(toggle([], 'h1:a'), ['h1:a'])
+  assert.deepEqual(toggle(['h1:a', 'h1:b'], 'h1:a'), ['h1:b'])
+})
+
+test('a range covers both ends, whichever way it was dragged', () => {
+  assert.deepEqual(extend([], ordered, 'h1:a', 'h1:c'), ['h1:a', 'h1:b', 'h1:c'])
+  assert.deepEqual(extend([], ordered, 'h1:c', 'h1:a'), ['h1:a', 'h1:b', 'h1:c'])
+})
+
+test('a range keeps what was already held and adds nothing twice', () => {
+  assert.deepEqual(extend(['h2:d'], ordered, 'h1:a', 'h1:b'), ['h2:d', 'h1:a', 'h1:b'])
+  assert.deepEqual(extend(['h1:b'], ordered, 'h1:a', 'h1:c'), ['h1:b', 'h1:a', 'h1:c'])
+})
+
+test('shift with nothing to extend from is an ordinary tick', () => {
+  assert.deepEqual(extend([], ordered, null, 'h1:b'), ['h1:b'])
+})
+
+test('a group header ticks all of its rows, and untticks them when they are all held', () => {
+  const group = ['h1:a', 'h1:b']
+  assert.deepEqual(toggleAll([], group), ['h1:a', 'h1:b'])
+  assert.deepEqual(toggleAll(['h1:a', 'h1:b', 'h2:d'], group), ['h2:d'])
+  // Half held reads as "not all", so the header fills the rest rather than
+  // clearing what is there.
+  assert.deepEqual(toggleAll(['h1:a'], group), ['h1:a', 'h1:b'])
+})
+
+test('a header knows whether it is empty, part full, or full', () => {
+  assert.equal(coverage([], ['h1:a']), 'none')
+  assert.equal(coverage(['h1:a'], ['h1:a', 'h1:b']), 'some')
+  assert.equal(coverage(['h1:a', 'h1:b'], ['h1:a', 'h1:b']), 'all')
+  assert.equal(coverage(['h1:a'], []), 'none')
+})
+
+test('the calls are grouped by the host that has to answer them', () => {
+  const hosts = byHost(['h1:a', 'h2:d', 'h1:b'])
+  assert.deepEqual([...hosts.keys()], ['h1', 'h2'])
+  assert.deepEqual(hosts.get('h1'), ['a', 'b'])
+})
+
+test('a mixed selection pins, and an all-pinned one unpins', () => {
+  const rows = [
+    { hostId: 'h1', session: session('a', { pinned: true }) },
+    { hostId: 'h1', session: session('b') },
+  ]
+  assert.equal(actionsFor(['h1:a', 'h1:b'], rows).pin, 'pin')
+  assert.equal(actionsFor(['h1:a'], rows).pin, 'unpin')
+})
+
+test('filing is only offered while the selection is on one host', () => {
+  const rows = [
+    { hostId: 'h1', session: session('a') },
+    { hostId: 'h2', session: session('d') },
+  ]
+  assert.equal(actionsFor(['h1:a'], rows).canFile, true)
+  assert.equal(actionsFor(['h1:a', 'h2:d'], rows).canFile, false)
+  assert.equal(actionsFor(['h1:a', 'h2:d'], rows).hosts, 2)
+})
+
+test('a selection of nothing but ended sessions has nothing to terminate', () => {
+  const rows = [
+    { hostId: 'h1', session: session('a', { status: 'terminated' }) },
+    { hostId: 'h1', session: session('b', { status: 'idle' }) },
+  ]
+  assert.equal(actionsFor(['h1:a'], rows).canTerminate, false)
+  assert.equal(actionsFor(['h1:a', 'h1:b'], rows).canTerminate, true)
+})
+
+test('the count is of rows that exist, not of keys held', () => {
+  const rows = [{ hostId: 'h1', session: session('a') }]
+  // A session deleted under the selection leaves its key behind; it must not
+  // be counted, or the bar offers to act on a row that is gone.
+  assert.equal(actionsFor(['h1:a', 'h1:gone'], rows).count, 1)
+})
+
+test('a group header covers the rows under it, at any depth', () => {
+  const tree = {
+    sessions: [{ session_id: 'a' }],
+    children: [
+      { sessions: [{ session_id: 'b' }], children: [] },
+      { sessions: [{ session_id: 'c' }], children: [{ sessions: [{ session_id: 'd' }], children: [] }] },
+    ],
+  }
+  assert.deepEqual(keysInNode('h1', tree), ['h1:a', 'h1:b', 'h1:c', 'h1:d'])
+})
+
+test('an empty group covers nothing, and its header reads as empty', () => {
+  assert.deepEqual(keysInNode('h1', { sessions: [], children: [] }), [])
+  assert.equal(coverage(['h1:a'], keysInNode('h1', { sessions: [], children: [] })), 'none')
+})


### PR DESCRIPTION
## Summary

Clearing out a screen of finished sessions meant opening a menu on each row and answering the same question a dozen times.

**Picking**
- A tick button in the list header shows the boxes. ⌘-click picks a row without opening it; Shift-click takes the run between this row and the last, in the order the list is drawn in.
- A group header's box covers everything under it at any depth, and reads as full, half full, or empty. Ticking a group whose rows are all held clears them, so the header is a toggle rather than a one-way gate.

**Acting** — a bar under the search says how many are held and what can be done: Pin/Unpin, Move to group, Permission mode, Terminate, Delete. The destructive two ask once, naming the count.

- Calls go out per host, since a selection spans daemons. `allSettled`, not `all`: one unreachable host must not leave the rest undone, so failures are counted and reported afterwards.
- Filing is offered only while the selection is on one host — no group means the same thing on two daemons — and Terminate only while something held is still running.
- A mixed pin state pins: picking ten rows and pressing Pin means all ten pinned.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 340 pass, 15 new in `test/session-selection.test.ts`: range selection from either end, ranges that keep what was held, group coverage at depth, cycle-free host splitting, pin polarity, filing across hosts, and a count that ignores keys whose session has gone
- [x] `npx playwright test e2e/bulk-sessions.spec.ts` — 6 pass, asserting what reached the daemon rather than what the bar said: two deletes for two rows, nothing at all when the confirmation is refused, one patch per row for Pin, and ⌘-click picking without opening the session
- [x] `npx playwright test e2e/sidebar.spec.ts` — 3 pass, list behaviour unchanged
- [x] Drove it in the built app and checked the layout
- [ ] Full e2e suite — left to CI

The stub daemon now records `DELETE` and `PATCH` on a session, which it previously ignored; that is what lets the spec check the calls.