### PR TITLE
fix(terminal): clamp a scroll region to the grid it is drawn on

### DIFF
--- a/internal/terminal/margins.go
+++ b/internal/terminal/margins.go
@@ -1,0 +1,138 @@
+package terminal
+
+import (
+	"slices"
+	"strconv"
+)
+
+// clampMargins rewrites any scroll region that does not fit the grid.
+//
+// DECSTBM (`ESC [ top ; bottom r`) names the rows a scroll is confined to. The
+// emulator indexes its cell buffer with those rows and does not check them, so
+// a bottom margin past the last row panics on the next scroll: `index out of
+// range [98] with length 60`.
+//
+// Nothing exotic produces one. A pane is resized smaller while a full-screen
+// program is drawing, or an agent prints a transcript captured from a taller
+// terminal, and the region arrives describing a screen that no longer exists.
+// Screen.Write recovers from the panic, but recovery costs the whole write —
+// which is a redraw the viewer never sees — so the sequence is corrected on
+// the way in instead.
+//
+// Only the bottom is clamped: a top margin past the grid is nonsense the
+// emulator handles by ignoring the sequence, and rewriting it would invent a
+// region the application did not ask for.
+func clampMargins(p []byte, rows int) ([]byte, bool) {
+	if rows <= 0 {
+		return p, false
+	}
+	// The common case by far: nothing here sets a region, and a scan that
+	// allocates nothing is worth having on every write from the PTY.
+	if !hasCSI(p) {
+		return p, false
+	}
+
+	out := p
+	copied := false
+	for at := 0; at+1 < len(out); at++ {
+		if out[at] != 0x1b || out[at+1] != '[' {
+			continue
+		}
+		params, end, ok := csiParams(out, at+2)
+		if !ok || end >= len(out) || out[end] != 'r' {
+			continue
+		}
+		// `ESC [ ? … r` is DECRST, a different sequence that happens to end in
+		// the same letter.
+		if len(params) > 0 && params[0] == '?' {
+			continue
+		}
+		fixed, changed := clampOne(params, rows)
+		if !changed {
+			continue
+		}
+		if !copied {
+			out = slices.Clone(out)
+			copied = true
+		}
+		// The replacement is never longer than what it replaces — a clamped
+		// bottom is a smaller number — but splicing rather than overwriting
+		// keeps that from being load-bearing.
+		tail := slices.Clone(out[end:])
+		out = append(out[:at+2], append([]byte(fixed), tail...)...)
+		at += 2 + len(fixed)
+	}
+	return out, copied
+}
+
+func hasCSI(p []byte) bool {
+	for at := 0; at+1 < len(p); at++ {
+		if p[at] == 0x1b && p[at+1] == '[' {
+			return true
+		}
+	}
+	return false
+}
+
+/*
+csiParams reads the parameter bytes of a CSI sequence, returning them and the
+index of the final byte. Parameters are digits and semicolons; anything else
+ends the sequence, and a sequence that runs off the end of the buffer is not
+one this write can judge.
+*/
+func csiParams(p []byte, from int) (string, int, bool) {
+	at := from
+	for at < len(p) && ((p[at] >= '0' && p[at] <= '9') || p[at] == ';' || p[at] == '?') {
+		at++
+	}
+	if at >= len(p) {
+		return "", at, false
+	}
+	return string(p[from:at]), at, true
+}
+
+// clampOne returns the parameters with the bottom margin brought inside the
+// grid, and whether it had to change anything.
+func clampOne(params string, rows int) (string, bool) {
+	// `ESC [ r` with no parameters resets the region to the whole grid, which
+	// always fits.
+	if params == "" {
+		return params, false
+	}
+	top, bottom, ok := twoParams(params)
+	if !ok || bottom <= rows {
+		return params, false
+	}
+	// A region has to hold at least two rows for a scroll to mean anything; a
+	// top that has been pushed past the new bottom is dropped along with it,
+	// which is what `ESC [ r` means.
+	if top >= rows {
+		return "", true
+	}
+	return strconv.Itoa(top) + ";" + strconv.Itoa(rows), true
+}
+
+func twoParams(params string) (top, bottom int, ok bool) {
+	semi := -1
+	for at := range len(params) {
+		if params[at] == ';' {
+			if semi != -1 {
+				// Three parameters is not DECSTBM; leave it alone.
+				return 0, 0, false
+			}
+			semi = at
+		}
+	}
+	if semi == -1 {
+		return 0, 0, false
+	}
+	top, err := strconv.Atoi(params[:semi])
+	if err != nil {
+		return 0, 0, false
+	}
+	bottom, err = strconv.Atoi(params[semi+1:])
+	if err != nil {
+		return 0, 0, false
+	}
+	return top, bottom, true
+}

--- a/internal/terminal/margins_test.go
+++ b/internal/terminal/margins_test.go
@@ -1,0 +1,117 @@
+package terminal
+
+import "testing"
+
+// The sequence CI panicked on: a scroll region describing a taller screen than
+// the one being drawn, followed by a scroll into it.
+func TestScreenSurvivesAScrollRegionLargerThanTheGrid(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	if _, err := s.Write([]byte("\x1b[1;98r")); err != nil {
+		t.Fatalf("set margins: %v", err)
+	}
+	if _, err := s.Write([]byte("\x1bM hello\r\n")); err != nil {
+		t.Fatalf("scroll: %v", err)
+	}
+
+	if n := s.Panics(); n != 0 {
+		t.Errorf("panics = %d, want 0", n)
+	}
+}
+
+// Recovery costs the write it happened on, which is why the region is clamped
+// rather than caught: the text has to arrive.
+func TestOutputSurvivesAnOversizedScrollRegion(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	if _, err := s.Write([]byte("\x1b[1;98r\x1bMsecond\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := s.Text(); !contains(got, "second") {
+		t.Errorf("the screen lost the text: %q", got)
+	}
+}
+
+func TestClampMargins(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		rows    int
+		want    string
+		changed bool
+	}{
+		{name: "a region inside the grid is left alone", in: "\x1b[1;24r", rows: 60, want: "\x1b[1;24r"},
+		{name: "the bottom is brought to the last row", in: "\x1b[1;98r", rows: 60, want: "\x1b[1;60r", changed: true},
+		{
+			name:    "a top past the grid drops the region, as a bare reset does",
+			in:      "\x1b[70;98r",
+			rows:    60,
+			want:    "\x1b[r",
+			changed: true,
+		},
+		{name: "a bare reset always fits", in: "\x1b[r", rows: 60, want: "\x1b[r"},
+		{name: "text with no escapes is untouched", in: "just output\r\n", rows: 60, want: "just output\r\n"},
+		// `r` is the final byte of DECRST as well, and that one is about modes,
+		// not rows.
+		{name: "a private mode reset is not a scroll region", in: "\x1b[?1049r", rows: 60, want: "\x1b[?1049r"},
+		{name: "one parameter is not DECSTBM", in: "\x1b[98r", rows: 60, want: "\x1b[98r"},
+		{
+			name:    "the region is corrected where it sits in a longer write",
+			in:      "before\x1b[1;98rafter",
+			rows:    60,
+			want:    "before\x1b[1;60rafter",
+			changed: true,
+		},
+		{
+			name:    "every region in one write is corrected",
+			in:      "\x1b[1;98r\x1b[2;99r",
+			rows:    60,
+			want:    "\x1b[1;60r\x1b[2;60r",
+			changed: true,
+		},
+		// A sequence cut in half by the read boundary is left for the recover
+		// in Write, which is still there for exactly this.
+		{name: "a truncated sequence is left alone", in: "\x1b[1;98", rows: 60, want: "\x1b[1;98"},
+		{name: "a grid of no rows cannot be judged", in: "\x1b[1;98r", rows: 0, want: "\x1b[1;98r"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := clampMargins([]byte(tc.in), tc.rows)
+			if string(got) != tc.want {
+				t.Errorf("clampMargins(%q, %d) = %q, want %q", tc.in, tc.rows, got, tc.want)
+			}
+			if changed != tc.changed {
+				t.Errorf("changed = %v, want %v", changed, tc.changed)
+			}
+		})
+	}
+}
+
+// The caller counts bytes it handed over, not bytes the emulator received: a
+// rewrite makes those differ, and a short count would have the pump resend.
+func TestWriteReportsTheCallersLength(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	in := []byte("\x1b[1;98rtail")
+	n, err := s.Write(in)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(in) {
+		t.Errorf("n = %d, want %d", n, len(in))
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for at := 0; at+len(needle) <= len(haystack); at++ {
+		if haystack[at:at+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/terminal/screen.go
+++ b/internal/terminal/screen.go
@@ -117,6 +117,17 @@ func (s *Screen) Write(p []byte) (n int, err error) {
 			n, err = len(p), nil
 		}
 	}()
+	// A scroll region larger than the grid is what the emulator panics on, so
+	// it is corrected here rather than recovered from below: recovery costs
+	// the whole write, and the write is a redraw somebody is waiting to see.
+	if fixed, changed := clampMargins(p, s.rows); changed {
+		if _, werr := s.em.Write(fixed); werr != nil {
+			return 0, werr
+		}
+		// The caller's bytes are all accounted for, whatever the rewrite made
+		// of them; a short count would only have it retry the difference.
+		return len(p), nil
+	}
 	return s.em.Write(p)
 }
 

--- a/internal/terminal/screen_panic_test.go
+++ b/internal/terminal/screen_panic_test.go
@@ -12,9 +12,12 @@ import (
 // A mirror runs Write on its own goroutine inside the daemon, so this panic
 // killed every session at once — and printed to a stderr the daemon had pointed
 // at /dev/null, which is why it looked like an external kill for hours.
+//
+// Write clamps the region on the way in now, so this arrives harmless. The
+// recover behind it is still load-bearing — see the split write below.
 const panicSequence = "\x1b[1;100r\x1b[1;1H\x1bM"
 
-func TestScreenSurvivesAnEmulatorPanic(t *testing.T) {
+func TestScreenClampsTheSequenceThatTookTheDaemonDown(t *testing.T) {
 	s := NewScreen(80, 60)
 
 	n, err := s.Write([]byte(panicSequence))
@@ -24,8 +27,24 @@ func TestScreenSurvivesAnEmulatorPanic(t *testing.T) {
 	if n != len(panicSequence) {
 		t.Errorf("wrote %d of %d bytes", n, len(panicSequence))
 	}
+	if s.Panics() != 0 {
+		t.Errorf("panics = %d, want 0 — the region should be clamped before the emulator sees it", s.Panics())
+	}
+}
+
+// What the clamp cannot see: a sequence cut in half by a read boundary. Neither
+// write holds a whole region, so the emulator gets it and still panics — which
+// is why the recover stays, and why this asserts that it still fires.
+func TestScreenSurvivesASequenceSplitAcrossWrites(t *testing.T) {
+	s := NewScreen(80, 60)
+
+	for _, half := range []string{"\x1b[1;100", "r\x1b[1;1H\x1bM"} {
+		if _, err := s.Write([]byte(half)); err != nil {
+			t.Fatalf("write %q: %v", half, err)
+		}
+	}
 	if s.Panics() != 1 {
-		t.Fatalf("panics = %d, want 1 — the sequence no longer reproduces, so this test guards nothing", s.Panics())
+		t.Fatalf("panics = %d, want 1 — if this stops reproducing the recover guards nothing", s.Panics())
 	}
 
 	// Still usable afterwards: the daemon keeps mirroring the session rather


### PR DESCRIPTION
## What broke

CI on `main` (run 34569708355):

```
--- FAIL: TestHostViewerReceivesSnapshotAndLiveOutput
    host_test.go:113: did not receive live output after the snapshot
screen: emulator panicked on 16 bytes at 80x60: runtime error: index out of range [98] with length 60
```

`DECSTBM` (`ESC [ top ; bottom r`) names the rows a scroll is confined to, and the emulator indexes its cell buffer with them without checking. A bottom margin past the last row panics on the next scroll — index 98 into 60 rows.

`Screen.Write` already recovered from that. But recovery costs the write it happened on, and in this test that write *was* the session's live output — so the viewer was never sent it, and the failure read as a lost frame rather than as a panic. Reproduced deterministically: `\x1b[1;98r` on an 80x60 screen, then a reverse index.

## The fix

The region is corrected before the emulator sees it: a bottom past the last row is brought back to it, and a top past the grid drops the region, which is what a bare `ESC [ r` means. Nothing exotic produces one — a pane resized under a full-screen program, or a transcript captured on a taller terminal and printed here.

The recover stays. The test that guards it now uses a sequence split across two writes: neither half holds a whole region, so the clamp cannot see it and the emulator still panics — which is exactly the case recovery exists for, and the test fails if that stops reproducing.

## Test plan

- [x] `go test ./...` — whole suite green, including `internal/terminal` (87s)
- [x] New `internal/terminal/margins_test.go`: the CI sequence no longer panics, the output on that write survives, `Write` still reports the caller's length after a rewrite, and a table covering regions inside the grid, a clamped bottom, a dropped region, a bare reset, `DECRST` (`ESC [ ? … r`, same final byte, different sequence), one-parameter and truncated sequences, and several regions in one write
- [x] `gofmt` / `go vet` clean