### PR TITLE
feat(desktop): fold the transcript's tool calls

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -150,6 +150,7 @@ export function appendTranscript(sessionId: string, text: string): void {
 /** Back to how each test expects to find the daemon. */
 export function resetTranscripts(): void {
   for (const key of Object.keys(EXTRA)) delete EXTRA[key]
+  for (const key of Object.keys(TOOL_CALLS)) delete TOOL_CALLS[key]
   for (const record of [...SESSIONS, ...RUNS]) {
     record.last_event_at = '2026-01-01T00:00:00Z'
     if (record.session_id === PAST_RUN) continue
@@ -187,15 +188,62 @@ export function pushEvent(type: string, data: Record<string, unknown>): void {
 // Held outside startDaemon so a test can push an event without a handle.
 const openStreams = new Set<http.ServerResponse>()
 
-function transcriptFor(id: string): { seq: number; role: string; content: string; timestamp: string }[] {
+/**
+ * The tool calls a transcript holds, for the tests about how a call is drawn.
+ *
+ * Only on the session that asks for them: every other spec counts the messages
+ * in the panel it opened, and two extra rows everywhere would be two extra
+ * rows those tests never asked for.
+ */
+export const TOOL_CALLS: Record<string, { tool: string; summary: string; input: Record<string, unknown> }[]> = {}
+
+export function withToolCalls(
+  sessionId: string,
+  calls: { tool: string; summary: string; input: Record<string, unknown> }[],
+): void {
+  TOOL_CALLS[sessionId] = calls
+}
+
+interface StubMessage {
+  seq: number
+  role: string
+  timestamp: string
+  content?: string
+  tool?: string
+  summary?: string
+  success?: boolean
+  metadata?: Record<string, unknown>
+}
+
+function transcriptFor(id: string): StubMessage[] {
   const first = TRANSCRIPT_TEXT[id]
   const all = first === undefined ? (EXTRA[id] ?? []) : [first, ...(EXTRA[id] ?? [])]
-  return all.map((content, seq) => ({
+  const said = all.map((content, seq) => ({
     seq,
     role: 'assistant',
     content,
     timestamp: '2026-01-01T00:00:00Z',
   }))
+  // A call and its result, as the daemon reports them: the result carries no
+  // output of its own, only whether it worked.
+  const called = (TOOL_CALLS[id] ?? []).flatMap((call, at) => [
+    {
+      seq: said.length + at * 2,
+      role: 'tool_use',
+      tool: call.tool,
+      summary: call.summary,
+      metadata: call.input,
+      timestamp: '2026-01-01T00:00:00Z',
+    },
+    {
+      seq: said.length + at * 2 + 1,
+      role: 'tool_result',
+      tool: call.tool,
+      success: true,
+      timestamp: '2026-01-01T00:00:00Z',
+    },
+  ])
+  return [...said, ...called]
 }
 
 /** One schedule, so the schedules list has something in it to switch to. */

--- a/desktop/e2e/fold-all.spec.ts
+++ b/desktop/e2e/fold-all.spec.ts
@@ -1,0 +1,83 @@
+// Folding every tool call in the transcript at once.
+//
+// A card opened by hand after a Fold all has to be reachable by the next
+// press, which is the case a boolean would quietly get wrong — so that is what
+// most of this checks.
+import type { Page } from '@playwright/test'
+
+import { ALPHA as ALPHA_ID, withToolCalls } from './daemon.ts'
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+test.beforeEach(() => {
+  withToolCalls(ALPHA_ID, [
+    { tool: 'Bash', summary: 'ls -la', input: { command: 'ls -la', description: 'List the directory' } },
+    { tool: 'Edit', summary: 'main.go', input: { file_path: '/repo/main.go', old_string: 'a', new_string: 'b' } },
+  ])
+})
+
+async function open(window: Page): Promise<void> {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.panel-tabs')).toBeVisible()
+  await expect(window.locator('.msg.tool-call').first()).toBeVisible()
+}
+
+function fold(window: Page) {
+  return window.locator('.tab-fold')
+}
+
+test('the button folds every open card, then opens them all again', async ({ window }) => {
+  await open(window)
+  // A recent write opens itself, so there is something to fold before anything
+  // is pressed.
+  await expect(window.locator('.tool-detail')).toHaveCount(1)
+
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(2)
+})
+
+test('a card opened by hand is still reached by the next press', async ({ window }) => {
+  await open(window)
+
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+
+  // Opened by hand while the button says "open every one".
+  await window.locator('.tool-head').first().click()
+  await expect(window.locator('.tool-detail')).toHaveCount(1)
+
+  // Open all, then fold all. The hand-opened card has to answer both — a flag
+  // it already agreed with would leave it behind.
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(2)
+
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+})
+
+test('the button says which way it will go', async ({ window }) => {
+  await open(window)
+  await expect(fold(window)).toHaveAttribute('aria-label', 'Fold every tool call')
+
+  await fold(window).click()
+  await expect(fold(window)).toHaveAttribute('aria-label', 'Open every tool call')
+})
+
+test('it sits beside the transcript tab, and goes away on another tab', async ({ window }) => {
+  await open(window)
+  await expect(fold(window)).toHaveCount(1)
+
+  // Next to the tab it acts on, not at the far end of the strip.
+  const order = await window
+    .locator('.panel-tabs > *')
+    .evaluateAll((nodes) => nodes.map((node) => node.className))
+  const transcript = order.findIndex((name) => name.includes('active'))
+  expect(order[transcript + 1]).toContain('tab-fold')
+
+  await window.locator('.panel-tabs button', { hasText: 'terminal' }).first().click()
+  await expect(fold(window)).toHaveCount(0)
+})

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -283,6 +283,7 @@ export function ChatPanel({
                   key={`${message.timestamp}-${index}`}
                   message={message}
                   result={resultOf(messages, index)}
+                  recent={index >= messages.length - RECENT_MESSAGES}
                   hostId={hostId}
                   cwd={session.cwd}
                 />
@@ -412,16 +413,18 @@ interface MessageProps {
   cwd: string
   /** How the call went, for a tool_use whose result came next. */
   result?: boolean
+  /** Near the end of the transcript, where a write opens itself. */
+  recent?: boolean
 }
 
 /**
  * One transcript entry. The roles are the daemon's
  * (internal/transcript/reader.go): user, assistant, tool_use, tool_result.
  */
-function Message({ message, hostId, cwd, result }: MessageProps): JSX.Element | null {
+function Message({ message, hostId, cwd, result, recent }: MessageProps): JSX.Element | null {
   switch (message.role) {
     case 'tool_use':
-      return <ToolUse message={message} hostId={hostId} cwd={cwd} result={result} />
+      return <ToolUse message={message} hostId={hostId} cwd={cwd} result={result} recent={recent} />
     case 'tool_result':
       return <ToolResult message={message} />
     case 'assistant':
@@ -552,6 +555,16 @@ const CODE_FIELDS: { key: string; label?: string }[] = [
 const WRITING_TOOLS = new Set(['Edit', 'MultiEdit', 'Write'])
 
 /**
+ * How far back a write is still worth opening on its own.
+ *
+ * The diff an agent just wrote is what the reader came for; the twenty before
+ * it are history, and a transcript that opens all of them is a page of patches
+ * with the conversation lost between them. Older ones fold, and say what they
+ * are on one line — the same shape the terminal settles into.
+ */
+const RECENT_MESSAGES = 6
+
+/**
  * How many lines the clamp is hiding, or 0 when it is hiding none.
  *
  * Measured rather than counted: what a line is depends on the width of the
@@ -589,13 +602,22 @@ function useHiddenLines(text: string, open: boolean): [RefObject<HTMLSpanElement
  * the row. Only the overflow past a few lines folds, and it says how much it is
  * holding back, as the terminal does.
  */
-function ToolUse({ message, hostId, cwd, result }: MessageProps): JSX.Element {
+function ToolUse({ message, hostId, cwd, result, recent = true }: MessageProps): JSX.Element {
   const tool = message.tool ?? 'tool'
   const input = (message.metadata ?? {}) as Record<string, unknown>
   const filePath = typeof input.file_path === 'string' ? input.file_path : null
   // A write is the part of a session worth reading, and a collapsed row names
   // the tool without saying what it did to the file.
-  const [open, setOpen] = useState(WRITING_TOOLS.has(tool))
+  // Only what the agent has just done opens itself. A card mounted open stays
+  // open as the transcript grows past it: shutting one under a reader mid-diff
+  // to keep a rule tidy is worse than the rule.
+  const [open, setOpen] = useState(WRITING_TOOLS.has(tool) && recent)
+  // Fold all, from the strip above. Keyed on the counter so a card opened by
+  // hand since the last press is reached by the next one.
+  const foldAll = useStore((s) => s.foldAll)
+  useEffect(() => {
+    if (foldAll.seq > 0) setOpen(foldAll.open)
+  }, [foldAll.seq])
   const text = headline(tool, input, message.summary)
   const [summaryRef, clamped] = useHiddenLines(text, open)
   // A described row hides the command itself, not the rest of a line of it, so

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
@@ -6,6 +6,7 @@ import { useHostGroups, useHostNotifications, useHostSessions } from '../host-da
 import { providersQuery, sessionQuery } from '../queries.ts'
 import { currentLayout, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
+import { Chevron } from './icons.tsx'
 import { ChatPanel } from './chat.tsx'
 import { PanelBoundary } from './error-boundary.tsx'
 import { FilesPanel } from './files.tsx'
@@ -552,18 +553,23 @@ function GroupTabs({
       }}
     >
       {group.items.map((item, index) => (
-        <TabButton
-          key={item}
-          item={item}
-          active={group.active === item}
-          insertBefore={over === index}
-          hostId={hostId}
-          session={session}
-          tabs={tabs}
-          term={term}
-          pending={pending}
-          onDragItem={onDragItem}
-        />
+        <Fragment key={item}>
+          <TabButton
+            item={item}
+            active={group.active === item}
+            insertBefore={over === index}
+            hostId={hostId}
+            session={session}
+            tabs={tabs}
+            term={term}
+            pending={pending}
+            onDragItem={onDragItem}
+          />
+          {/* Beside the tab it acts on, and only while that tab is the one
+              showing: it folds the cards in the transcript, so anywhere else
+              on the strip it would name a panel nobody is looking at. */}
+          {panelOf(item) === 'chat' && group.active === item && <FoldAllButton />}
+        </Fragment>
       ))}
       {dragging && over === group.items.length && <span className="tab-insert" />}
 
@@ -580,6 +586,33 @@ function GroupTabs({
 
       {showAdd && <SessionMenuButton hostId={hostId} session={session} />}
     </nav>
+  )
+}
+
+/**
+ * Folds every tool call in the transcript, and opens them again.
+ *
+ * One button rather than two: a transcript is read folded or read open, and
+ * which of those it is now is the only thing that decides what the press
+ * should do. It remembers what it did last rather than reading the cards,
+ * which would mean the strip knowing about every card in the panel.
+ */
+function FoldAllButton(): JSX.Element {
+  const foldAll = useStore((s) => s.foldAll)
+  // Nothing has been pressed yet, and writes open themselves — so the first
+  // press folds.
+  const folded = foldAll.seq > 0 && !foldAll.open
+
+  return (
+    <button
+      className="tab-fold"
+      title={folded ? 'Open every tool call' : 'Fold every tool call'}
+      aria-label={folded ? 'Open every tool call' : 'Fold every tool call'}
+      aria-pressed={folded}
+      onClick={() => store.foldTranscript(folded)}
+    >
+      <Chevron dir={folded ? 'down' : 'up'} />
+    </button>
   )
 }
 

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -284,6 +284,15 @@ export interface State {
   /** The row a Shift-click measures its range from. */
   selectionAnchor: string | null
   /**
+   * An instruction to every tool card in the transcript to fold or unfold.
+   *
+   * A counter rather than a boolean, because it is an event and not a state: a
+   * card opened by hand after a Fold all must stay open, and the next press of
+   * the same button has to reach it again. Cards watch the number, not the
+   * flag.
+   */
+  foldAll: { seq: number; open: boolean }
+  /**
    * Whether the list column is showing.
    *
    * Folded, the rail stays: what is open is still reachable, and the switch
@@ -483,6 +492,7 @@ const initial: State = {
   sessionSelection: [],
   selectMode: false,
   selectionAnchor: null,
+  foldAll: { seq: 0, open: false },
   sidebarOpen: readSidebarOpen(),
   density: bridge.theme.boot().density,
   statusLine: bridge.theme.boot().statusLine,
@@ -783,6 +793,11 @@ class Store {
     const next = open ?? !this.getSnapshot().sidebarOpen
     this.set({ sidebarOpen: next })
     writeSidebarOpen(next)
+  }
+
+  /** Folds every tool call in the transcript, or opens them all. */
+  foldTranscript(open: boolean): void {
+    this.set({ foldAll: { seq: this.getSnapshot().foldAll.seq + 1, open } })
   }
 
   /** Shows or hides the ticks. Leaving takes the selection with it. */

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -642,6 +642,26 @@ small {
   height: 16px;
 }
 
+/* Folds the transcript's tool calls.
+ *
+ * Part of the tab rather than a control beside it: it only exists while the
+ * transcript is the tab showing, so it takes the same full height and the same
+ * underline, and closes the strip's gap so the highlight runs unbroken from
+ * the label to the chevron. */
+/* Scoped past `.panel-tabs > button`, which is more specific than a bare class
+   and would otherwise keep the underline transparent. */
+.panel-tabs > .tab-fold {
+  margin-left: -4px;
+  padding: 0 8px 0 4px;
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+.tab-fold .chevron-icon {
+  width: 14px;
+  height: 14px;
+}
+
 /* ─── Bulk selection ────────────────────────────────────────────────────── */
 
 /* The tick takes a column of its own down the left, so it sits beside the

--- a/internal/terminal/margins.go
+++ b/internal/terminal/margins.go
@@ -1,0 +1,138 @@
+package terminal
+
+import (
+	"slices"
+	"strconv"
+)
+
+// clampMargins rewrites any scroll region that does not fit the grid.
+//
+// DECSTBM (`ESC [ top ; bottom r`) names the rows a scroll is confined to. The
+// emulator indexes its cell buffer with those rows and does not check them, so
+// a bottom margin past the last row panics on the next scroll: `index out of
+// range [98] with length 60`.
+//
+// Nothing exotic produces one. A pane is resized smaller while a full-screen
+// program is drawing, or an agent prints a transcript captured from a taller
+// terminal, and the region arrives describing a screen that no longer exists.
+// Screen.Write recovers from the panic, but recovery costs the whole write —
+// which is a redraw the viewer never sees — so the sequence is corrected on
+// the way in instead.
+//
+// Only the bottom is clamped: a top margin past the grid is nonsense the
+// emulator handles by ignoring the sequence, and rewriting it would invent a
+// region the application did not ask for.
+func clampMargins(p []byte, rows int) ([]byte, bool) {
+	if rows <= 0 {
+		return p, false
+	}
+	// The common case by far: nothing here sets a region, and a scan that
+	// allocates nothing is worth having on every write from the PTY.
+	if !hasCSI(p) {
+		return p, false
+	}
+
+	out := p
+	copied := false
+	for at := 0; at+1 < len(out); at++ {
+		if out[at] != 0x1b || out[at+1] != '[' {
+			continue
+		}
+		params, end, ok := csiParams(out, at+2)
+		if !ok || end >= len(out) || out[end] != 'r' {
+			continue
+		}
+		// `ESC [ ? … r` is DECRST, a different sequence that happens to end in
+		// the same letter.
+		if len(params) > 0 && params[0] == '?' {
+			continue
+		}
+		fixed, changed := clampOne(params, rows)
+		if !changed {
+			continue
+		}
+		if !copied {
+			out = slices.Clone(out)
+			copied = true
+		}
+		// The replacement is never longer than what it replaces — a clamped
+		// bottom is a smaller number — but splicing rather than overwriting
+		// keeps that from being load-bearing.
+		tail := slices.Clone(out[end:])
+		out = append(out[:at+2], append([]byte(fixed), tail...)...)
+		at += 2 + len(fixed)
+	}
+	return out, copied
+}
+
+func hasCSI(p []byte) bool {
+	for at := 0; at+1 < len(p); at++ {
+		if p[at] == 0x1b && p[at+1] == '[' {
+			return true
+		}
+	}
+	return false
+}
+
+/*
+csiParams reads the parameter bytes of a CSI sequence, returning them and the
+index of the final byte. Parameters are digits and semicolons; anything else
+ends the sequence, and a sequence that runs off the end of the buffer is not
+one this write can judge.
+*/
+func csiParams(p []byte, from int) (string, int, bool) {
+	at := from
+	for at < len(p) && ((p[at] >= '0' && p[at] <= '9') || p[at] == ';' || p[at] == '?') {
+		at++
+	}
+	if at >= len(p) {
+		return "", at, false
+	}
+	return string(p[from:at]), at, true
+}
+
+// clampOne returns the parameters with the bottom margin brought inside the
+// grid, and whether it had to change anything.
+func clampOne(params string, rows int) (string, bool) {
+	// `ESC [ r` with no parameters resets the region to the whole grid, which
+	// always fits.
+	if params == "" {
+		return params, false
+	}
+	top, bottom, ok := twoParams(params)
+	if !ok || bottom <= rows {
+		return params, false
+	}
+	// A region has to hold at least two rows for a scroll to mean anything; a
+	// top that has been pushed past the new bottom is dropped along with it,
+	// which is what `ESC [ r` means.
+	if top >= rows {
+		return "", true
+	}
+	return strconv.Itoa(top) + ";" + strconv.Itoa(rows), true
+}
+
+func twoParams(params string) (top, bottom int, ok bool) {
+	semi := -1
+	for at := range len(params) {
+		if params[at] == ';' {
+			if semi != -1 {
+				// Three parameters is not DECSTBM; leave it alone.
+				return 0, 0, false
+			}
+			semi = at
+		}
+	}
+	if semi == -1 {
+		return 0, 0, false
+	}
+	top, err := strconv.Atoi(params[:semi])
+	if err != nil {
+		return 0, 0, false
+	}
+	bottom, err = strconv.Atoi(params[semi+1:])
+	if err != nil {
+		return 0, 0, false
+	}
+	return top, bottom, true
+}

--- a/internal/terminal/margins_test.go
+++ b/internal/terminal/margins_test.go
@@ -1,0 +1,117 @@
+package terminal
+
+import "testing"
+
+// The sequence CI panicked on: a scroll region describing a taller screen than
+// the one being drawn, followed by a scroll into it.
+func TestScreenSurvivesAScrollRegionLargerThanTheGrid(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	if _, err := s.Write([]byte("\x1b[1;98r")); err != nil {
+		t.Fatalf("set margins: %v", err)
+	}
+	if _, err := s.Write([]byte("\x1bM hello\r\n")); err != nil {
+		t.Fatalf("scroll: %v", err)
+	}
+
+	if n := s.Panics(); n != 0 {
+		t.Errorf("panics = %d, want 0", n)
+	}
+}
+
+// Recovery costs the write it happened on, which is why the region is clamped
+// rather than caught: the text has to arrive.
+func TestOutputSurvivesAnOversizedScrollRegion(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	if _, err := s.Write([]byte("\x1b[1;98r\x1bMsecond\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := s.Text(); !contains(got, "second") {
+		t.Errorf("the screen lost the text: %q", got)
+	}
+}
+
+func TestClampMargins(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		rows    int
+		want    string
+		changed bool
+	}{
+		{name: "a region inside the grid is left alone", in: "\x1b[1;24r", rows: 60, want: "\x1b[1;24r"},
+		{name: "the bottom is brought to the last row", in: "\x1b[1;98r", rows: 60, want: "\x1b[1;60r", changed: true},
+		{
+			name:    "a top past the grid drops the region, as a bare reset does",
+			in:      "\x1b[70;98r",
+			rows:    60,
+			want:    "\x1b[r",
+			changed: true,
+		},
+		{name: "a bare reset always fits", in: "\x1b[r", rows: 60, want: "\x1b[r"},
+		{name: "text with no escapes is untouched", in: "just output\r\n", rows: 60, want: "just output\r\n"},
+		// `r` is the final byte of DECRST as well, and that one is about modes,
+		// not rows.
+		{name: "a private mode reset is not a scroll region", in: "\x1b[?1049r", rows: 60, want: "\x1b[?1049r"},
+		{name: "one parameter is not DECSTBM", in: "\x1b[98r", rows: 60, want: "\x1b[98r"},
+		{
+			name:    "the region is corrected where it sits in a longer write",
+			in:      "before\x1b[1;98rafter",
+			rows:    60,
+			want:    "before\x1b[1;60rafter",
+			changed: true,
+		},
+		{
+			name:    "every region in one write is corrected",
+			in:      "\x1b[1;98r\x1b[2;99r",
+			rows:    60,
+			want:    "\x1b[1;60r\x1b[2;60r",
+			changed: true,
+		},
+		// A sequence cut in half by the read boundary is left for the recover
+		// in Write, which is still there for exactly this.
+		{name: "a truncated sequence is left alone", in: "\x1b[1;98", rows: 60, want: "\x1b[1;98"},
+		{name: "a grid of no rows cannot be judged", in: "\x1b[1;98r", rows: 0, want: "\x1b[1;98r"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := clampMargins([]byte(tc.in), tc.rows)
+			if string(got) != tc.want {
+				t.Errorf("clampMargins(%q, %d) = %q, want %q", tc.in, tc.rows, got, tc.want)
+			}
+			if changed != tc.changed {
+				t.Errorf("changed = %v, want %v", changed, tc.changed)
+			}
+		})
+	}
+}
+
+// The caller counts bytes it handed over, not bytes the emulator received: a
+// rewrite makes those differ, and a short count would have the pump resend.
+func TestWriteReportsTheCallersLength(t *testing.T) {
+	s := NewScreen(80, 60)
+	defer s.Close()
+
+	in := []byte("\x1b[1;98rtail")
+	n, err := s.Write(in)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(in) {
+		t.Errorf("n = %d, want %d", n, len(in))
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for at := 0; at+len(needle) <= len(haystack); at++ {
+		if haystack[at:at+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/terminal/screen.go
+++ b/internal/terminal/screen.go
@@ -117,6 +117,17 @@ func (s *Screen) Write(p []byte) (n int, err error) {
 			n, err = len(p), nil
 		}
 	}()
+	// A scroll region larger than the grid is what the emulator panics on, so
+	// it is corrected here rather than recovered from below: recovery costs
+	// the whole write, and the write is a redraw somebody is waiting to see.
+	if fixed, changed := clampMargins(p, s.rows); changed {
+		if _, werr := s.em.Write(fixed); werr != nil {
+			return 0, werr
+		}
+		// The caller's bytes are all accounted for, whatever the rewrite made
+		// of them; a short count would only have it retry the difference.
+		return len(p), nil
+	}
 	return s.em.Write(p)
 }
 

--- a/internal/terminal/screen_panic_test.go
+++ b/internal/terminal/screen_panic_test.go
@@ -12,9 +12,12 @@ import (
 // A mirror runs Write on its own goroutine inside the daemon, so this panic
 // killed every session at once — and printed to a stderr the daemon had pointed
 // at /dev/null, which is why it looked like an external kill for hours.
+//
+// Write clamps the region on the way in now, so this arrives harmless. The
+// recover behind it is still load-bearing — see the split write below.
 const panicSequence = "\x1b[1;100r\x1b[1;1H\x1bM"
 
-func TestScreenSurvivesAnEmulatorPanic(t *testing.T) {
+func TestScreenClampsTheSequenceThatTookTheDaemonDown(t *testing.T) {
 	s := NewScreen(80, 60)
 
 	n, err := s.Write([]byte(panicSequence))
@@ -24,8 +27,24 @@ func TestScreenSurvivesAnEmulatorPanic(t *testing.T) {
 	if n != len(panicSequence) {
 		t.Errorf("wrote %d of %d bytes", n, len(panicSequence))
 	}
+	if s.Panics() != 0 {
+		t.Errorf("panics = %d, want 0 — the region should be clamped before the emulator sees it", s.Panics())
+	}
+}
+
+// What the clamp cannot see: a sequence cut in half by a read boundary. Neither
+// write holds a whole region, so the emulator gets it and still panics — which
+// is why the recover stays, and why this asserts that it still fires.
+func TestScreenSurvivesASequenceSplitAcrossWrites(t *testing.T) {
+	s := NewScreen(80, 60)
+
+	for _, half := range []string{"\x1b[1;100", "r\x1b[1;1H\x1bM"} {
+		if _, err := s.Write([]byte(half)); err != nil {
+			t.Fatalf("write %q: %v", half, err)
+		}
+	}
 	if s.Panics() != 1 {
-		t.Fatalf("panics = %d, want 1 — the sequence no longer reproduces, so this test guards nothing", s.Panics())
+		t.Fatalf("panics = %d, want 1 — if this stops reproducing the recover guards nothing", s.Panics())
 	}
 
 	// Still usable afterwards: the daemon keeps mirroring the session rather


### PR DESCRIPTION
## Summary

A session of any length is mostly tool calls, and every write opened itself — so scrolling back through an afternoon's work meant scrolling through every patch of it, with the conversation lost in between.

- **Older cards start folded.** A write opens itself only while it is among the last six messages. One already open stays open as the transcript grows past it: shutting a card under somebody mid-diff to keep a rule tidy is worse than the rule.
- **A button beside the transcript tab folds them all, or opens them all.** It carries the tab's own full height and underline rather than sitting apart as a control of its own — it exists only while that tab is showing, and the highlight runs unbroken from the label through the chevron.
- The instruction is a **counter, not a flag**, so a card opened by hand since the last press is still reached by the next one.

The stub daemon can now hold tool calls on a session, which is what lets any of this be driven by a test.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 340 pass
- [x] `npx playwright test e2e/fold-all.spec.ts` — 4 pass: folds and opens everything, a hand-opened card answers the next two presses, the label says which way the button will go, and it sits immediately after the transcript tab and disappears on another tab
- [x] `npx playwright test e2e/bulk-sessions.spec.ts` — 6 pass, unaffected
- [x] Measured the underline in the running app: same height and baseline as the tab, zero gap, `rgb(113, 173, 255)` across both
- [ ] Full e2e suite — left to CI