### PR TITLE
fix(desktop): let a write open itself again

### DIFF
--- a/desktop/e2e/daemon.ts
+++ b/desktop/e2e/daemon.ts
@@ -204,6 +204,16 @@ export function withToolCalls(
   TOOL_CALLS[sessionId] = calls
 }
 
+/** One more call, as the agent making one looks to a panel that is watching. */
+export function addToolCall(
+  sessionId: string,
+  call: { tool: string; summary: string; input: Record<string, unknown> },
+): void {
+  ;(TOOL_CALLS[sessionId] ??= []).push(call)
+  const record = [...SESSIONS, ...RUNS].find((s) => s.session_id === sessionId)
+  if (record) record.last_event_at = new Date().toISOString()
+}
+
 interface StubMessage {
   seq: number
   role: string

--- a/desktop/e2e/fold-all.spec.ts
+++ b/desktop/e2e/fold-all.spec.ts
@@ -5,7 +5,7 @@
 // most of this checks.
 import type { Page } from '@playwright/test'
 
-import { ALPHA as ALPHA_ID, withToolCalls } from './daemon.ts'
+import { ALPHA as ALPHA_ID, addToolCall, pushEvent, withToolCalls } from './daemon.ts'
 import { expect, test } from './fixtures.ts'
 
 const ALPHA = 'Alpha'
@@ -57,6 +57,27 @@ test('a card opened by hand is still reached by the next press', async ({ window
 
   await fold(window).click()
   await expect(window.locator('.tool-detail')).toHaveCount(0)
+})
+
+// The bug this guards: the fold ran on mount, so once the button had been
+// pressed at all, every card that arrived afterwards was folded by a press
+// that happened before it existed — and a write never opened itself again.
+test('a write that arrives after a fold all still opens itself', async ({ window }) => {
+  await open(window)
+
+  await fold(window).click()
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+
+  addToolCall(ALPHA_ID, {
+    tool: 'Edit',
+    summary: 'later.go',
+    input: { file_path: '/repo/later.go', old_string: 'x', new_string: 'y' },
+  })
+  // The record moving is what tells the panel there is more to read.
+  pushEvent('session_status', { session_id: ALPHA_ID, status: 'idle' })
+
+  await expect(window.locator('.msg.tool-call')).toHaveCount(3)
+  await expect(window.locator('.tool-detail')).toHaveCount(1)
 })
 
 test('the button says which way it will go', async ({ window }) => {

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -52,6 +52,20 @@ export function ChatPanel({
   const client = useQueryClient()
   const transcript = useInfiniteQuery({ ...transcriptQuery(hostId, session.session_id), enabled: active })
   const messages = useMemo(() => transcriptMessages(transcript.data), [transcript.data])
+  /**
+   * The last few calls, by their place in the list.
+   *
+   * A card reads this once, when it mounts. Recomputing it as the transcript
+   * grows would close a card somebody is reading, so what it decides is only
+   * ever the state a new card starts in.
+   */
+  const recentCalls = useMemo(() => {
+    const calls = messages.reduce<number[]>((held, message, index) => {
+      if (message.role === 'tool_use') held.push(index)
+      return held
+    }, [])
+    return new Set(calls.slice(-RECENT_CALLS))
+  }, [messages])
   // The newest page answers for the whole conversation: its total is the count,
   // and the epoch is which parse the held seq numbers count against.
   const newestPage = transcript.data?.pages[0]
@@ -283,7 +297,7 @@ export function ChatPanel({
                   key={`${message.timestamp}-${index}`}
                   message={message}
                   result={resultOf(messages, index)}
-                  recent={index >= messages.length - RECENT_MESSAGES}
+                  recent={recentCalls.has(index)}
                   hostId={hostId}
                   cwd={session.cwd}
                 />
@@ -555,14 +569,17 @@ const CODE_FIELDS: { key: string; label?: string }[] = [
 const WRITING_TOOLS = new Set(['Edit', 'MultiEdit', 'Write'])
 
 /**
- * How far back a write is still worth opening on its own.
+ * How many tool calls back a write is still worth opening on its own.
  *
- * The diff an agent just wrote is what the reader came for; the twenty before
- * it are history, and a transcript that opens all of them is a page of patches
- * with the conversation lost between them. Older ones fold, and say what they
- * are on one line — the same shape the terminal settles into.
+ * Counted in calls rather than messages: a write is followed by its own
+ * result, then a line of the agent's prose, then the next call — so a window
+ * measured in messages closes on the patch the reader is still looking at.
+ *
+ * The diff an agent has just written is what the reader came for; the twenty
+ * before it are history, and a transcript that opens all of them is a page of
+ * patches with the conversation lost between them.
  */
-const RECENT_MESSAGES = 6
+const RECENT_CALLS = 3
 
 /**
  * How many lines the clamp is hiding, or 0 when it is hiding none.
@@ -615,9 +632,16 @@ function ToolUse({ message, hostId, cwd, result, recent = true }: MessageProps):
   // Fold all, from the strip above. Keyed on the counter so a card opened by
   // hand since the last press is reached by the next one.
   const foldAll = useStore((s) => s.foldAll)
+  // The press this card has already answered. Seeded with whatever the counter
+  // stands at when the card mounts: a card that arrives after a Fold all is
+  // new work, and folding it because of a press that happened before it
+  // existed is how every later write came to arrive shut.
+  const answered = useRef(foldAll.seq)
   useEffect(() => {
-    if (foldAll.seq > 0) setOpen(foldAll.open)
-  }, [foldAll.seq])
+    if (foldAll.seq === answered.current) return
+    answered.current = foldAll.seq
+    setOpen(foldAll.open)
+  }, [foldAll.seq, foldAll.open])
   const text = headline(tool, input, message.summary)
   const [summaryRef, clamped] = useHiddenLines(text, open)
   // A described row hides the command itself, not the rest of a line of it, so


### PR DESCRIPTION
## What was wrong

You reported that a write no longer expands by default. Two separate causes:

1. **The fold-all effect ran on mount.** Once the button had been pressed at all, every card mounting afterwards applied that press — a press that happened before the card existed. So one Fold all meant no write opened itself again for the rest of the session. A card now records the counter it mounted at and reacts only to presses after that.

2. **The recency window was measured in messages** — six of them. A write is followed by its own result, then a line of the agent's prose, then the next call, so the patch being read fell out of the window while it was still on screen. It counts tool calls now: the last three stay open.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 340 pass
- [x] `npx playwright test e2e/fold-all.spec.ts` — 5 pass, one new: a write arriving after a Fold all still opens itself
- [x] Confirmed the new test fails with the fix reverted, and passes with it — it catches the actual bug rather than the arrangement around it