### PR TITLE
feat(desktop): remember that a session is being read folded

### DIFF
--- a/desktop/e2e/fold-all.spec.ts
+++ b/desktop/e2e/fold-all.spec.ts
@@ -59,10 +59,9 @@ test('a card opened by hand is still reached by the next press', async ({ window
   await expect(window.locator('.tool-detail')).toHaveCount(0)
 })
 
-// The bug this guards: the fold ran on mount, so once the button had been
-// pressed at all, every card that arrived afterwards was folded by a press
-// that happened before it existed — and a write never opened itself again.
-test('a write that arrives after a fold all still opens itself', async ({ window }) => {
+// Folding is a standing instruction for the session, not a press that expires:
+// a write the agent makes afterwards arrives folded too.
+test('a write that arrives after a fold all arrives folded', async ({ window }) => {
   await open(window)
 
   await fold(window).click()
@@ -77,7 +76,33 @@ test('a write that arrives after a fold all still opens itself', async ({ window
   pushEvent('session_status', { session_id: ALPHA_ID, status: 'idle' })
 
   await expect(window.locator('.msg.tool-call')).toHaveCount(3)
-  await expect(window.locator('.tool-detail')).toHaveCount(1)
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+})
+
+// The panel is unmounted after five minutes out of sight, so without this the
+// fold lasts exactly as long as the reader's attention does.
+test('the fold outlives the panel, and the window', async ({ window }) => {
+  await open(window)
+  await fold(window).click()
+
+  const stored = await window.evaluate(() => localStorage.getItem('helios.foldModes'))
+  expect(stored).toContain('folded')
+
+  // What a remounted panel reads: the mode, not the press.
+  await window.reload()
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.msg.tool-call').first()).toBeVisible()
+  await expect(window.locator('.tool-detail')).toHaveCount(0)
+  await expect(fold(window)).toHaveAttribute('aria-label', 'Open every tool call')
+})
+
+test('opening them all again is remembered too', async ({ window }) => {
+  await open(window)
+  await fold(window).click()
+  await fold(window).click()
+
+  const stored = await window.evaluate(() => localStorage.getItem('helios.foldModes'))
+  expect(stored).toContain('open')
 })
 
 test('the button says which way it will go', async ({ window }) => {

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -21,7 +21,7 @@ import {
   resolveFilePath,
 } from '../markdown.ts'
 import { useMermaid } from '../mermaid.ts'
-import { store, useStore } from '../store.ts'
+import { sessionKey, store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
   canResume,
@@ -59,6 +59,8 @@ export function ChatPanel({
    * grows would close a card somebody is reading, so what it decides is only
    * ever the state a new card starts in.
    */
+  // Set by the button beside the tab, and remembered for this session.
+  const folded = useStore((s) => s.foldModes[sessionKey(hostId, session.session_id)]) === 'folded'
   const recentCalls = useMemo(() => {
     const calls = messages.reduce<number[]>((held, message, index) => {
       if (message.role === 'tool_use') held.push(index)
@@ -298,6 +300,7 @@ export function ChatPanel({
                   message={message}
                   result={resultOf(messages, index)}
                   recent={recentCalls.has(index)}
+                  folded={folded}
                   hostId={hostId}
                   cwd={session.cwd}
                 />
@@ -429,16 +432,27 @@ interface MessageProps {
   result?: boolean
   /** Near the end of the transcript, where a write opens itself. */
   recent?: boolean
+  /** The session is being read folded, so nothing opens itself. */
+  folded?: boolean
 }
 
 /**
  * One transcript entry. The roles are the daemon's
  * (internal/transcript/reader.go): user, assistant, tool_use, tool_result.
  */
-function Message({ message, hostId, cwd, result, recent }: MessageProps): JSX.Element | null {
+function Message({ message, hostId, cwd, result, recent, folded }: MessageProps): JSX.Element | null {
   switch (message.role) {
     case 'tool_use':
-      return <ToolUse message={message} hostId={hostId} cwd={cwd} result={result} recent={recent} />
+      return (
+        <ToolUse
+          message={message}
+          hostId={hostId}
+          cwd={cwd}
+          result={result}
+          recent={recent}
+          folded={folded}
+        />
+      )
     case 'tool_result':
       return <ToolResult message={message} />
     case 'assistant':
@@ -619,16 +633,24 @@ function useHiddenLines(text: string, open: boolean): [RefObject<HTMLSpanElement
  * the row. Only the overflow past a few lines folds, and it says how much it is
  * holding back, as the terminal does.
  */
-function ToolUse({ message, hostId, cwd, result, recent = true }: MessageProps): JSX.Element {
+function ToolUse({
+  message,
+  hostId,
+  cwd,
+  result,
+  recent = true,
+  folded = false,
+}: MessageProps): JSX.Element {
   const tool = message.tool ?? 'tool'
   const input = (message.metadata ?? {}) as Record<string, unknown>
   const filePath = typeof input.file_path === 'string' ? input.file_path : null
   // A write is the part of a session worth reading, and a collapsed row names
   // the tool without saying what it did to the file.
-  // Only what the agent has just done opens itself. A card mounted open stays
-  // open as the transcript grows past it: shutting one under a reader mid-diff
-  // to keep a rule tidy is worse than the rule.
-  const [open, setOpen] = useState(WRITING_TOOLS.has(tool) && recent)
+  // Only what the agent has just done opens itself, and not even that while
+  // the session is being read folded — that is a standing instruction, not a
+  // press that expires. A card mounted open stays open as the transcript grows
+  // past it: shutting one under a reader mid-diff is worse than the rule.
+  const [open, setOpen] = useState(!folded && WRITING_TOOLS.has(tool) && recent)
   // Fold all, from the strip above. Keyed on the counter so a card opened by
   // hand since the last press is reached by the next one.
   const foldAll = useStore((s) => s.foldAll)

--- a/desktop/src/renderer/components/detail.tsx
+++ b/desktop/src/renderer/components/detail.tsx
@@ -4,7 +4,15 @@ import { useQuery } from '@tanstack/react-query'
 import { api } from '../bridge.ts'
 import { useHostGroups, useHostNotifications, useHostSessions } from '../host-data.ts'
 import { providersQuery, sessionQuery } from '../queries.ts'
-import { currentLayout, store, terminalId, useStore, type RightPanel, type Tab } from '../store.ts'
+import {
+  currentLayout,
+  sessionKey,
+  store,
+  terminalId,
+  useStore,
+  type RightPanel,
+  type Tab,
+} from '../store.ts'
 import { ApprovalsPanel } from './approvals.tsx'
 import { Chevron } from './icons.tsx'
 import { ChatPanel } from './chat.tsx'
@@ -568,7 +576,9 @@ function GroupTabs({
           {/* Beside the tab it acts on, and only while that tab is the one
               showing: it folds the cards in the transcript, so anywhere else
               on the strip it would name a panel nobody is looking at. */}
-          {panelOf(item) === 'chat' && group.active === item && <FoldAllButton />}
+          {panelOf(item) === 'chat' && group.active === item && (
+            <FoldAllButton hostId={hostId} sessionId={session.session_id} />
+          )}
         </Fragment>
       ))}
       {dragging && over === group.items.length && <span className="tab-insert" />}
@@ -597,11 +607,10 @@ function GroupTabs({
  * should do. It remembers what it did last rather than reading the cards,
  * which would mean the strip knowing about every card in the panel.
  */
-function FoldAllButton(): JSX.Element {
-  const foldAll = useStore((s) => s.foldAll)
-  // Nothing has been pressed yet, and writes open themselves — so the first
-  // press folds.
-  const folded = foldAll.seq > 0 && !foldAll.open
+function FoldAllButton({ hostId, sessionId }: { hostId: string; sessionId: string }): JSX.Element {
+  // The session's own mode, not the last press anywhere: two sessions can be
+  // read differently, and reopening one should find it as it was left.
+  const folded = useStore((s) => s.foldModes[sessionKey(hostId, sessionId)]) === 'folded'
 
   return (
     <button
@@ -609,7 +618,7 @@ function FoldAllButton(): JSX.Element {
       title={folded ? 'Open every tool call' : 'Fold every tool call'}
       aria-label={folded ? 'Open every tool call' : 'Fold every tool call'}
       aria-pressed={folded}
-      onClick={() => store.foldTranscript(folded)}
+      onClick={() => store.foldTranscript(hostId, sessionId, folded)}
     >
       <Chevron dir={folded ? 'down' : 'up'} />
     </button>

--- a/desktop/src/renderer/store.ts
+++ b/desktop/src/renderer/store.ts
@@ -293,6 +293,14 @@ export interface State {
    */
   foldAll: { seq: number; open: boolean }
   /**
+   * Whether each session's transcript is being read folded, by session key.
+   *
+   * Kept per session rather than per card: what a reader means by folding is
+   * "this session is history, keep it quiet", and that outlives both the panel
+   * — which is unmounted after five minutes out of sight — and the window.
+   */
+  foldModes: Record<string, 'folded' | 'open'>
+  /**
    * Whether the list column is showing.
    *
    * Folded, the rail stays: what is open is still reachable, and the switch
@@ -360,6 +368,39 @@ function writeGroupMode(mode: GroupMode): void {
 
 const TERMINAL_UPLOADS_KEY = 'helios.terminalUploads'
 const SIDEBAR_OPEN_KEY = 'helios.sidebarOpen'
+const FOLD_MODE_KEY = 'helios.foldModes'
+
+/**
+ * How many sessions' fold modes are worth keeping.
+ *
+ * One line per session read, and a machine that has read a thousand should not
+ * carry a thousand: the oldest are dropped, which at worst costs a session its
+ * fold the next time it is opened.
+ */
+const FOLD_MODE_LIMIT = 200
+
+/** Whether a session's transcript was left folded, by session key. */
+function readFoldModes(): Record<string, 'folded' | 'open'> {
+  try {
+    const raw = localStorage.getItem(FOLD_MODE_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, 'folded' | 'open'>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeFoldModes(modes: Record<string, 'folded' | 'open'>): void {
+  try {
+    const keys = Object.keys(modes)
+    const kept = keys.length > FOLD_MODE_LIMIT ? keys.slice(keys.length - FOLD_MODE_LIMIT) : keys
+    localStorage.setItem(
+      FOLD_MODE_KEY,
+      JSON.stringify(Object.fromEntries(kept.map((key) => [key, modes[key]]))),
+    )
+  } catch {
+    // A full or unavailable store costs the preference, not the fold.
+  }
+}
 
 /** Open unless it has been folded away, and it stays folded across restarts. */
 function readSidebarOpen(): boolean {
@@ -493,6 +534,7 @@ const initial: State = {
   selectMode: false,
   selectionAnchor: null,
   foldAll: { seq: 0, open: false },
+  foldModes: readFoldModes(),
   sidebarOpen: readSidebarOpen(),
   density: bridge.theme.boot().density,
   statusLine: bridge.theme.boot().statusLine,
@@ -795,9 +837,19 @@ class Store {
     writeSidebarOpen(next)
   }
 
-  /** Folds every tool call in the transcript, or opens them all. */
-  foldTranscript(open: boolean): void {
-    this.set({ foldAll: { seq: this.getSnapshot().foldAll.seq + 1, open } })
+  /**
+   * Folds every tool call in a session's transcript, or opens them all.
+   *
+   * Two things at once: the counter reaches the cards already on screen, and
+   * the mode is what a card mounting later starts as — including one the agent
+   * has not written yet. A reader who folded a session asked for a quiet
+   * transcript, not for a quiet minute.
+   */
+  foldTranscript(hostId: string, sessionId: string, open: boolean): void {
+    const mode: 'open' | 'folded' = open ? 'open' : 'folded'
+    const modes = { ...this.getSnapshot().foldModes, [sessionKey(hostId, sessionId)]: mode }
+    writeFoldModes(modes)
+    this.set({ foldAll: { seq: this.getSnapshot().foldAll.seq + 1, open }, foldModes: modes })
   }
 
   /** Shows or hides the ticks. Leaving takes the selection with it. */


### PR DESCRIPTION
## Summary

Answering the question directly: nothing was persisted. A card's state was React state inside the card, and it survived a tab switch only because a hidden panel stays mounted for five minutes (`PANEL_TTL`). Past that the panel unmounts and every card resets; a restart lost it regardless.

- The fold is now a property of the **session**, kept in `localStorage` under `helios.foldModes` and read when a card mounts. Two sessions can be read differently, and the button beside the tab reflects the one on screen rather than the last press anywhere.
- **A write arriving while the session is folded arrives folded.** The counter still reaches cards already on screen, but it is no longer what a new card consults — folding is a standing instruction, not a press that expires.
- Only the last two hundred sessions are kept, which at worst costs an old session its fold.

Note this deliberately reverses half of #196: there, a card mounting after a press ignored it, because the press was the only signal and it leaked forever. Now the *mode* is the signal, so a new card can honour it without that bug returning — the mount-time guard on the counter stays.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 340 pass
- [x] `npx playwright test e2e/fold-all.spec.ts` — 7 pass, three new: a write arriving after a fold arrives folded, the fold survives a full window reload with the button still reading "Open every tool call", and opening them all again is remembered too