### PR TITLE
feat(desktop): focus the prompt, and keep what was typed into it

### DIFF
--- a/desktop/e2e/composer-focus.spec.ts
+++ b/desktop/e2e/composer-focus.spec.ts
@@ -1,0 +1,39 @@
+// The prompt takes the keyboard when the transcript comes up.
+//
+// Coming back to a session to say something is the usual reason for coming
+// back to it — and for anyone dictating, a click on the box first is the whole
+// cost of the feature.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+
+/** What has the keyboard: the tag, and whether it is the composer's. */
+function focused(window: Page): Promise<string> {
+  return window.evaluate(() => {
+    const el = document.activeElement
+    if (!el) return 'nothing'
+    return `${el.tagName}${el.closest('.composer') ? ':composer' : ''}`
+  })
+}
+
+test('opening a session puts the caret in the prompt', async ({ window }) => {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.composer textarea')).toBeVisible()
+
+  await expect.poll(() => focused(window)).toBe('TEXTAREA:composer')
+  // And it is ready to type into, with no click anywhere.
+  await window.keyboard.type('rebase onto main')
+  await expect(window.locator('.composer textarea')).toHaveValue('rebase onto main')
+})
+
+test('coming back from the terminal gives the prompt the keyboard again', async ({ window }) => {
+  await window.locator('.session-row', { hasText: ALPHA }).click()
+  await expect(window.locator('.composer textarea')).toBeVisible()
+
+  await window.locator('.panel-tabs button', { hasText: 'terminal' }).first().click()
+  await window.locator('.panel-tabs button', { hasText: 'transcript' }).first().click()
+
+  await expect.poll(() => focused(window)).toBe('TEXTAREA:composer')
+})

--- a/desktop/e2e/composer-focus.spec.ts
+++ b/desktop/e2e/composer-focus.spec.ts
@@ -9,20 +9,11 @@ import { expect, test } from './fixtures.ts'
 
 const ALPHA = 'Alpha'
 
-/** What has the keyboard: the tag, and whether it is the composer's. */
-function focused(window: Page): Promise<string> {
-  return window.evaluate(() => {
-    const el = document.activeElement
-    if (!el) return 'nothing'
-    return `${el.tagName}${el.closest('.composer') ? ':composer' : ''}`
-  })
-}
-
 test('opening a session puts the caret in the prompt', async ({ window }) => {
   await window.locator('.session-row', { hasText: ALPHA }).click()
   await expect(window.locator('.composer textarea')).toBeVisible()
 
-  await expect.poll(() => focused(window)).toBe('TEXTAREA:composer')
+  await expect(window.locator('.composer textarea')).toBeFocused()
   // And it is ready to type into, with no click anywhere.
   await window.keyboard.type('rebase onto main')
   await expect(window.locator('.composer textarea')).toHaveValue('rebase onto main')
@@ -35,5 +26,5 @@ test('coming back from the terminal gives the prompt the keyboard again', async 
   await window.locator('.panel-tabs button', { hasText: 'terminal' }).first().click()
   await window.locator('.panel-tabs button', { hasText: 'transcript' }).first().click()
 
-  await expect.poll(() => focused(window)).toBe('TEXTAREA:composer')
+  await expect(window.locator('.composer textarea')).toBeFocused()
 })

--- a/desktop/e2e/drafts.spec.ts
+++ b/desktop/e2e/drafts.spec.ts
@@ -1,0 +1,78 @@
+// A half-written prompt is work. These check it survives the three ways it
+// used to be lost: switching session, closing the dialog, and the panel being
+// unmounted after five minutes off screen.
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures.ts'
+
+const ALPHA = 'Alpha'
+const BETA = 'Beta'
+
+async function open(window: Page, title: string): Promise<void> {
+  await window.locator('.session-row', { hasText: title }).click()
+  await expect(window.locator('.composer textarea')).toBeVisible()
+}
+
+function box(window: Page) {
+  return window.locator('.composer textarea')
+}
+
+test('a draft survives switching to another session and back', async ({ window }) => {
+  await open(window, ALPHA)
+  await box(window).fill('rebase onto main and re-run the gates')
+
+  await open(window, BETA)
+  // Another session is another draft, not the same one.
+  await expect(box(window)).toHaveValue('')
+
+  await open(window, ALPHA)
+  await expect(box(window)).toHaveValue('rebase onto main and re-run the gates')
+})
+
+test('each session keeps its own', async ({ window }) => {
+  await open(window, ALPHA)
+  await box(window).fill('for alpha')
+  await open(window, BETA)
+  await box(window).fill('for beta')
+
+  await open(window, ALPHA)
+  await expect(box(window)).toHaveValue('for alpha')
+  await open(window, BETA)
+  await expect(box(window)).toHaveValue('for beta')
+})
+
+test('sending clears it, so it does not come back next time', async ({ window }) => {
+  await open(window, ALPHA)
+  await box(window).fill('send me')
+  await box(window).press('Enter')
+
+  await expect(box(window)).toHaveValue('')
+  await open(window, BETA)
+  await open(window, ALPHA)
+  await expect(box(window)).toHaveValue('')
+})
+
+test('a draft outlives the window itself', async ({ window }) => {
+  await open(window, ALPHA)
+  await box(window).fill('still here tomorrow')
+
+  await window.reload()
+  await open(window, ALPHA)
+  await expect(box(window)).toHaveValue('still here tomorrow')
+})
+
+test('what was typed into the new-session dialog is there when it reopens', async ({ window }) => {
+  await window.locator('.tool.primary').click()
+  const prompt = window.locator('.modal-backdrop textarea').first()
+  await expect(prompt).toBeVisible()
+  await prompt.fill('look into the flake in the hooks test')
+
+  // Closed the way somebody closes it to go and check something.
+  await window.keyboard.press('Escape')
+  await expect(window.locator('.modal-backdrop')).toHaveCount(0)
+
+  await window.locator('.tool.primary').click()
+  await expect(window.locator('.modal-backdrop textarea').first()).toHaveValue(
+    'look into the flake in the hooks test',
+  )
+})

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -205,6 +205,23 @@ export function ChatPanel({
 
   useEffect(() => () => retries.current.forEach(clearTimeout), [])
 
+  /**
+   * The prompt takes the keyboard when the transcript comes up.
+   *
+   * Coming back to a session to say something is the usual reason for coming
+   * back to it, and a click on the box first is a step nobody wanted — least of
+   * all somebody dictating, who has to put the pointer somewhere before they
+   * can speak.
+   *
+   * Only when this panel is the one showing: a hidden panel stays mounted for
+   * five minutes, and one of those quietly taking the keyboard would type into
+   * the wrong session.
+   */
+  useEffect(() => {
+    if (!active || terminated) return
+    composer.current?.focus()
+  }, [active, terminated, hostId, session.session_id])
+
   // One line until there is more than one line to show. Measured rather than
   // counted: the box's width decides where the text wraps, and a newline is
   // not the only thing that starts a row. The cap is in the stylesheet, so

--- a/desktop/src/renderer/components/chat.tsx
+++ b/desktop/src/renderer/components/chat.tsx
@@ -22,6 +22,7 @@ import {
   resolveFilePath,
 } from '../markdown.ts'
 import { useMermaid } from '../mermaid.ts'
+import { clearDraft, loadDraft, saveDraft, sessionDraftKey } from '../drafts.ts'
 import { sessionKey, store, useStore } from '../store.ts'
 import {
   BUSY_STATUSES,
@@ -95,7 +96,11 @@ export function ChatPanel({
   // Switching sessions must not show the previous transcript, nor "No
   // transcript yet." for one that is merely still loading.
   const loaded = transcript.isSuccess
-  const [draft, setDraft] = useState('')
+  // What was typed here last, whether or not this panel has been alive since:
+  // switching session to check something must not cost a half-written prompt,
+  // and the panel is unmounted five minutes after it leaves the screen.
+  const draftKey = sessionDraftKey(hostId, session.session_id)
+  const [draft, setDraft] = useState(() => loadDraft(draftKey))
   const [sending, setSending] = useState(false)
   const files = useAttachments()
   const { dropping, handlers: dropHandlers } = useDropTarget((dropped) => void files.attach(dropped))
@@ -189,6 +194,19 @@ export function ChatPanel({
     // seq, not text: sending the same lines twice has to append twice.
   }, [promptDraft?.seq])
 
+  // Written on every change rather than on a timer: the cost is a string in
+  // localStorage, and the thing being protected is somebody's sentence.
+  useEffect(() => {
+    saveDraft(draftKey, draft)
+  }, [draftKey, draft])
+
+  // A different session is a different draft. Without this the box would keep
+  // the last one's text, which is worse than losing it: it would be sent to
+  // the wrong agent.
+  useEffect(() => {
+    setDraft(loadDraft(draftKey))
+  }, [draftKey])
+
   useEffect(() => {
     messagesRef.current = messages
     const el = scroller.current
@@ -267,6 +285,7 @@ export function ChatPanel({
 
       const result = await api(hostId).sendPrompt(session.session_id, message)
       setDraft('')
+      clearDraft(draftKey)
       files.clear()
       if (result.queued) store.notify('Queued — the agent is mid-turn')
       void store.invalidateSessionsFor(hostId)

--- a/desktop/src/renderer/components/newsession.tsx
+++ b/desktop/src/renderer/components/newsession.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { api } from '../bridge.ts'
 import { removeFirst } from '../attachments.ts'
+import { NEW_SESSION_DRAFT, clearDraft, loadDraft, saveDraft } from '../drafts.ts'
 import { directoriesQuery, dirQuery, modelsQuery, providersQuery } from '../queries.ts'
 import { store, useStore } from '../store.ts'
 import {
@@ -24,6 +25,25 @@ const NO_DIRECTORIES: DirectoryInfo[] = []
 /** Module scope so the cache memoises the filtered list. */
 const onlyReady = (all: ProviderInfo[]): ProviderInfo[] => all.filter((p) => p.ready !== false)
 
+/** The fields the dialog keeps between openings. */
+interface NewSessionDraft {
+  hostId?: string
+  provider?: string
+  model?: string
+  cwd?: string
+  mode?: string
+  prompt?: string
+}
+
+function readDraft(): NewSessionDraft {
+  try {
+    const raw = loadDraft(NEW_SESSION_DRAFT)
+    return raw ? (JSON.parse(raw) as NewSessionDraft) : {}
+  } catch {
+    return {}
+  }
+}
+
 export function NewSessionDialog({
   seed,
   onClose,
@@ -35,15 +55,33 @@ export function NewSessionDialog({
 }): JSX.Element {
   const hosts = useStore((s) => s.hosts)
   const hostStatus = useStore((s) => s.hostStatus)
-  const [hostId, setHostId] = useState(seed?.hostId ?? hosts[0]?.id ?? '')
-  const [provider, setProvider] = useState('claude')
-  const [model, setModel] = useState('')
-  const [cwd, setCwd] = useState('')
-  const [mode, setMode] = useState('')
-  const [prompt, setPrompt] = useState('')
+  /**
+   * What was in the dialog when it was last closed.
+   *
+   * Closing it to go and look something up — a path, a branch, what the error
+   * actually said — used to cost everything typed into it. The seed wins where
+   * it has an opinion: a + pressed on a project means that project, whatever
+   * the last dialog was about.
+   */
+  const kept = useMemo(() => readDraft(), [])
+  const [hostId, setHostId] = useState(seed?.hostId ?? kept.hostId ?? hosts[0]?.id ?? '')
+  const [provider, setProvider] = useState(kept.provider ?? 'claude')
+  const [model, setModel] = useState(kept.model ?? '')
+  const [cwd, setCwd] = useState(seed?.cwd ?? kept.cwd ?? '')
+  const [mode, setMode] = useState(kept.mode ?? '')
+  const [prompt, setPrompt] = useState(kept.prompt ?? '')
   // Held out here rather than in the picker, which unmounts with its popover: a
   // half-typed path must still be there when the chip is opened again.
   const [typed, setTyped] = useState('')
+
+  // Written as one record: the fields are one thought, and restoring half of
+  // them would be worse than restoring none.
+  useEffect(() => {
+    saveDraft(
+      NEW_SESSION_DRAFT,
+      JSON.stringify({ hostId, provider, model, cwd, mode, prompt } satisfies NewSessionDraft),
+    )
+  }, [hostId, provider, model, cwd, mode, prompt])
   const files = useAttachments()
   const { dropping, handlers: dropHandlers } = useDropTarget((dropped) => void files.attach(dropped))
   const [starting, setStarting] = useState(false)
@@ -138,6 +176,8 @@ export function NewSessionDialog({
       const session = store.sessionById(hostId, result.session_id)
       // Freshly created sessions are always warm, so attaching never wakes.
       if (session) await store.openTerminal(hostId, session, false)
+      // Started, so there is nothing left to come back to.
+      clearDraft(NEW_SESSION_DRAFT)
       onClose()
     } catch (err) {
       store.fail(err)

--- a/desktop/src/renderer/drafts.ts
+++ b/desktop/src/renderer/drafts.ts
@@ -1,0 +1,87 @@
+/**
+ * What was typed and not yet sent.
+ *
+ * A prompt half-written is work: switching session to check something, or
+ * closing the new-session dialog to look up a path, should not cost it. The
+ * panel is unmounted five minutes after it leaves the screen, so holding this
+ * in component state means losing it to a coffee break.
+ *
+ * Kept per session, and swept, because a machine that has touched a thousand
+ * sessions should not carry a thousand drafts for ever.
+ */
+
+const DRAFTS_KEY = 'helios.drafts'
+
+/** Beyond this the oldest are dropped, newest kept. */
+const KEEP = 100
+
+interface Draft {
+  text: string
+  /** When it was last typed into, which is what decides who gets dropped. */
+  at: number
+}
+
+function read(): Record<string, Draft> {
+  try {
+    const raw = localStorage.getItem(DRAFTS_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, Draft>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function write(drafts: Record<string, Draft>): void {
+  try {
+    const entries = Object.entries(drafts)
+    // Oldest first, so slicing from the end keeps what was touched most
+    // recently rather than whatever the object happened to enumerate first.
+    const kept =
+      entries.length > KEEP
+        ? entries.sort((a, b) => a[1].at - b[1].at).slice(entries.length - KEEP)
+        : entries
+    localStorage.setItem(DRAFTS_KEY, JSON.stringify(Object.fromEntries(kept)))
+  } catch {
+    // A full or unavailable store costs the draft, not the typing.
+  }
+}
+
+/** What was left in this box, or '' for a box nobody has typed in. */
+export function loadDraft(key: string): string {
+  return read()[key]?.text ?? ''
+}
+
+/**
+ * Remembers what is in the box, or forgets it once it is empty.
+ *
+ * An empty draft is not worth a record: it would take a slot from a session
+ * that has something in it, and reading it back gives the same '' either way.
+ */
+export function saveDraft(key: string, text: string): void {
+  const drafts = read()
+  if (text === '') {
+    if (drafts[key] === undefined) return
+    delete drafts[key]
+  } else {
+    drafts[key] = { text, at: Date.now() }
+  }
+  write(drafts)
+}
+
+/** Called when the text has gone somewhere: sent, or started as a session. */
+export function clearDraft(key: string): void {
+  saveDraft(key, '')
+}
+
+/** The key a session's prompt is held under. */
+export function sessionDraftKey(hostId: string, sessionId: string): string {
+  return `session:${hostId}:${sessionId}`
+}
+
+/**
+ * The new-session dialog's own key.
+ *
+ * One draft for the dialog rather than one per host: it is a single form the
+ * user opens, fills in, and closes — and what they typed into it is the same
+ * thought whichever host it ends up starting on.
+ */
+export const NEW_SESSION_DRAFT = 'new-session'

--- a/desktop/test/drafts.test.ts
+++ b/desktop/test/drafts.test.ts
@@ -1,0 +1,104 @@
+// Losing a half-written prompt is the failure this exists to prevent, so what
+// is tested is mostly what must survive: a switch, a reopen, and a store that
+// has filled up.
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+
+import {
+  NEW_SESSION_DRAFT,
+  clearDraft,
+  loadDraft,
+  saveDraft,
+  sessionDraftKey,
+} from '../src/renderer/drafts.ts'
+
+/** The browser's store, as much of it as this module touches. */
+function fakeStorage(): Storage {
+  const held = new Map<string, string>()
+  return {
+    get length() {
+      return held.size
+    },
+    clear: () => held.clear(),
+    getItem: (key: string) => held.get(key) ?? null,
+    key: (at: number) => [...held.keys()][at] ?? null,
+    removeItem: (key: string) => void held.delete(key),
+    setItem: (key: string, value: string) => void held.set(key, value),
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { localStorage: Storage }).localStorage = fakeStorage()
+})
+
+test('what was typed comes back', () => {
+  const key = sessionDraftKey('h1', 's1')
+  saveDraft(key, 'rebase onto main')
+  assert.equal(loadDraft(key), 'rebase onto main')
+})
+
+test("one session does not read another session's draft", () => {
+  saveDraft(sessionDraftKey('h1', 's1'), 'for the first')
+  saveDraft(sessionDraftKey('h1', 's2'), 'for the second')
+  assert.equal(loadDraft(sessionDraftKey('h1', 's1')), 'for the first')
+  assert.equal(loadDraft(sessionDraftKey('h1', 's2')), 'for the second')
+})
+
+test('the same session id on two hosts is two drafts', () => {
+  saveDraft(sessionDraftKey('h1', 'same'), 'one machine')
+  saveDraft(sessionDraftKey('h2', 'same'), 'another machine')
+  assert.equal(loadDraft(sessionDraftKey('h1', 'same')), 'one machine')
+})
+
+test('a box nobody has typed in reads as empty', () => {
+  assert.equal(loadDraft(sessionDraftKey('h1', 'never')), '')
+})
+
+test('sending it clears it', () => {
+  const key = sessionDraftKey('h1', 's1')
+  saveDraft(key, 'something')
+  clearDraft(key)
+  assert.equal(loadDraft(key), '')
+})
+
+test('emptying the box takes the record with it', () => {
+  const key = sessionDraftKey('h1', 's1')
+  saveDraft(key, 'typed')
+  saveDraft(key, '')
+  const raw = localStorage.getItem('helios.drafts') ?? '{}'
+  assert.equal(Object.keys(JSON.parse(raw)).length, 0)
+})
+
+test('the dialog has a draft of its own', () => {
+  saveDraft(NEW_SESSION_DRAFT, '{"prompt":"look at the flake"}')
+  assert.equal(loadDraft(NEW_SESSION_DRAFT), '{"prompt":"look at the flake"}')
+})
+
+test('past a hundred sessions the oldest go, not the newest', () => {
+  for (let at = 0; at < 120; at++) saveDraft(sessionDraftKey('h1', `s${at}`), `draft ${at}`)
+
+  // The last one typed into is the one that must still be there.
+  assert.equal(loadDraft(sessionDraftKey('h1', 's119')), 'draft 119')
+  assert.equal(loadDraft(sessionDraftKey('h1', 's0')), '')
+  const raw = localStorage.getItem('helios.drafts') ?? '{}'
+  assert.ok(Object.keys(JSON.parse(raw)).length <= 100)
+})
+
+test('a store that refuses costs the draft, not the typing', () => {
+  ;(globalThis as { localStorage: Storage }).localStorage = {
+    ...fakeStorage(),
+    setItem: () => {
+      throw new Error('quota')
+    },
+  }
+  assert.doesNotThrow(() => saveDraft(sessionDraftKey('h1', 's1'), 'typed'))
+  assert.equal(loadDraft(sessionDraftKey('h1', 's1')), '')
+})
+
+test('unreadable storage reads as no drafts rather than throwing', () => {
+  ;(globalThis as { localStorage: Storage }).localStorage = {
+    ...fakeStorage(),
+    getItem: () => 'not json',
+  }
+  assert.equal(loadDraft(sessionDraftKey('h1', 's1')), '')
+})


### PR DESCRIPTION
## Summary

**The prompt takes the keyboard** when a session opens or the transcript comes back into view. No click before typing — or before dictating, where reaching for the pointer first is the whole cost. Guarded twice: only the panel actually showing (a hidden one stays mounted for five minutes and would type into the wrong session), and not a terminated session, which has a Resume banner instead of a prompt.

**Drafts survive.** Three ways a half-written prompt used to be lost:

- switching session to check something,
- the panel being unmounted after five minutes off screen,
- closing the new-session dialog to go and look up a path.

Session drafts are kept per session in `localStorage`, restored when the box returns, cleared when sent. Each session keeps its own — showing another session's text would be worse than losing it, since it would be sent to the wrong agent.

The new-session dialog keeps host, agent, model, directory, mode and prompt as **one record**: they are one thought, and restoring half of them is worse than restoring none. A seed still wins, because a `+` pressed on a project means that project. Starting the session clears it.

A hundred drafts are kept, oldest dropped first; a store that refuses costs the draft and nothing else.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 362 pass, 10 new in `test/drafts.test.ts`: round trip, one session not reading another's, the same session id on two hosts, clearing on send, emptying removing the record, the hundred-draft sweep keeping the newest, and both failure paths (a store that throws on write, and unparseable contents)
- [x] `npx playwright test e2e/drafts.spec.ts` — 5 new: survives a session switch, each session keeps its own, sending clears it, it outlives a window reload, and the dialog's prompt is there when reopened after Escape
- [x] `npx playwright test e2e/composer-focus.spec.ts` — 2, now using `toBeFocused`
- [x] `npx playwright test e2e/new-session.spec.ts e2e/composer-focus.spec.ts e2e/drafts.spec.ts` — 31 pass together
- [ ] Full e2e suite — left to CI